### PR TITLE
Add POST /api/ai/translate for mobile email translation

### DIFF
--- a/apps/web/app/api/ai/translate/route.ts
+++ b/apps/web/app/api/ai/translate/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import { translateBody } from "@/app/api/ai/translate/validation";
+import { getEmailAccountWithAi } from "@/utils/user/get";
+import { assertHasAiAccess } from "@/utils/premium/limits";
+import { aiTranslateEmails } from "@/utils/ai/translate-email";
+
+export const maxDuration = 60;
+
+export type TranslateResponse = { translations: string[] };
+
+export const POST = withEmailAccount(async (request) => {
+  const emailAccountId = request.auth.emailAccountId;
+
+  const json = await request.json();
+  const body = translateBody.parse(json);
+
+  const emailAccount = await getEmailAccountWithAi({ emailAccountId });
+
+  if (!emailAccount) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  await assertHasAiAccess({
+    userId: emailAccount.userId,
+    hasUserApiKey: !!emailAccount.user.aiApiKey,
+  });
+
+  const translations = await aiTranslateEmails({
+    texts: body.texts,
+    targetLanguage: body.targetLanguage,
+    emailAccount,
+  });
+
+  return NextResponse.json({ translations } satisfies TranslateResponse);
+});

--- a/apps/web/app/api/ai/translate/validation.test.ts
+++ b/apps/web/app/api/ai/translate/validation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { translateBody } from "./validation";
+
+describe("translateBody", () => {
+  it("accepts BCP 47 language tags and one or more texts", () => {
+    expect(
+      translateBody.parse({
+        texts: ["Hello"],
+        targetLanguage: "en",
+      }),
+    ).toEqual({
+      texts: ["Hello"],
+      targetLanguage: "en",
+    });
+
+    expect(
+      translateBody.parse({
+        texts: ["Hola", "Mundo"],
+        targetLanguage: "es-ES",
+      }).targetLanguage,
+    ).toBe("es-ES");
+  });
+
+  it("rejects empty texts and invalid language tags", () => {
+    expect(() =>
+      translateBody.parse({
+        texts: [],
+        targetLanguage: "en",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      translateBody.parse({
+        texts: ["Hello"],
+        targetLanguage: "not a language!",
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/web/app/api/ai/translate/validation.ts
+++ b/apps/web/app/api/ai/translate/validation.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const bcp47LanguageTag = z
+  .string()
+  .trim()
+  .min(2)
+  .max(35)
+  .regex(
+    /^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$/,
+    "Must be a BCP 47 language tag (e.g. en, es-ES)",
+  );
+
+export const translateBody = z.object({
+  texts: z.array(z.string()).min(1).max(20),
+  targetLanguage: bcp47LanguageTag,
+});
+export type TranslateBody = z.infer<typeof translateBody>;

--- a/apps/web/utils/ai/translate-email.test.ts
+++ b/apps/web/utils/ai/translate-email.test.ts
@@ -91,4 +91,53 @@ describe("aiTranslateEmails", () => {
       }),
     ).rejects.toThrow("Expected 2 translations, received 1");
   });
+
+  it("hard-slices long texts without appending an ellipsis", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        translations: ["ok"],
+      },
+    });
+
+    const longText = `${"a".repeat(30_000)}SHOULD_NOT_APPEAR`;
+
+    await aiTranslateEmails({
+      texts: [longText],
+      targetLanguage: "en",
+      emailAccount: getEmailAccount(),
+    });
+
+    const call = mockGenerateObject.mock.calls[0]?.[0] as { prompt: string };
+
+    expect(call.prompt).toContain("a".repeat(30_000));
+    expect(call.prompt).not.toContain("SHOULD_NOT_APPEAR");
+    expect(call.prompt).not.toContain(`${"a".repeat(30_000)}...`);
+  });
+
+  it("pins the output schema length to the number of input texts", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        translations: ["one", "two", "three"],
+      },
+    });
+
+    await aiTranslateEmails({
+      texts: ["a", "b", "c"],
+      targetLanguage: "en",
+      emailAccount: getEmailAccount(),
+    });
+
+    const call = mockGenerateObject.mock.calls[0]?.[0] as {
+      schema: {
+        safeParse: (value: unknown) => { success: boolean };
+      };
+    };
+
+    expect(
+      call.schema.safeParse({ translations: ["one", "two", "three"] }).success,
+    ).toBe(true);
+    expect(
+      call.schema.safeParse({ translations: ["one", "two"] }).success,
+    ).toBe(false);
+  });
 });

