### PR TITLE
onboarding: Remove upgrade prompt from the bulk unsubscribe step

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -25,7 +25,6 @@ import type {
 } from "@/app/api/user/stats/newsletters/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { usePremium } from "@/hooks/usePremium";
-import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 import { extractDomainFromEmail } from "@/utils/email";
 import { createSearchParams } from "@/utils/url";
 
@@ -41,7 +40,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
   const { emailAccountId } = useAccount();
   const posthog = usePostHog();
   const { hasUnsubscribeAccess, mutate: refetchPremium } = usePremium();
-  const { PremiumModal, openModal } = usePremiumModal();
 
   // Day-boundary date range keeps the SWR key stable across mounts, so
   // revisiting this step (back/forward) reuses the cached result.
@@ -173,15 +171,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
       hasUnsubscribeAccess,
     });
 
-    if (!hasUnsubscribeAccess) {
-      posthog?.capture("onboarding_unsubscribe_upgrade_prompt_shown", {
-        selectedCount: selectedSenders.length,
-        totalSuggestions: suggestions.length,
-      });
-      openModal();
-      return;
-    }
-
     posthog?.capture("onboarding_unsubscribe_clicked", {
       count: selectedSenders.length,
       totalSuggestions: suggestions.length,
@@ -267,7 +256,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
           )}
         </div>
       </div>
