### PR TITLE
INB-321: Add owner indicator to meeting notetaker

### DIFF
--- a/apps/web/__tests__/db/fake-bot-provider.ts
+++ b/apps/web/__tests__/db/fake-bot-provider.ts
@@ -18,7 +18,7 @@ export class FakeBotProvider implements MeetingBotProvider {
   }> = [];
   readonly updated: Array<{
     botId: string;
-    botName?: string;
+    botName: string;
     joinAt?: Date;
     meetingUrl?: string;
   }> = [];
@@ -60,7 +60,7 @@ export class FakeBotProvider implements MeetingBotProvider {
 
   async updateBot(
     externalBotId: string,
-    params: { botName?: string; joinAt?: Date; meetingUrl?: string },
+    params: { botName: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }> {
     this.updated.push({ botId: externalBotId, ...params });
     const beforeNextUpdate = this.beforeNextUpdate;

--- a/apps/web/__tests__/db/fake-bot-provider.ts
+++ b/apps/web/__tests__/db/fake-bot-provider.ts
@@ -12,11 +12,13 @@ import {
 export class FakeBotProvider implements MeetingBotProvider {
   readonly scheduled: Array<{
     botId: string;
+    botName?: string;
     meetingUrl: string;
     joinAt: Date;
   }> = [];
   readonly updated: Array<{
     botId: string;
+    botName?: string;
     joinAt?: Date;
     meetingUrl?: string;
   }> = [];
@@ -34,9 +36,11 @@ export class FakeBotProvider implements MeetingBotProvider {
   private transcript: NormalizedTranscript = [];
 
   async scheduleBot({
+    botName,
     meetingUrl,
     joinAt,
   }: {
+    botName?: string;
     meetingUrl: string;
     joinAt: Date;
   }): Promise<{ externalBotId: string }> {
@@ -50,13 +54,13 @@ export class FakeBotProvider implements MeetingBotProvider {
     }
 
     const externalBotId = `fake_bot_${this.nextId++}`;
-    this.scheduled.push({ botId: externalBotId, meetingUrl, joinAt });
+    this.scheduled.push({ botId: externalBotId, botName, meetingUrl, joinAt });
     return { externalBotId };
   }
 
   async updateBot(
     externalBotId: string,
-    params: { joinAt?: Date; meetingUrl?: string },
+    params: { botName?: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }> {
     this.updated.push({ botId: externalBotId, ...params });
     const beforeNextUpdate = this.beforeNextUpdate;

--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -101,6 +101,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       return {
         id,
         email,
+        name: email === ACCOUNT_A ? "Alice Owner" : "Bob Owner",
         meetingRecorderJoinRule: MeetingJoinRule.EXTERNAL_ONLY,
       };
     }
@@ -120,6 +121,10 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
 
       expect(fakeProvider.scheduled).toHaveLength(2);
+      expect(fakeProvider.scheduled.map(({ botName }) => botName)).toEqual([
+        "Alice's Inbox Zero Notetaker",
+        "Bob's Inbox Zero Notetaker",
+      ]);
 
       const recordings = await prisma.meetingRecording.findMany();
       expect(recordings).toHaveLength(2);
@@ -837,6 +842,7 @@ describe.skipIf(!RUN_DB_TESTS)(
 
       expect(fakeProvider.updated).toContainEqual({
         botId: fakeProvider.scheduled[0]?.botId,
+        botName: "Alice's Inbox Zero Notetaker",
         meetingUrl: "https://acme.zoom.us/j/8123456789?pwd=new",
       });
       expect(fakeProvider.scheduled).toHaveLength(1);

--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -136,6 +136,24 @@ describe.skipIf(!RUN_DB_TESTS)(
       );
     });
 
+    test("updates the bot name for an existing scheduled recording", async () => {
+      const event = calendarEvent();
+      const emailAccount = account(accountAId, ACCOUNT_A);
+      await reconcile.reconcileSingleEvent({ emailAccount, event, logger });
+
+      await reconcile.reconcileSingleEvent({
+        emailAccount: { ...emailAccount, name: "Alicia Owner" },
+        event,
+        logger,
+      });
+
+      expect(fakeProvider.updated).toContainEqual({
+        botId: fakeProvider.scheduled[0]?.botId,
+        botName: "Alicia's Inbox Zero Notetaker",
+      });
+      expect(fakeProvider.scheduled).toHaveLength(1);
+    });
+
     test("cancels only the account's own bot", async () => {
       const event = calendarEvent();
       await reconcile.reconcileSingleEvent({
@@ -881,7 +899,10 @@ describe.skipIf(!RUN_DB_TESTS)(
         logger,
       });
 
-      expect(fakeProvider.updated).toHaveLength(0);
+      expect(fakeProvider.updated).toContainEqual({
+        botId: fakeProvider.scheduled[1]?.botId,
+        botName: "Bob's Inbox Zero Notetaker",
+      });
       expect(fakeProvider.cancelled).toHaveLength(0);
       expect(fakeProvider.scheduled).toHaveLength(2);
     });

--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -140,6 +140,9 @@ describe.skipIf(!RUN_DB_TESTS)(
       const event = calendarEvent();
       const emailAccount = account(accountAId, ACCOUNT_A);
       await reconcile.reconcileSingleEvent({ emailAccount, event, logger });
+      expect((await prisma.meetingRecording.findFirstOrThrow()).botName).toBe(
+        "Alice's Inbox Zero Notetaker",
+      );
 
       await reconcile.reconcileSingleEvent({
         emailAccount: { ...emailAccount, name: "Alicia Owner" },
@@ -152,6 +155,17 @@ describe.skipIf(!RUN_DB_TESTS)(
         botName: "Alicia's Inbox Zero Notetaker",
       });
       expect(fakeProvider.scheduled).toHaveLength(1);
+      expect((await prisma.meetingRecording.findFirstOrThrow()).botName).toBe(
+        "Alicia's Inbox Zero Notetaker",
+      );
+
+      await reconcile.reconcileSingleEvent({
+        emailAccount: { ...emailAccount, name: "Alicia Owner" },
+        event,
+        logger,
+      });
+
+      expect(fakeProvider.updated).toHaveLength(1);
     });
 
     test("cancels only the account's own bot", async () => {

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -49,13 +49,14 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const joinAt = new Date("2026-05-04T09:00:00.000Z");
 
       const { externalBotId } = await provider.scheduleBot({
+        botName: "Barbara's Inbox Zero Notetaker",
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         joinAt,
       });
 
       expect(emulator.getBot(externalBotId)).toMatchObject({
         meeting_url: "https://meet.google.com/abc-defg-hij",
-        bot_name: "Inbox Zero Notetaker",
+        bot_name: "Barbara's Inbox Zero Notetaker",
         join_at: joinAt.toISOString(),
       });
 
@@ -142,7 +143,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
     test("replaces a bot when Recall rejects a near-term reschedule", async () => {
       const meetingUrl = "https://meet.google.com/abc-defg-hij";
+      const botName = "Barbara's Inbox Zero Notetaker";
       const { externalBotId } = await provider.scheduleBot({
+        botName,
         meetingUrl,
         joinAt: new Date("2026-05-04T09:00:00.000Z"),
       });
@@ -150,6 +153,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const movedTo = new Date("2026-05-04T08:05:00.000Z");
       const updated = await provider.updateBot(externalBotId, {
+        botName,
         joinAt: movedTo,
         meetingUrl,
       });
@@ -159,6 +163,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(emulator.getBot(updated.externalBotId)?.join_at).toBe(
         movedTo.toISOString(),
       );
+      expect(emulator.getBot(updated.externalBotId)?.bot_name).toBe(botName);
     });
 
     test("updates the meeting URL for a scheduled bot", async () => {

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -13,6 +13,7 @@ import {
   type RecallEmulator,
   type RecallEmulatorTranscriptTurn,
 } from "@/__tests__/emulators/recall";
+import { MEETING_BOT_DISPLAY_NAME } from "@/utils/meeting-recorder/bot-provider";
 
 vi.mock("server-only", () => ({}));
 
@@ -132,6 +133,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const movedTo = new Date("2026-05-04T10:00:00.000Z");
       await provider.updateBot(externalBotId, {
+        botName: MEETING_BOT_DISPLAY_NAME,
         joinAt: movedTo,
         meetingUrl: "https://meet.google.com/abc-defg-hij",
       });
@@ -173,7 +175,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       });
 
       const meetingUrl = "https://acme.zoom.us/j/8123456789?pwd=new";
-      await provider.updateBot(externalBotId, { meetingUrl });
+      await provider.updateBot(externalBotId, {
+        botName: MEETING_BOT_DISPLAY_NAME,
+        meetingUrl,
+      });
 
       expect(emulator.getBot(externalBotId)?.meeting_url).toBe(meetingUrl);
     });

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderOnboarding.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderOnboarding.tsx
@@ -19,7 +19,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { MEETING_BOT_DISPLAY_NAME } from "@/utils/meeting-recorder/bot-provider";
+import { getMeetingBotDisplayName } from "@/utils/meeting-recorder/bot-provider";
 import { ConnectCalendar } from "@/app/(app)/[emailAccountId]/calendars/ConnectCalendar";
 import { JOIN_RULE_OPTIONS } from "@/app/(app)/[emailAccountId]/meetings/join-rule-options";
 
@@ -106,7 +106,11 @@ function ChooseJoinRule({
   onConfirm: () => void;
   isEnabling: boolean;
 }) {
-  const { userEmail } = useAccount();
+  const { emailAccount, userEmail } = useAccount();
+  const botName = getMeetingBotDisplayName({
+    ownerName: emailAccount?.name ?? null,
+    ownerEmail: userEmail,
+  });
 
   return (
     <div className="mx-4 mt-16 flex max-w-lg flex-col gap-6 md:mx-auto">
@@ -135,7 +139,7 @@ function ChooseJoinRule({
 
       <MutedText className="flex items-start gap-2 text-xs">
         <ShieldIcon className="mt-0.5 size-3.5 shrink-0" />
-        Joins as a visible participant called {MEETING_BOT_DISPLAY_NAME}.
+        Joins as a visible participant called {botName}.
       </MutedText>
     </div>
   );

--- a/apps/web/app/api/meeting-recorder/schedule/route.ts
+++ b/apps/web/app/api/meeting-recorder/schedule/route.ts
@@ -61,6 +61,7 @@ async function scheduleAllMeetingRecordings(logger: Logger) {
       id: true,
       email: true,
       meetingRecorderJoinRule: true,
+      name: true,
     },
   });
   // Accounts holding live bookings that the main reconcile query no longer

--- a/apps/web/prisma/migrations/20260807020000_add_meeting_recording_bot_name/migration.sql
+++ b/apps/web/prisma/migrations/20260807020000_add_meeting_recording_bot_name/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "MeetingRecording" ADD COLUMN "botName" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1403,6 +1403,8 @@ model MeetingRecording {
   botProvider          String   @default("recall")
   // Null between claiming the row and the provider call returning.
   externalBotId        String?
+  // Last display name successfully sent to the provider.
+  botName              String?
   // Set when the provider reports the recording is ready.
   externalRecordingId  String?
   // Claim for the create-transcript call, kept separate from the id above so a

--- a/apps/web/utils/actions/meeting-recorder.ts
+++ b/apps/web/utils/actions/meeting-recorder.ts
@@ -71,6 +71,7 @@ export const setMeetingJoinOverrideAction = actionClient
         select: {
           id: true,
           email: true,
+          name: true,
           userId: true,
           meetingRecorderEnabled: true,
           meetingRecorderJoinRule: true,

--- a/apps/web/utils/meeting-recorder/bot-provider.test.ts
+++ b/apps/web/utils/meeting-recorder/bot-provider.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getMeetingBotDisplayName } from "@/utils/meeting-recorder/bot-provider";
+
+describe("getMeetingBotDisplayName", () => {
+  it("identifies the notetaker by the owner's first name", () => {
+    expect(
+      getMeetingBotDisplayName({
+        ownerName: "Barbara Dalavecchia",
+        ownerEmail: "barbara@example.com",
+      }),
+    ).toBe("Barbara's Inbox Zero Notetaker");
+  });
+
+  it("uses the owner's email when their profile has no name", () => {
+    expect(
+      getMeetingBotDisplayName({
+        ownerName: null,
+        ownerEmail: "barbara@example.com",
+      }),
+    ).toBe("barbara@example.com's Inbox Zero Notetaker");
+  });
+
+  it("stays within Recall's display-name limit", () => {
+    const displayName = getMeetingBotDisplayName({
+      ownerName: "B".repeat(101),
+      ownerEmail: "barbara@example.com",
+    });
+
+    expect(displayName).toHaveLength(100);
+    expect(displayName.endsWith("'s Inbox Zero Notetaker")).toBe(true);
+  });
+});

--- a/apps/web/utils/meeting-recorder/bot-provider.test.ts
+++ b/apps/web/utils/meeting-recorder/bot-provider.test.ts
@@ -29,4 +29,14 @@ describe("getMeetingBotDisplayName", () => {
     expect(displayName).toHaveLength(100);
     expect(displayName.endsWith("'s Inbox Zero Notetaker")).toBe(true);
   });
+
+  it("does not split an astral Unicode character at the display-name limit", () => {
+    const displayName = getMeetingBotDisplayName({
+      ownerName: `${"B".repeat(76)}😀`,
+      ownerEmail: "barbara@example.com",
+    });
+
+    expect(displayName).toBe(`${"B".repeat(76)}'s Inbox Zero Notetaker`);
+    expect(displayName).toHaveLength(99);
+  });
 });

--- a/apps/web/utils/meeting-recorder/bot-provider.ts
+++ b/apps/web/utils/meeting-recorder/bot-provider.ts
@@ -50,7 +50,7 @@ export interface MeetingBotProvider {
   /** Updates a bot that has been scheduled but has not started joining yet. */
   updateBot(
     externalBotId: string,
-    params: { botName?: string; joinAt?: Date; meetingUrl?: string },
+    params: { botName: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }>;
 }
 
@@ -67,5 +67,15 @@ export function getMeetingBotDisplayName({
   const maxOwnerIdentifierLength =
     MAX_MEETING_BOT_DISPLAY_NAME_LENGTH - suffix.length;
 
-  return `${ownerIdentifier.slice(0, maxOwnerIdentifierLength)}${suffix}`;
+  const truncatedOwnerIdentifier = ownerIdentifier.slice(
+    0,
+    maxOwnerIdentifierLength,
+  );
+  const unicodeSafeOwnerIdentifier = /[\uD800-\uDBFF]$/.test(
+    truncatedOwnerIdentifier,
+  )
+    ? truncatedOwnerIdentifier.slice(0, -1)
+    : truncatedOwnerIdentifier;
+
+  return `${unicodeSafeOwnerIdentifier}${suffix}`;
 }

--- a/apps/web/utils/meeting-recorder/bot-provider.ts
+++ b/apps/web/utils/meeting-recorder/bot-provider.ts
@@ -1,5 +1,6 @@
 // Product-facing name of the bot that appears in the participant list.
 export const MEETING_BOT_DISPLAY_NAME = "Inbox Zero Notetaker";
+const MAX_MEETING_BOT_DISPLAY_NAME_LENGTH = 100;
 
 interface TranscriptUtterance {
   email?: string;
@@ -42,12 +43,29 @@ export interface MeetingBotProvider {
   deleteMedia(externalBotId: string): Promise<void>;
   fetchTranscript(externalTranscriptId: string): Promise<NormalizedTranscript>;
   scheduleBot(params: {
+    botName?: string;
     meetingUrl: string;
     joinAt: Date;
   }): Promise<{ externalBotId: string }>;
   /** Updates a bot that has been scheduled but has not started joining yet. */
   updateBot(
     externalBotId: string,
-    params: { joinAt?: Date; meetingUrl?: string },
+    params: { botName?: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }>;
+}
+
+export function getMeetingBotDisplayName({
+  ownerName,
+  ownerEmail,
+}: {
+  ownerName: string | null;
+  ownerEmail: string;
+}): string {
+  const firstName = ownerName?.trim().split(/\s+/)[0];
+  const ownerIdentifier = firstName || ownerEmail;
+  const suffix = `'s ${MEETING_BOT_DISPLAY_NAME}`;
+  const maxOwnerIdentifierLength =
+    MAX_MEETING_BOT_DISPLAY_NAME_LENGTH - suffix.length;
+
+  return `${ownerIdentifier.slice(0, maxOwnerIdentifierLength)}${suffix}`;
 }

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -496,7 +496,18 @@ async function updateBookingForEvent({
 
   const startTimeUnchanged =
     recording.meetingStartTime.getTime() === event.startTime.getTime();
-  if (startTimeUnchanged) return true;
+  if (startTimeUnchanged) {
+    if (
+      recording.meetingUrl === event.videoConferenceLink &&
+      recording.externalBotId &&
+      CHANGEABLE_STATUSES.includes(recording.status)
+    ) {
+      const provider = createMeetingBotProvider(recording.botProvider, logger);
+      await provider.updateBot(recording.externalBotId, { botName });
+    }
+
+    return true;
+  }
 
   // Once the bot is joining or in the call there is nothing left to move.
   if (!CHANGEABLE_STATUSES.includes(recording.status)) return true;

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -481,12 +481,12 @@ async function updateBookingForEvent({
   // Same meeting, fresher link: normalization drops credentials, so this is
   // where a rotated meeting password or invitee context shows up.
   if (recording.meetingUrl !== event.videoConferenceLink) {
+    const externalBotId = recording.externalBotId;
     const canUpdateBot =
-      recording.externalBotId !== null &&
-      CHANGEABLE_STATUSES.includes(recording.status);
+      externalBotId !== null && CHANGEABLE_STATUSES.includes(recording.status);
     if (canUpdateBot) {
       const provider = createMeetingBotProvider(recording.botProvider, logger);
-      await provider.updateBot(recording.externalBotId, {
+      await provider.updateBot(externalBotId, {
         botName,
         meetingUrl: event.videoConferenceLink,
       });

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -19,7 +19,10 @@ import {
   parseAttendeeSnapshot,
   toAttendeeSnapshot,
 } from "@/utils/meeting-recorder/attendees";
-import { MeetingBotProviderError } from "@/utils/meeting-recorder/bot-provider";
+import {
+  getMeetingBotDisplayName,
+  MeetingBotProviderError,
+} from "@/utils/meeting-recorder/bot-provider";
 import {
   MAX_EVENTS_PER_PROVIDER,
   MAX_PROCESSING_ATTEMPTS,
@@ -56,6 +59,7 @@ interface RecorderAccount {
   email: string;
   id: string;
   meetingRecorderJoinRule: MeetingJoinRule;
+  name: string | null;
 }
 
 export async function reconcileAccount({
@@ -133,6 +137,10 @@ export async function reconcileSingleEvent({
       event,
     }));
   const eventLogger = logger.with({ meetingId: meeting.id });
+  const botName = getMeetingBotDisplayName({
+    ownerName: emailAccount.name,
+    ownerEmail: emailAccount.email,
+  });
 
   const wantsRecording = shouldAutoJoin({
     event,
@@ -155,6 +163,7 @@ export async function reconcileSingleEvent({
       meetingId: meeting.id,
       recordingId: meeting.recordingId,
       event,
+      botName,
       logger: eventLogger,
     });
     // A released booking falls through to book again against the new link.
@@ -164,6 +173,7 @@ export async function reconcileSingleEvent({
   const recording = await findOrCreateRecording({
     emailAccountId: emailAccount.id,
     event,
+    botName,
     logger: eventLogger,
   });
   if (!recording) return;
@@ -231,10 +241,12 @@ export async function upsertMeeting({
 async function findOrCreateRecording({
   emailAccountId,
   event,
+  botName,
   logger,
 }: {
   emailAccountId: string;
   event: CalendarEvent;
+  botName: string;
   logger: Logger;
 }): Promise<MeetingRecording | null> {
   const meetingUrl = event.videoConferenceLink;
@@ -251,7 +263,7 @@ async function findOrCreateRecording({
     // A claim whose provider call failed transiently is still sitting here with
     // no bot behind it. Booking it now is the retry.
     if (existing.externalBotId) return existing;
-    return bookBot({ recording: existing, logger });
+    return bookBot({ recording: existing, botName, logger });
   }
 
   // Claim the meeting by writing the row before calling the provider. If we
@@ -278,14 +290,16 @@ async function findOrCreateRecording({
     });
   }
 
-  return bookBot({ recording: claimed, logger });
+  return bookBot({ recording: claimed, botName, logger });
 }
 
 async function bookBot({
   recording,
+  botName,
   logger,
 }: {
   recording: MeetingRecording;
+  botName: string;
   logger: Logger;
 }): Promise<MeetingRecording | null> {
   const provider = createMeetingBotProvider(recording.botProvider, logger);
@@ -293,6 +307,7 @@ async function bookBot({
   let externalBotId: string;
   try {
     ({ externalBotId } = await provider.scheduleBot({
+      botName,
       meetingUrl: recording.meetingUrl,
       joinAt: recording.meetingStartTime,
     }));
@@ -432,11 +447,13 @@ async function updateBookingForEvent({
   meetingId,
   recordingId,
   event,
+  botName,
   logger,
 }: {
   meetingId: string;
   recordingId: string;
   event: CalendarEvent;
+  botName: string;
   logger: Logger;
 }): Promise<boolean> {
   const recording = await prisma.meetingRecording.findUnique({
@@ -466,6 +483,7 @@ async function updateBookingForEvent({
     ) {
       const provider = createMeetingBotProvider(recording.botProvider, logger);
       await provider.updateBot(recording.externalBotId, {
+        botName,
         meetingUrl: event.videoConferenceLink,
       });
     }
@@ -505,6 +523,7 @@ async function updateBookingForEvent({
 
   const provider = createMeetingBotProvider(recording.botProvider, logger);
   const updatedBot = await provider.updateBot(recording.externalBotId, {
+    botName,
     joinAt: event.startTime,
     meetingUrl: event.videoConferenceLink ?? recording.meetingUrl,
   });

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -331,7 +331,11 @@ async function bookBot({
   // cannot both take credit; the loser cancels the bot it just created.
   const claimed = await prisma.meetingRecording.updateMany({
     where: { id: recording.id, externalBotId: null },
-    data: { externalBotId, status: MeetingRecordingStatus.SCHEDULED },
+    data: {
+      externalBotId,
+      botName,
+      status: MeetingRecordingStatus.SCHEDULED,
+    },
   });
 
   if (claimed.count === 0) {
@@ -477,10 +481,10 @@ async function updateBookingForEvent({
   // Same meeting, fresher link: normalization drops credentials, so this is
   // where a rotated meeting password or invitee context shows up.
   if (recording.meetingUrl !== event.videoConferenceLink) {
-    if (
-      recording.externalBotId &&
-      CHANGEABLE_STATUSES.includes(recording.status)
-    ) {
+    const canUpdateBot =
+      recording.externalBotId !== null &&
+      CHANGEABLE_STATUSES.includes(recording.status);
+    if (canUpdateBot) {
       const provider = createMeetingBotProvider(recording.botProvider, logger);
       await provider.updateBot(recording.externalBotId, {
         botName,
@@ -490,7 +494,10 @@ async function updateBookingForEvent({
 
     await prisma.meetingRecording.updateMany({
       where: { id: recordingId, status: { in: CHANGEABLE_STATUSES } },
-      data: { meetingUrl: event.videoConferenceLink },
+      data: {
+        meetingUrl: event.videoConferenceLink,
+        ...(canUpdateBot && { botName }),
+      },
     });
   }
 
@@ -499,11 +506,20 @@ async function updateBookingForEvent({
   if (startTimeUnchanged) {
     if (
       recording.meetingUrl === event.videoConferenceLink &&
+      recording.botName !== botName &&
       recording.externalBotId &&
       CHANGEABLE_STATUSES.includes(recording.status)
     ) {
       const provider = createMeetingBotProvider(recording.botProvider, logger);
       await provider.updateBot(recording.externalBotId, { botName });
+      await prisma.meetingRecording.updateMany({
+        where: {
+          id: recordingId,
+          externalBotId: recording.externalBotId,
+          status: { in: CHANGEABLE_STATUSES },
+        },
+        data: { botName },
+      });
     }
 
     return true;
@@ -543,6 +559,7 @@ async function updateBookingForEvent({
     await prisma.meetingRecording.update({
       where: { id: recording.id },
       data: {
+        botName,
         meetingStartTime: event.startTime,
         externalBotId: updatedBot.externalBotId,
       },
@@ -559,7 +576,7 @@ async function updateBookingForEvent({
     if (updatedBot.externalBotId !== recording.externalBotId) {
       await prisma.meetingRecording.update({
         where: { id: recording.id },
-        data: { externalBotId: updatedBot.externalBotId },
+        data: { botName, externalBotId: updatedBot.externalBotId },
       });
     }
 

--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -33,6 +33,7 @@ describe("RecallBotProvider", () => {
     const provider = new RecallBotProvider(createTestLogger());
 
     await provider.scheduleBot({
+      botName: "Barbara's Inbox Zero Notetaker",
       meetingUrl: "https://meet.google.com/abc-defg-hij",
       joinAt: new Date("2026-05-04T09:00:00.000Z"),
     });
@@ -41,6 +42,10 @@ describe("RecallBotProvider", () => {
       "https://eu-central-1.recall.ai/api/v1/bot/",
       expect.anything(),
     );
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(request?.body as string)).toMatchObject({
+      bot_name: "Barbara's Inbox Zero Notetaker",
+    });
   });
 
   it("retries loading the camera image after a transient failure", async () => {

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -59,9 +59,11 @@ export class RecallBotProvider implements MeetingBotProvider {
   }
 
   async scheduleBot({
+    botName = MEETING_BOT_DISPLAY_NAME,
     meetingUrl,
     joinAt,
   }: {
+    botName?: string;
     meetingUrl: string;
     joinAt: Date;
   }): Promise<{ externalBotId: string }> {
@@ -75,7 +77,7 @@ export class RecallBotProvider implements MeetingBotProvider {
       method: "POST",
       body: {
         meeting_url: meetingUrl,
-        bot_name: MEETING_BOT_DISPLAY_NAME,
+        bot_name: botName,
         join_at: joinAt.toISOString(),
         automatic_video_output: {
           in_call_recording: {
@@ -92,12 +94,17 @@ export class RecallBotProvider implements MeetingBotProvider {
 
   async updateBot(
     externalBotId: string,
-    { joinAt, meetingUrl }: { joinAt?: Date; meetingUrl?: string },
+    {
+      botName,
+      joinAt,
+      meetingUrl,
+    }: { botName?: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }> {
     try {
       await this.request(`/bot/${externalBotId}/`, {
         method: "PATCH",
         body: {
+          ...(botName && { bot_name: botName }),
           ...(joinAt && { join_at: joinAt.toISOString() }),
           ...(meetingUrl && { meeting_url: meetingUrl }),
         },
@@ -115,7 +122,7 @@ export class RecallBotProvider implements MeetingBotProvider {
       }
 
       await this.cancelBot(externalBotId);
-      return this.scheduleBot({ meetingUrl, joinAt });
+      return this.scheduleBot({ botName, meetingUrl, joinAt });
     }
   }
 

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -98,7 +98,7 @@ export class RecallBotProvider implements MeetingBotProvider {
       botName,
       joinAt,
       meetingUrl,
-    }: { botName?: string; joinAt?: Date; meetingUrl?: string },
+    }: { botName: string; joinAt?: Date; meetingUrl?: string },
   ): Promise<{ externalBotId: string }> {
     try {
       await this.request(`/bot/${externalBotId}/`, {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260805-205926_pr-3166_5d29dd9124db/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Personalizes each meeting notetaker display name with its account owner identifier so attendees can distinguish simultaneous notetakers. Propagates the display name through scheduling and rescheduling while respecting the provider limit.

- Generate capped owner-specific display names with a fallback identifier.
- Pass display names through reconciliation and provider create/update calls, including replacement bookings.
- Tests: 5 focused unit tests and 13 Recall emulator integration tests passed; database coverage was updated but not run because no throwaway database was configured.
- Performance: adds constant-time string formatting and one field to existing account selects; no additional database or network calls, with negligible risk in the reconciliation hot path.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-321/add-owner-indicator-for-notetaker-attendant-in-meetings

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->