### PR TITLE
chore: Trim comments on the unsubscribe allowance code

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -131,9 +131,8 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
 
   if (!emailAccountId) return null;
 
-  // Show the shape of the list rather than the static content, so the screen
-  // doesn't swap to the personalized version under the user moments later.
-  // The fetch can run long on a phone, where a blank screen reads as broken.
+  // The shape of the list, not the static content, so the screen doesn't swap
+  // out from under the user once the personalized version arrives.
   if (isLoading && !data) return <LoadingBulkUnsubscribeStep />;
 
   // On error or with nothing to suggest, fall back to the static marketing

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -95,9 +95,7 @@ async function getUser({
     announcementDismissedAt: user.announcementDismissedAt,
     dismissedHints: user.dismissedHints,
     premium,
-    // Resolved server side so the client never compares billing periods against
-    // its own clock, and so an account with no premium row still reports the
-    // free allowance it has never spent against.
+    // Resolved here so the client never compares periods against its own clock.
     unsubscribeCreditsRemaining: getRemainingUnsubscribeCredits(
       user.premium ?? {},
     ),

--- a/apps/web/providers/GlobalProviders.tsx
+++ b/apps/web/providers/GlobalProviders.tsx
@@ -22,13 +22,9 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
   );
 }
 
-// SerwistProvider's own `register` fires the registration promise without a
-// rejection handler. Registration legitimately fails for a small share of page
-// loads (crawlers, in-app webviews, private browsing, blocked site data), and
-// each failure surfaced as an unhandled rejection in error tracking. The
-// service worker is precache-only, so a failure is safe to ignore.
-// Unlike the built in path this doesn't check the page against a custom scope,
-// which is equivalent while no scope option is passed above.
+// SerwistProvider's own register drops the promise, so the failures that come
+// with crawlers, webviews and private browsing surface as unhandled rejections.
+// The worker is precache-only, so swallowing them is safe.
 function RegisterServiceWorker() {
   const { serwist } = useSerwist();
 

--- a/apps/web/utils/analytics/auth-funnel.ts
+++ b/apps/web/utils/analytics/auth-funnel.ts
@@ -117,11 +117,8 @@ export function trackAuthFailure(
   clearPendingAuthProvider();
 }
 
-// Providers can return free-form text carrying tenant, trace, or account
-// identifiers, so this is an allowlist rather than a shape check: anything not
-// named here is dropped. It covers the codes getAuthErrorCategory recognises
-// plus ones that currently fall through to "unknown", which is where the
-// category alone stops being diagnostic.
+// An allowlist rather than a shape check: provider error text can carry tenant,
+// trace, or account identifiers, so anything not named here is dropped.
 const KNOWN_AUTH_ERROR_CODES = new Set([
   "access_denied",
   "account_already_linked_to_different_user",

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -196,16 +196,11 @@ function getTiersAtOrAbove(minimumTier: PremiumTier): PremiumTier[] {
     .map(([tier]) => tier as PremiumTier);
 }
 
-// Year aware so the same calendar month a year later is a different period.
-// Legacy rows hold a bare 1-12 month, which never matches a period and so
-// grants one reset on next use.
+// Legacy rows hold a bare 1-12 month, which never matches a period, so they
+// get one reset on next use.
 export const getUnsubscribePeriod = (now = new Date()): number =>
   now.getFullYear() * 100 + now.getMonth() + 1;
 
-// Credits reset on the first use of a new period, so an untouched period still
-// carries the full allowance. Callers must pass credits already resolved
-// against the server's clock, since a device clock can disagree across a period
-// boundary. See getRemainingUnsubscribeCredits.
 export const getRemainingUnsubscribeCredits = ({
   unsubscribeCredits,
   unsubscribeMonth,


### PR DESCRIPTION
## Summary

Comment-only cleanup of code added in #3143. No behaviour changes.

That change carried more commentary than it needed, much of it restating what the code already said. This trims it back to the constraints a reader can't infer from the code:

- **Why the auth error list is an allowlist rather than a pattern match** — provider error text can carry tenant, trace, and account identifiers, so a shape check would let them through. Without this noted, the obvious "simplification" reintroduces the leak.
- **Why the unsubscribe allowance is resolved server side** — otherwise the natural move is to compute it in the hook, which reintroduces client/server clock drift across a period boundary.
- **Why service worker registration rejections are swallowed** — the worker is precache-only, so a failure is safe to ignore rather than an error being hidden.
- **What legacy period rows do on first use** — a migration consequence with no trace in the code.

Removed along the way: a stale comment on `getRemainingUnsubscribeCredits` that ended by pointing at itself, left over from splitting the period helpers apart.

Net effect is 25 comment lines down to 10.

## Testing

- `pnpm test utils/premium utils/analytics/auth-funnel "app/(app)/[emailAccountId]/onboarding" providers/` — 171 passing
- Lint clean on all changed files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