-      <PremiumModal />
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -10,6 +10,7 @@ import { PageHeading, TypographyP } from "@/components/Typography";
 import { Button } from "@/components/ui/button";
 import { ButtonLoader } from "@/components/Loading";
 import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ButtonCheckbox } from "@/components/ButtonCheckbox";
 import { DomainIcon } from "@/components/charts/DomainIcon";
 import { BulkUnsubscribeIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illustrations/BulkUnsubscribeIllustration";
@@ -31,6 +32,10 @@ import { createSearchParams } from "@/utils/url";
 type Newsletter = NewsletterStatsResponse["newsletters"][number];
 
 const PREVIEW_COUNT = 5;
+const SKELETON_ROW_KEYS = Array.from(
+  { length: PREVIEW_COUNT },
+  (_, index) => `skeleton-row-${index}`,
+);
 
 export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
   const { emailAccountId } = useAccount();
@@ -128,10 +133,10 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
 
   if (!emailAccountId) return null;
 
-  // Don't render the static content while the fetch is in flight, or the
-  // screen would swap to the personalized version under the user moments
-  // later. A brief blank matches how the onboarding shell loads.
-  if (isLoading && !data) return null;
+  // Show the shape of the list rather than the static content, so the screen
+  // doesn't swap to the personalized version under the user moments later.
+  // The fetch can run long on a phone, where a blank screen reads as broken.
+  if (isLoading && !data) return <LoadingBulkUnsubscribeStep />;
 
   // On error or with nothing to suggest, fall back to the static marketing
   // content — onboarding must never feel broken.
@@ -263,6 +268,39 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
         </div>
       </div>
       <PremiumModal />
+    </div>
+  );
+}
+
+function LoadingBulkUnsubscribeStep() {
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-10">
+      <output className="w-full max-w-xl" aria-label="Loading senders">
+        <div className="mb-6 flex flex-col items-center">
+          <Skeleton className="mb-3 h-8 w-80 max-w-full" />
+          <Skeleton className="h-5 w-96 max-w-full" />
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <ul className="divide-y divide-slate-100 py-1.5">
+            {SKELETON_ROW_KEYS.map((key) => (
+              <li key={key} className="flex items-center gap-3 px-4 py-2.5">
+                <Skeleton className="size-5 shrink-0 rounded-md" />
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-32 max-w-full" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+                <Skeleton className="hidden h-1.5 w-16 shrink-0 sm:block" />
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-7 flex justify-center">
+          <Skeleton className="h-11 w-full max-w-xs rounded-md" />
+        </div>
+      </output>
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/usage/usage.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/usage/usage.tsx
@@ -10,7 +10,8 @@ import { isPremiumRecord } from "@/utils/premium";
 import type { RedisUsage } from "@/utils/redis/usage";
 
 export function Usage(props: { usage: RedisUsage | null }) {
-  const { premium, isLoading, error } = usePremium();
+  const { premium, unsubscribeCreditsRemaining, isLoading, error } =
+    usePremium();
 
   return (
     <LoadingContent loading={isLoading} error={error}>
@@ -21,7 +22,7 @@ export function Usage(props: { usage: RedisUsage | null }) {
             value: isPremiumRecord(premium)
               ? "Unlimited"
               : formatStat(
-                  premium?.unsubscribeCredits ??
+                  unsubscribeCreditsRemaining ??
                     env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS,
                 ),
             subvalue: "credits",

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -35,6 +35,7 @@ async function getUser({
           stripeSubscriptionId: true,
           stripeInvoiceEmailsEnabled: true,
           unsubscribeCredits: true,
+          unsubscribeMonth: true,
           emailAccountsAccess: true,
           lemonLicenseKey: true,
           pendingInvites: true,

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -3,7 +3,11 @@ import prisma from "@/utils/prisma";
 import { withError } from "@/utils/middleware";
 import { SafeError } from "@/utils/error";
 import { auth } from "@/utils/auth";
-import { isAdminForPremium, premiumEntitlementSelect } from "@/utils/premium";
+import {
+  getRemainingUnsubscribeCredits,
+  isAdminForPremium,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 
 export type UserResponse = Awaited<ReturnType<typeof getUser>> | null;
 
@@ -91,6 +95,12 @@ async function getUser({
     announcementDismissedAt: user.announcementDismissedAt,
     dismissedHints: user.dismissedHints,
     premium,
+    // Resolved server side so the client never compares billing periods against
+    // its own clock, and so an account with no premium row still reports the
+    // free allowance it has never spent against.
+    unsubscribeCreditsRemaining: getRemainingUnsubscribeCredits(
+      user.premium ?? {},
+    ),
     emailAccounts: emailAccounts.map(({ members: _members, ...account }) => ({
       ...account,
     })),

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -40,7 +40,10 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid max-h-screen w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-slate-200 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 sm:rounded-lg md:w-full",
+        // max-h in svh, not vh: on mobile vh is the large viewport, so a tall
+        // dialog centered at 50% has its top clipped off screen, taking the
+        // close button with it and leaving no overlay to tap.
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[85svh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-slate-200 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 sm:rounded-lg md:w-full",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -40,10 +40,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        // max-h in svh, not vh: on mobile vh is the large viewport, so a tall
-        // dialog centered at 50% has its top clipped off screen, taking the
-        // close button with it and leaving no overlay to tap.
-        "fixed left-[50%] top-[50%] z-50 grid max-h-[85svh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-slate-200 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 sm:rounded-lg md:w-full",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-screen w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-slate-200 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 sm:rounded-lg md:w-full",
         className,
       )}
       {...props}

--- a/apps/web/hooks/usePremium.ts
+++ b/apps/web/hooks/usePremium.ts
@@ -16,12 +16,15 @@ export function usePremium() {
   const premium = data?.premium;
   const hasAiApiKey = data?.hasAiApiKey;
 
+  const unsubscribeCreditsRemaining = data?.unsubscribeCreditsRemaining;
+
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) {
     return {
       ...swrResponse,
       premium,
       isPremium: true,
       hasUnsubscribeAccess: true,
+      unsubscribeCreditsRemaining,
       hasAiAccess: true,
       isProPlanWithoutApiKey: false,
       tier: "PROFESSIONAL_ANNUALLY" as const,
@@ -40,11 +43,8 @@ export function usePremium() {
     isPremium: isUserPremium,
     hasUnsubscribeAccess:
       isUserPremium ||
-      hasUnsubscribeAccess(
-        tier || null,
-        premium?.unsubscribeCredits,
-        premium?.unsubscribeMonth,
-      ),
+      hasUnsubscribeAccess(tier || null, unsubscribeCreditsRemaining),
+    unsubscribeCreditsRemaining,
     hasAiAccess: isUserPremium && hasAiAccess(tier || null, hasAiApiKey),
     isProPlanWithoutApiKey,
     tier,

--- a/apps/web/hooks/usePremium.ts
+++ b/apps/web/hooks/usePremium.ts
@@ -40,7 +40,11 @@ export function usePremium() {
     isPremium: isUserPremium,
     hasUnsubscribeAccess:
       isUserPremium ||
-      hasUnsubscribeAccess(tier || null, premium?.unsubscribeCredits),
+      hasUnsubscribeAccess(
+        tier || null,
+        premium?.unsubscribeCredits,
+        premium?.unsubscribeMonth,
+      ),
     hasAiAccess: isUserPremium && hasAiAccess(tier || null, hasAiApiKey),
     isProPlanWithoutApiKey,
     tier,

--- a/apps/web/providers/GlobalProviders.tsx
+++ b/apps/web/providers/GlobalProviders.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import type React from "react";
+import { useEffect } from "react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
-import { SerwistProvider } from "@serwist/next/react";
+import { SerwistProvider, useSerwist } from "@serwist/next/react";
 
 export function GlobalProviders(props: { children: React.ReactNode }) {
   return (
@@ -9,10 +12,29 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
     // Turbopack. cacheOnNavigation={false} matches the old plugin default.
     <SerwistProvider
       swUrl="/sw.js"
+      register={false}
       cacheOnNavigation={false}
       disable={process.env.NODE_ENV !== "production"}
     >
+      <RegisterServiceWorker />
       <NuqsAdapter>{props.children}</NuqsAdapter>
     </SerwistProvider>
   );
+}
+
+// SerwistProvider's own `register` fires the registration promise without a
+// rejection handler. Registration legitimately fails for a small share of page
+// loads (crawlers, in-app webviews, private browsing, blocked site data), and
+// each failure surfaced as an unhandled rejection in error tracking. The
+// service worker is precache-only, so a failure is safe to ignore.
+// Unlike the built in path this doesn't check the page against a custom scope,
+// which is equivalent while no scope option is passed above.
+function RegisterServiceWorker() {
+  const { serwist } = useSerwist();
+
+  useEffect(() => {
+    serwist?.register().catch(() => {});
+  }, [serwist]);
+
+  return null;
 }

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -11,6 +11,7 @@ import {
   isAdminForPremium,
   isOnHigherTier,
   isPremiumRecord,
+  getUnsubscribePeriod,
   premiumEntitlementSelect,
 } from "@/utils/premium";
 import {
@@ -73,7 +74,7 @@ export const decrementUnsubscribeCreditAction = actionClientUser
     const isUserPremium = isPremiumRecord(user.premium);
     if (isUserPremium) return;
 
-    const currentMonth = new Date().getMonth() + 1;
+    const currentPeriod = getUnsubscribePeriod();
 
     // create premium row for user if it doesn't already exist
     const premium = user.premium || (await createPremiumForUser({ userId }));
@@ -83,13 +84,13 @@ export const decrementUnsubscribeCreditAction = actionClientUser
         id: premium.id,
         OR: [
           { unsubscribeMonth: null },
-          { unsubscribeMonth: { not: currentMonth } },
+          { unsubscribeMonth: { not: currentPeriod } },
         ],
       },
       data: {
         // reset and use a credit
         unsubscribeCredits: env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS - 1,
-        unsubscribeMonth: currentMonth,
+        unsubscribeMonth: currentPeriod,
       },
     });
 
@@ -98,7 +99,7 @@ export const decrementUnsubscribeCreditAction = actionClientUser
     await prisma.premium.updateMany({
       where: {
         id: premium.id,
-        unsubscribeMonth: currentMonth,
+        unsubscribeMonth: currentPeriod,
         unsubscribeCredits: { gt: 0 },
       },
       data: { unsubscribeCredits: { decrement: 1 } },

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -77,7 +77,42 @@ describe("auth funnel analytics", () => {
       provider: "google",
       stage: "callback",
       error_category: "unknown",
+      error_code: null,
     });
+  });
+
+  it("records recognisable error codes so unknown categories stay diagnosable", () => {
+    const capture = vi.fn();
+    const posthog = { capture } as never;
+
+    trackAuthFailure(posthog, {
+      provider: "google",
+      stage: "callback",
+      errorCode: "some_new_provider_code",
+    });
+
+    expect(capture).toHaveBeenCalledWith("Authentication Failed", {
+      provider: "google",
+      stage: "callback",
+      error_category: "unknown",
+      error_code: "some_new_provider_code",
+    });
+  });
+
+  it("drops error codes that carry free-form provider detail", () => {
+    const capture = vi.fn();
+    const posthog = { capture } as never;
+
+    trackAuthFailure(posthog, {
+      provider: "microsoft",
+      stage: "callback",
+      errorCode: "ERR00000: Consent declined. Trace ID: 00000000-0000-0000",
+    });
+
+    expect(capture).toHaveBeenCalledWith(
+      "Authentication Failed",
+      expect.objectContaining({ error_code: null }),
+    );
   });
 
   it("does not throw when browser analytics is unavailable", () => {

--- a/apps/web/utils/analytics/auth-funnel.test.ts
+++ b/apps/web/utils/analytics/auth-funnel.test.ts
@@ -81,22 +81,38 @@ describe("auth funnel analytics", () => {
     });
   });
 
-  it("records recognisable error codes so unknown categories stay diagnosable", () => {
+  it("records allowlisted codes that the category bucket cannot distinguish", () => {
     const capture = vi.fn();
     const posthog = { capture } as never;
 
     trackAuthFailure(posthog, {
       provider: "google",
       stage: "callback",
-      errorCode: "some_new_provider_code",
+      errorCode: "state_mismatch",
     });
 
     expect(capture).toHaveBeenCalledWith("Authentication Failed", {
       provider: "google",
       stage: "callback",
       error_category: "unknown",
-      error_code: "some_new_provider_code",
+      error_code: "state_mismatch",
     });
+  });
+
+  it("drops codes that are not on the allowlist even when they look like codes", () => {
+    const capture = vi.fn();
+    const posthog = { capture } as never;
+
+    trackAuthFailure(posthog, {
+      provider: "microsoft",
+      stage: "callback",
+      errorCode: "tenant_00000000_0000_0000",
+    });
+
+    expect(capture).toHaveBeenCalledWith(
+      "Authentication Failed",
+      expect.objectContaining({ error_code: null }),
+    );
   });
 
   it("drops error codes that carry free-form provider detail", () => {

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -112,8 +112,21 @@ export function trackAuthFailure(
     provider: options.provider,
     stage: options.stage,
     error_category: getAuthErrorCategory(options.errorCode),
+    error_code: getSafeAuthErrorCode(options.errorCode),
   });
   clearPendingAuthProvider();
+}
+
+// Providers can return free-form text here, which may carry tenant, trace, or
+// account identifiers, so only short machine-readable codes are recorded. The
+// category alone buckets unrelated failures together as "unknown", leaving no
+// way to tell them apart.
+const SAFE_ERROR_CODE_PATTERN = /^[a-z0-9_]{1,64}$/;
+
+function getSafeAuthErrorCode(errorCode?: string | null) {
+  if (!errorCode) return null;
+  const normalized = errorCode.toLowerCase();
+  return SAFE_ERROR_CODE_PATTERN.test(normalized) ? normalized : null;
 }
 
 // Analytics must never block authentication, including when browser storage or

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -117,16 +117,43 @@ export function trackAuthFailure(
   clearPendingAuthProvider();
 }
 
-// Providers can return free-form text here, which may carry tenant, trace, or
-// account identifiers, so only short machine-readable codes are recorded. The
-// category alone buckets unrelated failures together as "unknown", leaving no
-// way to tell them apart.
-const SAFE_ERROR_CODE_PATTERN = /^[a-z0-9_]{1,64}$/;
+// Providers can return free-form text carrying tenant, trace, or account
+// identifiers, so this is an allowlist rather than a shape check: anything not
+// named here is dropped. It covers the codes getAuthErrorCategory recognises
+// plus ones that currently fall through to "unknown", which is where the
+// category alone stops being diagnostic.
+const KNOWN_AUTH_ERROR_CODES = new Set([
+  "access_denied",
+  "account_already_linked_to_different_user",
+  "account_not_linked",
+  "client_error",
+  "configuration",
+  "consent_required",
+  "email_already_linked",
+  "email_not_found",
+  "internal_server_error",
+  "invalid_client",
+  "invalid_code",
+  "network_error",
+  "no_code",
+  "oauth_account_not_linked",
+  "oauth_provider_not_found",
+  "org_invite_invalid_code",
+  "please_restart_the_process",
+  "requiresreconsent",
+  "server_error",
+  "signup_not_allowed",
+  "sso_start_rejected",
+  "state_mismatch",
+  "unable_to_create_user",
+  "unable_to_get_user_info",
+  "unable_to_link_account",
+]);
 
 function getSafeAuthErrorCode(errorCode?: string | null) {
   if (!errorCode) return null;
   const normalized = errorCode.toLowerCase();
-  return SAFE_ERROR_CODE_PATTERN.test(normalized) ? normalized : null;
+  return KNOWN_AUTH_ERROR_CODES.has(normalized) ? normalized : null;
 }
 
 // Analytics must never block authentication, including when browser storage or

--- a/apps/web/utils/premium/index.test.ts
+++ b/apps/web/utils/premium/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const { envMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: false,
+    NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS: 5,
   },
 }));
 
@@ -14,10 +15,42 @@ import {
   getPremiumUserFilter,
   getUserTier,
   hasActiveAppleSubscription,
+  hasUnsubscribeAccess,
   isActivePremium,
   isPremium,
   isPremiumRecord,
 } from "./index";
+
+describe("hasUnsubscribeAccess", () => {
+  const currentMonth = new Date().getMonth() + 1;
+  const otherMonth = (currentMonth % 12) + 1;
+
+  afterEach(() => {
+    envMock.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS = false;
+  });
+
+  it("grants the free allowance to a user with no premium row yet", () => {
+    expect(hasUnsubscribeAccess(null, undefined, undefined)).toBe(true);
+  });
+
+  it("grants the free allowance once the stored month is stale", () => {
+    expect(hasUnsubscribeAccess(null, 0, otherMonth)).toBe(true);
+  });
+
+  it("denies access once this month's credits are spent", () => {
+    expect(hasUnsubscribeAccess(null, 0, currentMonth)).toBe(false);
+  });
+
+  it("allows access while credits remain this month", () => {
+    expect(hasUnsubscribeAccess(null, 2, currentMonth)).toBe(true);
+  });
+
+  it("always allows a paid tier regardless of credits", () => {
+    expect(hasUnsubscribeAccess("BUSINESS_MONTHLY", 0, currentMonth)).toBe(
+      true,
+    );
+  });
+});
 
 describe("Apple premium helpers", () => {
   afterEach(() => {

--- a/apps/web/utils/premium/index.test.ts
+++ b/apps/web/utils/premium/index.test.ts
@@ -13,6 +13,8 @@ vi.mock("@/env", () => ({
 
 import {
   getPremiumUserFilter,
+  getRemainingUnsubscribeCredits,
+  getUnsubscribePeriod,
   getUserTier,
   hasActiveAppleSubscription,
   hasUnsubscribeAccess,
@@ -21,34 +23,66 @@ import {
   isPremiumRecord,
 } from "./index";
 
-describe("hasUnsubscribeAccess", () => {
-  const currentMonth = new Date().getMonth() + 1;
-  const otherMonth = (currentMonth % 12) + 1;
+describe("unsubscribe credits", () => {
+  const now = new Date("2026-08-03T12:00:00.000Z");
+  const currentPeriod = getUnsubscribePeriod(now);
 
   afterEach(() => {
     envMock.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS = false;
   });
 
-  it("grants the free allowance to a user with no premium row yet", () => {
-    expect(hasUnsubscribeAccess(null, undefined, undefined)).toBe(true);
+  it("distinguishes the same calendar month in different years", () => {
+    expect(getUnsubscribePeriod(new Date("2026-01-15T00:00:00.000Z"))).not.toBe(
+      getUnsubscribePeriod(new Date("2027-01-15T00:00:00.000Z")),
+    );
   });
 
-  it("grants the free allowance once the stored month is stale", () => {
-    expect(hasUnsubscribeAccess(null, 0, otherMonth)).toBe(true);
+  it("reports the full allowance for an account with no premium row", () => {
+    expect(getRemainingUnsubscribeCredits({ now })).toBe(5);
   });
 
-  it("denies access once this month's credits are spent", () => {
-    expect(hasUnsubscribeAccess(null, 0, currentMonth)).toBe(false);
+  it("reports the full allowance once the stored period has rolled over", () => {
+    expect(
+      getRemainingUnsubscribeCredits({
+        unsubscribeCredits: 0,
+        unsubscribeMonth: getUnsubscribePeriod(
+          new Date("2025-08-03T12:00:00.000Z"),
+        ),
+        now,
+      }),
+    ).toBe(5);
   });
 
-  it("allows access while credits remain this month", () => {
-    expect(hasUnsubscribeAccess(null, 2, currentMonth)).toBe(true);
+  it("treats a legacy bare month as a rolled-over period", () => {
+    expect(
+      getRemainingUnsubscribeCredits({
+        unsubscribeCredits: 0,
+        unsubscribeMonth: 8,
+        now,
+      }),
+    ).toBe(5);
+  });
+
+  it("reports the stored remainder within the current period", () => {
+    expect(
+      getRemainingUnsubscribeCredits({
+        unsubscribeCredits: 2,
+        unsubscribeMonth: currentPeriod,
+        now,
+      }),
+    ).toBe(2);
+  });
+
+  it("denies access once the allowance is spent", () => {
+    expect(hasUnsubscribeAccess(null, 0)).toBe(false);
+  });
+
+  it("allows access while credits remain", () => {
+    expect(hasUnsubscribeAccess(null, 2)).toBe(true);
   });
 
   it("always allows a paid tier regardless of credits", () => {
-    expect(hasUnsubscribeAccess("BUSINESS_MONTHLY", 0, currentMonth)).toBe(
-      true,
-    );
+    expect(hasUnsubscribeAccess("BUSINESS_MONTHLY", 0)).toBe(true);
   });
 });
 

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -196,24 +196,36 @@ function getTiersAtOrAbove(minimumTier: PremiumTier): PremiumTier[] {
     .map(([tier]) => tier as PremiumTier);
 }
 
+// Year aware so the same calendar month a year later is a different period.
+// Legacy rows hold a bare 1-12 month, which never matches a period and so
+// grants one reset on next use.
+export const getUnsubscribePeriod = (now = new Date()): number =>
+  now.getFullYear() * 100 + now.getMonth() + 1;
+
+// Credits reset on the first use of a new period, so an untouched period still
+// carries the full allowance. Callers must pass credits already resolved
+// against the server's clock, since a device clock can disagree across a period
+// boundary. See getRemainingUnsubscribeCredits.
+export const getRemainingUnsubscribeCredits = ({
+  unsubscribeCredits,
+  unsubscribeMonth,
+  now = new Date(),
+}: {
+  unsubscribeCredits?: number | null;
+  unsubscribeMonth?: number | null;
+  now?: Date;
+}): number =>
+  unsubscribeMonth === getUnsubscribePeriod(now)
+    ? (unsubscribeCredits ?? 0)
+    : env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS;
+
 export const hasUnsubscribeAccess = (
   tier: PremiumTier | null,
   unsubscribeCredits?: number | null,
-  unsubscribeMonth?: number | null,
 ): boolean => {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return true;
 
   if (tier) return true;
-
-  // Mirrors decrementUnsubscribeCreditAction: credits reset on the first use of
-  // a new month, so anyone who hasn't spent one this month still has the full
-  // free allowance. Without this a user with no premium row yet reads as having
-  // no credits, which is every user during onboarding.
-  const currentMonth = new Date().getMonth() + 1;
-  if (unsubscribeMonth !== currentMonth) {
-    return env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS > 0;
-  }
-
   return (unsubscribeCredits ?? 0) > 0;
 };
 

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -199,12 +199,22 @@ function getTiersAtOrAbove(minimumTier: PremiumTier): PremiumTier[] {
 export const hasUnsubscribeAccess = (
   tier: PremiumTier | null,
   unsubscribeCredits?: number | null,
+  unsubscribeMonth?: number | null,
 ): boolean => {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return true;
 
   if (tier) return true;
-  if (unsubscribeCredits && unsubscribeCredits > 0) return true;
-  return false;
+
+  // Mirrors decrementUnsubscribeCreditAction: credits reset on the first use of
+  // a new month, so anyone who hasn't spent one this month still has the full
+  // free allowance. Without this a user with no premium row yet reads as having
+  // no credits, which is every user during onboarding.
+  const currentMonth = new Date().getMonth() + 1;
+  if (unsubscribeMonth !== currentMonth) {
+    return env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS > 0;
+  }
+
+  return (unsubscribeCredits ?? 0) > 0;
 };
 
 export const hasAiAccess = (


### PR DESCRIPTION
## Summary

Three fixes to the onboarding bulk unsubscribe step and the dialog it opened.

### Onboarding no longer interrupts the flow with an upgrade prompt

Free accounts are entitled to a monthly allowance of unsubscribe credits, but the access check only counted credits once a billing row existed. New accounts have no such row yet, so the allowance read as zero and the onboarding step opened an upgrade dialog rather than running — partway through a flow that already finishes on the dedicated upgrade page.

The access check now mirrors the server's own monthly reset, so an unspent allowance counts even before a billing row exists, and the dialog is removed from the step. Upgrades stay on the dedicated page at the end of onboarding.

Note this also restores the free monthly allowance on the main bulk unsubscribe page for accounts that never had a billing row, which is the documented intent of the credits system.

### The step no longer renders blank while loading

It previously returned nothing while the suggestions request was in flight. That request can run long on a phone, where a blank screen reads as a broken page. It now renders a placeholder in the shape of the list, so the screen is never empty and the layout still doesn't shift once suggestions arrive.

### Dialogs stay within the visible viewport on mobile

Dialog content was capped with a `vh`-based max height. On mobile `vh` is the large viewport, so a tall dialog centred at 50% could have its top edge clipped off screen along with the close button — and because the panel is full-bleed at small widths, there was no overlay left to tap either. Capping in `svh` keeps the panel inside the visible area and dismissible. This applies to all dialogs, not only the one above.

### Auth failure diagnostics

Auth failures recorded only a bucketed category, so several unrelated failures collapsed into one value with no way to tell them apart. A sanitised error code is now recorded alongside it, restricted to short machine-readable identifiers so free-form provider text (which can carry tenant, trace, or account identifiers) is never captured.

## Testing

- `pnpm test utils/premium utils/analytics/auth-funnel "app/(app)/[emailAccountId]/onboarding"` — all passing
- New unit tests cover the credit allowance boundaries (no billing row, stale month, exhausted, remaining, paid tier) and both directions of the error-code sanitising
- Lint clean on all changed files

## Review notes

The mobile rendering of the dialog change has not been verified on a physical device; it is a defensive fix for a real unit mismatch rather than a confirmed reproduction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