--- a/apps/web/utils/ai/translate-email.test.ts
+++ b/apps/web/utils/ai/translate-email.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEmailAccount } from "@/__tests__/helpers";
+import { aiTranslateEmails } from "./translate-email";
+
+const { mockCreateGenerateObject, mockGenerateObject } = vi.hoisted(() => {
+  const mockGenerateObject = vi.fn();
+  const mockCreateGenerateObject = vi.fn(() => mockGenerateObject);
+  return { mockCreateGenerateObject, mockGenerateObject };
+});
+
+vi.mock("@/utils/llms", () => ({
+  createGenerateObject: mockCreateGenerateObject,
+}));
+
+vi.mock("@/utils/llms/model", () => ({
+  getModel: vi.fn(() => ({
+    provider: "openai",
+    modelName: "test-model",
+    model: {},
+    providerOptions: undefined,
+    fallbackModels: [],
+  })),
+}));
+
+describe("aiTranslateEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty array without calling the LLM when texts is empty", async () => {
+    const result = await aiTranslateEmails({
+      texts: [],
+      targetLanguage: "en",
+      emailAccount: getEmailAccount(),
+    });
+
+    expect(result).toEqual([]);
+    expect(mockCreateGenerateObject).not.toHaveBeenCalled();
+  });
+
+  it("returns empty strings without calling the LLM when every text is blank", async () => {
+    const result = await aiTranslateEmails({
+      texts: ["", "   ", "\n"],
+      targetLanguage: "es",
+      emailAccount: getEmailAccount(),
+    });
+
+    expect(result).toEqual(["", "", ""]);
+    expect(mockCreateGenerateObject).not.toHaveBeenCalled();
+  });
+
+  it("returns translations in the same order as the inputs", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        translations: ["Hello", "World"],
+      },
+    });
+
+    const result = await aiTranslateEmails({
+      texts: ["Hola", "Mundo"],
+      targetLanguage: "en",
+      emailAccount: getEmailAccount(),
+    });
+
+    expect(result).toEqual(["Hello", "World"]);
+    expect(mockCreateGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Translate email",
+        promptHardening: { trust: "untrusted", level: "compact" },
+      }),
+    );
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Target language (BCP 47): en"),
+      }),
+    );
+  });
+
+  it("throws when the model returns the wrong number of translations", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        translations: ["only one"],
+      },
+    });
+
+    await expect(
+      aiTranslateEmails({
+        texts: ["uno", "dos"],
+        targetLanguage: "en",
+        emailAccount: getEmailAccount(),
+      }),
+    ).rejects.toThrow("Expected 2 translations, received 1");
+  });
+});

--- a/apps/web/utils/ai/translate-email.ts
+++ b/apps/web/utils/ai/translate-email.ts
@@ -3,19 +3,10 @@ import { createGenerateObject } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createScopedLogger } from "@/utils/logger";
-import { truncate } from "@/utils/string";
 
 const logger = createScopedLogger("translate-email");
 
 const MAX_TEXT_LENGTH = 30_000;
