### PR TITLE
pricing: Tighten the upgrade page layout on mobile

### DIFF
--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -123,7 +123,7 @@ export default function Pricing(props: PricingProps) {
       <div
         id="pricing"
         className={cn(
-          "relative isolate mx-auto max-w-7xl bg-white px-6 pt-10 lg:px-8",
+          "relative isolate mx-auto max-w-7xl bg-white px-6 pt-6 sm:pt-10 lg:px-8",
           props.className,
         )}
       >
@@ -175,7 +175,7 @@ export default function Pricing(props: PricingProps) {
 
         <div
           className={cn(
-            "isolate mx-auto mt-10 grid grid-cols-1 gap-y-8 gap-4",
+            "isolate mx-auto mt-6 grid grid-cols-1 gap-y-8 gap-4 sm:mt-10",
             displayedTiers.length === 2
               ? "max-w-3xl lg:grid-cols-2"
               : "max-w-7xl lg:mx-0 lg:max-w-none lg:grid-cols-3",
@@ -243,9 +243,13 @@ function PriceTier({
   }
 
   return (
-    <ThreeColItem
-      key={tier.name}
-      className="flex flex-col rounded-3xl bg-white p-8 ring-1 ring-gray-200 xl:p-10"
+    <div
+      className={cn(
+        "flex flex-col rounded-3xl bg-white p-6 ring-1 ring-gray-200 sm:p-8 xl:p-10",
+        // Stacked on mobile, the recommended plan would otherwise sit a full
+        // screen below the fold.
+        tier.mostPopular && "order-first lg:order-none",
+      )}
     >
       <div className="flex-1">
         <div className="flex items-center justify-between gap-x-4">
@@ -423,16 +427,6 @@ function PriceTier({
           getCTAText()
         )}
       </button>
-    </ThreeColItem>
+    </div>
   );
-}
-
-function ThreeColItem({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return <div className={cn(className)}>{children}</div>;
 }

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -243,14 +243,7 @@ function PriceTier({
   }
 
   return (
-    <div
-      className={cn(
-        "flex flex-col rounded-3xl bg-white p-6 ring-1 ring-gray-200 sm:p-8 xl:p-10",
-        // Stacked on mobile, the recommended plan would otherwise sit a full
-        // screen below the fold.
-        tier.mostPopular && "order-first lg:order-none",
-      )}
-    >
+    <div className="flex flex-col rounded-3xl bg-white p-6 ring-1 ring-gray-200 sm:p-8 xl:p-10">
       <div className="flex-1">
         <div className="flex items-center justify-between gap-x-4">
           <h3

--- a/apps/web/app/(landing)/welcome-upgrade/WelcomeUpgradeHeader.tsx
+++ b/apps/web/app/(landing)/welcome-upgrade/WelcomeUpgradeHeader.tsx
@@ -6,22 +6,22 @@ import { BRAND_NAME } from "@/utils/branding";
 
 export function WelcomeUpgradeHeader() {
   return (
-    <div className="mb-8 flex flex-col items-start">
+    <div className="mb-6 flex flex-col items-start sm:mb-8">
       <div className="mx-auto text-center">
-        <h2 className="font-title text-base leading-7 text-blue-600">
+        <h2 className="font-title text-sm leading-6 text-blue-600 sm:text-base sm:leading-7">
           Spend 50% less time on email
         </h2>
         <div>
-          <h1 className="mt-2 font-title text-2xl text-gray-900 sm:text-3xl">
+          <h1 className="mt-1 font-title text-2xl text-gray-900 sm:mt-2 sm:text-3xl">
             Start your 7-day FREE trial
           </h1>
-          <p className="mt-2 text-lg text-gray-900 sm:text-xl">
+          <p className="mt-2 text-base text-gray-900 sm:text-xl">
             {`Join ${userCount} users that use ${BRAND_NAME} to be more productive!`}
           </p>
         </div>
       </div>
 
-      <div className="mx-auto mt-4 flex flex-col items-start gap-2">
+      <div className="mx-auto mt-3 flex flex-col items-start gap-1.5 sm:mt-4 sm:gap-2">
         <TrialFeature>100% no-risk trial</TrialFeature>
         <TrialFeature>Free for the first 7 days</TrialFeature>
         <TrialFeature>Cancel anytime, hassle-free</TrialFeature>
@@ -31,7 +31,7 @@ export function WelcomeUpgradeHeader() {
 }
 
 const TrialFeature = ({ children }: { children: React.ReactNode }) => (
-  <p className="flex items-center text-gray-900">
+  <p className="flex items-center text-sm text-gray-900 sm:text-base">
     <CheckCircleIcon className="mr-2 h-4 w-4 text-green-500" />
     {children}
   </p>

--- a/apps/web/app/(landing)/welcome-upgrade/WelcomeUpgradeNav.tsx
+++ b/apps/web/app/(landing)/welcome-upgrade/WelcomeUpgradeNav.tsx
@@ -5,13 +5,15 @@ import { logOut } from "@/utils/user";
 
 export function WelcomeUpgradeNav() {
   return (
-    <nav className="w-full px-6 py-4">
+    <nav className="w-full px-6 py-3">
       <div className="flex justify-end">
         <Button
           onClick={() => {
             logOut("/");
           }}
           variant="ghost"
+          size="sm"
+          className="text-muted-foreground"
         >
           Log out
         </Button>

--- a/apps/web/app/(landing)/welcome-upgrade/page.tsx
+++ b/apps/web/app/(landing)/welcome-upgrade/page.tsx
@@ -11,7 +11,11 @@ export default function WelcomeUpgradePage() {
       <div className="mt-8">
         <Testimonial />
       </div>
-      <Footer />
+      {/* The marketing footer is a wall of exits on a page whose only job is
+          starting a trial, and on mobile it dwarfs the plans themselves. */}
+      <div className="hidden md:block">
+        <Footer />
+      </div>
     </>
   );
 }

--- a/apps/web/app/(landing)/welcome-upgrade/page.tsx
+++ b/apps/web/app/(landing)/welcome-upgrade/page.tsx
@@ -11,8 +11,6 @@ export default function WelcomeUpgradePage() {
       <div className="mt-8">
         <Testimonial />
       </div>
-      {/* The marketing footer is a wall of exits on a page whose only job is
-          starting a trial, and on mobile it dwarfs the plans themselves. */}
       <div className="hidden md:block">
         <Footer />
       </div>


### PR DESCRIPTION
Mobile drop-off on the welcome upgrade page is higher than desktop. Measuring comparable pricing pages at a 390px viewport, total page length is not the outlier: the upgrade page is shorter than every marketing pricing page checked, including our own. What this changes is how much height the first screen spends before a user reaches a price.

Plan order is unchanged. The entry plan still leads when the cards stack.

## Changes

**Less vertical spend above the first CTA.** Trimmed the header's type scale and margins, the container top padding, the gap above the card grid, and card padding from `p-8` to `p-6` on mobile. Copy is unchanged; desktop is unchanged.

**Marketing footer hidden on mobile.** On a page whose only job is starting a trial, the footer is roughly 60 links to blog, socials, comparison pages, and changelog. It stays on desktop.

**Log out de-emphasised.** It was the most prominent control on the first screen. Kept as an escape hatch for a wrong-account sign-in, now small and muted.

Also inlined `ThreeColItem`, which only forwarded a className.

## Not included

- Reordering plans so the recommended tier leads on mobile. Considered and rejected: the entry price should be what users see first.
- Fixing "Everything in Starter, plus" for the stacked layout. It reads oddly when the referenced tier is not adjacent, but spelling out inherited features roughly doubles card height, which works against everything above.
- Enlarging the tooltip hit area. The icons are 16px and the click handler sits on an SVG, so they are neither thumb-friendly nor keyboard reachable. That is a shared component used across the app and belongs in its own change.
- Sticky CTA and moving social proof up, both considered and dropped.

## Testing

Layout-only changes, verified by reading the responsive classes. Not visually confirmed in a running app, since the page sits behind auth in the onboarding flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)