### PR TITLE
Widen the reply-memory candidate pool

### DIFF
--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -162,7 +162,7 @@ describe("reply-memory", () => {
         scopeType: ReplyMemoryScopeType.GLOBAL,
       },
       orderBy: { updatedAt: "desc" },
-      take: 25,
+      take: 100,
     });
     expect(prisma.replyMemory.findMany).toHaveBeenNthCalledWith(
       4,

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -27,7 +27,7 @@ const MAX_EXISTING_PREFERENCE_MEMORIES_IN_PROMPT = 8;
 // Candidate pool sizes for AI relevance selection. Wider than the injected
 // cap so relevant older memories can still surface.
 const MAX_SCOPED_MEMORY_CANDIDATES = 10;
-const MAX_BROAD_MEMORY_CANDIDATES = 25;
+const MAX_BROAD_MEMORY_CANDIDATES = 100;
 const PROMPTABLE_REPLY_MEMORY_KINDS = [
   ReplyMemoryKind.FACT,
   ReplyMemoryKind.PROCEDURE,


### PR DESCRIPTION
Stacked on #3137 (copy only, unrelated files — either can merge first, this just avoids a conflict-free rebase dance).

`MAX_BROAD_MEMORY_CANDIDATES` bounds the two arms of memory retrieval that have **no content filter at all** — GLOBAL and recent-TOPIC. On an account with a large memory pool that cap, and not any judgement about the email, is what decides whether a relevant memory reaches the selector.

The one arm that does read the email is a SQL `LIKE` matching a stored topic phrase against the message body. Checked against real accounts, it rescues very little on its own, so in practice the recency caps are the retrieval.

The AI selector still cuts to six, so this changes what it chooses from, not how much reaches the draft. The cost is prompt length on one cheap call.

`DRAFT_PIPELINE_VERSION` bumped, since which memories the prompt sees is a drafting change.

`reply-memory.test.ts` pinned `take: 25` on the GLOBAL query; updated. Tests under `utils/ai/reply/` and `__tests__/eval/select-reply-memories.test.ts` pass locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

