### PR TITLE
Improve Microsoft Teams app validation guidance

### DIFF
--- a/apps/web/app/api/slack/commands/route.ts
+++ b/apps/web/app/api/slack/commands/route.ts
@@ -51,7 +51,10 @@ export const POST = withError("slack/commands", async (request) => {
   if (command.replace(/^\//, "") === "help") {
     return NextResponse.json({
       response_type: "ephemeral",
-      text: getHelpText("slack"),
+      text: getHelpText("slack", {
+        baseUrl: env.NEXT_PUBLIC_BASE_URL,
+        supportEmail: env.NEXT_PUBLIC_SUPPORT_EMAIL,
+      }),
     });
   }
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -2037,7 +2037,7 @@ async function handleUnsupportedCommand({
 }): Promise<boolean> {
   const provider = thread.adapter.name;
   if (provider !== "telegram" && provider !== "teams") return false;
-  if (!isUnsupportedSlashCommand(message.text, provider)) return false;
+  if (!isUnsupportedSlashCommand(message.text)) return false;
 
   if (!thread.isDM) {
     await sendDmRequiredMessage({ provider, thread, logger });

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -58,6 +58,7 @@ import {
   expandPromptCommand,
   getHelpText,
   isHelpCommand,
+  isUnsupportedSlashCommand,
 } from "@/utils/messaging/prompt-commands";
 import {
   FOLLOW_UP_REMINDER_ACTION_IDS,
@@ -572,6 +573,13 @@ async function processMessagingAssistantMessage({
     logger,
   });
   if (helpCommandHandled) return true;
+
+  const unsupportedCommandHandled = await handleUnsupportedCommand({
+    thread,
+    message,
+    logger,
+  });
+  if (unsupportedCommandHandled) return true;
 
   const clearProcessingReaction = await startSlackProcessingReaction({
     adapters,
@@ -1846,7 +1854,7 @@ async function handleMessagingLinkCommand({
   await postMessagingThreadMessage({
     thread,
     logger,
-    message: `Connected successfully. You can now chat with your Inbox Zero assistant in this ${provider} DM.`,
+    message: `Connected successfully. You can now chat with your Inbox Zero assistant in this ${provider === "teams" ? "Microsoft Teams" : "Telegram"} direct message. Type \`/help\` to see what I can do.`,
     errorLogMessage: "Failed to send messaging link confirmation",
     logMeta: {
       provider,
@@ -2003,8 +2011,41 @@ async function handleHelpCommand({
   await postMessagingThreadMessage({
     thread,
     logger,
-    message: getHelpText(provider),
+    message: getHelpText(provider, {
+      baseUrl: env.NEXT_PUBLIC_BASE_URL,
+      supportEmail: env.NEXT_PUBLIC_SUPPORT_EMAIL,
+    }),
     errorLogMessage: `Failed to send ${provider} help command response`,
+    logMeta: { provider },
+  });
+
+  return true;
+}
+
+async function handleUnsupportedCommand({
+  thread,
+  message,
+  logger,
+}: {
+  thread: MessagingThread;
+  message: Message;
+  logger: Logger;
+}): Promise<boolean> {
+  const provider = thread.adapter.name;
+  if (provider !== "telegram" && provider !== "teams") return false;
+  if (!isUnsupportedSlashCommand(message.text)) return false;
+
+  if (!thread.isDM) {
+    await sendDmRequiredMessage({ provider, thread, logger });
+    return true;
+  }
+
+  await postMessagingThreadMessage({
+    thread,
+    logger,
+    message:
+      "Sorry, I don't recognize that command. Type `/help` to see the commands I support.",
+    errorLogMessage: `Failed to send ${provider} unsupported command response`,
     logMeta: { provider },
   });
 
@@ -2562,12 +2603,23 @@ async function sendLinkRequiredMessage({
   thread: MessagingThread;
   logger: Logger;
 }): Promise<void> {
-  const providerName = provider === "teams" ? "Teams" : "Telegram";
+  const providerName = provider === "teams" ? "Microsoft Teams" : "Telegram";
+  const baseUrl = env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, "");
 
   await postMessagingThreadMessage({
     thread,
     logger,
-    message: `Your ${providerName} account is not linked yet. In Inbox Zero settings, generate a ${providerName} connect code and send \`/connect <code>\` in this DM.`,
+    message: [
+      `Welcome to Inbox Zero for ${providerName}. I can help you summarize, organize, and draft replies to email from this chat.`,
+      "An active Inbox Zero account is required.",
+      "",
+      "To get started:",
+      `1. Sign in or create an account at ${baseUrl}.`,
+      `2. Open ${baseUrl}/channels and choose ${providerName}.`,
+      "3. Generate a connect code and send `/connect <code>` in this direct message.",
+      "",
+      `Type \`/help\` for supported commands or contact ${env.NEXT_PUBLIC_SUPPORT_EMAIL} for help.`,
+    ].join("\n"),
     errorLogMessage: "Failed to send link-required message",
     logMeta: { provider },
   });

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -58,6 +58,7 @@ import {
   expandPromptCommand,
   getHelpText,
   isHelpCommand,
+  isTelegramStartCommand,
   isUnsupportedSlashCommand,
 } from "@/utils/messaging/prompt-commands";
 import {
@@ -2001,7 +2002,10 @@ async function handleHelpCommand({
 }): Promise<boolean> {
   const provider = thread.adapter.name;
   if (provider !== "telegram" && provider !== "teams") return false;
-  if (!isHelpCommand(message.text)) return false;
+  const isHelp =
+    isHelpCommand(message.text) ||
+    (provider === "telegram" && isTelegramStartCommand(message.text));
+  if (!isHelp) return false;
 
   if (!thread.isDM) {
     await sendDmRequiredMessage({ provider, thread, logger });
@@ -2033,7 +2037,7 @@ async function handleUnsupportedCommand({
 }): Promise<boolean> {
   const provider = thread.adapter.name;
   if (provider !== "telegram" && provider !== "teams") return false;
-  if (!isUnsupportedSlashCommand(message.text)) return false;
+  if (!isUnsupportedSlashCommand(message.text, provider)) return false;
 
   if (!thread.isDM) {
     await sendDmRequiredMessage({ provider, thread, logger });

--- a/apps/web/utils/messaging/prompt-commands.test.ts
+++ b/apps/web/utils/messaging/prompt-commands.test.ts
@@ -87,24 +87,14 @@ describe("getHelpText", () => {
 
 describe("isUnsupportedSlashCommand", () => {
   it("identifies unknown slash commands", () => {
-    expect(isUnsupportedSlashCommand("/unknown", "teams")).toBe(true);
-    expect(
-      isUnsupportedSlashCommand("/unknown@InboxZeroBot value", "teams"),
-    ).toBe(true);
+    expect(isUnsupportedSlashCommand("/unknown")).toBe(true);
+    expect(isUnsupportedSlashCommand("/unknown@InboxZeroBot value")).toBe(true);
   });
 
   it("allows supported commands and regular messages", () => {
-    expect(isUnsupportedSlashCommand("/help", "teams")).toBe(false);
-    expect(isUnsupportedSlashCommand("/connect abc123", "teams")).toBe(false);
-    expect(isUnsupportedSlashCommand("/summary", "teams")).toBe(false);
-    expect(isUnsupportedSlashCommand("Hello", "teams")).toBe(false);
-  });
-
-  it("allows Telegram's standard onboarding command", () => {
-    expect(isUnsupportedSlashCommand("/start", "telegram")).toBe(false);
-    expect(isUnsupportedSlashCommand("/start@InboxZeroBot", "telegram")).toBe(
-      false,
-    );
-    expect(isUnsupportedSlashCommand("/start", "teams")).toBe(true);
+    expect(isUnsupportedSlashCommand("/help")).toBe(false);
+    expect(isUnsupportedSlashCommand("/connect abc123")).toBe(false);
+    expect(isUnsupportedSlashCommand("/summary")).toBe(false);
+    expect(isUnsupportedSlashCommand("Hello")).toBe(false);
   });
 });

--- a/apps/web/utils/messaging/prompt-commands.test.ts
+++ b/apps/web/utils/messaging/prompt-commands.test.ts
@@ -4,7 +4,13 @@ import {
   expandPromptCommand,
   getHelpText,
   isHelpCommand,
+  isUnsupportedSlashCommand,
 } from "./prompt-commands";
+
+const HELP_OPTIONS = {
+  baseUrl: "https://example.com/",
+  supportEmail: "support@example.com",
+};
 
 describe("expandPromptCommand", () => {
   it("maps cleanup command to a concrete inbox prompt", () => {
@@ -45,9 +51,13 @@ describe("isHelpCommand", () => {
 });
 
 describe("getHelpText", () => {
-  it("includes the available slash commands", () => {
-    const helpText = getHelpText("slack");
+  it("includes account setup and the available Teams commands", () => {
+    const helpText = getHelpText("teams", HELP_OPTIONS);
     expect(helpText).toContain("Commands:");
+    expect(helpText).toContain("Microsoft Teams");
+    expect(helpText).toContain("An active Inbox Zero account is required.");
+    expect(helpText).toContain("https://example.com/channels");
+    expect(helpText).toContain("support@example.com");
 
     for (const key of Object.keys(PROMPT_COMMANDS)) {
       expect(helpText).toContain(`/${key}`);
@@ -55,5 +65,27 @@ describe("getHelpText", () => {
 
     expect(helpText).toContain("/connect <code>");
     expect(helpText).toContain("/switch");
+  });
+
+  it("omits account-linking commands that Slack does not support", () => {
+    const helpText = getHelpText("slack", HELP_OPTIONS);
+
+    expect(helpText).not.toContain("/connect");
+    expect(helpText).not.toContain("/switch");
+    expect(helpText).toContain("/help");
+  });
+});
+
+describe("isUnsupportedSlashCommand", () => {
+  it("identifies unknown slash commands", () => {
+    expect(isUnsupportedSlashCommand("/unknown")).toBe(true);
+    expect(isUnsupportedSlashCommand("/unknown@InboxZeroBot value")).toBe(true);
+  });
+
+  it("allows supported commands and regular messages", () => {
+    expect(isUnsupportedSlashCommand("/help")).toBe(false);
+    expect(isUnsupportedSlashCommand("/connect abc123")).toBe(false);
+    expect(isUnsupportedSlashCommand("/summary")).toBe(false);
+    expect(isUnsupportedSlashCommand("Hello")).toBe(false);
   });
 });

--- a/apps/web/utils/messaging/prompt-commands.test.ts
+++ b/apps/web/utils/messaging/prompt-commands.test.ts
@@ -4,6 +4,7 @@ import {
   expandPromptCommand,
   getHelpText,
   isHelpCommand,
+  isTelegramStartCommand,
   isUnsupportedSlashCommand,
 } from "./prompt-commands";
 
@@ -50,6 +51,14 @@ describe("isHelpCommand", () => {
   });
 });
 
+describe("isTelegramStartCommand", () => {
+  it("recognizes Telegram start command variants", () => {
+    expect(isTelegramStartCommand("/start")).toBe(true);
+    expect(isTelegramStartCommand("/start@InboxZeroBot")).toBe(true);
+    expect(isTelegramStartCommand("/start referral-code")).toBe(true);
+  });
+});
+
 describe("getHelpText", () => {
   it("includes account setup and the available Teams commands", () => {
     const helpText = getHelpText("teams", HELP_OPTIONS);
@@ -78,14 +87,24 @@ describe("getHelpText", () => {
 
 describe("isUnsupportedSlashCommand", () => {
   it("identifies unknown slash commands", () => {
-    expect(isUnsupportedSlashCommand("/unknown")).toBe(true);
-    expect(isUnsupportedSlashCommand("/unknown@InboxZeroBot value")).toBe(true);
+    expect(isUnsupportedSlashCommand("/unknown", "teams")).toBe(true);
+    expect(
+      isUnsupportedSlashCommand("/unknown@InboxZeroBot value", "teams"),
+    ).toBe(true);
   });
 
   it("allows supported commands and regular messages", () => {
-    expect(isUnsupportedSlashCommand("/help")).toBe(false);
-    expect(isUnsupportedSlashCommand("/connect abc123")).toBe(false);
-    expect(isUnsupportedSlashCommand("/summary")).toBe(false);
-    expect(isUnsupportedSlashCommand("Hello")).toBe(false);
+    expect(isUnsupportedSlashCommand("/help", "teams")).toBe(false);
+    expect(isUnsupportedSlashCommand("/connect abc123", "teams")).toBe(false);
+    expect(isUnsupportedSlashCommand("/summary", "teams")).toBe(false);
+    expect(isUnsupportedSlashCommand("Hello", "teams")).toBe(false);
+  });
+
+  it("allows Telegram's standard onboarding command", () => {
+    expect(isUnsupportedSlashCommand("/start", "telegram")).toBe(false);
+    expect(isUnsupportedSlashCommand("/start@InboxZeroBot", "telegram")).toBe(
+      false,
+    );
+    expect(isUnsupportedSlashCommand("/start", "teams")).toBe(true);
   });
 });

--- a/apps/web/utils/messaging/prompt-commands.ts
+++ b/apps/web/utils/messaging/prompt-commands.ts
@@ -10,20 +10,37 @@ export const PROMPT_COMMANDS: Record<string, string> = {
   followups: "Which emails should I follow up on this week?",
 };
 
-const COMMAND_LINES = [
+const ACCOUNT_COMMAND_LINES = [
   "/connect <code> - Link your Inbox Zero account",
   "/switch - List linked accounts",
   "/switch <number> - Switch active account",
+];
+
+const COMMAND_LINES = [
+  "/help - Show help and supported commands",
   "/cleanup - Help me clean up my inbox today",
   "/summary - Summarize what needs attention today",
   "/draftreply - Draft a response to my most urgent unread email",
   "/followups - Show emails I should follow up on this week",
 ];
 
+const SUPPORTED_COMMANDS = new Set([
+  "connect",
+  "help",
+  "switch",
+  ...Object.keys(PROMPT_COMMANDS),
+]);
+
 const PLATFORM_INTRO: Record<MessagingPlatform, string> = {
   telegram: "I can help you manage your inbox from this Telegram DM.",
-  teams: "I can help you manage your inbox from this Teams DM.",
+  teams:
+    "I can help you manage your inbox from this Microsoft Teams direct message.",
   slack: "I can help you manage your inbox from Slack.",
+};
+
+type HelpTextOptions = {
+  baseUrl: string;
+  supportEmail: string;
 };
 
 export function expandPromptCommand(text: string): string {
@@ -37,10 +54,29 @@ export function isHelpCommand(text: string): boolean {
   return HELP_COMMAND_REGEX.test(text.trim());
 }
 
-export function getHelpText(platform: MessagingPlatform): string {
-  return [PLATFORM_INTRO[platform], "", "Commands:", ...COMMAND_LINES].join(
-    "\n",
-  );
+export function isUnsupportedSlashCommand(text: string): boolean {
+  const command = parseSlashCommand(text);
+  return command !== null && !SUPPORTED_COMMANDS.has(command);
+}
+
+export function getHelpText(
+  platform: MessagingPlatform,
+  { baseUrl, supportEmail }: HelpTextOptions,
+): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
+  const accountCommands = platform === "slack" ? [] : ACCOUNT_COMMAND_LINES;
+
+  return [
+    PLATFORM_INTRO[platform],
+    "An active Inbox Zero account is required.",
+    `Get started: ${normalizedBaseUrl}/channels`,
+    `Help: ${normalizedBaseUrl}/docs/essentials/channels`,
+    `Contact support: ${supportEmail}`,
+    "",
+    "Commands:",
+    ...accountCommands,
+    ...COMMAND_LINES,
+  ].join("\n");
 }
 
 function parseSlashCommand(text: string): string | null {

--- a/apps/web/utils/messaging/prompt-commands.ts
+++ b/apps/web/utils/messaging/prompt-commands.ts
@@ -59,12 +59,7 @@ export function isTelegramStartCommand(text: string): boolean {
   return TELEGRAM_START_COMMAND_REGEX.test(text.trim());
 }
 
-export function isUnsupportedSlashCommand(
-  text: string,
-  platform: MessagingPlatform,
-): boolean {
-  if (platform === "telegram" && isTelegramStartCommand(text)) return false;
-
+export function isUnsupportedSlashCommand(text: string): boolean {
   const command = parseSlashCommand(text);
   return command !== null && !SUPPORTED_COMMANDS.has(command);
 }

--- a/apps/web/utils/messaging/prompt-commands.ts
+++ b/apps/web/utils/messaging/prompt-commands.ts
@@ -2,6 +2,7 @@ import type { MessagingPlatform } from "@/utils/messaging/platforms";
 
 const SLASH_COMMAND_REGEX = /^\/([a-z0-9_]+)(?:@[A-Za-z0-9_]+)?(?:\s+.*)?$/i;
 const HELP_COMMAND_REGEX = /^\/help(?:@[A-Za-z0-9_]+)?\s*$/i;
+const TELEGRAM_START_COMMAND_REGEX = /^\/start(?:@[A-Za-z0-9_]+)?(?:\s+.*)?$/i;
 
 export const PROMPT_COMMANDS: Record<string, string> = {
   cleanup: "Help me clean up my inbox today.",
@@ -54,7 +55,16 @@ export function isHelpCommand(text: string): boolean {
   return HELP_COMMAND_REGEX.test(text.trim());
 }
 
-export function isUnsupportedSlashCommand(text: string): boolean {
+export function isTelegramStartCommand(text: string): boolean {
+  return TELEGRAM_START_COMMAND_REGEX.test(text.trim());
+}
+
+export function isUnsupportedSlashCommand(
+  text: string,
+  platform: MessagingPlatform,
+): boolean {
+  if (platform === "telegram" && isTelegramStartCommand(text)) return false;
+
   const command = parseSlashCommand(text);
   return command !== null && !SUPPORTED_COMMANDS.has(command);
 }

--- a/docs/teams/setup.mdx
+++ b/docs/teams/setup.mdx
@@ -83,8 +83,8 @@ Create a `manifest.json` file with your bot details:
     "full": "Inbox Zero Assistant"
   },
   "description": {
-    "short": "AI email assistant",
-    "full": "Chat with your Inbox Zero AI assistant directly from Teams."
+    "short": "Manage email with Inbox Zero for Microsoft Teams",
+    "full": "Manage email with your Inbox Zero AI assistant in Microsoft Teams. An active Inbox Zero account is required. Sign up or get started at https://your-domain.com. For help, visit https://your-domain.com/docs/essentials/channels or contact support@your-domain.com. AI-generated content may be inaccurate and should be reviewed before use. Report objectionable AI-generated content to support@your-domain.com."
   },
   "icons": {
     "outline": "outline.png",
@@ -96,7 +96,19 @@ Create a `manifest.json` file with your bot details:
       "botId": "<your-app-id>",
       "scopes": ["personal"],
       "supportsFiles": false,
-      "isNotificationOnly": false
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal"],
+          "commands": [
+            { "title": "help", "description": "Show help and supported commands" },
+            { "title": "cleanup", "description": "Help clean up your inbox" },
+            { "title": "summary", "description": "Summarize what needs attention" },
+            { "title": "draftreply", "description": "Draft a reply to an urgent email" },
+            { "title": "followups", "description": "Show emails that need a follow-up" }
+          ]
+        }
+      ]
     }
   ],
   "permissions": ["identity", "messageTeamMembers"],
@@ -106,7 +118,7 @@ Create a `manifest.json` file with your bot details:
 
 Replace `<your-app-id>` with your `TEAMS_BOT_APP_ID` and `your-domain.com` with your actual domain.
 
-You'll also need two icon files: a 32×32 `outline.png` and a 192×192 `color.png`. Zip those three files together.
+You'll also need two matching icon files: a 32×32 `outline.png` and a 192×192 `color.png`. The outline icon must use a white symbol on a transparent background, contain no extra padding, and depict the same symbol as the color icon. Zip those three files together.
 
 **To install for testing (sideloading):**
 
@@ -150,8 +162,10 @@ After linking, the user can chat with the assistant in that DM.
 Quick checks:
 
 1. `POST /api/teams/events` returns `200` for valid bot activity
-2. Sending `/connect <code>` in the bot DM links the account
-3. A normal DM message gets an assistant response
+2. Before linking, `Hello` returns account setup guidance and `/help` lists supported commands
+3. An unknown slash command points the user to `/help`
+4. Sending `/connect <code>` in the bot DM links the account
+5. `/summary`, `/cleanup`, `/draftreply`, and `/followups` return useful responses after linking
 
 If linking fails, generate a new code — codes are one-time and expire after 10 minutes.
 

--- a/docs/teams/setup.mdx
+++ b/docs/teams/setup.mdx
@@ -101,6 +101,8 @@ Create a `manifest.json` file with your bot details:
         {
           "scopes": ["personal"],
           "commands": [
+            { "title": "connect", "description": "Link an Inbox Zero account with a connect code" },
+            { "title": "switch", "description": "List or switch linked Inbox Zero accounts" },
             { "title": "help", "description": "Show help and supported commands" },
             { "title": "cleanup", "description": "Help clean up your inbox" },
             { "title": "summary", "description": "Summarize what needs attention" },


### PR DESCRIPTION
## Summary

- improve Microsoft Teams onboarding and help copy with setup, documentation, and support guidance
- respond deterministically to unsupported slash commands before account linking
- update the public Teams manifest example with Microsoft naming, commands, AI disclosure, and icon requirements
- expand the Teams end-to-end validation checklist

## Tests

- `pnpm test utils/messaging/prompt-commands.test.ts utils/messaging/chat-sdk/bot.test.ts`
- `pnpm exec ultracite check apps/web/app/api/slack/commands/route.ts apps/web/utils/messaging/chat-sdk/bot.ts apps/web/utils/messaging/prompt-commands.ts apps/web/utils/messaging/prompt-commands.test.ts`
- validated that the Teams manifest example parses as JSON

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

