### PR TITLE
fix: Address meeting and digest review feedback

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -99,7 +99,7 @@ function MeetingRecorderPageContent() {
 
   // Enabling is entitlement-gated server-side, so a non-premium user needs the
   // upgrade path on the onboarding screen too, not just once they are set up.
-  if (!hasCalendarConnected || !settings?.enabled) {
+  if (!settings?.enabled) {
     return (
       <PageWrapper>
         <div className="mx-auto max-w-lg">
@@ -134,6 +134,17 @@ function MeetingRecorderPageContent() {
 
       <div className="mt-6 max-w-3xl space-y-8">
         <PremiumAlertWithData />
+
+        {!hasCalendarConnected && (
+          <MeetingRecorderOnboarding
+            emailAccountId={emailAccountId}
+            hasCalendarConnected={hasCalendarConnected}
+            onEnable={(joinRule: MeetingJoinRule) =>
+              execute({ enabled: true, joinRule })
+            }
+            isEnabling={status === "executing"}
+          />
+        )}
 
         <UpcomingMeetingsToggleList emailAccountId={emailAccountId} />
 

--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { MicIcon, SettingsIcon } from "lucide-react";
+import { CalendarIcon, MicIcon, SettingsIcon } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { LoadingContent } from "@/components/LoadingContent";
 import { PageHeader } from "@/components/PageHeader";
@@ -23,6 +23,7 @@ import { MeetingRecorderSettingsDialog } from "@/app/(app)/[emailAccountId]/meet
 import { MeetingsList } from "@/app/(app)/[emailAccountId]/meetings/MeetingsList";
 import { UpcomingMeetingsToggleList } from "@/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList";
 import { hasConnectedCalendar } from "@/app/(app)/[emailAccountId]/meetings/calendar-connection-state";
+import { ConnectCalendar } from "@/app/(app)/[emailAccountId]/calendars/ConnectCalendar";
 
 export default function MeetingsPage() {
   const meetingRecorderEnabled = useMeetingRecorderEnabled();
@@ -136,13 +137,22 @@ function MeetingRecorderPageContent() {
         <PremiumAlertWithData />
 
         {!hasCalendarConnected && (
-          <MeetingRecorderOnboarding
-            emailAccountId={emailAccountId}
-            hasCalendarConnected={hasCalendarConnected}
-            onEnable={(joinRule: MeetingJoinRule) =>
-              execute({ enabled: true, joinRule })
+          <ActionCard
+            variant="blue"
+            icon={<CalendarIcon className="h-5 w-5" />}
+            title="Reconnect your calendar"
+            description={
+              <div className="space-y-4">
+                <p>
+                  Your meeting notetaker is still enabled. Connect a calendar so
+                  it can find upcoming meetings.
+                </p>
+                <ConnectCalendar
+                  analyticsPage="meetings"
+                  onboardingReturnPath={`/${emailAccountId}/meetings`}
+                />
+              </div>
             }
-            isEnabling={status === "executing"}
           />
         )}
 

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { useAction } from "next-safe-action/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -42,6 +42,7 @@ import {
 } from "@/utils/schedule";
 import { getEstimatedDigestDeliveryAt } from "@/utils/digest/schedule";
 import { getAccountScopedKey } from "@/utils/swr";
+import { reconcileDigestSelection } from "@/app/(app)/[emailAccountId]/settings/digest-selection";
 
 const digestSettingsSchema = z.object({
   selectedItems: z.set(z.string()),
@@ -133,15 +134,9 @@ function LoadedDigestSettingsForm({
   onSuccess?: () => void;
   showChannelsHint: boolean;
 }) {
+  const previousServerSelection = useRef(getSelectedDigestItemIds(rules));
   const [selectedDigestItems, setSelectedDigestItems] = useState<Set<string>>(
-    () =>
-      new Set(
-        rules
-          .filter((rule) =>
-            rule.actions.some((action) => action.type === ActionType.DIGEST),
-          )
-          .map((rule) => rule.id),
-      ),
+    () => getSelectedDigestItemIds(rules),
   );
   const {
     schedule: initialSchedule,
@@ -165,6 +160,22 @@ function LoadedDigestSettingsForm({
   });
 
   const watchedValues = watch();
+
+  useEffect(() => {
+    const previousSelection = previousServerSelection.current;
+    const nextServerSelection = getSelectedDigestItemIds(rules);
+    const availableRuleIds = new Set(rules.map((rule) => rule.id));
+
+    setSelectedDigestItems((currentSelection) =>
+      reconcileDigestSelection({
+        currentSelection,
+        previousServerSelection: previousSelection,
+        nextServerSelection,
+        availableRuleIds,
+      }),
+    );
+    previousServerSelection.current = nextServerSelection;
+  }, [rules]);
 
   const { executeAsync: executeItems } = useAction(
     updateDigestItemsAction.bind(null, emailAccountId),
@@ -593,6 +604,16 @@ function getInitialScheduleProps(
     dayOfWeek: initialDayOfWeek,
     time: initialTime,
   };
+}
+
+function getSelectedDigestItemIds(rules: RulesResponse) {
+  return new Set(
+    rules
+      .filter((rule) =>
+        rule.actions.some((action) => action.type === ActionType.DIGEST),
+      )
+      .map((rule) => rule.id),
+  );
 }
 
 function formatDigestDeliveryTime(date: Date, timezone?: string | null) {

--- a/apps/web/app/(app)/[emailAccountId]/settings/digest-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/settings/digest-selection.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { reconcileDigestSelection } from "./digest-selection";
+
+describe("reconcileDigestSelection", () => {
+  it("preserves unsaved edits when the server selection is unchanged", () => {
+    const result = reconcileDigestSelection({
+      currentSelection: new Set(["kept", "locally-added"]),
+      previousServerSelection: new Set(["kept", "locally-removed"]),
+      nextServerSelection: new Set(["kept", "locally-removed"]),
+      availableRuleIds: new Set(["kept", "locally-added", "locally-removed"]),
+    });
+
+    expect(result).toEqual(new Set(["kept", "locally-added"]));
+  });
+
+  it("applies additions and removals received from the server", () => {
+    const result = reconcileDigestSelection({
+      currentSelection: new Set(["removed-by-server", "local-edit"]),
+      previousServerSelection: new Set(["removed-by-server"]),
+      nextServerSelection: new Set(["added-by-server"]),
+      availableRuleIds: new Set([
+        "removed-by-server",
+        "added-by-server",
+        "local-edit",
+      ]),
+    });
+
+    expect(result).toEqual(new Set(["local-edit", "added-by-server"]));
+  });
+
+  it("drops selections for rules that no longer exist", () => {
+    const result = reconcileDigestSelection({
+      currentSelection: new Set(["existing", "deleted"]),
+      previousServerSelection: new Set(["existing"]),
+      nextServerSelection: new Set(["existing"]),
+      availableRuleIds: new Set(["existing"]),
+    });
+
+    expect(result).toEqual(new Set(["existing"]));
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/settings/digest-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/settings/digest-selection.ts
@@ -1,0 +1,36 @@
+export function reconcileDigestSelection({
+  currentSelection,
+  previousServerSelection,
+  nextServerSelection,
+  availableRuleIds,
+}: {
+  currentSelection: Set<string>;
+  previousServerSelection: Set<string>;
+  nextServerSelection: Set<string>;
+  availableRuleIds: Set<string>;
+}) {
+  const reconciledSelection = new Set(
+    [...currentSelection].filter((id) => availableRuleIds.has(id)),
+  );
+
+  for (const id of availableRuleIds) {
+    const wasSelected = previousServerSelection.has(id);
+    const isSelected = nextServerSelection.has(id);
+
+    if (wasSelected === isSelected) continue;
+
+    if (isSelected) {
+      reconciledSelection.add(id);
+    } else {
+      reconciledSelection.delete(id);
+    }
+  }
+
+  return setsAreEqual(currentSelection, reconciledSelection)
+    ? currentSelection
+    : reconciledSelection;
+}
+
+function setsAreEqual(left: Set<string>, right: Set<string>) {
+  return left.size === right.size && [...left].every((id) => right.has(id));
+}


### PR DESCRIPTION
Addresses the valid automated-review findings left after #3151 and #3152 were merged.

- keep meeting settings, upcoming toggles, and recordings accessible when an enabled account disconnects its calendars
- continue showing the calendar connection setup in that state
- reconcile external digest-rule changes without overwriting unrelated unsaved selections
- remove selections for deleted rules
- add focused tests for digest selection reconciliation

Validation: focused Vitest suite (3 tests) and Ultracite checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

