### PR TITLE
automation: Avoid forwarding to existing message participants

### DIFF
--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -615,6 +615,79 @@ describe("runActionFunction", () => {
     );
   });
 
+  describe("forward", () => {
+    const executedRule = {
+      id: "executed-rule-1",
+      threadId: "thread-1",
+      emailAccountId: "account-1",
+      ruleId: "rule-1",
+    } as any;
+
+    it.each([
+      {
+        name: "to",
+        recipients: { to: "Sender <SENDER@example.com>" },
+      },
+      {
+        name: "cc",
+        recipients: {
+          to: "archive@example.com",
+          cc: "sender@example.com",
+        },
+      },
+      {
+        name: "bcc",
+        recipients: {
+          to: "archive@example.com",
+          bcc: "Sender <sender@example.com>",
+        },
+      },
+    ])("does not forward back to the sender through $name", async ({
+      recipients,
+    }) => {
+      const client = createMockEmailProvider();
+
+      const result = await runActionFunction({
+        client,
+        email,
+        action: {
+          id: "action-1",
+          type: ActionType.FORWARD,
+          ...recipients,
+        },
+        emailAccount,
+        executedRule,
+        logger,
+      });
+
+      expect(result).toEqual({
+        skipped: true,
+        reason: "RECIPIENT_IS_SENDER",
+      });
+      expect(client.forwardEmail).not.toHaveBeenCalled();
+    });
+
+    it("forwards when every recipient differs from the sender", async () => {
+      const client = createMockEmailProvider();
+
+      await runActionFunction({
+        client,
+        email,
+        action: {
+          id: "action-1",
+          type: ActionType.FORWARD,
+          to: "archive@example.com",
+          cc: "reviewer@example.com",
+        },
+        emailAccount,
+        executedRule,
+        logger,
+      });
+
+      expect(client.forwardEmail).toHaveBeenCalledOnce();
+    });
+  });
+
   it("does not try to resolve attachments when drafts have no selected attachments", async () => {
     const client = createMockEmailProvider();
 

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -681,6 +681,68 @@ describe("runActionFunction", () => {
       expect(client.forwardEmail).not.toHaveBeenCalled();
     });
 
+    it("promotes a new CC recipient when every primary recipient is already on the message", async () => {
+      const client = createMockEmailProvider();
+
+      await runActionFunction({
+        client,
+        email,
+        action: {
+          id: "action-1",
+          type: ActionType.FORWARD,
+          to: "sender@example.com",
+          cc: "Reviewer <reviewer@example.com>, auditor@example.com",
+        },
+        emailAccount,
+        executedRule,
+        logger,
+      });
+
+      expect(client.forwardEmail).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          to: "Reviewer <reviewer@example.com>",
+          cc: "auditor@example.com",
+        }),
+      );
+    });
+
+    it("forwards separately to new BCC recipients when no visible recipient remains", async () => {
+      const client = createMockEmailProvider();
+
+      await runActionFunction({
+        client,
+        email,
+        action: {
+          id: "action-1",
+          type: ActionType.FORWARD,
+          to: "sender@example.com",
+          bcc: "Reviewer <reviewer@example.com>, auditor@example.com",
+        },
+        emailAccount,
+        executedRule,
+        logger,
+      });
+
+      expect(client.forwardEmail).toHaveBeenCalledTimes(2);
+      expect(client.forwardEmail).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          to: "Reviewer <reviewer@example.com>",
+        }),
+      );
+      expect(client.forwardEmail).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({
+          to: "auditor@example.com",
+        }),
+      );
+      expect(client.forwardEmail.mock.calls[0]?.[1]).not.toHaveProperty("bcc");
+      expect(client.forwardEmail.mock.calls[1]?.[1]).not.toHaveProperty("bcc");
+    });
+
     it("forwards when every recipient is new to the message", async () => {
       const client = createMockEmailProvider();
 

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -623,28 +623,42 @@ describe("runActionFunction", () => {
       ruleId: "rule-1",
     } as any;
 
-    it.each([
-      {
-        name: "to",
-        recipients: { to: "Sender <SENDER@example.com>" },
-      },
-      {
-        name: "cc",
-        recipients: {
-          to: "archive@example.com",
-          cc: "sender@example.com",
+    it("removes message participants while forwarding to remaining recipients", async () => {
+      const client = createMockEmailProvider();
+
+      await runActionFunction({
+        client,
+        email: {
+          ...email,
+          headers: {
+            ...email.headers,
+            cc: "Existing <existing@example.com>",
+            bcc: "hidden@example.com",
+          },
         },
-      },
-      {
-        name: "bcc",
-        recipients: {
-          to: "archive@example.com",
-          bcc: "Sender <sender@example.com>",
+        action: {
+          id: "action-1",
+          type: ActionType.FORWARD,
+          to: "Sender <SENDER@example.com>, user@example.com, Archive <archive@example.com>",
+          cc: "existing@example.com, Reviewer <reviewer@example.com>",
+          bcc: "hidden@example.com, auditor@example.com",
         },
-      },
-    ])("does not forward back to the sender through $name", async ({
-      recipients,
-    }) => {
+        emailAccount,
+        executedRule,
+        logger,
+      });
+
+      expect(client.forwardEmail).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          to: "Archive <archive@example.com>",
+          cc: "Reviewer <reviewer@example.com>",
+          bcc: "auditor@example.com",
+        }),
+      );
+    });
+
+    it("skips forwarding when every configured recipient is already on the message", async () => {
       const client = createMockEmailProvider();
 
       const result = await runActionFunction({
@@ -653,7 +667,7 @@ describe("runActionFunction", () => {
         action: {
           id: "action-1",
           type: ActionType.FORWARD,
-          ...recipients,
+          to: "Sender <SENDER@example.com>, user@example.com",
         },
         emailAccount,
         executedRule,
@@ -662,12 +676,12 @@ describe("runActionFunction", () => {
 
       expect(result).toEqual({
         skipped: true,
-        reason: "RECIPIENT_IS_SENDER",
+        reason: "NO_NEW_FORWARD_RECIPIENTS",
       });
       expect(client.forwardEmail).not.toHaveBeenCalled();
     });
 
-    it("forwards when every recipient differs from the sender", async () => {
+    it("forwards when every recipient is new to the message", async () => {
       const client = createMockEmailProvider();
 
       await runActionFunction({

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -793,9 +793,10 @@ describe("runActionFunction", () => {
       ["a colleague on the account owner's domain", "ceo@example.com"],
       ["the account owner", "user@example.com"],
     ])("does not notify %s", async (_name, from) => {
-      await runNotifySender(from);
+      const result = await runNotifySender(from);
 
       expect(sendColdEmailNotification).not.toHaveBeenCalled();
+      expect(result).toEqual({ skipped: true, reason: "INTERNAL_SENDER" });
     });
   });
 });

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -20,6 +20,7 @@ import {
   extractEmailAddresses,
   isSameEmailAddress,
   isSameOrganization,
+  splitRecipientList,
 } from "@/utils/email";
 import { captureException } from "@/utils/error";
 import { env } from "@/env";
@@ -380,24 +381,37 @@ const forward: ActionFunction<{
 }> = async ({ client, email, args, logger }) => {
   if (!args.to) return;
 
+  const messageParticipants = [
+    email.headers.from,
+    email.headers.to,
+    email.headers.cc,
+    email.headers.bcc,
+  ].flatMap((value) => extractEmailAddresses(value ?? ""));
+
+  const to = removeMessageParticipants(args.to, messageParticipants);
+  const cc = removeMessageParticipants(args.cc, messageParticipants);
+  const bcc = removeMessageParticipants(args.bcc, messageParticipants);
+
+  if (!to) {
+    logger.warn("Skipping forward because no new primary recipients remain");
+    return { skipped: true, reason: "NO_NEW_FORWARD_RECIPIENTS" };
+  }
+
   const recipients = [args.to, args.cc, args.bcc].flatMap((value) =>
     extractEmailAddresses(value ?? ""),
   );
-
-  if (
-    recipients.some((recipient) =>
-      isSameEmailAddress(email.headers.from, recipient),
-    )
-  ) {
-    logger.warn("Skipping forward because the sender is a recipient");
-    return { skipped: true, reason: "RECIPIENT_IS_SENDER" };
+  const remainingRecipients = [to, cc, bcc].flatMap((value) =>
+    extractEmailAddresses(value),
+  );
+  if (remainingRecipients.length < recipients.length) {
+    logger.info("Removed existing message participants from forward");
   }
 
   const forwardArgs = {
     messageId: email.id,
-    to: args.to,
-    cc: args.cc ?? undefined,
-    bcc: args.bcc ?? undefined,
+    to,
+    cc: cc || undefined,
+    bcc: bcc || undefined,
     content: args.content ?? undefined,
   };
 
@@ -749,4 +763,18 @@ function isLegacyMessagingDraft({
   return !executedRule.actionItems?.some((action) =>
     isMessagingDraftActionType(action.type),
   );
+}
+
+function removeMessageParticipants(
+  recipientList: string | null | undefined,
+  messageParticipants: string[],
+) {
+  return splitRecipientList(recipientList ?? "")
+    .filter(
+      (recipient) =>
+        !messageParticipants.some((participant) =>
+          isSameEmailAddress(participant, recipient),
+        ),
+    )
+    .join(", ");
 }

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -438,11 +438,7 @@ const forward: ActionFunction<{
   }
 
   if (!toRecipients.length) {
-    const primaryRecipient = ccRecipients.shift();
-    if (!primaryRecipient) {
-      throw new Error("Forward action has no primary recipient");
-    }
-    toRecipients.push(primaryRecipient);
+    toRecipients.push(ccRecipients.shift()!);
   }
 
   await client.forwardEmail(forwardMessage, {

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -18,6 +18,7 @@ import { sendColdEmailNotification } from "@/utils/cold-email/send-notification"
 import {
   extractEmailAddress,
   extractEmailAddresses,
+  isSameEmailAddress,
   isSameOrganization,
 } from "@/utils/email";
 import { captureException } from "@/utils/error";
@@ -379,12 +380,15 @@ const forward: ActionFunction<{
 }> = async ({ client, email, args, logger }) => {
   if (!args.to) return;
 
-  const sender = extractEmailAddress(email.headers.from).toLowerCase();
-  const recipients = [args.to, args.cc, args.bcc]
-    .flatMap((value) => extractEmailAddresses(value ?? ""))
-    .map((recipient) => recipient.toLowerCase());
+  const recipients = [args.to, args.cc, args.bcc].flatMap((value) =>
+    extractEmailAddresses(value ?? ""),
+  );
 
-  if (sender && recipients.includes(sender)) {
+  if (
+    recipients.some((recipient) =>
+      isSameEmailAddress(email.headers.from, recipient),
+    )
+  ) {
     logger.warn("Skipping forward because the sender is a recipient");
     return { skipped: true, reason: "RECIPIENT_IS_SENDER" };
   }
@@ -558,7 +562,7 @@ const notify_sender: ActionFunction<Record<string, unknown>> = async ({
   // this action emails the sender, and a wrong one accuses a colleague of spamming.
   if (isSameOrganization(senderEmail, emailAccount.email)) {
     logger.warn("Skipping cold email notification to an internal sender");
-    return { success: false, errorCode: "INTERNAL_SENDER" };
+    return { skipped: true, reason: "INTERNAL_SENDER" };
   }
 
   const result = await sendColdEmailNotification({

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -15,7 +15,11 @@ import { labelMessageAndSync } from "@/utils/label.server";
 import { hasVariables } from "@/utils/template";
 import prisma from "@/utils/prisma";
 import { sendColdEmailNotification } from "@/utils/cold-email/send-notification";
-import { extractEmailAddress, isSameOrganization } from "@/utils/email";
+import {
+  extractEmailAddress,
+  extractEmailAddresses,
+  isSameOrganization,
+} from "@/utils/email";
 import { captureException } from "@/utils/error";
 import { env } from "@/env";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
@@ -372,8 +376,18 @@ const forward: ActionFunction<{
   to?: string | null;
   cc?: string | null;
   bcc?: string | null;
-}> = async ({ client, email, args }) => {
+}> = async ({ client, email, args, logger }) => {
   if (!args.to) return;
+
+  const sender = extractEmailAddress(email.headers.from).toLowerCase();
+  const recipients = [args.to, args.cc, args.bcc]
+    .flatMap((value) => extractEmailAddresses(value ?? ""))
+    .map((recipient) => recipient.toLowerCase());
+
+  if (sender && recipients.includes(sender)) {
+    logger.warn("Skipping forward because the sender is a recipient");
+    return { skipped: true, reason: "RECIPIENT_IS_SENDER" };
+  }
 
   const forwardArgs = {
     messageId: email.id,

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -388,47 +388,69 @@ const forward: ActionFunction<{
     email.headers.bcc,
   ].flatMap((value) => extractEmailAddresses(value ?? ""));
 
-  const to = removeMessageParticipants(args.to, messageParticipants);
-  const cc = removeMessageParticipants(args.cc, messageParticipants);
-  const bcc = removeMessageParticipants(args.bcc, messageParticipants);
+  const toRecipients = removeMessageParticipants(args.to, messageParticipants);
+  const ccRecipients = removeMessageParticipants(args.cc, messageParticipants);
+  const bccRecipients = removeMessageParticipants(
+    args.bcc,
+    messageParticipants,
+  );
 
-  if (!to) {
-    logger.warn("Skipping forward because no new primary recipients remain");
+  if (!toRecipients.length && !ccRecipients.length && !bccRecipients.length) {
+    logger.warn("Skipping forward because no new recipients remain");
     return { skipped: true, reason: "NO_NEW_FORWARD_RECIPIENTS" };
   }
 
   const recipients = [args.to, args.cc, args.bcc].flatMap((value) =>
     extractEmailAddresses(value ?? ""),
   );
-  const remainingRecipients = [to, cc, bcc].flatMap((value) =>
-    extractEmailAddresses(value),
-  );
-  if (remainingRecipients.length < recipients.length) {
+  const remainingRecipientCount =
+    toRecipients.length + ccRecipients.length + bccRecipients.length;
+  if (remainingRecipientCount < recipients.length) {
     logger.info("Removed existing message participants from forward");
   }
 
+  const forwardMessage = {
+    id: email.id,
+    threadId: email.threadId,
+    headers: email.headers,
+    internalDate: email.internalDate,
+    snippet: "",
+    historyId: "",
+    inline: [],
+    subject: email.headers.subject,
+    date: email.headers.date,
+  };
   const forwardArgs = {
     messageId: email.id,
-    to,
-    cc: cc || undefined,
-    bcc: bcc || undefined,
     content: args.content ?? undefined,
   };
 
-  await client.forwardEmail(
-    {
-      id: email.id,
-      threadId: email.threadId,
-      headers: email.headers,
-      internalDate: email.internalDate,
-      snippet: "",
-      historyId: "",
-      inline: [],
-      subject: email.headers.subject,
-      date: email.headers.date,
-    },
-    forwardArgs,
-  );
+  if (!toRecipients.length && !ccRecipients.length) {
+    // A primary recipient is required, so send BCC-only recipients separately
+    // to avoid exposing them to each other.
+    for (const recipient of bccRecipients) {
+      await client.forwardEmail(forwardMessage, {
+        ...forwardArgs,
+        to: recipient,
+      });
+    }
+    return;
+  }
+
+  if (!toRecipients.length) {
+    const primaryRecipient = ccRecipients.shift();
+    if (!primaryRecipient) {
+      throw new Error("Forward action has no primary recipient");
+    }
+    toRecipients.push(primaryRecipient);
+  }
+
+  await client.forwardEmail(forwardMessage, {
+    ...forwardArgs,
+    to: toRecipients.join(", "),
+    cc: ccRecipients.join(", ") || undefined,
+    bcc: bccRecipients.join(", ") || undefined,
+  });
 };
 
 const mark_spam: ActionFunction<Record<string, unknown>> = async ({
@@ -769,12 +791,10 @@ function removeMessageParticipants(
   recipientList: string | null | undefined,
   messageParticipants: string[],
 ) {
-  return splitRecipientList(recipientList ?? "")
-    .filter(
-      (recipient) =>
-        !messageParticipants.some((participant) =>
-          isSameEmailAddress(participant, recipient),
-        ),
-    )
-    .join(", ");
+  return splitRecipientList(recipientList ?? "").filter(
+    (recipient) =>
+      !messageParticipants.some((participant) =>
+        isSameEmailAddress(participant, recipient),
+      ),
+  );
 }

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -144,7 +144,7 @@ describe("executeAct", () => {
   it("records actions skipped by the executor without failing the rule", async () => {
     mockRunActionFunction.mockResolvedValueOnce({
       skipped: true,
-      reason: "RECIPIENT_IS_SENDER",
+      reason: "NO_NEW_FORWARD_RECIPIENTS",
     });
 
     const executedRule = {

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -141,6 +141,40 @@ describe("executeAct", () => {
     });
   });
 
+  it("records actions skipped by the executor without failing the rule", async () => {
+    mockRunActionFunction.mockResolvedValueOnce({
+      skipped: true,
+      reason: "RECIPIENT_IS_SENDER",
+    });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [{ id: "action-1", type: ActionType.FORWARD }],
+    } as any;
+
+    const result = await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      emailAccount,
+      logger,
+    });
+
+    expect(result).toBe(ExecutedRuleStatus.APPLIED);
+    expect(mockExecutedActionUpdate).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        executionStatus: "SKIPPED",
+        executedAt: expect.any(Date),
+        executionError: Prisma.DbNull,
+      },
+    });
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: { status: ExecutedRuleStatus.APPLIED },
+    });
+  });
+
   it("marks executed rule as ERROR when notify sender reports a failure", async () => {
     mockRunActionFunction.mockResolvedValueOnce({
       success: false,

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -16,6 +16,7 @@ import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archiv
 import { flushLoggerSafely } from "@/utils/logger-flush";
 import {
   getActionResultError,
+  isActionResultSkipped,
   normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
@@ -83,6 +84,16 @@ export async function executeAct({
         executedRule,
         logger: log,
       });
+
+      if (isActionResultSkipped(actionResult)) {
+        await persistExecutedActionOutcome({
+          actionId: action.id,
+          status: ExecutedActionStatus.SKIPPED,
+          error: null,
+          logger: log,
+        });
+        continue;
+      }
 
       const actionResultError = getActionResultError(action.type, actionResult);
       if (actionResultError) {

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -92,6 +92,15 @@ export function getActionResultError(
   };
 }
 
+export function isActionResultSkipped(actionResult: unknown) {
+  return (
+    typeof actionResult === "object" &&
+    actionResult !== null &&
+    "skipped" in actionResult &&
+    actionResult.skipped === true
+  );
+}
+
 export function normalizeActionExecutionError(
   error: unknown,
 ): ActionExecutionError {

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -93,12 +93,7 @@ export function getActionResultError(
 }
 
 export function isActionResultSkipped(actionResult: unknown) {
-  return (
-    typeof actionResult === "object" &&
-    actionResult !== null &&
-    "skipped" in actionResult &&
-    actionResult.skipped === true
-  );
+  return asRecord(actionResult)?.skipped === true;
 }
 
 export function normalizeActionExecutionError(

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -86,6 +86,35 @@ describe("executor", () => {
       expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
     });
 
+    it("records skipped delayed actions without failing the scheduled action", async () => {
+      mockScheduledActionUpdate(ScheduledActionStatus.COMPLETED);
+      mockExecutedActionCreate({ type: ActionType.FORWARD });
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 0 });
+      mockExecutedRuleUpdate(ExecutedRuleStatus.APPLIED);
+      vi.mocked(runActionFunction).mockResolvedValue({
+        skipped: true,
+        reason: "RECIPIENT_IS_SENDER",
+      });
+
+      const result = await executeScheduledAction(
+        { ...mockScheduledAction, actionType: ActionType.FORWARD },
+        await getMockEmailProvider(),
+        logger,
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.executedAction.update).toHaveBeenCalledWith({
+        where: { id: "executed-action-123" },
+        data: {
+          executionStatus: ExecutedActionStatus.SKIPPED,
+          executedAt: expect.any(Date),
+          executionError: Prisma.DbNull,
+        },
+      });
+      expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
+    });
+
     it("forwards selectedAttachments into the executed action", async () => {
       const selectedAttachments = [
         {

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -94,7 +94,7 @@ describe("executor", () => {
       mockExecutedRuleUpdate(ExecutedRuleStatus.APPLIED);
       vi.mocked(runActionFunction).mockResolvedValue({
         skipped: true,
-        reason: "RECIPIENT_IS_SENDER",
+        reason: "NO_NEW_FORWARD_RECIPIENTS",
       });
 
       const result = await executeScheduledAction(

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -16,6 +16,7 @@ import type {
 import type { EmailProvider } from "@/utils/email/types";
 import {
   getActionResultError,
+  isActionResultSkipped,
   normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
@@ -234,6 +235,20 @@ async function executeDelayedAction({
       logger: log,
     });
     throw error;
+  }
+
+  if (isActionResultSkipped(actionResult)) {
+    await persistExecutedActionOutcome({
+      actionId: executedAction.id,
+      status: ExecutedActionStatus.SKIPPED,
+      error: null,
+      logger: log,
+    });
+    log.info("Skipped delayed action", {
+      actionType: executedAction.type,
+      executedActionId: executedAction.id,
+    });
+    return executedAction;
   }
 
   const actionResultError = getActionResultError(


### PR DESCRIPTION
Filters configured forward recipients against addresses already present on the current message.

- Preserves forwarding to remaining configured recipients across To, CC, and BCC.
- Records fully filtered actions as skipped without failing immediate or delayed rule execution.