### PR TITLE
drafts: Improve reply completeness and scheduling notice

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -1078,7 +1078,7 @@ Morgan`,
             ].join("\n"),
             output: result.reply,
             expected:
-              "A useful reply that keeps both reported discrepancies in scope. It may answer them collectively when it is clear the answer or next step applies to both, but it must not ignore one, use general policy as a substitute for checking them, or claim that either was verified or corrected without supporting context.",
+              "A useful reply that keeps both reported discrepancies in scope. It may answer them collectively when it is clear the answer or next step applies to both, but it must not ignore one, use general policy as a substitute for checking them, or claim that either was verified or corrected without supporting context. It must not be high confidence because their current status is unknown.",
             criterion: {
               name: "Complete and grounded multi-part response",
               description:
@@ -1093,7 +1093,7 @@ Morgan`,
             model: model.label,
             pass,
             expected:
-              "both discrepancies addressed without unsupported verification or correction claims",
+              "both discrepancies addressed without unsupported verification or correction claims; not high confidence",
             actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
               result.reply,
               judgeResult,
@@ -1161,7 +1161,7 @@ Riley`,
             input: formatThreadForJudge(messages),
             output: result.reply,
             expected:
-              "A concise reply that treats both the duplicate invoice and disabled export access as unresolved because the sender directly contradicted the earlier resolution. It may promise to investigate or confirm later, but must not say either issue is already fixed without newer supporting context.",
+              "A concise reply that treats both the duplicate invoice and disabled export access as unresolved because the sender directly contradicted the earlier resolution. It may promise to investigate or confirm later, but must not say either issue is already fixed without newer supporting context. It must not be high confidence because no newer resolution is available.",
             criterion: {
               name: "Sender contradiction overrides stale resolution",
               description:
@@ -1176,7 +1176,7 @@ Riley`,
             model: model.label,
             pass,
             expected:
-              "both issues treated as unresolved; no unsupported fixed status",
+              "both issues treated as unresolved; no unsupported fixed status; not high confidence",
             actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
               result.reply,
               judgeResult,

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -1030,6 +1030,172 @@ thanks,`,
 
     describe("grounding and uncertainty", () => {
       test(
+        "addresses each item in a multi-part discrepancy report",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Morgan Lee <morgan@customer.example>",
+                to: emailAccount.email,
+                subject: "April usage discrepancies",
+                content: `Hi,
+
+Could you check two discrepancies in our April usage report?
+
+- API usage shows 128,000 requests, while our logs show 102,000.
+- Storage shows 4.2 TB, while the billing dashboard shows 3.7 TB.
+
+Have both figures been verified, and will either be corrected?
+
+Thanks,
+Morgan`,
+              }),
+              date: new Date("2026-05-05T10:00:00Z"),
+            },
+          ];
+          const knowledgeBaseContent =
+            "Usage reports are generated from provider data and can differ from customer dashboards because aggregation timing varies.";
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "multi-part discrepancy completeness";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Knowledge Base",
+              knowledgeBaseContent,
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A useful reply that keeps both reported discrepancies in scope. It may answer them collectively when it is clear the answer or next step applies to both, but it must not ignore one, use general policy as a substitute for checking them, or claim that either was verified or corrected without supporting context.",
+            criterion: {
+              name: "Complete and grounded multi-part response",
+              description:
+                "The draft should make clear that its answer or next step covers both reported discrepancies. A concise collective response is acceptable. General background must not replace the case-specific response, and neither item may be presented as verified or corrected without support.",
+            },
+          });
+          const pass =
+            result.confidence !== "HIGH_CONFIDENCE" && judgeResult.pass;
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "both discrepancies addressed without unsupported verification or correction claims",
+            actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
+              result.reply,
+              judgeResult,
+            )}`,
+          });
+
+          expect(
+            pass,
+            `Draft should cover both unresolved discrepancies without inventing their status.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "does not repeat a resolution contradicted by the sender",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: emailAccount.email,
+                to: "riley@customer.example",
+                subject: "Re: Account issues",
+                content:
+                  "We've corrected the duplicate invoice and reactivated export access. Both should work now.",
+              }),
+              date: new Date("2026-05-04T09:00:00Z"),
+            },
+            {
+              ...getEmail({
+                from: "Riley Stone <riley@customer.example>",
+                to: emailAccount.email,
+                subject: "Re: Account issues",
+                content: `Hi,
+
+The duplicate invoice is still on our account, and export access is still disabled.
+
+Please confirm once both have actually been fixed.
+
+Thanks,
+Riley`,
+              }),
+              date: new Date("2026-05-05T09:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "contradicted resolution remains unresolved";
+          const judgeResult = await judgeEvalOutput({
+            input: formatThreadForJudge(messages),
+            output: result.reply,
+            expected:
+              "A concise reply that treats both the duplicate invoice and disabled export access as unresolved because the sender directly contradicted the earlier resolution. It may promise to investigate or confirm later, but must not say either issue is already fixed without newer supporting context.",
+            criterion: {
+              name: "Sender contradiction overrides stale resolution",
+              description:
+                "The draft should recognize that both issues remain unresolved after the sender reported the previous fix did not work. It must not repeat or imply the earlier resolved status as current without new evidence.",
+            },
+          });
+          const pass =
+            result.confidence !== "HIGH_CONFIDENCE" && judgeResult.pass;
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "both issues treated as unresolved; no unsupported fixed status",
+            actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
+              result.reply,
+              judgeResult,
+            )}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not repeat a contradicted resolution.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
         "does not invent pricing terms without pricing context",
         async () => {
           const messages = [

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -238,4 +238,42 @@ describe("aiGetCalendarAvailability", () => {
       ],
     });
   });
+
+  it("does not report no availability when every suggestion is inside the notice window", async () => {
+    mockGenerateText.mockImplementation(async ({ tools }) => {
+      await tools.returnSuggestedTimes.execute({
+        suggestedTimes: [
+          {
+            start: "2026-05-04 10:30",
+            end: "2026-05-04 11:00",
+          },
+        ],
+      });
+    });
+
+    const result = await aiGetCalendarAvailability({
+      emailAccount: {
+        ...getEmailAccount(),
+        timezone: "UTC",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Meeting",
+          content: "Can we meet today?",
+          date: new Date("2026-05-04T09:00:00.000Z"),
+        },
+      ],
+      logger: createTestLogger(),
+      currentDate: new Date("2026-05-04T09:00:00.000Z"),
+      minimumNoticeMinutes: 120,
+    });
+
+    expect(result).toEqual({
+      timezone: "UTC",
+      suggestedTimes: [],
+    });
+  });
 });

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -86,6 +86,7 @@ describe("aiGetCalendarAvailability", () => {
         },
       ],
       logger: createTestLogger(),
+      currentDate: new Date("2026-04-30T08:48:00.000Z"),
     });
 
     expect(result).toEqual({
@@ -117,6 +118,7 @@ describe("aiGetCalendarAvailability", () => {
       ],
       logger: createTestLogger(),
       bookingLinkAvailable: true,
+      currentDate: new Date("2026-04-30T08:48:00.000Z"),
     });
 
     expect(mockGenerateText).toHaveBeenCalledWith(
@@ -176,6 +178,7 @@ describe("aiGetCalendarAvailability", () => {
         },
       ],
       logger: createTestLogger(),
+      currentDate: new Date("2026-04-30T08:48:00.000Z"),
     });
 
     expect(result).toEqual({
@@ -184,6 +187,53 @@ describe("aiGetCalendarAvailability", () => {
         {
           start: "2026-05-04 10:30",
           end: "2026-05-04 11:00",
+        },
+      ],
+    });
+  });
+
+  it("filters suggested times inside the minimum-notice window", async () => {
+    mockGenerateText.mockImplementation(async ({ tools }) => {
+      await tools.returnSuggestedTimes.execute({
+        suggestedTimes: [
+          {
+            start: "2026-05-04 10:30",
+            end: "2026-05-04 11:00",
+          },
+          {
+            start: "2026-05-04 11:00",
+            end: "2026-05-04 11:30",
+          },
+        ],
+      });
+    });
+
+    const result = await aiGetCalendarAvailability({
+      emailAccount: {
+        ...getEmailAccount(),
+        timezone: "UTC",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Meeting",
+          content: "Can we meet today?",
+          date: new Date("2026-05-04T09:00:00.000Z"),
+        },
+      ],
+      logger: createTestLogger(),
+      currentDate: new Date("2026-05-04T09:00:00.000Z"),
+      minimumNoticeMinutes: 120,
+    });
+
+    expect(result).toEqual({
+      timezone: "UTC",
+      suggestedTimes: [
+        {
+          start: "2026-05-04 11:00",
+          end: "2026-05-04 11:30",
         },
       ],
     });

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -10,7 +10,7 @@ import { formatInUserTimezone } from "@/utils/date";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailForLLM } from "@/utils/types";
 import prisma from "@/utils/prisma";
-import { getUserInfoPrompt } from "@/utils/ai/helpers";
+import { getTodayForLLM, getUserInfoPrompt } from "@/utils/ai/helpers";
 
 const timeSlotSchema = z.object({
   start: z.string().describe("Start time in format YYYY-MM-DD HH:MM"),
@@ -39,17 +39,22 @@ type BusyPeriod = { start: string | Date; end: string | Date };
 type AvailabilityWindow = { startTime: string; endTime: string };
 
 const MODEL_TIME_FORMAT = "yyyy-MM-dd HH:mm";
+const DEFAULT_MINIMUM_NOTICE_MINUTES = 120;
 
 export async function aiGetCalendarAvailability({
   emailAccount,
   messages,
   logger,
   bookingLinkAvailable = false,
+  minimumNoticeMinutes = DEFAULT_MINIMUM_NOTICE_MINUTES,
+  currentDate = new Date(),
 }: {
   emailAccount: EmailAccountWithAI;
   messages: EmailForLLM[];
   logger: Logger;
   bookingLinkAvailable?: boolean;
+  minimumNoticeMinutes?: number;
+  currentDate?: Date;
 }): Promise<CalendarAvailabilityContext | null> {
   if (!messages?.length) {
     logger.warn("No messages provided for calendar availability check");
@@ -106,6 +111,7 @@ export async function aiGetCalendarAvailability({
   ]);
 
   const hasDefaultAvailabilitySchedule = defaultAvailabilitySchedule != null;
+  const effectiveMinimumNoticeMinutes = Math.max(0, minimumNoticeMinutes);
   const userTimezone =
     defaultAvailabilitySchedule?.timezone ??
     getUserTimezone(emailAccount, calendarConnections);
@@ -125,6 +131,7 @@ Your task is to:
 5. Return time slots with start AND end times (infer duration from context: "quick call" = 30min, "meeting" = 60min)
 6. If there are NO available times (user is busy all day), set noAvailability=true and return empty suggestedTimes array
 ${hasDefaultAvailabilitySchedule ? "7. When checkCalendarAvailability returns availabilityWindows, suggest ONLY times fully inside those windows." : ""}
+Do not suggest times that begin less than ${effectiveMinimumNoticeMinutes} minutes after the current time.
 
 CRITICAL: Do NOT suggest times overlapping with busy periods.
 Example: If busy 2025-11-17 09:00 to 2025-11-17 17:00, suggest times AFTER 17:00 or BEFORE 09:00.
@@ -138,10 +145,8 @@ Only check calendar availability when manual calendar information is actually ne
 Call "returnSuggestedTimes" only once.`;
 
   const prompt = `${getUserInfoPrompt({ emailAccount })}
-  
-<current_time>
-${new Date().toISOString()}
-</current_time>
+
+${getTodayForLLM(currentDate)}
 
 <thread>
 ${threadContent}
@@ -246,6 +251,8 @@ ${threadContent}
               timezone: userTimezone,
               busyPeriods: lastBusyPeriods,
               availabilityWindows: lastAvailabilityWindows,
+              currentDate,
+              minimumNoticeMinutes: effectiveMinimumNoticeMinutes,
             }),
           );
           const noAvailability =
@@ -271,16 +278,24 @@ function isAllowedSuggestedSlot({
   timezone,
   busyPeriods,
   availabilityWindows,
+  currentDate,
+  minimumNoticeMinutes,
 }: {
   slot: z.infer<typeof timeSlotSchema>;
   timezone: string;
   busyPeriods: BusyPeriod[];
   availabilityWindows: AvailabilityWindow[] | null;
+  currentDate: Date;
+  minimumNoticeMinutes: number;
 }) {
   const start = parseModelLocalTime(slot.start, timezone);
   const end = parseModelLocalTime(slot.end, timezone);
 
   if (!start || !end || end <= start) return false;
+
+  const earliestStart =
+    currentDate.getTime() + minimumNoticeMinutes * 60 * 1000;
+  if (start.getTime() < earliestStart) return false;
 
   if (
     availabilityWindows &&

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -255,14 +255,10 @@ ${threadContent}
               minimumNoticeMinutes: effectiveMinimumNoticeMinutes,
             }),
           );
-          const noAvailability =
-            data.noAvailability ||
-            (data.suggestedTimes.length > 0 && suggestedTimes.length === 0);
 
           result = {
             ...data,
             suggestedTimes,
-            ...(noAvailability ? { noAvailability: true } : {}),
             timezone: userTimezone,
           };
         },

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 23;
+export const DRAFT_PIPELINE_VERSION = 24;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -36,6 +36,7 @@ IMPORTANT: Use placeholders sparingly! Only use them where you have limited info
 Never use placeholders for the user's name. You do not need to sign off with the user's name. Do not add a signature.
 Do not invent information.
 Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
+Address each distinct question or requested action that the available context can answer; do not trade away completeness for brevity.
 When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
 Inline image markers such as [image] or [image: ...] mean the sender included a real image in the email, but only the marker and label are available in this prompt. Do not say the image is missing, unreadable, unavailable, or needs to be resent; respond from the available text and image label.
 Treat email dates as message metadata, not calendar context.

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -684,7 +684,7 @@ describe("fetchMessagesAndGenerateDraft - thread ordering", () => {
       attribution: null,
     });
     vi.mocked(prisma.bookingLink.findMany).mockResolvedValue([
-      { slug: "user-booking-link" },
+      { slug: "user-booking-link", minimumNoticeMinutes: 240 },
     ] as any);
 
     await fetchMessagesAndGenerateDraftWithConfidenceThreshold(
@@ -699,12 +699,15 @@ describe("fetchMessagesAndGenerateDraft - thread ordering", () => {
     expect(aiGetCalendarAvailability).toHaveBeenCalledWith(
       expect.objectContaining({
         bookingLinkAvailable: true,
+        minimumNoticeMinutes: 240,
       }),
     );
     expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
       expect.objectContaining({
         emailAccount: expect.objectContaining({
-          bookingLinks: [{ slug: "user-booking-link" }],
+          bookingLinks: [
+            { slug: "user-booking-link", minimumNoticeMinutes: 240 },
+          ],
         }),
       }),
     );

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -288,7 +288,7 @@ async function generateDraftContent(
     where: { emailAccountId: emailAccount.id, isActive: true },
     orderBy: { createdAt: "desc" },
     take: 1,
-    select: { slug: true },
+    select: { slug: true, minimumNoticeMinutes: true },
   });
   const calendarAvailabilityPromise = activeBookingLinksPromise.then(
     (activeBookingLinks) =>
@@ -298,6 +298,8 @@ async function generateDraftContent(
         logger,
         bookingLinkAvailable:
           activeBookingLinks.length > 0 || !!emailAccount.calendarBookingLink,
+        minimumNoticeMinutes:
+          activeBookingLinks[0]?.minimumNoticeMinutes ?? undefined,
       }),
   );
   const [


### PR DESCRIPTION
Improves draft quality by keeping multi-part requests in scope and prevents calendar suggestions inside the configured minimum-notice window.

- reuse booking-link minimum notice with a two-hour fallback
- hard-filter suggested slots and share the standard current-date prompt helper
- add semantic reply evals and deterministic calendar coverage
- bump the draft pipeline version

Validation:
- 25 related unit tests passed
- 2 targeted live AI evals passed
- Ultracite and staged diff checks passed

Performance impact: adds only in-memory slot filtering and reuses an existing booking-link query; no additional database or network calls and negligible hot-path risk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