-
-const translationSchema = z.object({
-  translations: z
-    .array(z.string())
-    .describe(
-      "Translated texts in the same order and length as the input texts",
-    ),
-});
 
 export async function aiTranslateEmails({
   texts,
@@ -32,7 +23,8 @@ export async function aiTranslateEmails({
     return texts.map(() => "");
   }
 
-  const truncatedTexts = texts.map((text) => truncate(text, MAX_TEXT_LENGTH));
+  // Hard-slice without ellipsis so truncation markers aren't treated as content.
+  const truncatedTexts = texts.map((text) => text.slice(0, MAX_TEXT_LENGTH));
 
   const system = `You are a precise email translator.
 Translate each provided text into the target language identified by the BCP 47 language tag.
@@ -64,7 +56,7 @@ ${formatTextsForPrompt(truncatedTexts)}`;
     ...modelOptions,
     system,
     prompt,
-    schema: translationSchema,
+    schema: translationSchema(texts.length),
   });
 
   const translations = result.object.translations;
@@ -81,6 +73,17 @@ ${formatTextsForPrompt(truncatedTexts)}`;
   }
 
   return translations;
+}
+
+function translationSchema(textCount: number) {
+  return z.object({
+    translations: z
+      .array(z.string())
+      .length(textCount)
+      .describe(
+        "Translated texts in the same order and length as the input texts",
+      ),
+  });
 }
 
 function formatTextsForPrompt(texts: string[]) {

--- a/apps/web/utils/ai/translate-email.ts
+++ b/apps/web/utils/ai/translate-email.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { createGenerateObject } from "@/utils/llms";
+import type { EmailAccountWithAI } from "@/utils/llms/types";
+import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
+import { createScopedLogger } from "@/utils/logger";
+import { truncate } from "@/utils/string";
+
+const logger = createScopedLogger("translate-email");
+
+const MAX_TEXT_LENGTH = 30_000;
+
+const translationSchema = z.object({
+  translations: z
+    .array(z.string())
+    .describe(
+      "Translated texts in the same order and length as the input texts",
+    ),
+});
+
+export async function aiTranslateEmails({
+  texts,
+  targetLanguage,
+  emailAccount,
+}: {
+  texts: string[];
+  targetLanguage: string;
+  emailAccount: EmailAccountWithAI;
+}): Promise<string[]> {
+  if (texts.length === 0) return [];
+
+  if (texts.every((text) => !text.trim())) {
+    return texts.map(() => "");
+  }
+
+  const truncatedTexts = texts.map((text) => truncate(text, MAX_TEXT_LENGTH));
+
+  const system = `You are a precise email translator.
+Translate each provided text into the target language identified by the BCP 47 language tag.
+Return only translations — no commentary, preface, or explanation.
+Preserve the original formatting as much as possible (markdown, line breaks, bullet points, links, and whitespace structure).
+Keep proper nouns, email addresses, URLs, and code-like tokens unchanged when translating would break them.
+If a text is empty or only whitespace, return an empty string for that entry.
+The translations array must have the same length and order as the input texts.`;
+
+  const prompt = `Target language (BCP 47): ${targetLanguage}
+
+Translate each text below into the target language.
+
+${formatTextsForPrompt(truncatedTexts)}`;
+
+  const modelOptions = getModelForUseCase(
+    emailAccount.user,
+    LlmUseCase.TranslateEmail,
+  );
+
+  const generateObject = createGenerateObject({
+    emailAccount,
+    label: "Translate email",
+    modelOptions,
+    promptHardening: { trust: "untrusted", level: "compact" },
+  });
+
+  const result = await generateObject({
+    ...modelOptions,
+    system,
+    prompt,
+    schema: translationSchema,
+  });
+
+  const translations = result.object.translations;
+
+  if (translations.length !== texts.length) {
+    logger.error("Translation count mismatch", {
+      expected: texts.length,
+      actual: translations.length,
+      targetLanguage,
+    });
+    throw new Error(
+      `Expected ${texts.length} translations, received ${translations.length}`,
+    );
+  }
+
+  return translations;
+}
+
+function formatTextsForPrompt(texts: string[]) {
+  return texts
+    .map(
+      (text, index) => `<text index="${index}">
+${text}
+</text>`,
+    )
+    .join("\n\n");
+}

--- a/apps/web/utils/llms/use-cases.test.ts
+++ b/apps/web/utils/llms/use-cases.test.ts
@@ -145,6 +145,7 @@ describe("LLM use cases", () => {
       [LlmUseCase.ReplyMemorySelection]: "economy",
       [LlmUseCase.ReplyNudge]: "chat",
       [LlmUseCase.Summarise]: "default",
+      [LlmUseCase.TranslateEmail]: "economy",
       [LlmUseCase.WritingStyleAnalysis]: "default",
     });
   });

--- a/apps/web/utils/llms/use-cases.ts
+++ b/apps/web/utils/llms/use-cases.ts
@@ -42,6 +42,7 @@ export const LlmUseCase = {
   ReplyMemorySelection: "reply-memory-selection",
   ReplyNudge: "reply-nudge",
   Summarise: "summarise",
+  TranslateEmail: "translate-email",
   WritingStyleAnalysis: "writing-style-analysis",
 } as const;
 
@@ -87,6 +88,7 @@ export const LLM_USE_CASE_MODEL_TYPES = {
   [LlmUseCase.ReplyMemorySelection]: "economy",
   [LlmUseCase.ReplyNudge]: "chat",
   [LlmUseCase.Summarise]: "default",
+  [LlmUseCase.TranslateEmail]: "economy",
   [LlmUseCase.WritingStyleAnalysis]: "default",
 } as const satisfies Record<LlmUseCase, ModelType>;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a backend translate endpoint for the mobile app, modeled on `POST /api/ai/summarise`.

- **`POST /api/ai/translate`** — auth via `withEmailAccount` + `assertHasAiAccess`
- Request: `{ texts: string[], targetLanguage: string }` (BCP 47 tag)
- Response (JSON, not streamed): `{ translations: string[] }` — same length/order as `texts`
- `maxDuration = 60` to match the mobile client timeout

## Implementation
- New `LlmUseCase.TranslateEmail` routed to the economy model
- Single structured LLM call (`createGenerateObject`) returning a translations array
- Schema pins `.length(texts.length)` so the model is steered before a post-check
- Hard-slices texts over 30k without appending `...`
- Untrusted prompt hardening (email body content)
- Translates only — no commentary; preserves formatting where possible
- Blank-only inputs skip the LLM

## Test plan
- [x] Unit tests for validation (BCP 47 + texts constraints)
- [x] Unit tests for `aiTranslateEmails` (empty short-circuit, order, count mismatch, hard-slice, schema length)
- [x] `LlmUseCase` mapping test updated
- [ ] Mobile client can call endpoint and render translations

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b26abe9-5bed-47d5-8e11-381c5564e0a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b26abe9-5bed-47d5-8e11-381c5564e0a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

