### PR TITLE
pricing: Make the billing period default assignable by experiment

### DIFF
--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -9,6 +9,7 @@ import { usePostHog } from "posthog-js/react";
 import { env } from "@/env";
 import { LoadingContent } from "@/components/LoadingContent";
 import { usePremium } from "@/hooks/usePremium";
+import { usePricingFrequencyDefault } from "@/hooks/useFeatureFlags";
 import { Button } from "@/components/ui/button";
 import {
   PricingFrequencyToggle,
@@ -67,7 +68,14 @@ export default function Pricing(props: PricingProps) {
   );
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
 
-  const [frequency, setFrequency] = useState(frequencies[1]);
+  const defaultFrequency =
+    usePricingFrequencyDefault() === "monthly"
+      ? frequencies[0]
+      : frequencies[1];
+  const [chosenFrequency, setFrequency] = useState<
+    (typeof frequencies)[number] | null
+  >(null);
+  const frequency = chosenFrequency ?? defaultFrequency;
 
   const userPremiumTier = getUserTier(premium);
 

--- a/apps/web/components/new-landing/sections/Pricing.tsx
+++ b/apps/web/components/new-landing/sections/Pricing.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import type { PostHog } from "posthog-js";
 import { Label, Radio, RadioGroup } from "@headlessui/react";
+import { usePricingFrequencyDefault } from "@/hooks/useFeatureFlags";
 import { Sparkle } from "@/components/new-landing/icons/Sparkle";
 import { Zap } from "@/components/new-landing/icons/Zap";
 import { Check } from "@/components/new-landing/icons/Check";
@@ -88,7 +89,10 @@ const pricingTiers: PricingTier[] = [
 const frequencies = ["annually", "monthly"];
 
 export function Pricing() {
-  const [frequency, setFrequency] = useState(frequencies[0]);
+  const defaultFrequency =
+    usePricingFrequencyDefault() === "monthly" ? "monthly" : "annually";
+  const [chosenFrequency, setFrequency] = useState<string | null>(null);
+  const frequency = chosenFrequency ?? defaultFrequency;
   const posthog = usePostHog();
 
   return (


### PR DESCRIPTION
## Summary

Both pricing surfaces hard-coded `annually` as the preselected billing period. At the same tier, checkout completion is markedly lower for annual than for monthly, so which period is preselected is worth testing rather than assuming.

This wires up the existing `pricing-frequency-default` flag, which was already defined in `useFeatureFlags.ts` with exactly the right variants (`control` | `monthly`) but consumed nowhere.

- `control` keeps today's annual default, so **behaviour is unchanged until the experiment is switched on in PostHog**.
- `monthly` preselects monthly.

Applied to both the marketing pricing section and the in-app premium page, which previously set the default independently (`frequencies[0]` and `frequencies[1]` respectively, both resolving to annually).

## Implementation note

The default is derived rather than seeded into `useState`. Feature flags resolve asynchronously, so an initial-state approach would capture `control` on first render and never update once the variant arrived. Deriving it means the default applies whenever the flag lands, while an explicit user choice always takes precedence. This also follows the repo convention of preferring derived values and explicit edit state over a `useEffect` mirroring fetched data.

## Testing

- `pnpm test premium components/new-landing` — 63 passing
- Lint clean on both changed files
- No behaviour change with the flag off or absent

## Rollout

Create the `pricing-frequency-default` experiment in PostHog as a 50/50 split. Suggested decision metric is realised revenue per trial start at a fixed 90-day horizon rather than checkout conversion, since conversion and revenue can move in opposite directions here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

