### PR TITLE
Redesign the periodic inbox health email

### DIFF
--- a/apps/web/app/api/resend/inbox-health/helpers.test.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.test.ts
@@ -73,10 +73,18 @@ describe("getInboxHealthEmailData", () => {
       "d@example.com",
       "b@example.com",
     ]);
-    // 3 / 50 = 6%
-    expect(data?.senders[0].readPercentage).toBe(6);
+    // 50 received, 3 read
+    expect(data?.senders[0].readEmails).toBe(3);
+    expect(data?.senders[0].ignoredEmails).toBe(47);
     // Falls back to the email address when there is no display name
     expect(data?.senders[1].name).toBe("e@example.com");
+  });
+
+  it("reports the weekly volume the user never opens", () => {
+    // 130 ignored emails over 13 weeks
+    const senders = makeSenders(13, { value: 10, readEmails: 0 });
+
+    expect(getInboxHealthEmailData(senders)?.weeklyIgnoredEmails).toBe(10);
   });
 
   it("lists at most 10 senders but counts all suggestions", () => {
@@ -165,8 +173,11 @@ function makeSender(
   };
 }
 
-function makeSenders(count: number): InboxHealthSenderStats[] {
+function makeSenders(
+  count: number,
+  overrides?: Partial<InboxHealthSenderStats>,
+): InboxHealthSenderStats[] {
   return Array.from({ length: count }, (_, i) =>
-    makeSender({ name: `sender${i}@example.com`, value: 10 }),
+    makeSender({ name: `sender${i}@example.com`, value: 10, ...overrides }),
   );
 }

--- a/apps/web/app/api/resend/inbox-health/helpers.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.ts
@@ -7,6 +7,7 @@ export const INBOX_HEALTH_MIN_SUGGESTIONS = 5;
 export const INBOX_HEALTH_MAX_LISTED_SENDERS = 10;
 export const INBOX_HEALTH_INTERVAL_DAYS = 30;
 export const INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS = 7;
+const WEEKS_IN_THREE_MONTHS = 13;
 
 export type InboxHealthSenderStats = {
   /** Sender email address */
@@ -34,17 +35,23 @@ export function getInboxHealthEmailData(senders: InboxHealthSenderStats[]) {
     (sum, sender) => sum + sender.value,
     0,
   );
+  const threeMonthIgnored = suggestions.reduce(
+    (sum, sender) => sum + (sender.value - sender.readEmails),
+    0,
+  );
 
   return {
     suggestionCount: suggestions.length,
     yearlyEmailsAvoided: Math.round(threeMonthTotal * 4),
+    weeklyIgnoredEmails: Math.round(threeMonthIgnored / WEEKS_IN_THREE_MONTHS),
     senders: suggestions
       .slice(0, INBOX_HEALTH_MAX_LISTED_SENDERS)
       .map((sender) => ({
         name: sender.fromName || sender.name,
         email: sender.name,
         count: sender.value,
-        readPercentage: Math.round((sender.readEmails / sender.value) * 100),
+        readEmails: sender.readEmails,
+        ignoredEmails: sender.value - sender.readEmails,
       })),
   };
 }

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -106,15 +106,16 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                             verticalAlign: "middle",
                           }}
                         >
