### PR TITLE
meetings: Restore calendar connection gate

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -99,7 +99,7 @@ function MeetingRecorderPageContent() {
 
   // Enabling is entitlement-gated server-side, so a non-premium user needs the
   // upgrade path on the onboarding screen too, not just once they are set up.
-  if (!settings?.enabled) {
+  if (!hasCalendarConnected || !settings?.enabled) {
     return (
       <PageWrapper>
         <div className="mx-auto max-w-lg">


### PR DESCRIPTION
Restores the calendar connection guard from #3091 after its merge was lost from `main`.

- show meeting-recorder onboarding when no calendar is connected
- preserve the existing entitlement and enablement flow
- validated with the focused Ultracite check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

