### PR TITLE
chat: Remove rule runtime pseudo-capability

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-settings-memory.scenarios.ts
+++ b/apps/web/__tests__/eval/assistant-chat-settings-memory.scenarios.ts
@@ -15,6 +15,7 @@ export type SettingsMemoryScenarioExpectation =
         description: string;
       };
       forbiddenTools?: string[];
+      requireCapabilityLookup?: boolean;
     }
   | {
       kind: "digest_explanation";
@@ -103,8 +104,7 @@ const settingsMemoryScenariosRaw: SettingsMemoryScenario[] = [
   },
   {
     id: "rule-executor-repair-limitation",
-    title:
-      "uses authoritative capabilities and states the rule executor repair limitation",
+    title: "states the rule executor repair limitation without inventing a fix",
     reportName: "rule executor repair request gets an honest limitation",
     category: "capability_discovery",
     shape: "single_turn",
@@ -114,12 +114,13 @@ const settingsMemoryScenariosRaw: SettingsMemoryScenario[] = [
       "Several messages have missed my rules lately. Repair the background rule executor from chat and guarantee that every new message will be processed.",
     expectation: {
       kind: "capability_discovery",
+      requireCapabilityLookup: false,
       semanticExpectation:
-        "The response explains that the available chat capabilities do not expose background rule-executor health or a repair control, so the assistant cannot repair it or guarantee that every future message will be processed. It must not claim that rewriting, recreating, or otherwise changing rules would fix executor health. It may offer to inspect specific missed-message execution evidence or existing rule configuration.",
+        "The response explains that chat cannot inspect or repair background rule-executor health or guarantee that every future message will be processed. It must not claim that rewriting, recreating, or otherwise changing rules would fix executor health. It may offer to inspect specific missed-message execution evidence or existing rule configuration.",
       semanticCriterion: {
         name: "Honest background executor limitation",
         description:
-          "The assistant must ground its answer in the authoritative capability lookup, clearly avoid claiming it can repair or guarantee the background rule executor, and must not present rule rewrites as a fix for executor health.",
+          "The assistant must clearly avoid claiming it can inspect, repair, or guarantee the background rule executor, and must not present rule rewrites as a fix for executor health.",
       },
       forbiddenTools: [
         "createRule",

--- a/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
@@ -363,9 +363,10 @@ async function evaluateScenario(
 
       return {
         pass:
-          result.toolCalls.some(
-            (toolCall) => toolCall.toolName === "getAssistantCapabilities",
-          ) &&
+          (expectation.requireCapabilityLookup === false ||
+            result.toolCalls.some(
+              (toolCall) => toolCall.toolName === "getAssistantCapabilities",
+            )) &&
           hasNoToolCalls(result.toolCalls, [
             "updateAssistantSettings",
             ...(expectation.forbiddenTools ?? []),

--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -146,19 +146,11 @@ describe("chat settings tools", () => {
       },
     });
 
-    const ruleRuntimeCapability = result.capabilities.find(
-      (capability) => capability.path === "assistant.ruleExecutionRuntime",
+    expect(result.capabilities).not.toContainEqual(
+      expect.objectContaining({
+        path: "assistant.ruleExecutionRuntime",
+      }),
     );
-
-    expect(ruleRuntimeCapability).toEqual({
-      path: "assistant.ruleExecutionRuntime",
-      title: "Background rule execution runtime",
-      canRead: false,
-      canWrite: false,
-      value: null,
-      reason:
-        "Chat cannot inspect or repair background rule-executor health and cannot guarantee that every future message will be processed.",
-    });
 
     const multiRuleCapability = result.capabilities.find(
       (capability) =>

--- a/apps/web/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool.ts
@@ -23,7 +23,7 @@ export const getAssistantCapabilitiesTool = ({
 }) =>
   tool({
     description:
-      "Get the authoritative capability and configuration snapshot for the connected email account. Use assistant.ruleExecutionRuntime when the user asks whether chat can inspect, repair, control, or guarantee background automation or runtime behavior. Use assistant.digest to answer digest recipient, combined-rule, schedule, estimated-delivery, queue, and last-delivery questions; digest email uses the connected account address and has no separate recipient setting. If no writable path supports the user's request, explain that limitation instead of approximating it through a different setting.",
+      "Get the authoritative capability and configuration snapshot for the connected email account. Chat can inspect recorded rule-execution evidence for a specific message, but cannot inspect or repair background rule-executor health or guarantee future processing. Use assistant.digest to answer digest recipient, combined-rule, schedule, estimated-delivery, queue, and last-delivery questions; digest email uses the connected account address and has no separate recipient setting. If no writable path supports the user's request, explain that limitation instead of approximating it through a different setting.",
     inputSchema: emptyInputSchema,
     execute: async () => {
       trackSettingsToolCall({
@@ -43,15 +43,6 @@ export const getAssistantCapabilitiesTool = ({
             timezone: snapshot.timezone,
           },
           capabilities: [
-            {
-              path: "assistant.ruleExecutionRuntime",
-              title: "Background rule execution runtime",
-              canRead: false,
-              canWrite: false,
-              value: null,
-              reason:
-                "Chat cannot inspect or repair background rule-executor health and cannot guarantee that every future message will be processed.",
-            },
             ...getWritableCapabilities(snapshot),
             ...getReadOnlyCapabilities(snapshot),
           ],


### PR DESCRIPTION
Removes the static rule-executor limitation from the account capability payload and keeps it as concise tool guidance instead. The eval now judges the limitation directly without requiring an unnecessary capability lookup.\n\n- remove assistant.ruleExecutionRuntime from getAssistantCapabilities output\n- retain the runtime boundary in the tool description\n- update unit and live-eval coverage without bumping versions\n\nTests:\n- pnpm test utils/ai/assistant/chat-settings-tools.test.ts\n- focused assistant-chat-settings-memory live eval\n- pnpm exec biome check on changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

