### PR TITLE
email: Fix inbox health email on mobile

### DIFF
--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -88,7 +88,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 cellSpacing={0}
                 border={0}
                 width={600}
-                style={{ width: "600px", maxWidth: "600px" }}
+                style={{ width: "100%", maxWidth: "600px" }}
               >
                 <tr>
                   <td
@@ -133,7 +133,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 border={0}
                 width={600}
                 style={{
-                  width: "600px",
+                  width: "100%",
                   maxWidth: "600px",
                   backgroundColor: CARD_BACKGROUND,
                   border: `1px solid ${BORDER}`,
@@ -331,7 +331,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
                 cellSpacing={0}
                 border={0}
                 width={600}
-                style={{ width: "600px", maxWidth: "600px" }}
+                style={{ width: "100%", maxWidth: "600px" }}
               >
                 <tr>
                   <td


### PR DESCRIPTION
Makes the redesigned inbox health email fit narrow screens without horizontal scrolling. The existing 600px width attributes remain as email-client fallbacks while inline CSS becomes fluid up to the same maximum width.

- set the header, content card, and footer wrappers to 100% CSS width
- preserve the 600px maximum and HTML width fallback
- verified at 375px with no horizontal overflow

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

