### PR TITLE
Say what the two confidence settings cost

### DIFF
--- a/apps/web/utils/ai/reply/draft-confidence.ts
+++ b/apps/web/utils/ai/reply/draft-confidence.ts
@@ -17,12 +17,14 @@ export const DRAFT_REPLY_CONFIDENCE_OPTIONS = [
   {
     value: DraftReplyConfidence.STANDARD,
     label: "Standard",
-    description: "Skip drafting when the AI is unsure how to respond.",
+    description:
+      "Skip drafting when the AI is clearly unsure. Most emails still get a draft.",
   },
   {
     value: DraftReplyConfidence.HIGH_CONFIDENCE,
     label: "High confidence",
-    description: "Only draft when the AI is very sure of the right reply.",
+    description:
+      "Only draft when the AI is very sure of the right reply. Many emails will get no draft.",
   },
 ] as const;
 


### PR DESCRIPTION
Both descriptions in the draft-confidence setting promise more filtering than they deliver.

**Standard** — "Skip drafting when the AI is unsure how to respond" reads as though it holds back anything the model hesitates on. It is a light filter, and most emails still get a draft.

**High confidence** — "Only draft when the AI is very sure of the right reply" reads as a quality bar. The part people are surprised by is the volume trade: a meaningful share of emails get no draft at all.

Copy only, no behaviour change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

