### PR TITLE
analytics: preserve signup country attribution

### DIFF
--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -203,6 +203,7 @@ describe("user deletion events", () => {
       event: "User deletion requested",
       properties: { userId: "user-1" },
       sendFeatureFlags: false,
+      disableGeoip: true,
     });
     expect(shutdownMock).toHaveBeenCalledTimes(1);
   });
@@ -215,6 +216,7 @@ describe("user deletion events", () => {
       event: "User deleted",
       properties: { userId: "user-1" },
       sendFeatureFlags: false,
+      disableGeoip: true,
     });
     expect(shutdownMock).toHaveBeenCalledTimes(1);
   });
@@ -236,6 +238,7 @@ describe("trackProductFeedback", () => {
       event: "Product feedback submitted",
       properties: { feedback: "Love the assistant" },
       sendFeatureFlags: undefined,
+      disableGeoip: true,
     });
     expect(captureMock).toHaveBeenNthCalledWith(2, {
       distinctId: "user@example.com",
@@ -252,6 +255,7 @@ describe("trackProductFeedback", () => {
         $survey_completed: true,
       },
       sendFeatureFlags: undefined,
+      disableGeoip: true,
     });
   });
   it("still captures the regular event when survey env vars are missing", async () => {
@@ -266,6 +270,7 @@ describe("trackProductFeedback", () => {
       event: "Product feedback submitted",
       properties: { feedback: "Still useful" },
       sendFeatureFlags: undefined,
+      disableGeoip: true,
     });
   });
 });

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -148,6 +148,7 @@ export async function posthogCaptureEvent(
       event,
       properties,
       sendFeatureFlags,
+      disableGeoip: true,
     });
     await client.shutdown();
   } catch (error) {


### PR DESCRIPTION
Disable GeoIP enrichment for server-side PostHog events so billing webhooks cannot overwrite browser-derived country.

- preserve first-touch signup attribution
- add regression coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

