### PR TITLE
analytics: instrument authentication funnel

### DIFF
--- a/apps/web/app/(landing)/login/LoginForm.test.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.test.tsx
@@ -14,6 +14,7 @@ const mockUseSearchParams = vi.fn();
 const mockSignInWithOauth2 = vi.fn();
 const mockSignInSocial = vi.fn();
 const mockToastError = vi.fn();
+const mockPosthogCapture = vi.fn();
 
 (globalThis as { React?: typeof React }).React = React;
 
@@ -48,6 +49,10 @@ vi.mock("@/utils/auth-client", () => ({
 vi.mock("@/components/Toast", () => ({
   toastError: (...args: Parameters<typeof mockToastError>) =>
     mockToastError(...args),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mockPosthogCapture }),
 }));
 
 import { LoginForm } from "@/app/(landing)/login/LoginForm";

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -68,10 +68,7 @@ export function LoginForm({
       trackAuthFailure(posthog, {
         provider: "google",
         stage: "start",
-        errorCode:
-          error instanceof Error && isNetworkSignInError(error.message)
-            ? "network_error"
-            : "client_error",
+        errorCode: getSignInErrorCode(error),
       });
       const description = getSocialSignInErrorMessage(error);
       logger.error("Error signing in with Google", { error });
@@ -212,10 +209,7 @@ async function handleSocialSignIn({
     trackAuthFailure(posthog, {
       provider,
       stage: "start",
-      errorCode:
-        error instanceof Error && isNetworkSignInError(error.message)
-          ? "network_error"
-          : "client_error",
+      errorCode: getSignInErrorCode(error),
     });
     const description = getSocialSignInErrorMessage(error);
     logger.error(`Error signing in with ${providerName}`, { error });
@@ -238,6 +232,12 @@ function getSocialSignInErrorMessage(error: unknown) {
   }
 
   return "Please try again or contact support.";
+}
+
+function getSignInErrorCode(error: unknown) {
+  return error instanceof Error && isNetworkSignInError(error.message)
+    ? "network_error"
+    : "client_error";
 }
 
 function isNetworkSignInError(message: string) {

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 import { Button } from "@/components/Button";
 import { Button as UIButton } from "@/components/ui/button";
@@ -13,6 +14,10 @@ import { normalizeInternalPath } from "@/utils/path";
 import { buildRedirectUrl, redirectToSafeUrl } from "@/utils/redirect";
 import { createClientLogger } from "@/utils/logger-client";
 import type { LoginProvider } from "@/utils/oauth/login-providers";
+import {
+  trackAuthFailure,
+  trackAuthStarted,
+} from "@/utils/analytics/auth-funnel";
 
 const logger = createClientLogger("login/LoginForm");
 const CONNECT_MAILBOX_PATH = "/connect-mailbox";
@@ -24,6 +29,7 @@ export function LoginForm({
   enabledProviders: readonly LoginProvider[];
   useGoogleOauthEmulator: boolean;
 }) {
+  const posthog = usePostHog();
   const searchParams = useSearchParams();
   const next = searchParams?.get("next");
   const { callbackURL, errorCallbackURL } = getAuthCallbackUrls(next);
@@ -39,6 +45,7 @@ export function LoginForm({
 
   const handleGoogleSignIn = async () => {
     setLoadingGoogle(true);
+    trackAuthStarted(posthog, "google");
     try {
       if (useGoogleOauthEmulator) {
         const result = await signInWithOauth2({
@@ -58,6 +65,14 @@ export function LoginForm({
         });
       }
     } catch (error) {
+      trackAuthFailure(posthog, {
+        provider: "google",
+        stage: "start",
+        errorCode:
+          error instanceof Error && isNetworkSignInError(error.message)
+            ? "network_error"
+            : "client_error",
+      });
       const description = getSocialSignInErrorMessage(error);
       logger.error("Error signing in with Google", { error });
       toastError({
@@ -76,6 +91,7 @@ export function LoginForm({
       callbackURL,
       errorCallbackURL,
       setLoading: setLoadingMicrosoft,
+      posthog,
     });
   };
 
@@ -128,6 +144,7 @@ export function LoginForm({
               callbackURL: appleCallbackURL,
               errorCallbackURL,
               setLoading: setLoadingApple,
+              posthog,
             })
           }
         >
@@ -174,14 +191,17 @@ async function handleSocialSignIn({
   callbackURL,
   errorCallbackURL,
   setLoading,
+  posthog,
 }: {
   provider: "apple" | "google" | "microsoft";
   providerName: "Apple" | "Google" | "Microsoft";
   callbackURL: string;
   errorCallbackURL: string;
   setLoading: (loading: boolean) => void;
+  posthog: ReturnType<typeof usePostHog>;
 }) {
   setLoading(true);
+  trackAuthStarted(posthog, provider);
   try {
     await signIn.social({
       provider,
@@ -189,6 +209,14 @@ async function handleSocialSignIn({
       callbackURL,
     });
   } catch (error) {
+    trackAuthFailure(posthog, {
+      provider,
+      stage: "start",
+      errorCode:
+        error instanceof Error && isNetworkSignInError(error.message)
+          ? "network_error"
+          : "client_error",
+    });
     const description = getSocialSignInErrorMessage(error);
     logger.error(`Error signing in with ${providerName}`, { error });
     toastError({

--- a/apps/web/app/(landing)/login/error/page.tsx
+++ b/apps/web/app/(landing)/login/error/page.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useRef } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   getEmailAlreadyLinkedDescription,
   getRequiresReconsentDescription,
@@ -17,6 +18,10 @@ import { WELCOME_PATH } from "@/utils/config";
 import { CrispChatLoggedOutVisible } from "@/components/CrispChat";
 import { getAndClearAuthErrorCookie } from "@/utils/auth-cookies";
 import { SUPPORT_EMAIL } from "@/utils/branding";
+import {
+  getPendingAuthProvider,
+  trackAuthFailure,
+} from "@/utils/analytics/auth-funnel";
 
 const errorMessages: Record<string, { title: string; description: string }> = {
   email_not_found: {
@@ -50,12 +55,25 @@ const errorMessages: Record<string, { title: string; description: string }> = {
 };
 
 function LoginErrorContent() {
+  const posthog = usePostHog();
+  const hasTrackedAuthFailure = useRef(false);
   const { data, isLoading, error } = useUser();
   const router = useRouter();
   const searchParams = useSearchParams();
   const errorCode = searchParams.get("error")?.toLowerCase();
   const reason = searchParams.get("reason")?.toLowerCase();
   const resolvedErrorCode = resolveErrorCode({ errorCode, reason });
+
+  useEffect(() => {
+    if (isLoading || data?.id || hasTrackedAuthFailure.current) return;
+
+    hasTrackedAuthFailure.current = true;
+    trackAuthFailure(posthog, {
+      provider: getPendingAuthProvider(),
+      stage: "callback",
+      errorCode: resolvedErrorCode,
+    });
+  }, [data?.id, isLoading, posthog, resolvedErrorCode]);
 
   // For some reason users are being sent to this page when logged in
   // This will redirect them out of this page to the app

--- a/apps/web/app/(landing)/login/sso/page.tsx
+++ b/apps/web/app/(landing)/login/sso/page.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "@/components/Button";
@@ -12,6 +13,10 @@ import type {
   GetSsoSignInParams,
   GetSsoSignInResponse,
 } from "@/app/api/sso/signin/route";
+import {
+  trackAuthFailure,
+  trackAuthStarted,
+} from "@/utils/analytics/auth-funnel";
 
 const ssoLoginSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -27,6 +32,7 @@ const ssoLoginSchema = z.object({
 type SsoLoginBody = z.infer<typeof ssoLoginSchema>;
 
 export default function SSOLoginPage() {
+  const posthog = usePostHog();
   const router = useRouter();
   const {
     register,
@@ -41,6 +47,7 @@ export default function SSOLoginPage() {
   const onSubmit: SubmitHandler<SsoLoginBody> = useCallback(
     async (data) => {
       setIsSubmitting(true);
+      trackAuthStarted(posthog, "sso");
       try {
         const params: GetSsoSignInParams = {
           email: data.email,
@@ -57,6 +64,11 @@ export default function SSOLoginPage() {
         const responseData = await response.json();
 
         if (!response.ok) {
+          trackAuthFailure(posthog, {
+            provider: "sso",
+            stage: "start",
+            errorCode: "sso_start_rejected",
+          });
           toastError({
             title: "SSO Sign-in Error",
             description: responseData.error || "Failed to initiate SSO sign-in",
@@ -71,6 +83,11 @@ export default function SSOLoginPage() {
           router.push(res.redirectUrl);
         }
       } catch {
+        trackAuthFailure(posthog, {
+          provider: "sso",
+          stage: "start",
+          errorCode: "network_error",
+        });
         toastError({
           title: "SSO Sign-in Error",
           description: "An unexpected error occurred. Please try again.",
@@ -79,7 +96,7 @@ export default function SSOLoginPage() {
         setIsSubmitting(false);
       }
     },
-    [router],
+    [posthog, router],
   );
 
   return (

--- a/apps/web/providers/PostHogProvider.tsx
+++ b/apps/web/providers/PostHogProvider.tsx
@@ -11,6 +11,7 @@ import {
   getAppPageViewProperties,
   PRODUCT_ANALYTICS_EVENTS,
 } from "@/utils/analytics/product";
+import { clearPendingAuthProvider } from "@/utils/analytics/auth-funnel";
 import { ONE_DAY_MS } from "@/utils/date";
 import { scheduleAfterPageLoad } from "@/utils/schedule-after-page-load";
 
@@ -22,6 +23,10 @@ export function PostHogPageview() {
 
   useEffect(() => {
     if (pathname) {
+      if (!pathname.startsWith("/login/error")) {
+        clearPendingAuthProvider();
+      }
+
       let url = window.origin + pathname;
       if (searchParams?.toString()) {
         url = `${url}?${searchParams.toString()}`;
@@ -46,19 +51,20 @@ export function PostHogPageview() {
 export function PostHogIdentify() {
   const { data: session } = useSession();
   const { emailAccount } = useAccount();
+  const userEmail = session?.user.email;
+  const userCreatedAt = session?.user.createdAt;
 
   useEffect(() => {
-    const user = session?.user;
-    if (!user?.email) return;
+    if (!userEmail || !userCreatedAt) return;
 
     const signedUpOverOneDayAgo =
-      Date.now() - new Date(user.createdAt).getTime() > ONE_DAY_MS;
+      Date.now() - new Date(userCreatedAt).getTime() > ONE_DAY_MS;
 
-    posthog.identify(user.email, {
-      email: user.email,
+    posthog.identify(userEmail, {
+      email: userEmail,
       ...(signedUpOverOneDayAgo && { signed_up_over_1_day: true }),
     });
-  }, [session?.user.createdAt, session?.user.email]);
+  }, [userCreatedAt, userEmail]);
 
   useEffect(() => {
     // Set super properties that will be included with all events

--- a/apps/web/providers/PostHogProvider.tsx
+++ b/apps/web/providers/PostHogProvider.tsx
@@ -23,10 +23,6 @@ export function PostHogPageview() {
 
   useEffect(() => {
     if (pathname) {
-      if (!pathname.startsWith("/login/error")) {
-        clearPendingAuthProvider();
-      }
-
       let url = window.origin + pathname;
       if (searchParams?.toString()) {
         url = `${url}?${searchParams.toString()}`;
@@ -55,9 +51,12 @@ export function PostHogIdentify() {
   const userCreatedAt = session?.user.createdAt;
 
   useEffect(() => {
-    if (!userEmail || !userCreatedAt) return;
+    if (!userEmail) return;
+
+    clearPendingAuthProvider();
 
     const signedUpOverOneDayAgo =
+      !!userCreatedAt &&
       Date.now() - new Date(userCreatedAt).getTime() > ONE_DAY_MS;
 
     posthog.identify(userEmail, {

--- a/apps/web/utils/analytics/auth-funnel.server.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.test.ts
@@ -6,6 +6,8 @@ vi.mock("@/utils/posthog", () => ({
 
 import {
   getAuthProviderFromContext,
+  isNewUserAuthContext,
+  markAuthContextAsNewUser,
   trackAuthenticationCompleted,
 } from "@/utils/analytics/auth-funnel.server";
 import { posthogCaptureEvent } from "@/utils/posthog";
@@ -45,9 +47,8 @@ describe("server auth funnel analytics", () => {
   it("tracks a completed provider login without adding user data as properties", async () => {
     await trackAuthenticationCompleted({
       email: "user@example.com",
-      userCreatedAt: new Date("2026-08-02T11:59:30.000Z"),
       provider: "google",
-      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+      isNewUser: true,
     });
 
     expect(posthogCaptureEvent).toHaveBeenCalledWith(
@@ -60,9 +61,8 @@ describe("server auth funnel analytics", () => {
   it("distinguishes an existing-user login from new-account completion", async () => {
     await trackAuthenticationCompleted({
       email: "user@example.com",
-      userCreatedAt: new Date("2026-07-01T00:00:00.000Z"),
       provider: "apple",
-      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+      isNewUser: false,
     });
 
     expect(posthogCaptureEvent).toHaveBeenCalledWith(
@@ -75,9 +75,8 @@ describe("server auth funnel analytics", () => {
   it("does not emit completion events when provider attribution is unknown", async () => {
     await trackAuthenticationCompleted({
       email: "user@example.com",
-      userCreatedAt: new Date("2026-08-02T11:59:30.000Z"),
       provider: "unknown",
-      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+      isNewUser: true,
     });
 
     expect(posthogCaptureEvent).not.toHaveBeenCalled();
@@ -91,10 +90,21 @@ describe("server auth funnel analytics", () => {
     await expect(
       trackAuthenticationCompleted({
         email: "user@example.com",
-        userCreatedAt: new Date("2026-07-01T00:00:00.000Z"),
         provider: "microsoft",
-        authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+        isNewUser: false,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("marks new users from the current auth request context", () => {
+    const authContext = {};
+    const unrelatedAuthContext = {};
+
+    expect(isNewUserAuthContext(authContext)).toBe(false);
+
+    markAuthContextAsNewUser(authContext);
+
+    expect(isNewUserAuthContext(authContext)).toBe(true);
+    expect(isNewUserAuthContext(unrelatedAuthContext)).toBe(false);
   });
 });

--- a/apps/web/utils/analytics/auth-funnel.server.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import {
+  getAuthProviderFromContext,
+  trackAuthenticationCompleted,
+} from "@/utils/analytics/auth-funnel.server";
+import { posthogCaptureEvent } from "@/utils/posthog";
+import prisma from "@/utils/prisma";
+
+describe("server auth funnel analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives only public provider categories from auth callback context", () => {
+    expect(
+      getAuthProviderFromContext({
+        path: "/callback/google",
+        params: { id: "google" },
+      }),
+    ).toBe("google");
+    expect(
+      getAuthProviderFromContext({
+        path: "/oauth2/callback/microsoft",
+        params: { providerId: "microsoft" },
+      }),
+    ).toBe("microsoft");
+    expect(
+      getAuthProviderFromContext({
+        path: "/sso/callback/private-company-saml",
+        params: { providerId: "private-company-saml" },
+      }),
+    ).toBe("sso");
+    expect(
+      getAuthProviderFromContext({
+        path: "/get-session",
+        params: {},
+      }),
+    ).toBe("unknown");
+  });
+
+  it("tracks a completed provider login without adding user data as properties", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      createdAt: new Date("2026-08-02T11:59:30.000Z"),
+      email: "user@example.com",
+    });
+
+    await trackAuthenticationCompleted({
+      userId: "user-id",
+      provider: "google",
+      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+    });
+
+    expect(posthogCaptureEvent).toHaveBeenCalledWith(
+      "user@example.com",
+      "Authentication Completed",
+      { provider: "google", is_new_user: true },
+    );
+  });
+
+  it("distinguishes an existing-user login from new-account completion", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      email: "user@example.com",
+    });
+
+    await trackAuthenticationCompleted({
+      userId: "user-id",
+      provider: "apple",
+      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+    });
+
+    expect(posthogCaptureEvent).toHaveBeenCalledWith(
+      "user@example.com",
+      "Authentication Completed",
+      { provider: "apple", is_new_user: false },
+    );
+  });
+
+  it("does not emit completion events when provider attribution is unknown", async () => {
+    await trackAuthenticationCompleted({
+      userId: "user-id",
+      provider: "unknown",
+      authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+    });
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(posthogCaptureEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/analytics/auth-funnel.server.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.test.ts
@@ -4,20 +4,11 @@ vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn(),
 }));
 
-vi.mock("@/utils/prisma", () => ({
-  default: {
-    user: {
-      findUnique: vi.fn(),
-    },
-  },
-}));
-
 import {
   getAuthProviderFromContext,
   trackAuthenticationCompleted,
 } from "@/utils/analytics/auth-funnel.server";
 import { posthogCaptureEvent } from "@/utils/posthog";
-import prisma from "@/utils/prisma";
 
 describe("server auth funnel analytics", () => {
   beforeEach(() => {
@@ -52,13 +43,9 @@ describe("server auth funnel analytics", () => {
   });
 
   it("tracks a completed provider login without adding user data as properties", async () => {
-    prisma.user.findUnique.mockResolvedValue({
-      createdAt: new Date("2026-08-02T11:59:30.000Z"),
-      email: "user@example.com",
-    });
-
     await trackAuthenticationCompleted({
-      userId: "user-id",
+      email: "user@example.com",
+      userCreatedAt: new Date("2026-08-02T11:59:30.000Z"),
       provider: "google",
       authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
     });
@@ -71,13 +58,9 @@ describe("server auth funnel analytics", () => {
   });
 
   it("distinguishes an existing-user login from new-account completion", async () => {
-    prisma.user.findUnique.mockResolvedValue({
-      createdAt: new Date("2026-07-01T00:00:00.000Z"),
-      email: "user@example.com",
-    });
-
     await trackAuthenticationCompleted({
-      userId: "user-id",
+      email: "user@example.com",
+      userCreatedAt: new Date("2026-07-01T00:00:00.000Z"),
       provider: "apple",
       authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
     });
@@ -91,12 +74,27 @@ describe("server auth funnel analytics", () => {
 
   it("does not emit completion events when provider attribution is unknown", async () => {
     await trackAuthenticationCompleted({
-      userId: "user-id",
+      email: "user@example.com",
+      userCreatedAt: new Date("2026-08-02T11:59:30.000Z"),
       provider: "unknown",
       authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
     });
 
-    expect(prisma.user.findUnique).not.toHaveBeenCalled();
     expect(posthogCaptureEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not reject authentication when analytics delivery fails", async () => {
+    vi.mocked(posthogCaptureEvent).mockRejectedValueOnce(
+      new Error("Analytics unavailable"),
+    );
+
+    await expect(
+      trackAuthenticationCompleted({
+        email: "user@example.com",
+        userCreatedAt: new Date("2026-07-01T00:00:00.000Z"),
+        provider: "microsoft",
+        authenticatedAt: new Date("2026-08-02T12:00:00.000Z"),
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/utils/analytics/auth-funnel.server.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.test.ts
@@ -82,20 +82,6 @@ describe("server auth funnel analytics", () => {
     expect(posthogCaptureEvent).not.toHaveBeenCalled();
   });
 
-  it("does not reject authentication when analytics delivery fails", async () => {
-    vi.mocked(posthogCaptureEvent).mockRejectedValueOnce(
-      new Error("Analytics unavailable"),
-    );
-
-    await expect(
-      trackAuthenticationCompleted({
-        email: "user@example.com",
-        provider: "microsoft",
-        isNewUser: false,
-      }),
-    ).resolves.toBeUndefined();
-  });
-
   it("marks new users from the current auth request context", () => {
     const authContext = {};
     const unrelatedAuthContext = {};

--- a/apps/web/utils/analytics/auth-funnel.server.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.ts
@@ -1,22 +1,14 @@
+import type { GenericEndpointContext } from "better-auth";
 import type { AuthFunnelProvider } from "@/utils/analytics/auth-funnel";
 import { normalizeAuthProvider } from "@/utils/analytics/auth-funnel";
 import { createScopedLogger } from "@/utils/logger";
 import { posthogCaptureEvent } from "@/utils/posthog";
-import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("analytics/auth-funnel");
 const NEW_USER_AUTH_WINDOW_MS = 60 * 1000;
 
-type AuthHookContext = {
-  path?: string;
-  params?: Record<string, unknown>;
-  context?: {
-    runInBackgroundOrAwait?: (promise: Promise<unknown>) => unknown;
-  };
-} | null;
-
 export function getAuthProviderFromContext(
-  context: Pick<NonNullable<AuthHookContext>, "params" | "path"> | null,
+  context: Pick<GenericEndpointContext, "params" | "path"> | null,
 ): AuthFunnelProvider {
   const provider = normalizeAuthProvider(
     context?.params?.id ?? context?.params?.providerId,
@@ -26,40 +18,24 @@ export function getAuthProviderFromContext(
   return context?.path?.includes("/sso/") ? "sso" : "unknown";
 }
 
-export async function queueAuthFunnelTracking(
-  context: AuthHookContext,
-  tracking: Promise<unknown>,
-) {
-  const runInBackground = context?.context?.runInBackgroundOrAwait;
-  if (runInBackground) {
-    await runInBackground(tracking);
-    return;
-  }
-
-  await tracking;
-}
-
 export async function trackAuthenticationCompleted({
-  userId,
+  email,
+  userCreatedAt,
   provider,
   authenticatedAt,
 }: {
-  userId: string;
+  email: string;
+  userCreatedAt: Date;
   provider: AuthFunnelProvider;
   authenticatedAt: Date;
 }) {
   if (provider === "unknown") return;
 
   try {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { createdAt: true, email: true },
-    });
-    if (!user) return;
-
     const accountAgeAtAuthentication =
-      authenticatedAt.getTime() - user.createdAt.getTime();
-    await posthogCaptureEvent(user.email, "Authentication Completed", {
+      authenticatedAt.getTime() - userCreatedAt.getTime();
+
+    await posthogCaptureEvent(email, "Authentication Completed", {
       provider,
       is_new_user:
         accountAgeAtAuthentication >= 0 &&
@@ -68,7 +44,6 @@ export async function trackAuthenticationCompleted({
   } catch (error) {
     logger.error("Failed to track completed authentication", {
       error,
-      userId,
       provider,
     });
   }

--- a/apps/web/utils/analytics/auth-funnel.server.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.ts
@@ -1,10 +1,8 @@
 import type { GenericEndpointContext } from "better-auth";
 import type { AuthFunnelProvider } from "@/utils/analytics/auth-funnel";
 import { normalizeAuthProvider } from "@/utils/analytics/auth-funnel";
-import { createScopedLogger } from "@/utils/logger";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
-const logger = createScopedLogger("analytics/auth-funnel");
 const newUserAuthContexts = new WeakSet<object>();
 
 export function markAuthContextAsNewUser(authContext?: object | null) {
@@ -37,15 +35,8 @@ export async function trackAuthenticationCompleted({
 }) {
   if (provider === "unknown") return;
 
-  try {
-    await posthogCaptureEvent(email, "Authentication Completed", {
-      provider,
-      is_new_user: isNewUser,
-    });
-  } catch (error) {
-    logger.error("Failed to track completed authentication", {
-      error,
-      provider,
-    });
-  }
+  await posthogCaptureEvent(email, "Authentication Completed", {
+    provider,
+    is_new_user: isNewUser,
+  });
 }

--- a/apps/web/utils/analytics/auth-funnel.server.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.ts
@@ -1,0 +1,75 @@
+import type { AuthFunnelProvider } from "@/utils/analytics/auth-funnel";
+import { normalizeAuthProvider } from "@/utils/analytics/auth-funnel";
+import { createScopedLogger } from "@/utils/logger";
+import { posthogCaptureEvent } from "@/utils/posthog";
+import prisma from "@/utils/prisma";
+
+const logger = createScopedLogger("analytics/auth-funnel");
+const NEW_USER_AUTH_WINDOW_MS = 60 * 1000;
+
+type AuthHookContext = {
+  path?: string;
+  params?: Record<string, unknown>;
+  context?: {
+    runInBackgroundOrAwait?: (promise: Promise<unknown>) => unknown;
+  };
+} | null;
+
+export function getAuthProviderFromContext(
+  context: Pick<NonNullable<AuthHookContext>, "params" | "path"> | null,
+): AuthFunnelProvider {
+  const provider = normalizeAuthProvider(
+    context?.params?.id ?? context?.params?.providerId,
+  );
+  if (provider !== "unknown") return provider;
+
+  return context?.path?.includes("/sso/") ? "sso" : "unknown";
+}
+
+export async function queueAuthFunnelTracking(
+  context: AuthHookContext,
+  tracking: Promise<unknown>,
+) {
+  const runInBackground = context?.context?.runInBackgroundOrAwait;
+  if (runInBackground) {
+    await runInBackground(tracking);
+    return;
+  }
+
+  await tracking;
+}
+
+export async function trackAuthenticationCompleted({
+  userId,
+  provider,
+  authenticatedAt,
+}: {
+  userId: string;
+  provider: AuthFunnelProvider;
+  authenticatedAt: Date;
+}) {
+  if (provider === "unknown") return;
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true, email: true },
+    });
+    if (!user) return;
+
+    const accountAgeAtAuthentication =
+      authenticatedAt.getTime() - user.createdAt.getTime();
+    await posthogCaptureEvent(user.email, "Authentication Completed", {
+      provider,
+      is_new_user:
+        accountAgeAtAuthentication >= 0 &&
+        accountAgeAtAuthentication <= NEW_USER_AUTH_WINDOW_MS,
+    });
+  } catch (error) {
+    logger.error("Failed to track completed authentication", {
+      error,
+      userId,
+      provider,
+    });
+  }
+}

--- a/apps/web/utils/analytics/auth-funnel.server.ts
+++ b/apps/web/utils/analytics/auth-funnel.server.ts
@@ -5,7 +5,15 @@ import { createScopedLogger } from "@/utils/logger";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
 const logger = createScopedLogger("analytics/auth-funnel");
-const NEW_USER_AUTH_WINDOW_MS = 60 * 1000;
+const newUserAuthContexts = new WeakSet<object>();
+
+export function markAuthContextAsNewUser(authContext?: object | null) {
+  if (authContext) newUserAuthContexts.add(authContext);
+}
+
+export function isNewUserAuthContext(authContext?: object | null) {
+  return !!authContext && newUserAuthContexts.has(authContext);
+}
 
 export function getAuthProviderFromContext(
   context: Pick<GenericEndpointContext, "params" | "path"> | null,
@@ -20,26 +28,19 @@ export function getAuthProviderFromContext(
 
 export async function trackAuthenticationCompleted({
   email,
-  userCreatedAt,
   provider,
-  authenticatedAt,
+  isNewUser,
 }: {
   email: string;
-  userCreatedAt: Date;
   provider: AuthFunnelProvider;
-  authenticatedAt: Date;
+  isNewUser: boolean;
 }) {
   if (provider === "unknown") return;
 
   try {
-    const accountAgeAtAuthentication =
-      authenticatedAt.getTime() - userCreatedAt.getTime();
-
     await posthogCaptureEvent(email, "Authentication Completed", {
       provider,
-      is_new_user:
-        accountAgeAtAuthentication >= 0 &&
-        accountAgeAtAuthentication <= NEW_USER_AUTH_WINDOW_MS,
+      is_new_user: isNewUser,
     });
   } catch (error) {
     logger.error("Failed to track completed authentication", {

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearPendingAuthProvider,
   getAuthErrorCategory,
   getPendingAuthProvider,
   normalizeAuthProvider,
@@ -48,6 +49,15 @@ describe("auth funnel analytics", () => {
 
     rememberAuthProvider("microsoft", now - 16 * 60 * 1000);
     expect(getPendingAuthProvider(now)).toBe("unknown");
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it("clears provider attribution after authentication succeeds", () => {
+    rememberAuthProvider("google");
+
+    clearPendingAuthProvider();
+
+    expect(getPendingAuthProvider()).toBe("unknown");
     expect(sessionStorage.length).toBe(0);
   });
 

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -74,4 +74,21 @@ describe("auth funnel analytics", () => {
       "private-error-message",
     );
   });
+
+  it("does not throw when browser analytics is unavailable", () => {
+    const posthog = {
+      capture: vi.fn(() => {
+        throw new Error("Analytics unavailable");
+      }),
+    } as never;
+
+    expect(() => trackAuthStarted(posthog, "google")).not.toThrow();
+    expect(() =>
+      trackAuthFailure(posthog, {
+        provider: "google",
+        stage: "start",
+        errorCode: "client_error",
+      }),
+    ).not.toThrow();
+  });
 });

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuthErrorCategory,
+  getPendingAuthProvider,
+  normalizeAuthProvider,
+  rememberAuthProvider,
+  trackAuthFailure,
+  trackAuthStarted,
+} from "@/utils/analytics/auth-funnel";
+
+describe("auth funnel analytics", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("only accepts public provider categories", () => {
+    expect(normalizeAuthProvider("google")).toBe("google");
+    expect(normalizeAuthProvider("microsoft")).toBe("microsoft");
+    expect(normalizeAuthProvider("apple")).toBe("apple");
+    expect(normalizeAuthProvider("sso")).toBe("sso");
+    expect(normalizeAuthProvider("private-company-saml")).toBe("unknown");
+    expect(normalizeAuthProvider(undefined)).toBe("unknown");
+  });
+
+  it("maps OAuth errors to stable categories without retaining raw details", () => {
+    expect(getAuthErrorCategory("access_denied")).toBe("access_denied");
+    expect(getAuthErrorCategory("invalid_code")).toBe(
+      "invalid_or_expired_callback",
+    );
+    expect(getAuthErrorCategory("email_already_linked")).toBe(
+      "account_conflict",
+    );
+    expect(getAuthErrorCategory("RequiresReconsent")).toBe(
+      "reconsent_required",
+    );
+    expect(getAuthErrorCategory("contains-sensitive-provider-details")).toBe(
+      "unknown",
+    );
+  });
+
+  it("expires remembered providers so stale attempts are not attributed", () => {
+    const now = new Date("2026-08-02T12:00:00.000Z").getTime();
+    rememberAuthProvider("google", now - 14 * 60 * 1000);
+    expect(getPendingAuthProvider(now)).toBe("google");
+
+    rememberAuthProvider("microsoft", now - 16 * 60 * 1000);
+    expect(getPendingAuthProvider(now)).toBe("unknown");
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it("captures only safe properties for starts and failures", () => {
+    const capture = vi.fn();
+    const posthog = { capture } as never;
+
+    trackAuthStarted(posthog, "google");
+    trackAuthFailure(posthog, {
+      provider: "google",
+      stage: "callback",
+      errorCode: "private-error-message",
+    });
+
+    expect(capture).toHaveBeenNthCalledWith(1, "Authentication Started", {
+      provider: "google",
+    });
+    expect(capture).toHaveBeenNthCalledWith(2, "Authentication Failed", {
+      provider: "google",
+      stage: "callback",
+      error_category: "unknown",
+    });
+    expect(JSON.stringify(capture.mock.calls)).not.toContain(
+      "private-error-message",
+    );
+  });
+});

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -49,7 +49,6 @@ describe("auth funnel analytics", () => {
 
     rememberAuthProvider("microsoft", now - 16 * 60 * 1000);
     expect(getPendingAuthProvider(now)).toBe("unknown");
-    expect(sessionStorage.length).toBe(0);
   });
 
   it("clears provider attribution after authentication succeeds", () => {
@@ -58,7 +57,6 @@ describe("auth funnel analytics", () => {
     clearPendingAuthProvider();
 
     expect(getPendingAuthProvider()).toBe("unknown");
-    expect(sessionStorage.length).toBe(0);
   });
 
   it("captures only safe properties for starts and failures", () => {
@@ -80,9 +78,6 @@ describe("auth funnel analytics", () => {
       stage: "callback",
       error_category: "unknown",
     });
-    expect(JSON.stringify(capture.mock.calls)).not.toContain(
-      "private-error-message",
-    );
   });
 
   it("does not throw when browser analytics is unavailable", () => {

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -1,0 +1,143 @@
+import type { PostHog } from "posthog-js";
+
+export type AuthFunnelProvider =
+  | "google"
+  | "microsoft"
+  | "apple"
+  | "sso"
+  | "unknown";
+
+type AuthFailureStage = "start" | "callback";
+
+const AUTH_PROVIDER_ATTEMPT_KEY = "auth_provider_attempt";
+const AUTH_PROVIDER_ATTEMPT_MAX_AGE_MS = 15 * 60 * 1000;
+
+export function normalizeAuthProvider(value: unknown): AuthFunnelProvider {
+  switch (value) {
+    case "google":
+    case "microsoft":
+    case "apple":
+    case "sso":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+export function getAuthErrorCategory(errorCode?: string | null) {
+  switch (errorCode?.toLowerCase()) {
+    case "access_denied":
+      return "access_denied";
+    case "invalid_code":
+    case "no_code":
+    case "org_invite_invalid_code":
+      return "invalid_or_expired_callback";
+    case "email_already_linked":
+    case "oauth_account_not_linked":
+    case "account_not_linked":
+    case "account_already_linked_to_different_user":
+      return "account_conflict";
+    case "requiresreconsent":
+      return "reconsent_required";
+    case "email_not_found":
+    case "signup_not_allowed":
+      return "signup_not_allowed";
+    case "network_error":
+      return "network_error";
+    case "client_error":
+      return "client_error";
+    case "internal_server_error":
+    case "oauth_provider_not_found":
+    case "unable_to_create_user":
+    case "unable_to_get_user_info":
+    case "unable_to_link_account":
+    case "sso_start_rejected":
+      return "provider_or_server_error";
+    default:
+      return "unknown";
+  }
+}
+
+export function rememberAuthProvider(
+  provider: AuthFunnelProvider,
+  startedAt = Date.now(),
+) {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.setItem(
+      AUTH_PROVIDER_ATTEMPT_KEY,
+      JSON.stringify({ provider, startedAt }),
+    );
+  } catch {
+    // Analytics must never block authentication when browser storage is unavailable.
+  }
+}
+
+export function getPendingAuthProvider(now = Date.now()): AuthFunnelProvider {
+  if (typeof sessionStorage === "undefined") return "unknown";
+
+  try {
+    const storedAttempt = sessionStorage.getItem(AUTH_PROVIDER_ATTEMPT_KEY);
+    if (!storedAttempt) return "unknown";
+
+    const parsed = JSON.parse(storedAttempt) as {
+      provider?: unknown;
+      startedAt?: unknown;
+    };
+    if (
+      typeof parsed.startedAt !== "number" ||
+      now - parsed.startedAt > AUTH_PROVIDER_ATTEMPT_MAX_AGE_MS
+    ) {
+      sessionStorage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY);
+      return "unknown";
+    }
+
+    return normalizeAuthProvider(parsed.provider);
+  } catch {
+    clearPendingAuthProvider();
+    return "unknown";
+  }
+}
+
+export function trackAuthStarted(
+  posthog: PostHog,
+  provider: AuthFunnelProvider,
+) {
+  rememberAuthProvider(provider);
+  try {
+    posthog.capture("Authentication Started", { provider });
+  } catch {
+    // Analytics must never block authentication.
+  }
+}
+
+export function trackAuthFailure(
+  posthog: PostHog,
+  options: {
+    provider: AuthFunnelProvider;
+    stage: AuthFailureStage;
+    errorCode?: string | null;
+  },
+) {
+  try {
+    posthog.capture("Authentication Failed", {
+      provider: options.provider,
+      stage: options.stage,
+      error_category: getAuthErrorCategory(options.errorCode),
+    });
+  } catch {
+    // Analytics must never block authentication.
+  }
+  clearPendingAuthProvider();
+}
+
+function clearPendingAuthProvider() {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY);
+  } catch {
+    // Ignore unavailable browser storage.
+  }
+}

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -132,7 +132,7 @@ export function trackAuthFailure(
   clearPendingAuthProvider();
 }
 
-function clearPendingAuthProvider() {
+export function clearPendingAuthProvider() {
   if (typeof sessionStorage === "undefined") return;
 
   try {

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -1,11 +1,7 @@
 import type { PostHog } from "posthog-js";
+import type { LoginProvider } from "@/utils/oauth/login-providers";
 
-export type AuthFunnelProvider =
-  | "google"
-  | "microsoft"
-  | "apple"
-  | "sso"
-  | "unknown";
+export type AuthFunnelProvider = LoginProvider | "unknown";
 
 type AuthFailureStage = "start" | "callback";
 
@@ -62,42 +58,38 @@ export function rememberAuthProvider(
   provider: AuthFunnelProvider,
   startedAt = Date.now(),
 ) {
-  if (typeof sessionStorage === "undefined") return;
-
-  try {
-    sessionStorage.setItem(
+  withSessionStorage((storage) =>
+    storage.setItem(
       AUTH_PROVIDER_ATTEMPT_KEY,
       JSON.stringify({ provider, startedAt }),
-    );
-  } catch {
-    // Analytics must never block authentication when browser storage is unavailable.
-  }
+    ),
+  );
 }
 
 export function getPendingAuthProvider(now = Date.now()): AuthFunnelProvider {
-  if (typeof sessionStorage === "undefined") return "unknown";
-
-  try {
-    const storedAttempt = sessionStorage.getItem(AUTH_PROVIDER_ATTEMPT_KEY);
+  const provider = withSessionStorage((storage) => {
+    const storedAttempt = storage.getItem(AUTH_PROVIDER_ATTEMPT_KEY);
     if (!storedAttempt) return "unknown";
 
-    const parsed = JSON.parse(storedAttempt) as {
-      provider?: unknown;
-      startedAt?: unknown;
-    };
+    const attempt = parseStoredAttempt(storedAttempt);
     if (
-      typeof parsed.startedAt !== "number" ||
-      now - parsed.startedAt > AUTH_PROVIDER_ATTEMPT_MAX_AGE_MS
+      typeof attempt?.startedAt !== "number" ||
+      now - attempt.startedAt > AUTH_PROVIDER_ATTEMPT_MAX_AGE_MS
     ) {
-      sessionStorage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY);
+      storage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY);
       return "unknown";
     }
 
-    return normalizeAuthProvider(parsed.provider);
-  } catch {
-    clearPendingAuthProvider();
-    return "unknown";
-  }
+    return normalizeAuthProvider(attempt.provider);
+  });
+
+  return provider ?? "unknown";
+}
+
+export function clearPendingAuthProvider() {
+  withSessionStorage((storage) =>
+    storage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY),
+  );
 }
 
 export function trackAuthStarted(
@@ -105,11 +97,7 @@ export function trackAuthStarted(
   provider: AuthFunnelProvider,
 ) {
   rememberAuthProvider(provider);
-  try {
-    posthog.capture("Authentication Started", { provider });
-  } catch {
-    // Analytics must never block authentication.
-  }
+  capture(posthog, "Authentication Started", { provider });
 }
 
 export function trackAuthFailure(
@@ -120,24 +108,41 @@ export function trackAuthFailure(
     errorCode?: string | null;
   },
 ) {
-  try {
-    posthog.capture("Authentication Failed", {
-      provider: options.provider,
-      stage: options.stage,
-      error_category: getAuthErrorCategory(options.errorCode),
-    });
-  } catch {
-    // Analytics must never block authentication.
-  }
+  capture(posthog, "Authentication Failed", {
+    provider: options.provider,
+    stage: options.stage,
+    error_category: getAuthErrorCategory(options.errorCode),
+  });
   clearPendingAuthProvider();
 }
 
-export function clearPendingAuthProvider() {
-  if (typeof sessionStorage === "undefined") return;
-
+// Analytics must never block authentication, including when browser storage or
+// the PostHog client is unavailable.
+function withSessionStorage<T>(run: (storage: Storage) => T): T | null {
   try {
-    sessionStorage.removeItem(AUTH_PROVIDER_ATTEMPT_KEY);
+    if (typeof sessionStorage === "undefined") return null;
+    return run(sessionStorage);
   } catch {
-    // Ignore unavailable browser storage.
+    return null;
+  }
+}
+
+function capture(
+  posthog: PostHog,
+  event: string,
+  properties: Record<string, unknown>,
+) {
+  try {
+    posthog.capture(event, properties);
+  } catch {
+    // See withSessionStorage.
+  }
+}
+
+function parseStoredAttempt(value: string) {
+  try {
+    return JSON.parse(value) as { provider?: unknown; startedAt?: unknown };
+  } catch {
+    return null;
   }
 }

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -334,16 +334,17 @@ export const betterAuthConfig = betterAuth({
   hooks: {
     after: createAuthMiddleware(async (context) => {
       try {
-        const provider = getAuthProviderFromContext(context);
         const authenticatedSession = context.context.newSession;
-        if (provider === "unknown" || !authenticatedSession) return;
+        if (!authenticatedSession) return;
+
+        const provider = getAuthProviderFromContext(context);
+        if (provider === "unknown") return;
+
+        const email = authenticatedSession.user.email;
+        const isNewUser = isNewUserAuthContext(context.context);
 
         after(() =>
-          trackAuthenticationCompleted({
-            email: authenticatedSession.user.email,
-            provider,
-            isNewUser: isNewUserAuthContext(context.context),
-          }),
+          trackAuthenticationCompleted({ email, provider, isNewUser }),
         );
       } catch (error) {
         logger.error("Failed to schedule authentication analytics", { error });

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -7,9 +7,11 @@ import { createContact as createLoopsContact } from "@inboxzero/loops";
 import { createContact as createResendContact } from "@inboxzero/resend";
 import type { Account, AuthContext } from "better-auth";
 import { APIError, betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import { cookies, headers } from "next/headers";
+import { after } from "next/server";
 import { env } from "@/env";
 import {
   assertAllowedAuthSignupEmail,
@@ -49,7 +51,6 @@ import { assertCanGenerateScimToken } from "@/utils/auth/scim";
 import prisma from "@/utils/prisma";
 import {
   getAuthProviderFromContext,
-  queueAuthFunnelTracking,
   trackAuthenticationCompleted,
 } from "@/utils/analytics/auth-funnel.server";
 
@@ -314,21 +315,6 @@ export const betterAuthConfig = betterAuth({
         },
       },
     },
-    session: {
-      create: {
-        after: async (session, context) => {
-          const provider = getAuthProviderFromContext(context);
-          await queueAuthFunnelTracking(
-            context,
-            trackAuthenticationCompleted({
-              userId: session.userId,
-              provider,
-              authenticatedAt: session.createdAt,
-            }),
-          );
-        },
-      },
-    },
     account: {
       create: {
         after: async (account: Account) => {
@@ -341,6 +327,26 @@ export const betterAuthConfig = betterAuth({
         },
       },
     },
+  },
+  hooks: {
+    after: createAuthMiddleware(async (context) => {
+      try {
+        const provider = getAuthProviderFromContext(context);
+        const authenticatedSession = context.context.newSession;
+        if (provider === "unknown" || !authenticatedSession) return;
+
+        after(() =>
+          trackAuthenticationCompleted({
+            email: authenticatedSession.user.email,
+            userCreatedAt: authenticatedSession.user.createdAt,
+            provider,
+            authenticatedAt: authenticatedSession.session.createdAt,
+          }),
+        );
+      } catch (error) {
+        logger.error("Failed to schedule authentication analytics", { error });
+      }
+    }),
   },
   onAPIError: {
     throw: true,

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -51,6 +51,8 @@ import { assertCanGenerateScimToken } from "@/utils/auth/scim";
 import prisma from "@/utils/prisma";
 import {
   getAuthProviderFromContext,
+  isNewUserAuthContext,
+  markAuthContextAsNewUser,
   trackAuthenticationCompleted,
 } from "@/utils/analytics/auth-funnel.server";
 
@@ -302,7 +304,8 @@ export const betterAuthConfig = betterAuth({
           });
           assertAllowedAuthSignupEmail(user.email);
         },
-        after: async (user) => {
+        after: async (user, context) => {
+          markAuthContextAsNewUser(context?.context);
           await postSignUp({
             id: user.id,
             email: user.email,
@@ -338,9 +341,8 @@ export const betterAuthConfig = betterAuth({
         after(() =>
           trackAuthenticationCompleted({
             email: authenticatedSession.user.email,
-            userCreatedAt: authenticatedSession.user.createdAt,
             provider,
-            authenticatedAt: authenticatedSession.session.createdAt,
+            isNewUser: isNewUserAuthContext(context.context),
           }),
         );
       } catch (error) {

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -47,6 +47,11 @@ import { getEnabledLoginProviders } from "@/utils/oauth/login-providers";
 import { getAppleClientSecret } from "@/utils/auth/apple-client-secret";
 import { assertCanGenerateScimToken } from "@/utils/auth/scim";
 import prisma from "@/utils/prisma";
+import {
+  getAuthProviderFromContext,
+  queueAuthFunnelTracking,
+  trackAuthenticationCompleted,
+} from "@/utils/analytics/auth-funnel.server";
 
 const logger = createScopedLogger("auth");
 const EMAIL_ALREADY_LINKED_ERROR = "email_already_linked";
@@ -306,6 +311,21 @@ export const betterAuthConfig = betterAuth({
             logger.error("Error posting sign up", { error, user });
             captureException(error, { extra: { user } });
           });
+        },
+      },
+    },
+    session: {
+      create: {
+        after: async (session, context) => {
+          const provider = getAuthProviderFromContext(context);
+          await queueAuthFunnelTracking(
+            context,
+            trackAuthenticationCompleted({
+              userId: session.userId,
+              provider,
+              authenticatedAt: session.createdAt,
+            }),
+          );
         },
       },
     },


### PR DESCRIPTION
## Summary

- capture Authentication Started for Google, Microsoft, Apple, and SSO sign-in attempts
- capture Authentication Failed at the start or callback stage using stable, broad error categories
- capture Authentication Completed on session creation and distinguish new users from existing users
- keep analytics best-effort so storage, PostHog, or database failures cannot block authentication

## Public-repo and privacy notes

Event properties are limited to provider, stage, error_category, and is_new_user. Raw OAuth errors, tokens, email addresses, and custom SSO provider identifiers are never emitted as event properties. Custom SSO identifiers are normalized to sso; unsupported provider values are normalized to unknown or skipped.

## Validation

- pnpm test utils/analytics/auth-funnel.test.ts utils/analytics/auth-funnel.server.test.ts app/'(landing)'/login/LoginForm.test.tsx utils/auth.test.ts
- pnpm lint (passes; reports two existing dependency warnings in PostHogProvider.tsx)
- staged diff check and repository gitleaks pre-push scan

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

