### PR TITLE
evals: Update judge model configuration

### DIFF
--- a/apps/web/__tests__/eval/harness/judge-model.ts
+++ b/apps/web/__tests__/eval/harness/judge-model.ts
@@ -4,16 +4,13 @@ import { getModel } from "@/utils/llms/model";
 import { getEvalJudgeUserAi } from "@/__tests__/eval/judge-provider";
 
 /**
- * The judge is deliberately from a different model family than the system under
- * test. A same-family judge exhibits self-preference bias: it recognises its own
- * generation style, hedging habits, and sentence rhythm as "good writing", so it
- * passes drafts a human would rewrite. That bias points in exactly the direction
- * this harness exists to eliminate, and it is unobservable from inside the run
- * because a lenient judge just reports a high number.
+ * The judge is configured separately from the system under test so eval runs can
+ * avoid same-family self-preference bias. When evaluating a DeepSeek model,
+ * override this default with EVAL_JUDGE_PROVIDER / EVAL_JUDGE_MODEL if an
+ * independent model family is required.
  *
- * The default (`google/gemini-3.1-flash-lite-preview`) is set by
- * `getEvalJudgeUserAi` and overridable with EVAL_JUDGE_PROVIDER /
- * EVAL_JUDGE_MODEL.
+ * The default (`~deepseek/deepseek-v4-flash-latest`) is set by
+ * `getEvalJudgeUserAi`.
  */
 export function getHarnessJudgeModel() {
   const judgeUserAi = getEvalJudgeUserAi();

--- a/apps/web/__tests__/eval/judge-provider.ts
+++ b/apps/web/__tests__/eval/judge-provider.ts
@@ -1,5 +1,5 @@
 const DEFAULT_EVAL_JUDGE_PROVIDER = "openrouter";
-const DEFAULT_EVAL_JUDGE_MODEL = "google/gemini-3.1-flash-lite-preview";
+const DEFAULT_EVAL_JUDGE_MODEL = "~deepseek/deepseek-v4-flash-latest";
 
 /**
  * Lives apart from the judge implementations because those reach vitest through

--- a/apps/web/__tests__/eval/judge-provider.ts
+++ b/apps/web/__tests__/eval/judge-provider.ts
@@ -1,4 +1,5 @@
 const DEFAULT_EVAL_JUDGE_PROVIDER = "openrouter";
+// OpenRouter's rolling alias redirects to the latest DeepSeek V4 Flash release.
 const DEFAULT_EVAL_JUDGE_MODEL = "~deepseek/deepseek-v4-flash-latest";
 
 /**

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -97,7 +97,7 @@ describe("eval reporter", () => {
       email: "user@example.com",
       emailAccountId: "email-account-1",
       provider: "openrouter",
-      model: "deepseek/deepseek-v4-flash",
+      model: "~deepseek/deepseek-v4-flash-latest",
       usage: {
         inputTokens: 1000,
         outputTokens: 500,
@@ -108,7 +108,7 @@ describe("eval reporter", () => {
     });
     reporter.record({
       testName: "example",
-      model: "DeepSeek V4 Flash",
+      model: "DeepSeek V4 Flash Latest",
       pass: true,
     });
 
@@ -120,7 +120,7 @@ describe("eval reporter", () => {
     );
     expect(markdown).toContain("## Eval Cost");
     expect(markdown).toContain("Provider-reported total: $0.000200");
-    expect(markdown).toContain("openrouter:deepseek/deepseek-v4-flash");
+    expect(markdown).toContain("openrouter:~deepseek/deepseek-v4-flash-latest");
   });
 
   it("writes eval history when AI tests are enabled", () => {

--- a/apps/web/utils/llms/pricing.generated.ts
+++ b/apps/web/utils/llms/pricing.generated.ts
@@ -114,15 +114,20 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_015,
     cachedInput: 3e-7,
   },
+  "DeepSeek-V4-Flash": {
+    input: 1.9e-7,
+    output: 5.1e-7,
+    cachedInput: 2.8e-8,
+  },
   "DeepSeek-V4-Pro": {
     input: 0.000_001_925,
     output: 0.000_003_828,
     cachedInput: 1.65e-7,
   },
   "deepseek/deepseek-v4-flash": {
-    input: 7.7e-8,
-    output: 1.54e-7,
-    cachedInput: 1.54e-8,
+    input: 1.4e-7,
+    output: 2.8e-7,
+    cachedInput: 2.8e-8,
   },
   "eu.anthropic.claude-sonnet-4-6": {
     input: 0.000_003,
@@ -252,7 +257,7 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
   "gpt-4o": {
     input: 0.000_002_5,
     output: 0.000_01,
-    cachedInput: 0.000_002_5,
+    cachedInput: 0.000_001_25,
   },
   "gpt-4o-mini": {
     input: 1.5e-7,
@@ -267,12 +272,12 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
   "gpt-5-nano": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 1e-8,
+    cachedInput: 5e-9,
   },
   "gpt-5.1": {
     input: 0.000_001_25,
     output: 0.000_01,
-    cachedInput: 1.3e-7,
+    cachedInput: 1.25e-7,
   },
   "gpt-5.4": {
     input: 0.000_002_5,
@@ -290,14 +295,14 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     cachedInput: 2e-8,
   },
   "gpt-5.6-luna": {
+    input: 1e-7,
+    output: 6e-7,
+    cachedInput: 1e-8,
+  },
+  "gpt-5.6-terra": {
     input: 0.000_001,
     output: 0.000_006,
     cachedInput: 1e-7,
-  },
-  "gpt-5.6-terra": {
-    input: 0.000_002_5,
-    output: 0.000_015,
-    cachedInput: 2.5e-7,
   },
   "llama-3.3-70b-versatile": {
     input: 5.9e-7,
@@ -317,12 +322,12 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
   "openai/gpt-5-nano": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 1e-8,
+    cachedInput: 5e-9,
   },
   "openai/gpt-5-nano-2025-08-07": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 1e-8,
+    cachedInput: 5e-9,
   },
   "sonar-pro": {
     input: 0.000_003,

--- a/apps/web/utils/llms/pricing.generated.ts
+++ b/apps/web/utils/llms/pricing.generated.ts
@@ -119,6 +119,11 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_003_828,
     cachedInput: 1.65e-7,
   },
+  "deepseek/deepseek-v4-flash": {
+    input: 7.7e-8,
+    output: 1.54e-7,
+    cachedInput: 1.54e-8,
+  },
   "eu.anthropic.claude-sonnet-4-6": {
     input: 0.000_003,
     output: 0.000_015,

--- a/apps/web/utils/llms/pricing.generated.ts
+++ b/apps/web/utils/llms/pricing.generated.ts
@@ -9,6 +9,11 @@ export type ModelPricing = {
 };
 
 export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
+  "~deepseek/deepseek-v4-flash-latest": {
+    input: 9e-8,
+    output: 1.8e-7,
+    cachedInput: 1.8e-8,
+  },
   "anthropic.claude-3-5-haiku-20241022-v1:0": {
     input: 8.000_000_000_000_001e-7,
     output: 0.000_004,
@@ -113,11 +118,6 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     input: 0.000_001_925,
     output: 0.000_003_828,
     cachedInput: 1.65e-7,
-  },
-  "deepseek/deepseek-v4-flash": {
-    input: 7.7e-8,
-    output: 1.54e-7,
-    cachedInput: 1.54e-8,
   },
   "eu.anthropic.claude-sonnet-4-6": {
     input: 0.000_003,

--- a/apps/web/utils/llms/supported-model-pricing.ts
+++ b/apps/web/utils/llms/supported-model-pricing.ts
@@ -151,6 +151,11 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
   "google/gemini-3-flash-preview": gemini3_0flash,
   "google/gemini-3-pro": gemini3_0pro,
   "google/gemini-3-pro-preview": gemini3_0pro,
+  "deepseek/deepseek-v4-flash": {
+    input: 0.1 / 1_000_000,
+    output: 0.2 / 1_000_000,
+    cachedInput: 0.02 / 1_000_000,
+  },
   "~deepseek/deepseek-v4-flash-latest": {
     input: 0.09 / 1_000_000,
     output: 0.18 / 1_000_000,
@@ -211,6 +216,7 @@ export const OPENROUTER_MODEL_ID_BY_SUPPORTED_MODEL: Partial<
   "gemini-2.5-flash": "google/gemini-2.5-flash",
   "gemini-3-flash": "google/gemini-3-flash-preview",
   "gemini-3-pro": "google/gemini-3-pro-preview",
+  "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
   "~deepseek/deepseek-v4-flash-latest": "~deepseek/deepseek-v4-flash-latest",
   "sonar-pro": "perplexity/sonar-pro",
 };

--- a/apps/web/utils/llms/supported-model-pricing.ts
+++ b/apps/web/utils/llms/supported-model-pricing.ts
@@ -151,10 +151,10 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
   "google/gemini-3-flash-preview": gemini3_0flash,
   "google/gemini-3-pro": gemini3_0pro,
   "google/gemini-3-pro-preview": gemini3_0pro,
-  "deepseek/deepseek-v4-flash": {
-    input: 0.1 / 1_000_000,
-    output: 0.2 / 1_000_000,
-    cachedInput: 0.02 / 1_000_000,
+  "~deepseek/deepseek-v4-flash-latest": {
+    input: 0.09 / 1_000_000,
+    output: 0.18 / 1_000_000,
+    cachedInput: 0.018 / 1_000_000,
   },
   "DeepSeek-V4-Pro": {
     input: 1.925 / 1_000_000,
@@ -211,6 +211,6 @@ export const OPENROUTER_MODEL_ID_BY_SUPPORTED_MODEL: Partial<
   "gemini-2.5-flash": "google/gemini-2.5-flash",
   "gemini-3-flash": "google/gemini-3-flash-preview",
   "gemini-3-pro": "google/gemini-3-pro-preview",
-  "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+  "~deepseek/deepseek-v4-flash-latest": "~deepseek/deepseek-v4-flash-latest",
   "sonar-pro": "perplexity/sonar-pro",
 };

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -150,13 +150,13 @@ describe("calculateUsageCost", () => {
     ).toBe(0);
   });
 
-  it("estimates DeepSeek V4 Flash Latest costs", () => {
+  it.each([
+    "deepseek/deepseek-v4-flash",
+    "~deepseek/deepseek-v4-flash-latest",
+  ])("estimates DeepSeek V4 Flash costs for %s", (model) => {
     const provider = "openrouter";
-    const model = "~deepseek/deepseek-v4-flash-latest";
     const pricing = OPENROUTER_MODEL_PRICING[model];
-    if (!pricing) {
-      throw new Error("Expected pricing for deepseek-v4-flash-latest");
-    }
+    if (!pricing) throw new Error(`Expected pricing for ${model}`);
 
     const usage: LanguageModelUsage = {
       inputTokens: 1000,

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -150,11 +150,13 @@ describe("calculateUsageCost", () => {
     ).toBe(0);
   });
 
-  it("estimates DeepSeek V4 Flash costs", () => {
+  it("estimates DeepSeek V4 Flash Latest costs", () => {
     const provider = "openrouter";
-    const model = "deepseek/deepseek-v4-flash";
+    const model = "~deepseek/deepseek-v4-flash-latest";
     const pricing = OPENROUTER_MODEL_PRICING[model];
-    if (!pricing) throw new Error("Expected pricing for deepseek-v4-flash");
+    if (!pricing) {
+      throw new Error("Expected pricing for deepseek-v4-flash-latest");
+    }
 
     const usage: LanguageModelUsage = {
       inputTokens: 1000,
@@ -591,7 +593,7 @@ describe("saveAiUsage", () => {
     };
     const estimatedCost = calculateUsageCost({
       provider: "openrouter",
-      model: "deepseek/deepseek-v4-flash",
+      model: "~deepseek/deepseek-v4-flash-latest",
       usage,
     });
     const listener = vi.fn();
@@ -603,7 +605,7 @@ describe("saveAiUsage", () => {
         email: "user@example.com",
         emailAccountId: "email-account-1",
         provider: "openrouter",
-        model: "deepseek/deepseek-v4-flash",
+        model: "~deepseek/deepseek-v4-flash-latest",
         usage,
         label: "eval-test",
         providerReportedCost: 0.000_18,
@@ -615,7 +617,7 @@ describe("saveAiUsage", () => {
     expect(listener).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openrouter",
-        model: "deepseek/deepseek-v4-flash",
+        model: "~deepseek/deepseek-v4-flash-latest",
         label: "eval-test",
         estimatedCost,
         platformCost: 0.000_18,


### PR DESCRIPTION
Updates the default evaluation judge to a current low-cost model.

- Refreshes matching pricing metadata.
- Updates usage and reporting fixtures.
- Preserves provider-specific overrides for independent judging.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

