### PR TITLE
Filter bulk unsubscribe to suggested senders

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { subDays } from "date-fns/subDays";
 import { ChevronDown } from "lucide-react";
@@ -34,7 +33,8 @@ import {
 import { createSearchParams } from "@/utils/url";
 import type { NewsletterFilterType } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
 import {
-  isUnsubscribeSuggestion,
+  SUGGESTION_LIMIT,
+  SUGGESTION_MIN_EMAILS,
   SUGGESTION_READ_RATE_THRESHOLD,
 } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 import { useStatLoader } from "@/providers/StatLoaderProvider";
@@ -67,12 +67,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 type Newsletter = NewsletterStatsResponse["newsletters"][number];
 
@@ -82,6 +76,11 @@ const filterOptions: {
   icon: React.ReactNode;
   separatorAfter?: boolean;
 }[] = [
+  {
+    label: "Suggested",
+    value: "suggested",
+    icon: <SparklesIcon className="size-4 text-amber-500" />,
+  },
   {
     label: "Unhandled",
     value: "unhandled",
@@ -183,6 +182,8 @@ export function BulkUnsubscribe() {
 
   const [expanded, setExpanded] = useState(false);
 
+  const isSuggestedFilter = filter === "suggested";
+
   const params: NewsletterStatsQuery = {
     types: typesArray,
     filters: filtersArray,
@@ -190,6 +191,7 @@ export function BulkUnsubscribe() {
     orderDirection: sortDirection,
     limit: expanded ? 500 : 50,
     includeMissingUnsubscribe: true,
+    ...(isSuggestedFilter ? { suggested: true } : {}),
     ...getDateRangeParams(dateRange),
     ...(search ? { search } : {}),
   };
@@ -253,52 +255,15 @@ export function BulkUnsubscribe() {
     isAllSelected,
     onToggleSelect,
     onToggleSelectAll,
-    selectItems,
     clearSelection,
     deselectItem,
   } = useToggleSelect(rows?.map((item) => ({ id: item.name })) || []);
-
-  const suggestedRows = useMemo(
-    () => rows?.filter(isUnsubscribeSuggestion) ?? [],
-    [rows],
-  );
-
-  const onSelectSuggested = useCallback(() => {
-    selectItems(suggestedRows.map((row) => row.name));
-    posthog?.capture("Clicked Select Suggested Unsubscribes", {
-      count: suggestedRows.length,
-    });
-  }, [selectItems, suggestedRows, posthog]);
 
   // Clear selection when filter changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally clearing selection when filter changes
   useEffect(() => {
     clearSelection();
   }, [filter]);
-
-  // Deep link (e.g. from the inbox health email or onboarding):
-  // ?select=suggested auto-selects the suggested rows once after the first
-  // rows load, then strips the param so re-renders and filter changes don't
-  // reselect.
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-  const hasAppliedSelectParamRef = useRef(false);
-
-  useEffect(() => {
-    if (hasAppliedSelectParamRef.current) return;
-    if (searchParams.get("select") !== "suggested") return;
-    if (!rows) return;
-
-    hasAppliedSelectParamRef.current = true;
-    selectItems(rows.filter(isUnsubscribeSuggestion).map((row) => row.name));
-
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete("select");
-    router.replace(nextParams.size ? `${pathname}?${nextParams}` : pathname, {
-      scroll: false,
-    });
-  }, [searchParams, rows, selectItems, router, pathname]);
 
   const isSomeSelected =
     Array.from(selected.values()).filter(Boolean).length > 0;
@@ -412,32 +377,6 @@ export function BulkUnsubscribe() {
             onSetDateDropdown={onSetDateDropdown}
           />
           <SearchBar onSearch={setSearch} />
-          {suggestedRows.length > 0 && (
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10"
-                    onClick={onSelectSuggested}
-                  >
-                    <SparklesIcon className="size-4 text-amber-500" />
-                    <span className="ml-2">
-                      Select {suggestedRows.length} suggested
-                    </span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p className="max-w-xs">
-                    Selects senders you rarely read (under{" "}
-                    {SUGGESTION_READ_RATE_THRESHOLD}% read rate) so you can
-                    unsubscribe or archive them in one go.
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
         </ActionBar>
       </div>
 
@@ -455,6 +394,14 @@ export function BulkUnsubscribe() {
         totalCount={rows?.length ?? 0}
         dateRange={dateRange}
       />
+
+      {isSuggestedFilter && (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Senders you get at least {SUGGESTION_MIN_EMAILS} emails from and read
+          less than {SUGGESTION_READ_RATE_THRESHOLD}% of the time, showing the{" "}
+          {SUGGESTION_LIMIT} that fill your inbox most.
+        </p>
+      )}
 
       <Card className="mt-2 md:mt-4 max-sm:border-0 max-sm:shadow-none">
         {(isStatsLoading && !isLoading && !data?.newsletters.length) ||

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState, useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import type { PostHog } from "posthog-js/react";
@@ -66,6 +67,7 @@ function itemMatchesFilter(
   switch (filter) {
     case "all":
       return true;
+    case "suggested":
     case "unhandled":
       return !status; // null/undefined status means unhandled
     case "unsubscribed":
@@ -1123,8 +1125,50 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
   ]);
 }
 
+const DEFAULT_NEWSLETTER_FILTER: NewsletterFilterType = "unhandled";
+
+const NEWSLETTER_FILTERS: NewsletterFilterType[] = [
+  "all",
+  "suggested",
+  "unhandled",
+  "unsubscribed",
+  "autoArchived",
+  "approved",
+];
+
 export function useNewsletterFilter() {
-  const [filter, setFilter] = useState<NewsletterFilterType>("unhandled");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [filter, setFilterState] = useState<NewsletterFilterType>(() => {
+    // `select=suggested` is the legacy form used by inbox health emails
+    // already sent out
+    if (searchParams.get("select") === "suggested") return "suggested";
+    const param = searchParams.get("filter") as NewsletterFilterType | null;
+    return param && NEWSLETTER_FILTERS.includes(param)
+      ? param
+      : DEFAULT_NEWSLETTER_FILTER;
+  });
+
+  // Keep the view in the URL so it survives a refresh and can be shared
+  const setFilter = useCallback(
+    (next: NewsletterFilterType) => {
+      setFilterState(next);
+
+      const params = new URLSearchParams(searchParams);
+      params.delete("select");
+      if (next === DEFAULT_NEWSLETTER_FILTER) {
+        params.delete("filter");
+      } else {
+        params.set("filter", next);
+      }
+      router.replace(params.size ? `${pathname}?${params}` : pathname, {
+        scroll: false,
+      });
+    },
+    [searchParams, router, pathname],
+  );
 
   // Convert single filter to array format for API compatibility
   const filtersArray: (
@@ -1135,7 +1179,9 @@ export function useNewsletterFilter() {
   )[] =
     filter === "all"
       ? ["unhandled", "unsubscribed", "autoArchived", "approved"]
-      : [filter];
+      : filter === "suggested"
+        ? ["unhandled"]
+        : [filter];
 
   return {
     filter,

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
@@ -3,42 +3,44 @@ import { NewsletterStatus } from "@/generated/prisma/enums";
 import {
   getUnsubscribeSuggestions,
   isUnsubscribeSuggestion,
+  SUGGESTION_LIMIT,
 } from "./suggestions";
 
 describe("isUnsubscribeSuggestion", () => {
   it("suggests senders with a low read rate", () => {
-    expect(isUnsubscribeSuggestion({ value: 10, readEmails: 1 })).toBe(true);
-    expect(isUnsubscribeSuggestion({ value: 10, readEmails: 0 })).toBe(true);
+    expect(isUnsubscribeSuggestion({ value: 20, readEmails: 1 })).toBe(true);
+    expect(isUnsubscribeSuggestion({ value: 20, readEmails: 0 })).toBe(true);
   });
 
   it("does not suggest senders the user reads", () => {
-    expect(isUnsubscribeSuggestion({ value: 10, readEmails: 2 })).toBe(false);
-    expect(isUnsubscribeSuggestion({ value: 10, readEmails: 9 })).toBe(false);
+    expect(isUnsubscribeSuggestion({ value: 20, readEmails: 3 })).toBe(false);
+    expect(isUnsubscribeSuggestion({ value: 20, readEmails: 18 })).toBe(false);
   });
 
   it("does not suggest senders with too few emails", () => {
     expect(isUnsubscribeSuggestion({ value: 1, readEmails: 0 })).toBe(false);
-    expect(isUnsubscribeSuggestion({ value: 2, readEmails: 0 })).toBe(false);
+    expect(isUnsubscribeSuggestion({ value: 9, readEmails: 0 })).toBe(false);
+    expect(isUnsubscribeSuggestion({ value: 10, readEmails: 0 })).toBe(true);
   });
 
   it("does not suggest senders the user already handled", () => {
     expect(
       isUnsubscribeSuggestion({
-        value: 10,
+        value: 20,
         readEmails: 0,
         status: NewsletterStatus.APPROVED,
       }),
     ).toBe(false);
     expect(
       isUnsubscribeSuggestion({
-        value: 10,
+        value: 20,
         readEmails: 0,
         status: NewsletterStatus.UNSUBSCRIBED,
       }),
     ).toBe(false);
     expect(
       isUnsubscribeSuggestion({
-        value: 10,
+        value: 20,
         readEmails: 0,
         autoArchived: { id: "filter-1" },
       }),
@@ -48,7 +50,7 @@ describe("isUnsubscribeSuggestion", () => {
   it("does not require an unsubscribe link by default", () => {
     expect(
       isUnsubscribeSuggestion({
-        value: 10,
+        value: 20,
         readEmails: 0,
       }),
     ).toBe(true);
@@ -56,7 +58,7 @@ describe("isUnsubscribeSuggestion", () => {
 });
 
 describe("getUnsubscribeSuggestions", () => {
-  it("keeps only suggested senders, ordered by email count descending", () => {
+  it("keeps only suggested senders", () => {
     const wellRead = { name: "read", value: 50, readEmails: 45 };
     const small = { name: "small", value: 5, readEmails: 0 };
     const big = { name: "big", value: 30, readEmails: 1 };
@@ -69,13 +71,37 @@ describe("getUnsubscribeSuggestions", () => {
 
     expect(getUnsubscribeSuggestions([wellRead, small, handled, big])).toEqual([
       big,
-      small,
     ]);
+  });
+
+  it("ranks by unread emails, not total emails", () => {
+    // Fewer emails overall, but every one of them ignored
+    const ignored = { name: "ignored", value: 100, readEmails: 0 };
+    // Higher volume, but the user does read some of them
+    const partlyRead = { name: "partlyRead", value: 110, readEmails: 15 };
+
+    expect(getUnsubscribeSuggestions([partlyRead, ignored])).toEqual([
+      ignored,
+      partlyRead,
+    ]);
+  });
+
+  it("caps the list so it stays actionable", () => {
+    const senders = Array.from({ length: SUGGESTION_LIMIT + 10 }, (_, i) => ({
+      name: `sender-${i}`,
+      value: 100 - i,
+      readEmails: 0,
+    }));
+
+    const suggestions = getUnsubscribeSuggestions(senders);
+
+    expect(suggestions).toHaveLength(SUGGESTION_LIMIT);
+    expect(suggestions[0].name).toBe("sender-0");
   });
 
   it("returns an empty list when nothing qualifies", () => {
     expect(getUnsubscribeSuggestions([])).toEqual([]);
-    expect(getUnsubscribeSuggestions([{ value: 10, readEmails: 8 }])).toEqual(
+    expect(getUnsubscribeSuggestions([{ value: 20, readEmails: 18 }])).toEqual(
       [],
     );
   });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
@@ -1,9 +1,11 @@
 import type { NewsletterStatus } from "@/generated/prisma/enums";
 import { getHttpUnsubscribeLink } from "@/utils/parse/unsubscribe";
 
-export const SUGGESTION_READ_RATE_THRESHOLD = 20;
+export const SUGGESTION_READ_RATE_THRESHOLD = 15;
 // Require enough emails that a low read rate is signal, not noise
-export const SUGGESTION_MIN_EMAILS = 3;
+export const SUGGESTION_MIN_EMAILS = 10;
+// A long list of suggestions is overwhelming rather than actionable
+export const SUGGESTION_LIMIT = 20;
 
 type UnsubscribeSuggestionItem = {
   value: number;
@@ -20,6 +22,15 @@ export function isUnsubscribeSuggestion(item: UnsubscribeSuggestionItem) {
   return readRate < SUGGESTION_READ_RATE_THRESHOLD;
 }
 
+/**
+ * The number of emails from this sender the user never opened. Ranking by this
+ * weights volume and read rate together, so a sender that floods the inbox
+ * outranks a rarely-read sender that only sends occasionally.
+ */
+function getIgnoredEmails(item: UnsubscribeSuggestionItem) {
+  return item.value - item.readEmails;
+}
+
 export function getUnsubscribeSuggestions<T extends UnsubscribeSuggestionItem>(
   items: T[],
   options?: { requireAutomaticUnsubscribeLink?: boolean },
@@ -31,7 +42,8 @@ export function getUnsubscribeSuggestions<T extends UnsubscribeSuggestionItem>(
         !options?.requireAutomaticUnsubscribeLink ||
         hasAutomaticUnsubscribeLink(item),
     )
-    .sort((a, b) => b.value - a.value);
+    .sort((a, b) => getIgnoredEmails(b) - getIgnoredEmails(a))
+    .slice(0, SUGGESTION_LIMIT);
 }
 
 export function hasAutomaticUnsubscribeLink(item: {

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/types.ts
@@ -5,6 +5,7 @@ import type { UserResponse } from "@/app/api/user/me/route";
 
 export type NewsletterFilterType =
   | "all"
+  | "suggested"
   | "unhandled"
   | "unsubscribed"
   | "autoArchived"

--- a/apps/web/app/api/resend/inbox-health/helpers.test.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { subDays } from "date-fns/subDays";
 import { Frequency, NewsletterStatus } from "@/generated/prisma/enums";
+import { SUGGESTION_LIMIT } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 import {
   getInboxHealthEmailData,
   getInboxHealthSkipReason,
@@ -64,7 +65,7 @@ describe("getInboxHealthEmailData", () => {
     expect(data?.suggestionCount).toBe(5);
     // (30 + 10 + 50 + 20 + 40) * 4
     expect(data?.yearlyEmailsAvoided).toBe(600);
-    // Sorted by email count descending
+    // Sorted by unread email count descending
     expect(data?.senders.map((sender) => sender.email)).toEqual([
       "c@example.com",
       "e@example.com",
@@ -87,6 +88,14 @@ describe("getInboxHealthEmailData", () => {
     expect(data?.senders).toHaveLength(10);
     // yearly estimate covers all 15 suggestions, not just the listed 10
     expect(data?.yearlyEmailsAvoided).toBe(15 * 10 * 4);
+  });
+
+  it("counts at most the capped number of suggestions", () => {
+    const data = getInboxHealthEmailData(makeSenders(30));
+
+    expect(data?.suggestionCount).toBe(SUGGESTION_LIMIT);
+    // The estimate reflects the capped list the email links to
+    expect(data?.yearlyEmailsAvoided).toBe(SUGGESTION_LIMIT * 10 * 4);
   });
 });
 

--- a/apps/web/app/api/resend/inbox-health/helpers.test.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.test.ts
@@ -73,10 +73,18 @@ describe("getInboxHealthEmailData", () => {
       "d@example.com",
       "b@example.com",
     ]);
-    // 3 / 50 = 6%
-    expect(data?.senders[0].readPercentage).toBe(6);
+    // 50 received, 3 read
+    expect(data?.senders[0].readEmails).toBe(3);
+    expect(data?.senders[0].ignoredEmails).toBe(47);
     // Falls back to the email address when there is no display name
     expect(data?.senders[1].name).toBe("e@example.com");
+  });
+
+  it("reports the weekly volume the user never opens", () => {
+    // 130 ignored emails over 13 weeks
+    const senders = makeSenders(13, { value: 10, readEmails: 0 });
+
+    expect(getInboxHealthEmailData(senders)?.weeklyIgnoredEmails).toBe(10);
   });
 
   it("lists at most 10 senders but counts all suggestions", () => {
@@ -165,8 +173,11 @@ function makeSender(
   };
 }
 
-function makeSenders(count: number): InboxHealthSenderStats[] {
+function makeSenders(
+  count: number,
+  overrides?: Partial<InboxHealthSenderStats>,
+): InboxHealthSenderStats[] {
   return Array.from({ length: count }, (_, i) =>
-    makeSender({ name: `sender${i}@example.com`, value: 10 }),
+    makeSender({ name: `sender${i}@example.com`, value: 10, ...overrides }),
   );
 }

--- a/apps/web/app/api/resend/inbox-health/helpers.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.ts
@@ -7,6 +7,7 @@ export const INBOX_HEALTH_MIN_SUGGESTIONS = 5;
 export const INBOX_HEALTH_MAX_LISTED_SENDERS = 10;
 export const INBOX_HEALTH_INTERVAL_DAYS = 30;
 export const INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS = 7;
+const WEEKS_IN_THREE_MONTHS = 13;
 
 export type InboxHealthSenderStats = {
   /** Sender email address */
@@ -34,17 +35,23 @@ export function getInboxHealthEmailData(senders: InboxHealthSenderStats[]) {
     (sum, sender) => sum + sender.value,
     0,
   );
+  const threeMonthIgnored = suggestions.reduce(
+    (sum, sender) => sum + (sender.value - sender.readEmails),
+    0,
+  );
 
   return {
     suggestionCount: suggestions.length,
     yearlyEmailsAvoided: Math.round(threeMonthTotal * 4),
+    weeklyIgnoredEmails: Math.round(threeMonthIgnored / WEEKS_IN_THREE_MONTHS),
     senders: suggestions
       .slice(0, INBOX_HEALTH_MAX_LISTED_SENDERS)
       .map((sender) => ({
         name: sender.fromName || sender.name,
         email: sender.name,
         count: sender.value,
-        readPercentage: Math.round((sender.readEmails / sender.value) * 100),
+        readEmails: sender.readEmails,
+        ignoredEmails: sender.value - sender.readEmails,
       })),
   };
 }

--- a/apps/web/app/api/resend/inbox-health/helpers.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.ts
@@ -1,6 +1,6 @@
 import { subDays } from "date-fns/subDays";
 import { Frequency, type NewsletterStatus } from "@/generated/prisma/enums";
-import { isUnsubscribeSuggestion } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
+import { getUnsubscribeSuggestions } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 import type { EmailFilter } from "@/utils/email/types";
 
 export const INBOX_HEALTH_MIN_SUGGESTIONS = 5;
@@ -24,9 +24,9 @@ export type InboxHealthSenderStats = {
  * content. Returns null when there are too few unsubscribe suggestions.
  */
 export function getInboxHealthEmailData(senders: InboxHealthSenderStats[]) {
-  const suggestions = senders
-    .filter(isUnsubscribeSuggestion)
-    .sort((a, b) => b.value - a.value);
+  // Same call the bulk unsubscribe page makes, so the count in the email
+  // matches the list the link lands on
+  const suggestions = getUnsubscribeSuggestions(senders);
 
   if (suggestions.length < INBOX_HEALTH_MIN_SUGGESTIONS) return null;
 

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -11,6 +11,10 @@ import type { Logger } from "@/utils/logger";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 import { getSenderEmailStats } from "@/utils/sender-stats";
 import {
+  SUGGESTION_MIN_EMAILS,
+  SUGGESTION_READ_RATE_THRESHOLD,
+} from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
+import {
   findAutoArchiveFilters,
   findNewsletterStatus,
   getEmailFilters,
@@ -155,6 +159,8 @@ async function sendEmail({
     getSenderEmailStats({
       emailAccountId,
       fromDate: subMonths(now, 3).getTime(),
+      minEmails: SUGGESTION_MIN_EMAILS,
+      maxReadRate: SUGGESTION_READ_RATE_THRESHOLD,
       logger,
     }),
     getNewsletterStatuses({ emailAccountId }),

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -7,6 +7,11 @@ import {
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { withEmailProvider } from "@/utils/middleware";
+import {
+  getUnsubscribeSuggestions,
+  SUGGESTION_MIN_EMAILS,
+  SUGGESTION_READ_RATE_THRESHOLD,
+} from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 import { getSenderEmailStats } from "@/utils/sender-stats";
 import {
   filterNewsletters,
@@ -34,6 +39,11 @@ const newsletterStatsQuery = z.object({
     .transform((arr) => arr?.filter(Boolean)),
   includeMissingUnsubscribe: z.boolean().optional(),
   search: z.string().optional(),
+  /**
+   * Return only the senders worth unsubscribing from, ranked and capped the
+   * same way the inbox health email does, so both surfaces show one list.
+   */
+  suggested: z.boolean().optional(),
 });
 
 export type NewsletterStatsQuery = z.infer<typeof newsletterStatsQuery>;
@@ -63,7 +73,13 @@ async function getEmailMessages(
       search: options.search,
       orderBy: options.orderBy,
       orderDirection: options.orderDirection,
-      limit: options.limit,
+      // Suggestions are ranked and capped below, so the row limit would
+      // otherwise decide which senders are eligible
+      limit: options.suggested ? null : options.limit,
+      minEmails: options.suggested ? SUGGESTION_MIN_EMAILS : undefined,
+      maxReadRate: options.suggested
+        ? SUGGESTION_READ_RATE_THRESHOLD
+        : undefined,
       logger,
     }),
     getEmailFilters(emailProvider, logger),
@@ -94,6 +110,18 @@ async function getEmailMessages(
     };
   });
 
+  // Already excludes handled senders, so the status filters don't apply.
+  // Suggestions pick which senders qualify; the rows keep their queried order
+  // so the table's sort columns still work.
+  if (options.suggested) {
+    const suggested = new Set(
+      getUnsubscribeSuggestions(newsletters).map((sender) => sender.name),
+    );
+    return {
+      newsletters: newsletters.filter((sender) => suggested.has(sender.name)),
+    };
+  }
+
   if (!options.filters?.length) return { newsletters };
 
   return {
@@ -119,6 +147,7 @@ export const GET = withEmailProvider(
       includeMissingUnsubscribe:
         searchParams.get("includeMissingUnsubscribe") === "true",
       search: searchParams.get("search") || undefined,
+      suggested: searchParams.get("suggested") === "true",
     });
 
     const result = await getEmailMessages({

--- a/apps/web/scripts/write-emulate-seed.test.ts
+++ b/apps/web/scripts/write-emulate-seed.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildEmulatorSeed } from "./write-emulate-seed";
+
+const NOW = Date.UTC(2026, 7, 5, 12);
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+describe("buildEmulatorSeed", () => {
+  it("keeps demo mail current and includes a deterministic unsubscribe suggestion", () => {
+    const seed = buildEmulatorSeed(NOW);
+    const messages = seed.google.messages;
+
+    expect(
+      messages.every((message) => {
+        const timestamp = Number(message.internal_date);
+        return timestamp <= NOW && timestamp > NOW - NINETY_DAYS_MS;
+      }),
+    ).toBe(true);
+
+    const suggestedSenderMessages = messages.filter(
+      (message) => message.from === "Inbox Offers <offers@example.test>",
+    );
+
+    expect(suggestedSenderMessages).toHaveLength(12);
+    expect(
+      suggestedSenderMessages.filter((message) =>
+        message.label_ids.includes("UNREAD"),
+      ),
+    ).toHaveLength(11);
+  });
+});

--- a/apps/web/scripts/write-emulate-seed.ts
+++ b/apps/web/scripts/write-emulate-seed.ts
@@ -18,7 +18,15 @@ const MICROSOFT_EMAIL = "developer@outlook.test";
 const MICROSOFT_NAME = "Developer";
 
 async function main() {
-  const seed = {
+  const seed = buildEmulatorSeed();
+
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(seed, null, 2)}\n`);
+  console.log(`Wrote emulator seed to ${relativeToRoot(OUTPUT_PATH)}`);
+}
+
+export function buildEmulatorSeed(now = Date.now()) {
+  return {
     google: {
       users: [{ email: GOOGLE_EMAIL, name: GOOGLE_NAME }],
       oauth_clients: [
@@ -35,10 +43,20 @@ async function main() {
         },
       ],
       labels: toSeedLabels(saasFounderMixedInbox, GOOGLE_EMAIL),
-      messages: toSeedMessages(saasFounderMixedInbox, {
-        email: GOOGLE_EMAIL,
-        name: GOOGLE_NAME,
-      }),
+      messages: [
+        ...toSeedMessages(
+          saasFounderMixedInbox,
+          {
+            email: GOOGLE_EMAIL,
+            name: GOOGLE_NAME,
+          },
+          now,
+        ),
+        ...createUnsubscribeSuggestionMessages(
+          { email: GOOGLE_EMAIL, name: GOOGLE_NAME },
+          now,
+        ),
+      ],
       calendars: [
         {
           id: "primary",
@@ -76,10 +94,6 @@ async function main() {
       ],
     },
   };
-
-  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
-  await writeFile(OUTPUT_PATH, `${JSON.stringify(seed, null, 2)}\n`);
-  console.log(`Wrote emulator seed to ${relativeToRoot(OUTPUT_PATH)}`);
 }
 
 function toSeedLabels(fixture: DemoInboxFixture, userEmail: string) {
@@ -94,9 +108,15 @@ function toSeedLabels(fixture: DemoInboxFixture, userEmail: string) {
 function toSeedMessages(
   fixture: DemoInboxFixture,
   mailbox: { email: string; name: string },
+  now: number,
 ) {
   const labelIdsByName = new Map(
     fixture.labels.map((label) => [label.name, label.id]),
+  );
+  const latestFixtureTimestamp = Math.max(
+    ...fixture.threads.flatMap((thread) =>
+      thread.messages.map((message) => new Date(message.date).getTime()),
+    ),
   );
 
   return fixture.threads.flatMap((thread) =>
@@ -121,9 +141,28 @@ function toSeedMessages(
       body_text: message.bodyText,
       body_html: message.bodyHtml,
       label_ids: getMessageLabelIds(message, labelIdsByName),
-      internal_date: String(new Date(message.date).getTime()),
+      internal_date: String(
+        now - (latestFixtureTimestamp - new Date(message.date).getTime()),
+      ),
     })),
   );
+}
+
+function createUnsubscribeSuggestionMessages(
+  mailbox: { email: string; name: string },
+  now: number,
+) {
+  return Array.from({ length: 12 }, (_, index) => ({
+    id: `19aa0000000000${(index + 1).toString(16).padStart(2, "0")}`,
+    thread_id: `19ab0000000000${(index + 1).toString(16).padStart(2, "0")}`,
+    user_email: mailbox.email,
+    from: "Inbox Offers <offers@example.test>",
+    to: `${mailbox.name} <${mailbox.email}>`,
+    subject: `Inbox Offers weekly roundup ${index + 1}`,
+    body_text: "A mostly unread newsletter used for emulator-backed QA.",
+    label_ids: index === 0 ? ["INBOX"] : ["INBOX", "UNREAD"],
+    internal_date: String(now - (index + 1) * 60 * 60 * 1000),
+  }));
 }
 
 function getMessageLabelIds(
@@ -162,7 +201,12 @@ function relativeToRoot(path: string) {
   return path.replace(`${ROOT_DIR}/`, "");
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apps/web/utils/sender-stats.ts
+++ b/apps/web/utils/sender-stats.ts
@@ -26,6 +26,10 @@ export type SenderEmailStatsOptions = {
   orderBy?: "emails" | "unread" | "unarchived";
   orderDirection?: "asc" | "desc";
   limit?: number | null;
+  /** Drop senders with fewer than this many emails */
+  minEmails?: number;
+  /** Drop senders whose read rate is at or above this percentage (0-100) */
+  maxReadRate?: number;
   logger: Logger;
 };
 
@@ -88,6 +92,24 @@ export async function getSenderEmailStats(
       ? Prisma.sql`WHERE ${Prisma.join(whereConditions, " AND ")}`
       : Prisma.empty;
 
+  // Narrow to unpopular senders in the database rather than fetching every
+  // sender and discarding most of them in JS
+  const havingConditions: Prisma.Sql[] = [];
+
+  if (options.minEmails) {
+    havingConditions.push(Prisma.sql`COUNT(*) >= ${options.minEmails}::int`);
+  }
+
+  if (options.maxReadRate !== undefined) {
+    havingConditions.push(
+      Prisma.sql`SUM(CASE WHEN read = true THEN 1 ELSE 0 END)::float / NULLIF(COUNT(*), 0) < ${options.maxReadRate / 100}::float`,
+    );
+  }
+
+  const havingClause = havingConditions.length
+    ? Prisma.sql`HAVING ${Prisma.join(havingConditions, " AND ")}`
+    : Prisma.empty;
+
   // Build order by clause (safe, no user input)
   const orderByClause = options.orderBy
     ? getOrderByClause(options.orderBy, options.orderDirection)
@@ -110,6 +132,7 @@ export async function getSenderEmailStats(
       FROM "EmailMessage"
       ${whereClause}
       GROUP BY LOWER("from")
+      ${havingClause}
     )
     SELECT * FROM email_message_stats
     ORDER BY ${Prisma.raw(orderByClause)}

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -88,7 +88,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 cellSpacing={0}
                 border={0}
                 width={600}
-                style={{ width: "600px", maxWidth: "600px" }}
+                style={{ width: "100%", maxWidth: "600px" }}
               >
                 <tr>
                   <td
@@ -133,7 +133,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 border={0}
                 width={600}
                 style={{
-                  width: "600px",
+                  width: "100%",
                   maxWidth: "600px",
                   backgroundColor: CARD_BACKGROUND,
                   border: `1px solid ${BORDER}`,
@@ -331,7 +331,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 cellSpacing={0}
                 border={0}
                 width={600}
-                style={{ width: "600px", maxWidth: "600px" }}
+                style={{ width: "100%", maxWidth: "600px" }}
               >
                 <tr>
                   <td

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -1,26 +1,11 @@
-import {
-  Body,
-  Button,
-  Column,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Img,
-  Link,
-  Preview,
-  Row,
-  Section,
-  Tailwind,
-  Text,
-} from "@react-email/components";
-import { StatsEmailFooter } from "./components/stats-email-footer";
+import { Body, Head, Html, Preview } from "@react-email/components";
 
 type SuggestedSender = {
   name: string;
   email: string;
   count: number;
-  readPercentage: number;
+  readEmails: number;
+  ignoredEmails: number;
 };
 
 export interface InboxHealthEmailProps {
@@ -29,8 +14,32 @@ export interface InboxHealthEmailProps {
   senders: SuggestedSender[];
   suggestionCount: number;
   unsubscribeToken: string;
+  weeklyIgnoredEmails: number;
   yearlyEmailsAvoided: number;
 }
+
+const FONT_STACK = "'Helvetica Neue',Helvetica,Arial,sans-serif";
+const PAGE_BACKGROUND = "#F1F1EE";
+const CARD_BACKGROUND = "#FDFDFD";
+const BORDER = "#EFEFEF";
+const TEXT = "#242424";
+const TEXT_MUTED = "#5C5C5C";
+const TEXT_SUBTLE = "#8C8C8C";
+const TEXT_FAINT = "#9A9A9A";
+const ACCENT = "#2965EC";
+const ACCENT_LINK = "#2563EB";
+const BAR_TRACK = "#F0F0EE";
+
+const MOBILE_STYLES = `
+  a{text-decoration:none;}
+  @media only screen and (max-width:620px){
+    .px{padding-left:24px !important;padding-right:24px !important;}
+    .h1{font-size:28px !important;line-height:34px !important;}
+    .stack{display:block !important;width:100% !important;text-align:left !important;padding-bottom:0 !important;}
+    .stack-r{display:block !important;width:100% !important;text-align:left !important;padding-top:6px !important;}
+    .btn a{display:block !important;}
+  }
+`;
 
 export default function InboxHealthEmail(props: InboxHealthEmailProps) {
   const {
@@ -38,85 +47,341 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
     emailAccountId,
     unsubscribeToken,
     suggestionCount,
+    weeklyIgnoredEmails,
     yearlyEmailsAvoided,
     senders,
   } = props;
 
   const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?filter=suggested`;
   const senderCountText = getSenderCountText(suggestionCount);
+  const yearlyText = yearlyEmailsAvoided.toLocaleString("en-US");
+  const remainingCount = suggestionCount - senders.length;
+  // Longest bar is the sender whose email you ignore most, so the rest read
+  // as a share of that
+  const maxIgnored = Math.max(...senders.map((sender) => sender.ignoredEmails));
 
   return (
-    <Html>
-      <Head />
+    <Html lang="en">
+      <Head>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style>{MOBILE_STYLES}</style>
+      </Head>
       <Preview>
-        We found {senderCountText} you rarely read. Clean them up in one click.
+        Unsubscribing from these {senderCountText} could save you about{" "}
+        {yearlyText} emails a year.
       </Preview>
-      <Tailwind>
-        <Body className="bg-white font-sans">
-          <Container className="mx-auto w-full max-w-[600px] p-0">
-            <Section className="p-8 text-center">
-              <Link href={baseUrl} className="text-[15px]">
-                <Img
-                  src={"https://www.getinboxzero.com/icon.png"}
-                  width="40"
-                  height="40"
-                  alt="Inbox Zero"
-                  className="mx-auto my-0"
-                />
-              </Link>
+      <Body style={{ margin: 0, padding: 0, backgroundColor: PAGE_BACKGROUND }}>
+        <table
+          role="presentation"
+          cellPadding={0}
+          cellSpacing={0}
+          border={0}
+          width="100%"
+          style={{ backgroundColor: PAGE_BACKGROUND }}
+        >
+          <tr>
+            <td align="center" style={{ padding: "32px 12px 48px 12px" }}>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{ width: "600px", maxWidth: "600px" }}
+              >
+                <tr>
+                  <td
+                    align="left"
+                    style={{
+                      padding: "0 8px 18px 8px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "15px",
+                      lineHeight: "20px",
+                      letterSpacing: "0.01em",
+                      color: TEXT,
+                      fontWeight: 700,
+                      // The brand wordmark is set in caps. Transforming rather
+                      // than hardcoding keeps the accessible name readable and
+                      // degrades to the plain brand name if a client drops it.
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    <a href={baseUrl} style={{ color: TEXT }}>
+                      Inbox Zero
+                    </a>
+                  </td>
+                  <td
+                    align="right"
+                    style={{
+                      padding: "0 8px 18px 8px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "20px",
+                      color: TEXT_SUBTLE,
+                    }}
+                  >
+                    Monthly inbox report
+                  </td>
+                </tr>
+              </table>
 
-              <Text className="mx-0 mb-8 mt-4 p-0 text-center text-2xl font-normal">
-                <span className="font-semibold tracking-tighter">
-                  Inbox Zero
-                </span>
-              </Text>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{
+                  width: "600px",
+                  maxWidth: "600px",
+                  backgroundColor: CARD_BACKGROUND,
+                  border: `1px solid ${BORDER}`,
+                  borderRadius: "24px",
+                }}
+              >
+                <tr>
+                  <td
+                    className="px"
+                    style={{
+                      padding: "44px 40px 0 40px",
+                      fontFamily: FONT_STACK,
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        lineHeight: "16px",
+                        color: ACCENT_LINK,
+                        fontWeight: 600,
+                        paddingBottom: "14px",
+                      }}
+                    >
+                      Rarely Read Senders
+                    </div>
+                    <h1
+                      className="h1"
+                      style={{
+                        margin: 0,
+                        fontSize: "32px",
+                        lineHeight: "38px",
+                        letterSpacing: "-0.02em",
+                        color: TEXT,
+                        fontWeight: 500,
+                        msoLineHeightRule: "exactly",
+                      }}
+                    >
+                      We found {senderCountText} you rarely read
+                    </h1>
+                    <p
+                      style={{
+                        margin: "14px 0 0 0",
+                        fontSize: "16px",
+                        lineHeight: "25px",
+                        color: TEXT_MUTED,
+                        msoLineHeightRule: "exactly",
+                      }}
+                    >
+                      Unsubscribing from them could save you around{" "}
+                      <span style={{ color: TEXT, fontWeight: 600 }}>
+                        {yearlyText} emails a year
+                      </span>
+                      . That&rsquo;s about {weeklyIgnoredEmails} a week you
+                      never open.
+                    </p>
+                  </td>
+                </tr>
 
-              <Heading className="my-4 text-4xl font-medium leading-tight">
-                We found {senderCountText} you rarely read
-              </Heading>
-              <Text className="mb-8 text-lg leading-8">
-                Unsubscribing from them could save you around{" "}
-                <span className="font-semibold">
-                  {yearlyEmailsAvoided.toLocaleString("en-US")} emails
-                </span>{" "}
-                a year.
-              </Text>
-            </Section>
+                <tr>
+                  <td className="px" style={{ padding: "26px 40px 34px 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      className="btn"
+                    >
+                      <tr>
+                        <td
+                          bgcolor={ACCENT}
+                          style={{
+                            borderRadius: "13px",
+                            backgroundColor: ACCENT,
+                            backgroundImage: `linear-gradient(180deg,${ACCENT} 0%,#5C89F8 100%)`,
+                          }}
+                        >
+                          <a
+                            href={bulkUnsubscribeUrl}
+                            style={{
+                              display: "inline-block",
+                              padding: "14px 26px",
+                              fontFamily: FONT_STACK,
+                              fontSize: "15px",
+                              lineHeight: "20px",
+                              fontWeight: 600,
+                              color: "#FFFFFF",
+                              borderRadius: "13px",
+                              msoLineHeightRule: "exactly",
+                            }}
+                          >
+                            Unsubscribe in one click
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
 
-            <Section className="rounded-2xl bg-[#3b82f6]/5 bg-[radial-gradient(circle_at_bottom_right,#3b82f6_0%,transparent_60%)] p-8 text-center">
-              <Heading className="m-0 text-3xl font-medium text-[#1e40af]">
-                Rarely Read Senders
-              </Heading>
-              <Text className="mb-4 text-gray-900">
-                Based on the last 3 months of your inbox
-              </Text>
+                <tr>
+                  <td className="px" style={{ padding: "0 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      width="100%"
+                      style={{
+                        width: "100%",
+                        borderTop: `1px solid ${BORDER}`,
+                      }}
+                    >
+                      <tr>
+                        <td align="left" style={listHeadingStyle}>
+                          Top {senders.length}, worst first
+                        </td>
+                        <td align="right" style={listHeadingStyle}>
+                          Last 3 months
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
 
-              {senders.map((sender) => (
-                <SenderCard key={sender.email} sender={sender} />
-              ))}
+                <tr>
+                  <td className="px" style={{ padding: "0 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      width="100%"
+                      style={{ width: "100%" }}
+                    >
+                      {senders.map((sender) => (
+                        <SenderRow
+                          key={sender.email}
+                          sender={sender}
+                          maxIgnored={maxIgnored}
+                        />
+                      ))}
+                    </table>
+                  </td>
+                </tr>
 
-              <Section className="text-center mt-[32px] mb-[32px]">
-                <Button
-                  href={bulkUnsubscribeUrl}
-                  style={{
-                    background: "#000",
-                    color: "#fff",
-                    padding: "12px 20px",
-                    borderRadius: "5px",
-                  }}
-                >
-                  Unsubscribe in One Click
-                </Button>
-              </Section>
-            </Section>
+                <tr>
+                  <td
+                    className="px"
+                    style={{
+                      padding:
+                        remainingCount > 0
+                          ? "26px 40px 40px 40px"
+                          : "0 40px 40px 40px",
+                    }}
+                  >
+                    {remainingCount > 0 && (
+                      <table
+                        role="presentation"
+                        cellPadding={0}
+                        cellSpacing={0}
+                        border={0}
+                        width="100%"
+                        style={{
+                          width: "100%",
+                          borderTop: `1px solid ${BORDER}`,
+                        }}
+                      >
+                        <tr>
+                          <td
+                            style={{
+                              padding: "20px 0 0 0",
+                              fontFamily: FONT_STACK,
+                              fontSize: "14px",
+                              lineHeight: "22px",
+                              color: TEXT_MUTED,
+                            }}
+                          >
+                            {getRemainingSendersText(remainingCount)}{" "}
+                            <a
+                              href={bulkUnsubscribeUrl}
+                              style={{ color: ACCENT_LINK, fontWeight: 600 }}
+                            >
+                              Review all {suggestionCount} &rarr;
+                            </a>
+                          </td>
+                        </tr>
+                      </table>
+                    )}
+                  </td>
+                </tr>
+              </table>
 
-            <StatsEmailFooter
-              baseUrl={baseUrl}
-              unsubscribeToken={unsubscribeToken}
-            />
-          </Container>
-        </Body>
-      </Tailwind>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{ width: "600px", maxWidth: "600px" }}
+              >
+                <tr>
+                  <td
+                    style={{
+                      padding: "24px 48px 0 48px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "20px",
+                      color: "#A0A0A0",
+                      textAlign: "center",
+                    }}
+                  >
+                    You&rsquo;re receiving this because you subscribed to Inbox
+                    Zero stats updates.
+                    <br />
+                    <a
+                      href={`${baseUrl}/settings#email-updates`}
+                      style={footerLinkStyle}
+                    >
+                      Change email settings
+                    </a>
+                    &nbsp;&middot;&nbsp;
+                    <a
+                      href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
+                      style={footerLinkStyle}
+                    >
+                      Unsubscribe from these updates
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    style={{
+                      padding: "14px 48px 0 48px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "18px",
+                      color: "#B4B4B4",
+                      textAlign: "center",
+                    }}
+                  >
+                    Inbox Zero &middot; 1111B S Governors Ave, STE 29390, Dover,
+                    DE 19904, United States
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </Body>
     </Html>
   );
 }
@@ -125,65 +390,203 @@ InboxHealthEmail.PreviewProps = {
   baseUrl: "https://www.getinboxzero.com",
   emailAccountId: "email-account-id",
   unsubscribeToken: "123",
-  suggestionCount: 7,
+  suggestionCount: 14,
   yearlyEmailsAvoided: 1248,
+  weeklyIgnoredEmails: 22,
   senders: [
     {
       name: "Daily Deals",
       email: "deals@shopping.example.com",
       count: 92,
-      readPercentage: 2,
+      readEmails: 2,
+      ignoredEmails: 90,
     },
     {
       name: "Tech Newsletter",
       email: "newsletter@technews.example.com",
       count: 64,
-      readPercentage: 8,
+      readEmails: 5,
+      ignoredEmails: 59,
     },
     {
       name: "Promo Updates",
       email: "promo@retailer.example.com",
       count: 48,
-      readPercentage: 0,
+      readEmails: 0,
+      ignoredEmails: 48,
     },
     {
       name: "Webinar Invites",
       email: "events@saas.example.com",
       count: 35,
-      readPercentage: 11,
+      readEmails: 4,
+      ignoredEmails: 31,
     },
     {
       name: "Job Alerts",
       email: "alerts@jobs.example.com",
       count: 26,
-      readPercentage: 15,
+      readEmails: 3,
+      ignoredEmails: 23,
     },
   ],
 } satisfies InboxHealthEmailProps;
 
-function SenderCard({ sender }: { sender: SuggestedSender }) {
+const listHeadingStyle = {
+  padding: "16px 0 4px 0",
+  fontFamily: FONT_STACK,
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: TEXT_SUBTLE,
+} as const;
+
+const footerLinkStyle = {
+  color: TEXT_SUBTLE,
+  textDecoration: "underline",
+} as const;
+
+const senderCellStyle = {
+  padding: "15px 0 13px 0",
+  fontFamily: FONT_STACK,
+  verticalAlign: "top",
+} as const;
+
+function SenderRow({
+  sender,
+  maxIgnored,
+}: {
+  sender: SuggestedSender;
+  maxIgnored: number;
+}) {
+  const filledPercentage = getBarPercentage(sender.ignoredEmails, maxIgnored);
+
   return (
-    <Section className="my-3 rounded-lg bg-white/50 p-4 text-left shadow-sm border border-[#3b82f6]/20">
-      <Row>
-        <Column>
-          <Text className="m-0 font-semibold">
+    <>
+      <tr>
+        <td
+          className="stack"
+          width={320}
+          style={{ ...senderCellStyle, width: "320px" }}
+        >
+          <div
+            style={{
+              fontSize: "15px",
+              lineHeight: "20px",
+              color: TEXT,
+              fontWeight: 600,
+            }}
+          >
             {sender.name || sender.email}
-          </Text>
-          <Text className="m-0 text-gray-600">{sender.email}</Text>
-        </Column>
-        <Column align="right">
-          <Text className="m-0 text-sm text-gray-500">
-            {sender.count} emails in the last 3 months
-          </Text>
-          <Text className="m-0 text-sm text-gray-500">
-            {sender.readPercentage}% read
-          </Text>
-        </Column>
-      </Row>
-    </Section>
+          </div>
+          <div
+            style={{
+              fontSize: "13px",
+              lineHeight: "18px",
+              color: TEXT_FAINT,
+              paddingTop: "2px",
+            }}
+          >
+            {sender.email}
+          </div>
+        </td>
+        <td
+          className="stack-r"
+          width={200}
+          align="right"
+          style={{ ...senderCellStyle, width: "200px" }}
+        >
+          <div
+            style={{
+              fontSize: "15px",
+              lineHeight: "20px",
+              color: TEXT,
+              fontWeight: 600,
+            }}
+          >
+            {sender.count} {sender.count === 1 ? "email" : "emails"}
+          </div>
+          <div
+            style={{
+              fontSize: "13px",
+              lineHeight: "18px",
+              color: TEXT_FAINT,
+              paddingTop: "2px",
+            }}
+          >
+            {getOpenedText(sender)}
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td colSpan={2} style={{ padding: 0 }}>
+          <table
+            role="presentation"
+            cellPadding={0}
+            cellSpacing={0}
+            border={0}
+            width="100%"
+            style={{ width: "100%", tableLayout: "fixed" }}
+          >
+            <tr>
+              <td
+                width={`${filledPercentage}%`}
+                height={3}
+                bgcolor={ACCENT}
+                style={{
+                  width: `${filledPercentage}%`,
+                  height: "3px",
+                  backgroundColor: ACCENT,
+                  borderRadius: "1.5px",
+                  fontSize: 0,
+                  lineHeight: 0,
+                }}
+              >
+                &nbsp;
+              </td>
+              {filledPercentage < 100 && (
+                <td
+                  width={`${100 - filledPercentage}%`}
+                  height={3}
+                  bgcolor={BAR_TRACK}
+                  style={{
+                    width: `${100 - filledPercentage}%`,
+                    height: "3px",
+                    backgroundColor: BAR_TRACK,
+                    fontSize: 0,
+                    lineHeight: 0,
+                  }}
+                >
+                  &nbsp;
+                </td>
+              )}
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </>
   );
 }
 
 export function getSenderCountText(count: number) {
   return `${count} ${count === 1 ? "sender" : "senders"}`;
+}
+
+function getRemainingSendersText(count: number) {
+  return count === 1
+    ? "1 more sender sends you email you rarely open."
+    : `${count} more senders send you email you rarely open.`;
+}
+
+/**
+ * "opened 1 in 8" reads faster than a read percentage, and stays honest for
+ * senders the user has never opened.
+ */
+function getOpenedText(sender: SuggestedSender) {
+  if (sender.readEmails <= 0) return "opened none";
+  return `opened 1 in ${Math.round(sender.count / sender.readEmails)}`;
+}
+
+function getBarPercentage(ignoredEmails: number, maxIgnored: number) {
+  if (maxIgnored <= 0) return 100;
+  return Math.round((ignoredEmails / maxIgnored) * 1000) / 10;
 }

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -42,7 +42,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
     senders,
   } = props;
 
-  const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?select=suggested`;
+  const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?filter=suggested`;
   const senderCountText = getSenderCountText(suggestionCount);
 
   return (


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260805-152658_pr-3134_d0c35f5c57f2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Problem

The periodic inbox health email deep-linked to the bulk unsubscribe page with `?select=suggested`, which auto-checked the suggested rows in the full sender table. With dozens of rows it was hard to tell what was selected and what wasn't, and a stray click could silently clobber the selection.

The counts could also disagree. The email computed suggestions over every sender in the window; the page recomputed the same predicate over whichever 50 rows it had loaded. So the email could say one number and the page show another.

## Changes

- **Suggested filter.** New first option in the filter dropdown showing only suggested senders, with a line explaining the rule. Replaces the select-on-load behaviour.
- **Suggestions computed server-side.** The API takes a `suggested` flag, pushes the volume and read-rate rules into the SQL `HAVING` clause, drops the row limit, and runs the same shared ranking function the email uses. Both surfaces now derive from identical input.
- **Tighter heuristic.** Higher minimum email count, lower read-rate cutoff, ranked by unread volume rather than total volume, and capped so a long list doesn't become unactionable.
- **Filter reflected in the URL**, so a view survives a refresh and can be shared. The legacy `select` param still resolves to the filter for links already in inboxes.

Rows keep their queried order, so the table's sort columns still work in the suggested view.

## Testing

- Unit tests updated and extended for the new thresholds, the unread-based ranking, and the cap
- Query change smoke-tested against a local Postgres to confirm the new `HAVING` clause binds and filters correctly
- Lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->