-                          <a href={baseUrl}>
-                            <Img
-                              src={ICON_URL}
-                              width="22"
-                              height="22"
-                              alt=""
-                              style={{ display: "block", border: 0 }}
-                            />
-                          </a>
+                          {/* Decorative: the adjacent link already names the
+                          brand, so linking the icon too would add a second
+                          unlabelled link to the same place */}
+                          <Img
+                            src={ICON_URL}
+                            width="22"
+                            height="22"
+                            alt=""
+                            style={{ display: "block", border: 0 }}
+                          />
                         </td>
                         <td
                           style={{

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -1,4 +1,4 @@
-import { Body, Head, Html, Img, Preview } from "@react-email/components";
+import { Body, Head, Html, Preview } from "@react-email/components";
 
 type SuggestedSender = {
   name: string;
@@ -18,7 +18,6 @@ export interface InboxHealthEmailProps {
   yearlyEmailsAvoided: number;
 }
 
-const ICON_URL = "https://www.getinboxzero.com/icon.png";
 const FONT_STACK = "'Helvetica Neue',Helvetica,Arial,sans-serif";
 const PAGE_BACKGROUND = "#F1F1EE";
 const CARD_BACKGROUND = "#FDFDFD";
@@ -92,48 +91,25 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 style={{ width: "600px", maxWidth: "600px" }}
               >
                 <tr>
-                  <td align="left" style={{ padding: "0 8px 18px 8px" }}>
-                    <table
-                      role="presentation"
-                      cellPadding={0}
-                      cellSpacing={0}
-                      border={0}
-                    >
-                      <tr>
-                        <td
-                          style={{
-                            paddingRight: "8px",
-                            verticalAlign: "middle",
-                          }}
-                        >
-                          {/* Decorative: the adjacent link already names the
-                          brand, so linking the icon too would add a second
-                          unlabelled link to the same place */}
-                          <Img
-                            src={ICON_URL}
-                            width="22"
-                            height="22"
-                            alt=""
-                            style={{ display: "block", border: 0 }}
-                          />
-                        </td>
-                        <td
-                          style={{
-                            fontFamily: FONT_STACK,
-                            fontSize: "17px",
-                            lineHeight: "22px",
-                            letterSpacing: "-0.02em",
-                            color: TEXT,
-                            fontWeight: 600,
-                            verticalAlign: "middle",
-                          }}
-                        >
-                          <a href={baseUrl} style={{ color: TEXT }}>
-                            Inbox Zero
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
+                  <td
+                    align="left"
+                    style={{
+                      padding: "0 8px 18px 8px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "15px",
+                      lineHeight: "20px",
+                      letterSpacing: "0.01em",
+                      color: TEXT,
+                      fontWeight: 700,
+                      // The brand wordmark is set in caps. Transforming rather
+                      // than hardcoding keeps the accessible name readable and
+                      // degrades to the plain brand name if a client drops it.
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    <a href={baseUrl} style={{ color: TEXT }}>
+                      Inbox Zero
+                    </a>
                   </td>
                   <td
                     align="right"

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -1,4 +1,4 @@
-import { Body, Head, Html, Preview } from "@react-email/components";
+import { Body, Head, Html, Img, Preview } from "@react-email/components";
 
 type SuggestedSender = {
   name: string;
@@ -18,6 +18,7 @@ export interface InboxHealthEmailProps {
   yearlyEmailsAvoided: number;
 }
 
+const ICON_URL = "https://www.getinboxzero.com/icon.png";
 const FONT_STACK = "'Helvetica Neue',Helvetica,Arial,sans-serif";
 const PAGE_BACKGROUND = "#F1F1EE";
 const CARD_BACKGROUND = "#FDFDFD";
@@ -91,19 +92,47 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 style={{ width: "600px", maxWidth: "600px" }}
               >
                 <tr>
-                  <td
-                    align="left"
-                    style={{
-                      padding: "0 8px 18px 8px",
-                      fontFamily: FONT_STACK,
-                      fontSize: "17px",
-                      lineHeight: "20px",
-                      letterSpacing: "-0.02em",
-                      color: TEXT,
-                      fontWeight: 600,
-                    }}
-                  >
-                    inbox zero
+                  <td align="left" style={{ padding: "0 8px 18px 8px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                    >
+                      <tr>
+                        <td
+                          style={{
+                            paddingRight: "8px",
+                            verticalAlign: "middle",
+                          }}
+                        >
+                          <a href={baseUrl}>
+                            <Img
+                              src={ICON_URL}
+                              width="22"
+                              height="22"
+                              alt=""
+                              style={{ display: "block", border: 0 }}
+                            />
+                          </a>
+                        </td>
+                        <td
+                          style={{
+                            fontFamily: FONT_STACK,
+                            fontSize: "17px",
+                            lineHeight: "22px",
+                            letterSpacing: "-0.02em",
+                            color: TEXT,
+                            fontWeight: 600,
+                            verticalAlign: "middle",
+                          }}
+                        >
+                          <a href={baseUrl} style={{ color: TEXT }}>
+                            Inbox Zero
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
                   </td>
                   <td
                     align="right"
@@ -367,8 +396,8 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                       textAlign: "center",
                     }}
                   >
-                    Inbox Zero &middot; 2261 Market Street #5039, San Francisco,
-                    CA 94114
+                    Inbox Zero &middot; 1111B S Governors Ave, STE 29390, Dover,
+                    DE 19904, United States
                   </td>
                 </tr>
               </table>

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -1,26 +1,11 @@
-import {
-  Body,
-  Button,
-  Column,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Img,
-  Link,
-  Preview,
-  Row,
-  Section,
-  Tailwind,
-  Text,
-} from "@react-email/components";
-import { StatsEmailFooter } from "./components/stats-email-footer";
+import { Body, Head, Html, Preview } from "@react-email/components";
 
 type SuggestedSender = {
   name: string;
   email: string;
   count: number;
-  readPercentage: number;
+  readEmails: number;
+  ignoredEmails: number;
 };
 
 export interface InboxHealthEmailProps {
@@ -29,8 +14,32 @@ export interface InboxHealthEmailProps {
   senders: SuggestedSender[];
   suggestionCount: number;
   unsubscribeToken: string;
+  weeklyIgnoredEmails: number;
   yearlyEmailsAvoided: number;
 }
+
+const FONT_STACK = "'Helvetica Neue',Helvetica,Arial,sans-serif";
+const PAGE_BACKGROUND = "#F1F1EE";
+const CARD_BACKGROUND = "#FDFDFD";
+const BORDER = "#EFEFEF";
+const TEXT = "#242424";
+const TEXT_MUTED = "#5C5C5C";
+const TEXT_SUBTLE = "#8C8C8C";
+const TEXT_FAINT = "#9A9A9A";
+const ACCENT = "#2965EC";
+const ACCENT_LINK = "#2563EB";
+const BAR_TRACK = "#F0F0EE";
+
+const MOBILE_STYLES = `
+  a{text-decoration:none;}
+  @media only screen and (max-width:620px){
+    .px{padding-left:24px !important;padding-right:24px !important;}
+    .h1{font-size:28px !important;line-height:34px !important;}
+    .stack{display:block !important;width:100% !important;text-align:left !important;padding-bottom:0 !important;}
+    .stack-r{display:block !important;width:100% !important;text-align:left !important;padding-top:6px !important;}
+    .btn a{display:block !important;}
+  }
+`;
 
 export default function InboxHealthEmail(props: InboxHealthEmailProps) {
   const {
@@ -38,85 +47,335 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
     emailAccountId,
     unsubscribeToken,
     suggestionCount,
+    weeklyIgnoredEmails,
     yearlyEmailsAvoided,
     senders,
   } = props;
 
   const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?filter=suggested`;
   const senderCountText = getSenderCountText(suggestionCount);
+  const yearlyText = yearlyEmailsAvoided.toLocaleString("en-US");
+  const remainingCount = suggestionCount - senders.length;
+  // Longest bar is the sender whose email you ignore most, so the rest read
+  // as a share of that
+  const maxIgnored = Math.max(...senders.map((sender) => sender.ignoredEmails));
 
   return (
-    <Html>
-      <Head />
+    <Html lang="en">
+      <Head>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="supported-color-schemes" content="light dark" />
+        <style>{MOBILE_STYLES}</style>
+      </Head>
       <Preview>
-        We found {senderCountText} you rarely read. Clean them up in one click.
+        Unsubscribing from these {senderCountText} could save you about{" "}
+        {yearlyText} emails a year.
       </Preview>
-      <Tailwind>
-        <Body className="bg-white font-sans">
-          <Container className="mx-auto w-full max-w-[600px] p-0">
-            <Section className="p-8 text-center">
-              <Link href={baseUrl} className="text-[15px]">
-                <Img
-                  src={"https://www.getinboxzero.com/icon.png"}
-                  width="40"
-                  height="40"
-                  alt="Inbox Zero"
-                  className="mx-auto my-0"
-                />
-              </Link>
+      <Body style={{ margin: 0, padding: 0, backgroundColor: PAGE_BACKGROUND }}>
+        <table
+          role="presentation"
+          cellPadding={0}
+          cellSpacing={0}
+          border={0}
+          width="100%"
+          style={{ backgroundColor: PAGE_BACKGROUND }}
+        >
+          <tr>
+            <td align="center" style={{ padding: "32px 12px 48px 12px" }}>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{ width: "600px", maxWidth: "600px" }}
+              >
+                <tr>
+                  <td
+                    align="left"
+                    style={{
+                      padding: "0 8px 18px 8px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "17px",
+                      lineHeight: "20px",
+                      letterSpacing: "-0.02em",
+                      color: TEXT,
+                      fontWeight: 600,
+                    }}
+                  >
+                    inbox zero
+                  </td>
+                  <td
+                    align="right"
+                    style={{
+                      padding: "0 8px 18px 8px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "20px",
+                      color: TEXT_SUBTLE,
+                    }}
+                  >
+                    Monthly inbox report
+                  </td>
+                </tr>
+              </table>
 
-              <Text className="mx-0 mb-8 mt-4 p-0 text-center text-2xl font-normal">
-                <span className="font-semibold tracking-tighter">
-                  Inbox Zero
-                </span>
-              </Text>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{
+                  width: "600px",
+                  maxWidth: "600px",
+                  backgroundColor: CARD_BACKGROUND,
+                  border: `1px solid ${BORDER}`,
+                  borderRadius: "24px",
+                }}
+              >
+                <tr>
+                  <td
+                    className="px"
+                    style={{
+                      padding: "44px 40px 0 40px",
+                      fontFamily: FONT_STACK,
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        lineHeight: "16px",
+                        color: ACCENT_LINK,
+                        fontWeight: 600,
+                        paddingBottom: "14px",
+                      }}
+                    >
+                      Rarely Read Senders
+                    </div>
+                    <h1
+                      className="h1"
+                      style={{
+                        margin: 0,
+                        fontSize: "32px",
+                        lineHeight: "38px",
+                        letterSpacing: "-0.02em",
+                        color: TEXT,
+                        fontWeight: 500,
+                        msoLineHeightRule: "exactly",
+                      }}
+                    >
+                      We found {senderCountText} you rarely read
+                    </h1>
+                    <p
+                      style={{
+                        margin: "14px 0 0 0",
+                        fontSize: "16px",
+                        lineHeight: "25px",
+                        color: TEXT_MUTED,
+                        msoLineHeightRule: "exactly",
+                      }}
+                    >
+                      Unsubscribing from them could save you around{" "}
+                      <span style={{ color: TEXT, fontWeight: 600 }}>
+                        {yearlyText} emails a year
+                      </span>
+                      . That&rsquo;s about {weeklyIgnoredEmails} a week you
+                      never open.
+                    </p>
+                  </td>
+                </tr>
 
-              <Heading className="my-4 text-4xl font-medium leading-tight">
-                We found {senderCountText} you rarely read
-              </Heading>
-              <Text className="mb-8 text-lg leading-8">
-                Unsubscribing from them could save you around{" "}
-                <span className="font-semibold">
-                  {yearlyEmailsAvoided.toLocaleString("en-US")} emails
-                </span>{" "}
-                a year.
-              </Text>
-            </Section>
+                <tr>
+                  <td className="px" style={{ padding: "26px 40px 34px 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      className="btn"
+                    >
+                      <tr>
+                        <td
+                          bgcolor={ACCENT}
+                          style={{
+                            borderRadius: "13px",
+                            backgroundColor: ACCENT,
+                            backgroundImage: `linear-gradient(180deg,${ACCENT} 0%,#5C89F8 100%)`,
+                          }}
+                        >
+                          <a
+                            href={bulkUnsubscribeUrl}
+                            style={{
+                              display: "inline-block",
+                              padding: "14px 26px",
+                              fontFamily: FONT_STACK,
+                              fontSize: "15px",
+                              lineHeight: "20px",
+                              fontWeight: 600,
+                              color: "#FFFFFF",
+                              borderRadius: "13px",
+                              msoLineHeightRule: "exactly",
+                            }}
+                          >
+                            Unsubscribe in one click
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
 
-            <Section className="rounded-2xl bg-[#3b82f6]/5 bg-[radial-gradient(circle_at_bottom_right,#3b82f6_0%,transparent_60%)] p-8 text-center">
-              <Heading className="m-0 text-3xl font-medium text-[#1e40af]">
-                Rarely Read Senders
-              </Heading>
-              <Text className="mb-4 text-gray-900">
-                Based on the last 3 months of your inbox
-              </Text>
+                <tr>
+                  <td className="px" style={{ padding: "0 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      width="100%"
+                      style={{
+                        width: "100%",
+                        borderTop: `1px solid ${BORDER}`,
+                      }}
+                    >
+                      <tr>
+                        <td align="left" style={listHeadingStyle}>
+                          Top {senders.length}, worst first
+                        </td>
+                        <td align="right" style={listHeadingStyle}>
+                          Last 3 months
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
 
-              {senders.map((sender) => (
-                <SenderCard key={sender.email} sender={sender} />
-              ))}
+                <tr>
+                  <td className="px" style={{ padding: "0 40px" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                      width="100%"
+                      style={{ width: "100%" }}
+                    >
+                      {senders.map((sender) => (
+                        <SenderRow
+                          key={sender.email}
+                          sender={sender}
+                          maxIgnored={maxIgnored}
+                        />
+                      ))}
+                    </table>
+                  </td>
+                </tr>
 
-              <Section className="text-center mt-[32px] mb-[32px]">
-                <Button
-                  href={bulkUnsubscribeUrl}
-                  style={{
-                    background: "#000",
-                    color: "#fff",
-                    padding: "12px 20px",
-                    borderRadius: "5px",
-                  }}
-                >
-                  Unsubscribe in One Click
-                </Button>
-              </Section>
-            </Section>
+                <tr>
+                  <td
+                    className="px"
+                    style={{
+                      padding:
+                        remainingCount > 0
+                          ? "26px 40px 40px 40px"
+                          : "0 40px 40px 40px",
+                    }}
+                  >
+                    {remainingCount > 0 && (
+                      <table
+                        role="presentation"
+                        cellPadding={0}
+                        cellSpacing={0}
+                        border={0}
+                        width="100%"
+                        style={{
+                          width: "100%",
+                          borderTop: `1px solid ${BORDER}`,
+                        }}
+                      >
+                        <tr>
+                          <td
+                            style={{
+                              padding: "20px 0 0 0",
+                              fontFamily: FONT_STACK,
+                              fontSize: "14px",
+                              lineHeight: "22px",
+                              color: TEXT_MUTED,
+                            }}
+                          >
+                            {getRemainingSendersText(remainingCount)}{" "}
+                            <a
+                              href={bulkUnsubscribeUrl}
+                              style={{ color: ACCENT_LINK, fontWeight: 600 }}
+                            >
+                              Review all {suggestionCount} &rarr;
+                            </a>
+                          </td>
+                        </tr>
+                      </table>
+                    )}
+                  </td>
+                </tr>
+              </table>
 
-            <StatsEmailFooter
-              baseUrl={baseUrl}
-              unsubscribeToken={unsubscribeToken}
-            />
-          </Container>
-        </Body>
-      </Tailwind>
+              <table
+                role="presentation"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+                width={600}
+                style={{ width: "600px", maxWidth: "600px" }}
+              >
+                <tr>
+                  <td
+                    style={{
+                      padding: "24px 48px 0 48px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "20px",
+                      color: "#A0A0A0",
+                      textAlign: "center",
+                    }}
+                  >
+                    You&rsquo;re receiving this because you subscribed to Inbox
+                    Zero stats updates.
+                    <br />
+                    <a
+                      href={`${baseUrl}/settings#email-updates`}
+                      style={footerLinkStyle}
+                    >
+                      Change email settings
+                    </a>
+                    &nbsp;&middot;&nbsp;
+                    <a
+                      href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
+                      style={footerLinkStyle}
+                    >
+                      Unsubscribe from these updates
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    style={{
+                      padding: "14px 48px 0 48px",
+                      fontFamily: FONT_STACK,
+                      fontSize: "12px",
+                      lineHeight: "18px",
+                      color: "#B4B4B4",
+                      textAlign: "center",
+                    }}
+                  >
+                    Inbox Zero &middot; 2261 Market Street #5039, San Francisco,
+                    CA 94114
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </Body>
     </Html>
   );
 }
@@ -125,65 +384,203 @@ InboxHealthEmail.PreviewProps = {
   baseUrl: "https://www.getinboxzero.com",
   emailAccountId: "email-account-id",
   unsubscribeToken: "123",
-  suggestionCount: 7,
+  suggestionCount: 14,
   yearlyEmailsAvoided: 1248,
+  weeklyIgnoredEmails: 22,
   senders: [
     {
       name: "Daily Deals",
       email: "deals@shopping.example.com",
       count: 92,
-      readPercentage: 2,
+      readEmails: 2,
+      ignoredEmails: 90,
     },
     {
       name: "Tech Newsletter",
       email: "newsletter@technews.example.com",
       count: 64,
-      readPercentage: 8,
+      readEmails: 5,
+      ignoredEmails: 59,
     },
     {
       name: "Promo Updates",
       email: "promo@retailer.example.com",
       count: 48,
-      readPercentage: 0,
+      readEmails: 0,
+      ignoredEmails: 48,
     },
     {
       name: "Webinar Invites",
       email: "events@saas.example.com",
       count: 35,
-      readPercentage: 11,
+      readEmails: 4,
+      ignoredEmails: 31,
     },
     {
       name: "Job Alerts",
       email: "alerts@jobs.example.com",
       count: 26,
-      readPercentage: 15,
+      readEmails: 3,
+      ignoredEmails: 23,
     },
   ],
 } satisfies InboxHealthEmailProps;
 
-function SenderCard({ sender }: { sender: SuggestedSender }) {
+const listHeadingStyle = {
+  padding: "16px 0 4px 0",
+  fontFamily: FONT_STACK,
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: TEXT_SUBTLE,
+} as const;
+
+const footerLinkStyle = {
+  color: TEXT_SUBTLE,
+  textDecoration: "underline",
+} as const;
+
+const senderCellStyle = {
+  padding: "15px 0 13px 0",
+  fontFamily: FONT_STACK,
+  verticalAlign: "top",
+} as const;
+
+function SenderRow({
+  sender,
+  maxIgnored,
+}: {
+  sender: SuggestedSender;
+  maxIgnored: number;
+}) {
+  const filledPercentage = getBarPercentage(sender.ignoredEmails, maxIgnored);
+
   return (
-    <Section className="my-3 rounded-lg bg-white/50 p-4 text-left shadow-sm border border-[#3b82f6]/20">
-      <Row>
-        <Column>
-          <Text className="m-0 font-semibold">
+    <>
+      <tr>
+        <td
+          className="stack"
+          width={320}
+          style={{ ...senderCellStyle, width: "320px" }}
+        >
+          <div
+            style={{
+              fontSize: "15px",
+              lineHeight: "20px",
+              color: TEXT,
+              fontWeight: 600,
+            }}
+          >
             {sender.name || sender.email}
-          </Text>
-          <Text className="m-0 text-gray-600">{sender.email}</Text>
-        </Column>
-        <Column align="right">
-          <Text className="m-0 text-sm text-gray-500">
-            {sender.count} emails in the last 3 months
-          </Text>
-          <Text className="m-0 text-sm text-gray-500">
-            {sender.readPercentage}% read
-          </Text>
-        </Column>
-      </Row>
-    </Section>
+          </div>
+          <div
+            style={{
+              fontSize: "13px",
+              lineHeight: "18px",
+              color: TEXT_FAINT,
+              paddingTop: "2px",
+            }}
+          >
+            {sender.email}
+          </div>
+        </td>
+        <td
+          className="stack-r"
+          width={200}
+          align="right"
+          style={{ ...senderCellStyle, width: "200px" }}
+        >
+          <div
+            style={{
+              fontSize: "15px",
+              lineHeight: "20px",
+              color: TEXT,
+              fontWeight: 600,
+            }}
+          >
+            {sender.count} {sender.count === 1 ? "email" : "emails"}
+          </div>
+          <div
+            style={{
+              fontSize: "13px",
+              lineHeight: "18px",
+              color: TEXT_FAINT,
+              paddingTop: "2px",
+            }}
+          >
+            {getOpenedText(sender)}
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td colSpan={2} style={{ padding: 0 }}>
+          <table
+            role="presentation"
+            cellPadding={0}
+            cellSpacing={0}
+            border={0}
+            width="100%"
+            style={{ width: "100%", tableLayout: "fixed" }}
+          >
+            <tr>
+              <td
+                width={`${filledPercentage}%`}
+                height={3}
+                bgcolor={ACCENT}
+                style={{
+                  width: `${filledPercentage}%`,
+                  height: "3px",
+                  backgroundColor: ACCENT,
+                  borderRadius: "1.5px",
+                  fontSize: 0,
+                  lineHeight: 0,
+                }}
+              >
+                &nbsp;
+              </td>
+              {filledPercentage < 100 && (
+                <td
+                  width={`${100 - filledPercentage}%`}
+                  height={3}
+                  bgcolor={BAR_TRACK}
+                  style={{
+                    width: `${100 - filledPercentage}%`,
+                    height: "3px",
+                    backgroundColor: BAR_TRACK,
+                    fontSize: 0,
+                    lineHeight: 0,
+                  }}
+                >
+                  &nbsp;
+                </td>
+              )}
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </>
   );
 }
 
 export function getSenderCountText(count: number) {
   return `${count} ${count === 1 ? "sender" : "senders"}`;
+}
+
+function getRemainingSendersText(count: number) {
+  return count === 1
+    ? "1 more sender sends you email you rarely open."
+    : `${count} more senders send you email you rarely open.`;
+}
+
+/**
+ * "opened 1 in 8" reads faster than a read percentage, and stays honest for
+ * senders the user has never opened.
+ */
+function getOpenedText(sender: SuggestedSender) {
+  if (sender.readEmails <= 0) return "opened none";
+  return `opened 1 in ${Math.round(sender.count / sender.readEmails)}`;
+}
+
+function getBarPercentage(ignoredEmails: number, maxIgnored: number) {
+  if (maxIgnored <= 0) return 100;
+  return Math.round((ignoredEmails / maxIgnored) * 1000) / 10;
 }


### PR DESCRIPTION
Stacked on #3134. Review that one first; this PR's diff is only the email.

## Changes

Rebuilds the rarely read senders email to the approved design.

- Card layout on a tinted page, brand header, single primary action
- Each sender row carries a bar sized by how much of that sender's mail goes unread, so the ranking is visible rather than implied
- Rows report an opened ratio ("opened 1 in 9", "opened none") instead of a read percentage. It reads faster and stays honest for senders never opened at all, where a percentage renders as a bare 0%
- The summary line reports the weekly volume the user never opens, computed from actual unread counts rather than derived from the yearly total, so the sentence is literally true
- List heading and the trailing "more senders" line adapt to how many senders are listed, so copy stays correct at the minimum threshold and when every suggestion already fits in the list
- Footer carries the postal address

The header uses the app icon plus the brand name, matching the other emails in this package, rather than the wordmark treatment in the design source.

## Data

`getInboxHealthEmailData` now returns per-sender read and ignored counts plus a weekly ignored figure. The API route spreads the helper's result into the email props, so no call-site changes were needed.

## Testing

- Rendered the component through `@react-email/render` and compared against the design at desktop and mobile widths, plus the edge case where every suggestion is listed and the trailing line is suppressed
- Verified the responsive stacking rules and MSO line-height hints survive the React render
- Helper tests updated for the new fields, with coverage for the weekly figure
- Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)