### PR TITLE
pricing: Default the billing period to monthly

### DIFF
--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -69,9 +69,9 @@ export default function Pricing(props: PricingProps) {
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
 
   const defaultFrequency =
-    usePricingFrequencyDefault() === "monthly"
-      ? frequencies[0]
-      : frequencies[1];
+    usePricingFrequencyDefault() === "annually"
+      ? frequencies[1]
+      : frequencies[0];
   const [chosenFrequency, setFrequency] = useState<
     (typeof frequencies)[number] | null
   >(null);

--- a/apps/web/components/new-landing/sections/Pricing.tsx
+++ b/apps/web/components/new-landing/sections/Pricing.tsx
@@ -90,7 +90,7 @@ const frequencies = ["annually", "monthly"];
 
 export function Pricing() {
   const defaultFrequency =
-    usePricingFrequencyDefault() === "monthly" ? "monthly" : "annually";
+    usePricingFrequencyDefault() === "annually" ? "annually" : "monthly";
   const [chosenFrequency, setFrequency] = useState<string | null>(null);
   const frequency = chosenFrequency ?? defaultFrequency;
   const posthog = usePostHog();

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -63,7 +63,7 @@ export function usePricingVariant() {
   );
 }
 
-export type PricingFrequencyDefault = "control" | "monthly";
+export type PricingFrequencyDefault = "control" | "annually";
 
 export function usePricingFrequencyDefault() {
   return (


### PR DESCRIPTION
Annual was the preselected billing period on both pricing surfaces. Checkout completion is lower for annual than monthly at the same tier, so monthly becomes the default.

The `pricing-frequency-default` experiment flag stays wired up, with the variant inverted: `control` is now monthly, and an `annually` variant restores the previous behaviour. No experiment is currently running, so this changes what every user sees.

## Changes

- `hooks/useFeatureFlags.ts`: variant type is now `"control" | "annually"`
- `app/(app)/premium/Pricing.tsx`: falls back to monthly
- `components/new-landing/sections/Pricing.tsx`: falls back to monthly

An explicit choice by the user still takes precedence, and the default still applies when the flag resolves after first render.

## Note

If the billing period is tested again, the PostHog variant needs to be named `annually` rather than `monthly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

