### PR TITLE
email: Prevent repeated scheduled job failures

### DIFF
--- a/apps/web/app/api/resend/inbox-health/queue/route.ts
+++ b/apps/web/app/api/resend/inbox-health/queue/route.ts
@@ -9,6 +9,7 @@ export const POST = createForwardingQueueHandler({
   path: "/api/resend/inbox-health",
   invalidPayloadMessage: "Invalid resend inbox health queue payload",
   visibilityTimeoutSeconds: 55,
+  maxDeliveryAttempts: 5,
   getLoggerContext: (payload) => ({
     emailAccountId: payload.emailAccountId,
   }),

--- a/apps/web/app/api/resend/inbox-health/route.test.ts
+++ b/apps/web/app/api/resend/inbox-health/route.test.ts
@@ -1,0 +1,130 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { Frequency } from "@/generated/prisma/enums";
+
+vi.mock("@/utils/prisma");
+
+const {
+  mockCreateEmailProvider,
+  mockHasCronSecret,
+  mockIsValidInternalApiKey,
+} = vi.hoisted(() => ({
+  mockCreateEmailProvider: vi.fn(),
+  mockHasCronSecret: vi.fn(),
+  mockIsValidInternalApiKey: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const {
+    createWithEmailAccountTestMiddleware,
+    createWithErrorTestMiddleware,
+  } = await vi.importActual<typeof import("@/__tests__/helpers")>(
+    "@/__tests__/helpers",
+  );
+
+  return {
+    ...createWithErrorTestMiddleware(),
+    ...createWithEmailAccountTestMiddleware({
+      auth: {
+        email: "user@example.com",
+        emailAccountId: "email-account-id",
+        userId: "user-id",
+      },
+    }),
+  };
+});
+
+vi.mock("@/utils/cron", () => ({
+  hasCronSecret: (...args: unknown[]) => mockHasCronSecret(...args),
+}));
+
+vi.mock("@/utils/internal-api", () => ({
+  isValidInternalApiKey: (...args: unknown[]) =>
+    mockIsValidInternalApiKey(...args),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: unknown[]) => mockCreateEmailProvider(...args),
+}));
+
+vi.mock("@inboxzero/resend", () => ({
+  sendInboxHealthEmail: vi.fn(),
+}));
+
+import { POST } from "./route";
+
+const emailAccount = {
+  userId: "user-id",
+  email: "user@example.com",
+  createdAt: new Date("2025-01-01T00:00:00.000Z"),
+  statsEmailFrequency: Frequency.MONTHLY,
+  lastInboxHealthEmailAt: null,
+  account: {
+    provider: "google",
+    refresh_token: "refresh-token",
+  },
+};
+
+describe("inbox health email route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasCronSecret.mockReturnValue(false);
+    mockIsValidInternalApiKey.mockReturnValue(true);
+    prisma.emailAccount.findUnique.mockResolvedValue(emailAccount as any);
+    prisma.emailAccount.update.mockResolvedValue({} as any);
+  });
+
+  it("accepts internal queue requests without logging a failed cron probe", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...emailAccount,
+      account: { ...emailAccount.account, refresh_token: null },
+    } as any);
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/inbox-health", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHasCronSecret).toHaveBeenCalledWith(expect.any(Request), {
+      logUnauthorized: false,
+    });
+    expect(mockIsValidInternalApiKey).toHaveBeenCalledOnce();
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges permanent provider failures and defers future sends", async () => {
+    mockCreateEmailProvider.mockRejectedValue(new Error("invalid_grant"));
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/inbox-health", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "email-account-id" },
+      data: { lastInboxHealthEmailAt: expect.any(Date) },
+    });
+  });
+
+  it("keeps transient provider failures retryable", async () => {
+    mockCreateEmailProvider.mockRejectedValue(new Error("Temporary outage"));
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/inbox-health", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/resend/inbox-health/route.test.ts
+++ b/apps/web/app/api/resend/inbox-health/route.test.ts
@@ -5,15 +5,11 @@ import { Frequency } from "@/generated/prisma/enums";
 
 vi.mock("@/utils/prisma");
 
-const {
-  mockCreateEmailProvider,
-  mockHasCronSecret,
-  mockIsValidInternalApiKey,
-} = vi.hoisted(() => ({
-  mockCreateEmailProvider: vi.fn(),
-  mockHasCronSecret: vi.fn(),
-  mockIsValidInternalApiKey: vi.fn(),
-}));
+const { mockCreateEmailProvider, mockIsAuthorizedCronOrInternalRequest } =
+  vi.hoisted(() => ({
+    mockCreateEmailProvider: vi.fn(),
+    mockIsAuthorizedCronOrInternalRequest: vi.fn(),
+  }));
 
 vi.mock("@/utils/middleware", async () => {
   const {
@@ -36,12 +32,8 @@ vi.mock("@/utils/middleware", async () => {
 });
 
 vi.mock("@/utils/cron", () => ({
-  hasCronSecret: (...args: unknown[]) => mockHasCronSecret(...args),
-}));
-
-vi.mock("@/utils/internal-api", () => ({
-  isValidInternalApiKey: (...args: unknown[]) =>
-    mockIsValidInternalApiKey(...args),
+  isAuthorizedCronOrInternalRequest: (...args: unknown[]) =>
+    mockIsAuthorizedCronOrInternalRequest(...args),
 }));
 
 vi.mock("@/utils/email/provider", () => ({
@@ -69,13 +61,12 @@ const emailAccount = {
 describe("inbox health email route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockHasCronSecret.mockReturnValue(false);
-    mockIsValidInternalApiKey.mockReturnValue(true);
+    mockIsAuthorizedCronOrInternalRequest.mockReturnValue(true);
     prisma.emailAccount.findUnique.mockResolvedValue(emailAccount as any);
     prisma.emailAccount.update.mockResolvedValue({} as any);
   });
 
-  it("accepts internal queue requests without logging a failed cron probe", async () => {
+  it("defers accounts without a refresh token instead of calling the provider", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...emailAccount,
       account: { ...emailAccount.account, refresh_token: null },
@@ -89,11 +80,11 @@ describe("inbox health email route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockHasCronSecret).toHaveBeenCalledWith(expect.any(Request), {
-      logUnauthorized: false,
-    });
-    expect(mockIsValidInternalApiKey).toHaveBeenCalledOnce();
     expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "email-account-id" },
+      data: { lastInboxHealthEmailAt: expect.any(Date) },
+    });
   });
 
   it("acknowledges permanent provider failures and defers future sends", async () => {

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -3,8 +3,7 @@ import { subMonths } from "date-fns/subMonths";
 import { sendInboxHealthEmail } from "@inboxzero/resend";
 import { withEmailAccount, withError } from "@/utils/middleware";
 import { env } from "@/env";
-import { hasCronSecret } from "@/utils/cron";
-import { isValidInternalApiKey } from "@/utils/internal-api";
+import { isAuthorizedCronOrInternalRequest } from "@/utils/cron";
 import { captureException } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
@@ -22,7 +21,10 @@ import {
 } from "@/utils/email";
 import { createEmailProvider } from "@/utils/email/provider";
 import { classifyEmailAccountProviderIssue } from "@/utils/email/provider-health";
-import { toRateLimitProvider } from "@/utils/email/rate-limit-mode-error";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
 import { sendInboxHealthEmailBody } from "./validation";
 import { getInboxHealthEmailData, getInboxHealthSkipReason } from "./helpers";
 
@@ -47,10 +49,7 @@ export const GET = withEmailAccount("resend/inbox-health", async (request) => {
 
 export const POST = withError("resend/inbox-health", async (request) => {
   const logger = request.logger;
-  if (
-    !hasCronSecret(request, { logUnauthorized: false }) &&
-    !isValidInternalApiKey(request.headers, logger)
-  ) {
+  if (!isAuthorizedCronOrInternalRequest(request)) {
     logger.error("Unauthorized cron request");
     captureException(new Error("Unauthorized cron request: resend"));
     return new Response("Unauthorized", { status: 401 });
@@ -138,12 +137,7 @@ async function sendEmail({
 
   if (!emailAccount.account.refresh_token) {
     logger.warn("Skipping inbox health email: account has no refresh token");
-    // Bump the timestamp so the daily fan-out doesn't re-enqueue this
-    // disconnected account every day until it reconnects.
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { lastInboxHealthEmailAt: new Date() },
-    });
+    await startNextInboxHealthWindow(emailAccountId);
     return { success: false, message: "Account has no refresh token" };
   }
 
@@ -155,21 +149,19 @@ async function sendEmail({
       logger,
     });
   } catch (error) {
-    const provider = toRateLimitProvider(emailAccount.account.provider);
-    const issue = provider
-      ? classifyEmailAccountProviderIssue({ error, provider })
-      : null;
+    const provider = emailAccount.account.provider;
 
+    if (!isGoogleProvider(provider) && !isMicrosoftProvider(provider))
+      throw error;
+
+    const issue = classifyEmailAccountProviderIssue({ error, provider });
     if (!issue) throw error;
 
     logger.warn("Skipping inbox health email: provider action required", {
       provider,
       reason: issue.reason,
     });
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { lastInboxHealthEmailAt: new Date() },
-    });
+    await startNextInboxHealthWindow(emailAccountId);
     return { success: false, skipped: "provider action required" };
   }
 
@@ -210,12 +202,7 @@ async function sendEmail({
     logger.info("Not enough unsubscribe suggestions, skipping", {
       senderCount: senders.length,
     });
-    // Still bump the timestamp so the daily fan-out doesn't re-run the
-    // expensive stats query for this account until the next 30-day window.
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { lastInboxHealthEmailAt: new Date() },
-    });
+    await startNextInboxHealthWindow(emailAccountId);
     return { success: true, skipped: "not enough suggestions" };
   }
 
@@ -237,10 +224,19 @@ async function sendEmail({
     },
   });
 
-  await prisma.emailAccount.update({
+  await startNextInboxHealthWindow(emailAccountId);
+
+  return { success: true };
+}
+
+/**
+ * Bump the timestamp on skips as well as sends, so the daily fan-out doesn't
+ * re-enqueue the account (and re-run the expensive stats query) until the next
+ * window.
+ */
+function startNextInboxHealthWindow(emailAccountId: string) {
+  return prisma.emailAccount.update({
     where: { id: emailAccountId },
     data: { lastInboxHealthEmailAt: new Date() },
   });
-
-  return { success: true };
 }

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -21,6 +21,8 @@ import {
   getNewsletterSenderDisplayName,
 } from "@/utils/email";
 import { createEmailProvider } from "@/utils/email/provider";
+import { classifyEmailAccountProviderIssue } from "@/utils/email/provider-health";
+import { toRateLimitProvider } from "@/utils/email/rate-limit-mode-error";
 import { sendInboxHealthEmailBody } from "./validation";
 import { getInboxHealthEmailData, getInboxHealthSkipReason } from "./helpers";
 
@@ -46,7 +48,7 @@ export const GET = withEmailAccount("resend/inbox-health", async (request) => {
 export const POST = withError("resend/inbox-health", async (request) => {
   const logger = request.logger;
   if (
-    !hasCronSecret(request) &&
+    !hasCronSecret(request, { logUnauthorized: false }) &&
     !isValidInternalApiKey(request.headers, logger)
   ) {
     logger.error("Unauthorized cron request");
@@ -145,11 +147,31 @@ async function sendEmail({
     return { success: false, message: "Account has no refresh token" };
   }
 
-  const emailProvider = await createEmailProvider({
-    emailAccountId,
-    provider: emailAccount.account.provider,
-    logger,
-  });
+  let emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
+  try {
+    emailProvider = await createEmailProvider({
+      emailAccountId,
+      provider: emailAccount.account.provider,
+      logger,
+    });
+  } catch (error) {
+    const provider = toRateLimitProvider(emailAccount.account.provider);
+    const issue = provider
+      ? classifyEmailAccountProviderIssue({ error, provider })
+      : null;
+
+    if (!issue) throw error;
+
+    logger.warn("Skipping inbox health email: provider action required", {
+      provider,
+      reason: issue.reason,
+    });
+    await prisma.emailAccount.update({
+      where: { id: emailAccountId },
+      data: { lastInboxHealthEmailAt: new Date() },
+    });
+    return { success: false, skipped: "provider action required" };
+  }
 
   const [senderStats, newsletterStatuses, emailFilters] = await Promise.all([
     getSenderEmailStats({

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -133,6 +133,9 @@ describe("summary email route", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(mockIsAuthorizedCronOrInternalRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+    );
     expect(mockCreateEmailProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         emailAccountId: "email-account-id",

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -140,6 +140,9 @@ describe("summary email route", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(mockHasCronSecret).toHaveBeenCalledWith(expect.any(Request), {
+      logUnauthorized: false,
+    });
     expect(mockCreateEmailProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         emailAccountId: "email-account-id",

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -14,14 +14,12 @@ vi.mock("@/utils/prisma");
 const {
   mockCreateEmailProvider,
   mockCreateUnsubscribeToken,
-  mockHasCronSecret,
-  mockIsValidInternalApiKey,
+  mockIsAuthorizedCronOrInternalRequest,
   mockSendSummaryEmail,
 } = vi.hoisted(() => ({
   mockCreateEmailProvider: vi.fn(),
   mockCreateUnsubscribeToken: vi.fn(),
-  mockHasCronSecret: vi.fn(),
-  mockIsValidInternalApiKey: vi.fn(),
+  mockIsAuthorizedCronOrInternalRequest: vi.fn(),
   mockSendSummaryEmail: vi.fn(),
 }));
 
@@ -46,12 +44,8 @@ vi.mock("@/utils/middleware", async () => {
 });
 
 vi.mock("@/utils/cron", () => ({
-  hasCronSecret: (...args: unknown[]) => mockHasCronSecret(...args),
-}));
-
-vi.mock("@/utils/internal-api", () => ({
-  isValidInternalApiKey: (...args: unknown[]) =>
-    mockIsValidInternalApiKey(...args),
+  isAuthorizedCronOrInternalRequest: (...args: unknown[]) =>
+    mockIsAuthorizedCronOrInternalRequest(...args),
 }));
 
 vi.mock("@/utils/email/provider", () => ({
@@ -72,8 +66,7 @@ import { POST } from "./route";
 describe("summary email route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockHasCronSecret.mockReturnValue(true);
-    mockIsValidInternalApiKey.mockReturnValue(false);
+    mockIsAuthorizedCronOrInternalRequest.mockReturnValue(true);
     mockCreateUnsubscribeToken.mockResolvedValue("unsubscribe-token");
     mockSendSummaryEmail.mockResolvedValue(undefined);
   });
@@ -140,9 +133,6 @@ describe("summary email route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockHasCronSecret).toHaveBeenCalledWith(expect.any(Request), {
-      logUnauthorized: false,
-    });
     expect(mockCreateEmailProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         emailAccountId: "email-account-id",

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -3,8 +3,7 @@ import { subHours } from "date-fns/subHours";
 import { sendSummaryEmail } from "@inboxzero/resend";
 import { withEmailAccount, withError } from "@/utils/middleware";
 import { env } from "@/env";
-import { hasCronSecret } from "@/utils/cron";
-import { isValidInternalApiKey } from "@/utils/internal-api";
+import { isAuthorizedCronOrInternalRequest } from "@/utils/cron";
 import { captureException } from "@/utils/error";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
@@ -49,10 +48,7 @@ export const GET = withEmailAccount("resend/summary", async (request) => {
 
 export const POST = withError("resend/summary", async (request) => {
   const logger = request.logger;
-  if (
-    !hasCronSecret(request, { logUnauthorized: false }) &&
-    !isValidInternalApiKey(request.headers, logger)
-  ) {
+  if (!isAuthorizedCronOrInternalRequest(request)) {
     logger.error("Unauthorized cron request");
     captureException(new Error("Unauthorized cron request: resend"));
     return new Response("Unauthorized", { status: 401 });

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -50,7 +50,7 @@ export const GET = withEmailAccount("resend/summary", async (request) => {
 export const POST = withError("resend/summary", async (request) => {
   const logger = request.logger;
   if (
-    !hasCronSecret(request) &&
+    !hasCronSecret(request, { logUnauthorized: false }) &&
     !isValidInternalApiKey(request.headers, logger)
   ) {
     logger.error("Unauthorized cron request");

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -105,7 +105,12 @@ describe("cleanupInvalidTokens", () => {
   it("clears stale credentials if account is already disconnected", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...mockEmailAccount,
-      account: { disconnectedAt: new Date() },
+      account: {
+        disconnectedAt: new Date(),
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_at: 1_700_000_000,
+      },
     } as any);
     prisma.account.updateMany.mockResolvedValue({ count: 1 });
 
@@ -116,15 +121,7 @@ describe("cleanupInvalidTokens", () => {
     });
 
     expect(prisma.account.updateMany).toHaveBeenCalledWith({
-      where: {
-        id: "acc_1",
-        disconnectedAt: { not: null },
-        OR: [
-          { access_token: { not: null } },
-          { refresh_token: { not: null } },
-          { expires_at: { not: null } },
-        ],
-      },
+      where: { id: "acc_1", disconnectedAt: { not: null } },
       data: {
         access_token: null,
         refresh_token: null,
@@ -134,6 +131,26 @@ describe("cleanupInvalidTokens", () => {
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
     expect(addUserErrorMessage).not.toHaveBeenCalled();
     expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not write when a disconnected account has no credentials left", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...mockEmailAccount,
+      account: {
+        disconnectedAt: new Date(),
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+      },
+    } as any);
+
+    await cleanupInvalidTokens({
+      emailAccountId: "ea_1",
+      reason: "invalid_grant",
+      logger,
+    });
+
+    expect(prisma.account.updateMany).not.toHaveBeenCalled();
   });
 
   it("sends action-required email for insufficient permissions", async () => {

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -118,6 +118,7 @@ describe("cleanupInvalidTokens", () => {
     expect(prisma.account.updateMany).toHaveBeenCalledWith({
       where: {
         id: "acc_1",
+        disconnectedAt: { not: null },
         OR: [
           { access_token: { not: null } },
           { refresh_token: { not: null } },

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -102,11 +102,12 @@ describe("cleanupInvalidTokens", () => {
     );
   });
 
-  it("returns early if account is already disconnected", async () => {
+  it("clears stale credentials if account is already disconnected", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...mockEmailAccount,
       account: { disconnectedAt: new Date() },
     } as any);
+    prisma.account.updateMany.mockResolvedValue({ count: 1 });
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
@@ -114,8 +115,24 @@ describe("cleanupInvalidTokens", () => {
       logger,
     });
 
-    expect(prisma.account.updateMany).not.toHaveBeenCalled();
+    expect(prisma.account.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "acc_1",
+        OR: [
+          { access_token: { not: null } },
+          { refresh_token: { not: null } },
+          { expires_at: { not: null } },
+        ],
+      },
+      data: {
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+      },
+    });
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
+    expect(addUserErrorMessage).not.toHaveBeenCalled();
+    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
   });
 
   it("sends action-required email for insufficient permissions", async () => {

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -59,6 +59,21 @@ export async function cleanupInvalidTokens({
   }
 
   if (emailAccount.account?.disconnectedAt) {
+    await prisma.account.updateMany({
+      where: {
+        id: emailAccount.accountId,
+        OR: [
+          { access_token: { not: null } },
+          { refresh_token: { not: null } },
+          { expires_at: { not: null } },
+        ],
+      },
+      data: {
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+      },
+    });
     logger.info("Account already marked as disconnected");
     return;
   }

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -62,6 +62,7 @@ export async function cleanupInvalidTokens({
     await prisma.account.updateMany({
       where: {
         id: emailAccount.accountId,
+        disconnectedAt: { not: null },
         OR: [
           { access_token: { not: null } },
           { refresh_token: { not: null } },

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -9,6 +9,12 @@ import {
 } from "@/utils/error-messages";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
+const clearedCredentials = {
+  access_token: null,
+  refresh_token: null,
+  expires_at: null,
+};
+
 /**
  * Cleans up invalid tokens when authentication fails permanently.
  * Used for:
@@ -48,6 +54,9 @@ export async function cleanupInvalidTokens({
       account: {
         select: {
           disconnectedAt: true,
+          access_token: true,
+          refresh_token: true,
+          expires_at: true,
         },
       },
     },
@@ -58,35 +67,26 @@ export async function cleanupInvalidTokens({
     return;
   }
 
-  if (emailAccount.account?.disconnectedAt) {
-    await prisma.account.updateMany({
-      where: {
-        id: emailAccount.accountId,
-        disconnectedAt: { not: null },
-        OR: [
-          { access_token: { not: null } },
-          { refresh_token: { not: null } },
-          { expires_at: { not: null } },
-        ],
-      },
-      data: {
-        access_token: null,
-        refresh_token: null,
-        expires_at: null,
-      },
-    });
+  const account = emailAccount.account;
+
+  if (account?.disconnectedAt) {
+    const hasStaleCredentials =
+      !!account.access_token || !!account.refresh_token || !!account.expires_at;
+
+    if (hasStaleCredentials) {
+      await prisma.account.updateMany({
+        where: { id: emailAccount.accountId, disconnectedAt: { not: null } },
+        data: clearedCredentials,
+      });
+    }
+
     logger.info("Account already marked as disconnected");
     return;
   }
 
   const updated = await prisma.account.updateMany({
     where: { id: emailAccount.accountId, disconnectedAt: null },
-    data: {
-      access_token: null,
-      refresh_token: null,
-      expires_at: null,
-      disconnectedAt: new Date(),
-    },
+    data: { ...clearedCredentials, disconnectedAt: new Date() },
   });
 
   if (updated.count === 0) {

--- a/apps/web/utils/cron.test.ts
+++ b/apps/web/utils/cron.test.ts
@@ -41,6 +41,16 @@ describe("hasCronSecret", () => {
     expect(hasCronSecret(request)).toBe(false);
   });
 
+  it("can validate without logging while another auth method is checked", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const request = createMockRequestWithLogger({
+      authorization: "Bearer wrong-secret",
+    });
+
+    expect(hasCronSecret(request, { logUnauthorized: false })).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
   it("should return false for missing authorization header", () => {
     const request = createMockRequestWithLogger();
 

--- a/apps/web/utils/cron.test.ts
+++ b/apps/web/utils/cron.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hasCronSecret } from "./cron";
+import { hasCronSecret, isAuthorizedCronOrInternalRequest } from "./cron";
 import type { RequestWithLogger } from "@/utils/middleware";
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
 
-vi.mock("@/env", () => ({ env: { CRON_SECRET: "test-secret-123" } }));
+vi.mock("@/env", () => ({
+  env: { CRON_SECRET: "test-secret-123", INTERNAL_API_KEY: "test-api-key" },
+}));
 
 function createMockRequestWithLogger(
   headers?: Record<string, string>,
@@ -45,16 +47,6 @@ describe("hasCronSecret", () => {
     expect(hasCronSecret(request)).toBe(false);
   });
 
-  it("can validate without logging while another auth method is checked", () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const request = createMockRequestWithLogger({
-      authorization: "Bearer wrong-secret",
-    });
-
-    expect(hasCronSecret(request, { logUnauthorized: false })).toBe(false);
-    expect(errorSpy).not.toHaveBeenCalled();
-  });
-
   it("should return false for missing authorization header", () => {
     const request = createMockRequestWithLogger();
 
@@ -67,5 +59,41 @@ describe("hasCronSecret", () => {
     });
 
     expect(hasCronSecret(request)).toBe(false);
+  });
+});
+
+describe("isAuthorizedCronOrInternalRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts an internal API key without logging a failed cron check", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const request = createMockRequestWithLogger({
+      "x-api-key": "test-api-key",
+    });
+
+    expect(isAuthorizedCronOrInternalRequest(request)).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid cron secret", () => {
+    const request = createMockRequestWithLogger({
+      authorization: "Bearer test-secret-123",
+    });
+
+    expect(isAuthorizedCronOrInternalRequest(request)).toBe(true);
+  });
+
+  it("rejects and logs a request with neither credential", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const request = createMockRequestWithLogger();
+
+    expect(isAuthorizedCronOrInternalRequest(request)).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/cron.test.ts
+++ b/apps/web/utils/cron.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hasCronSecret } from "./cron";
 import type { RequestWithLogger } from "@/utils/middleware";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -23,6 +23,10 @@ function createMockRequestWithLogger(
 describe("hasCronSecret", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should return true for valid authorization header", () => {

--- a/apps/web/utils/cron.ts
+++ b/apps/web/utils/cron.ts
@@ -1,24 +1,33 @@
 import { env } from "@/env";
 import { secureCompare } from "@/utils/crypto-compare";
+import { isValidInternalApiKey } from "@/utils/internal-api";
 import type { RequestWithLogger } from "@/utils/middleware";
 
-export function hasCronSecret(
-  request: RequestWithLogger,
-  { logUnauthorized = true }: { logUnauthorized?: boolean } = {},
-) {
+export function hasCronSecret(request: RequestWithLogger) {
   if (!env.CRON_SECRET) {
-    if (logUnauthorized)
-      request.logger.error("No cron secret set, unauthorized cron request");
+    request.logger.error("No cron secret set, unauthorized cron request");
     return false;
   }
 
-  const authHeader = request.headers.get("authorization");
-  const valid = secureCompare(authHeader, `Bearer ${env.CRON_SECRET}`);
+  const valid = isValidCronSecret(request);
 
-  if (!valid && logUnauthorized)
-    request.logger.error("Unauthorized cron request:", { authHeader });
+  if (!valid)
+    request.logger.error("Unauthorized cron request:", {
+      authHeader: request.headers.get("authorization"),
+    });
 
   return valid;
+}
+
+/**
+ * For routes reached both by cron and by an internal queue forward. The cron
+ * secret is checked quietly because a queue request only carries the internal
+ * API key, and logging that as unauthorized before the key is even checked
+ * floods the error logs.
+ */
+export function isAuthorizedCronOrInternalRequest(request: RequestWithLogger) {
+  if (isValidCronSecret(request)) return true;
+  return isValidInternalApiKey(request.headers, request.logger);
 }
 
 export async function hasPostCronSecret(request: RequestWithLogger) {
@@ -39,4 +48,12 @@ export async function hasPostCronSecret(request: RequestWithLogger) {
 
 export function getCronSecretHeader() {
   return new Headers({ authorization: `Bearer ${env.CRON_SECRET}` });
+}
+
+function isValidCronSecret(request: RequestWithLogger) {
+  if (!env.CRON_SECRET) return false;
+  return secureCompare(
+    request.headers.get("authorization"),
+    `Bearer ${env.CRON_SECRET}`,
+  );
 }

--- a/apps/web/utils/cron.ts
+++ b/apps/web/utils/cron.ts
@@ -2,16 +2,20 @@ import { env } from "@/env";
 import { secureCompare } from "@/utils/crypto-compare";
 import type { RequestWithLogger } from "@/utils/middleware";
 
-export function hasCronSecret(request: RequestWithLogger) {
+export function hasCronSecret(
+  request: RequestWithLogger,
+  { logUnauthorized = true }: { logUnauthorized?: boolean } = {},
+) {
   if (!env.CRON_SECRET) {
-    request.logger.error("No cron secret set, unauthorized cron request");
+    if (logUnauthorized)
+      request.logger.error("No cron secret set, unauthorized cron request");
     return false;
   }
 
   const authHeader = request.headers.get("authorization");
   const valid = secureCompare(authHeader, `Bearer ${env.CRON_SECRET}`);
 
-  if (!valid)
+  if (!valid && logUnauthorized)
     request.logger.error("Unauthorized cron request:", { authHeader });
 
   return valid;

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -156,13 +156,13 @@ describe("provider health", () => {
     });
   });
 
-  it("records malformed Outlook refresh credentials as reconnect-required issues", () => {
+  it("does not treat malformed Outlook requests as permanent credential failures", () => {
     expect(
       classifyEmailAccountProviderIssue({
         provider: "microsoft",
         error: new Error("AADSTS9002313: Invalid request."),
       }),
-    ).toEqual({ reason: "invalid_grant" });
+    ).toBeNull();
   });
 
   it("keeps provider error handling alive when cleanup fails", async () => {

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -156,6 +156,15 @@ describe("provider health", () => {
     });
   });
 
+  it("records malformed Outlook refresh credentials as reconnect-required issues", () => {
+    expect(
+      classifyEmailAccountProviderIssue({
+        provider: "microsoft",
+        error: new Error("AADSTS9002313: Invalid request."),
+      }),
+    ).toEqual({ reason: "invalid_grant" });
+  });
+
   it("keeps provider error handling alive when cleanup fails", async () => {
     const logger = createMockLogger();
     vi.mocked(cleanupInvalidTokens).mockRejectedValueOnce(

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -96,6 +96,10 @@ export function classifyEmailAccountProviderIssue({
     return { reason: "insufficient_permissions" };
   }
 
+  if (provider === "microsoft" && message?.includes("AADSTS9002313")) {
+    return { reason: "invalid_grant" };
+  }
+
   if (
     provider === "google" &&
     (message?.includes("policy_enforced") ||

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -96,10 +96,6 @@ export function classifyEmailAccountProviderIssue({
     return { reason: "insufficient_permissions" };
   }
 
-  if (provider === "microsoft" && message?.includes("AADSTS9002313")) {
-    return { reason: "invalid_grant" };
-  }
-
   if (
     provider === "google" &&
     (message?.includes("policy_enforced") ||

--- a/apps/web/utils/queue/create-forwarding-queue-handler.test.ts
+++ b/apps/web/utils/queue/create-forwarding-queue-handler.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const handleCallbackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@vercel/queue", () => ({
+  handleCallback: handleCallbackMock,
+}));
+
+import { createForwardingQueueHandler } from "./create-forwarding-queue-handler";
+
+describe("createForwardingQueueHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleCallbackMock.mockReturnValue(vi.fn());
+  });
+
+  it("acknowledges a failing message after the configured delivery limit", () => {
+    createForwardingQueueHandler({
+      loggerScope: "test/queue",
+      schema: z.object({ id: z.string() }),
+      path: "/api/test",
+      invalidPayloadMessage: "Invalid test payload",
+      visibilityTimeoutSeconds: 30,
+      maxDeliveryAttempts: 5,
+    });
+
+    const retry = handleCallbackMock.mock.calls[0][1].retry;
+
+    expect(
+      retry(new Error("Temporary failure"), {
+        messageId: "message-id",
+        deliveryCount: 4,
+      }),
+    ).toEqual({ afterSeconds: 80 });
+    expect(
+      retry(new Error("Persistent failure"), {
+        messageId: "message-id",
+        deliveryCount: 5,
+      }),
+    ).toEqual({ acknowledge: true });
+  });
+});

--- a/apps/web/utils/queue/create-forwarding-queue-handler.ts
+++ b/apps/web/utils/queue/create-forwarding-queue-handler.ts
@@ -15,6 +15,7 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
   path,
   invalidPayloadMessage,
   visibilityTimeoutSeconds,
+  maxDeliveryAttempts,
   getLoggerContext,
   getTraceContext,
 }: {
@@ -23,6 +24,7 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
   path: string;
   invalidPayloadMessage: string;
   visibilityTimeoutSeconds: number;
+  maxDeliveryAttempts?: number;
   getLoggerContext?: (
     payload: z.infer<TSchema>,
     metadata: QueueMetadata,
@@ -64,11 +66,24 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
     },
     {
       visibilityTimeoutSeconds,
-      retry: (_error, metadata) => ({
-        afterSeconds: getQueueRetryBackoffSeconds({
-          deliveryCount: metadata.deliveryCount,
-        }),
-      }),
+      retry: (_error, metadata) => {
+        if (
+          maxDeliveryAttempts &&
+          metadata.deliveryCount >= maxDeliveryAttempts
+        ) {
+          logger.warn("Queue retry limit reached; acknowledging message", {
+            queueMessageId: metadata.messageId,
+            deliveryCount: metadata.deliveryCount,
+          });
+          return { acknowledge: true };
+        }
+
+        return {
+          afterSeconds: getQueueRetryBackoffSeconds({
+            deliveryCount: metadata.deliveryCount,
+          }),
+        };
+      },
     },
   );
 


### PR DESCRIPTION
Prevents valid internal requests from producing false authorization errors and stops permanent provider credential failures from repeatedly retrying periodic jobs.

- keep unauthorized logging for requests that fail every supported auth method
- clear stale provider credentials and classify permanent authentication failures
- acknowledge permanent failures while preserving retries for transient errors
- add focused regression tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

