### PR TITLE
fix(docker): restore meriyah's ESM entry and smoke-test the standalone server

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -100,6 +100,20 @@ RUN cd /app/apps/web \
  && pnpm --filter @inboxzero/worker deploy --legacy --prod /tmp/apps/worker \
  && rm -rf apps/web/.next/cache
 
+# Tracing resolves meriyah through the `require` condition and ships only
+# dist/meriyah.cjs, but @sentry/nextjs imports it as ESM at runtime. Kept narrow
+# on purpose; tracing omits files by design. outputFileTracingIncludes does not
+# work here, Turbopack builds skip collect-build-traces.
+RUN set -eux; \
+    src=/app/node_modules/meriyah/dist; \
+    test -f "$src/meriyah.mjs"; \
+    found=0; \
+    for d in $(find /app/apps/web/.next/standalone -type d -path '*/node_modules/meriyah/dist'); do \
+        cp "$src/meriyah.mjs" "$src/meriyah.min.mjs" "$d/"; \
+        found=$((found + 1)); \
+    done; \
+    test "$found" -gt 0
+
 RUN rm -f /app/apps/web/.env /app/apps/web/.next/standalone/apps/web/.env
 
 FROM node:24-alpine AS runner
@@ -125,6 +139,10 @@ RUN test -f apps/web/server.js \
 # Copy runtime scripts
 COPY docker/scripts /app/docker/scripts
 RUN chmod +x /app/docker/scripts/*.sh
+
+# The check above only proves `next` resolves. Boot the server too, so a broken
+# traced output fails here instead of 500ing every request at runtime.
+RUN /app/docker/scripts/smoke-standalone.sh
 
 # Install Prisma CLI globally for migrations
 RUN npm install -g prisma@7.3.0

--- a/docker/scripts/smoke-standalone.sh
+++ b/docker/scripts/smoke-standalone.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Boot the standalone server and fail if it cannot load its instrumentation
+# hook. Resolving the package by name is not enough: `pnpm deploy` leaves a
+# complete copy in apps/web/node_modules that resolves fine even when the
+# traced copy the server actually uses is incomplete.
+set -e
+
+LOG=/tmp/smoke-standalone.log
+
+node /app/apps/web/server.js >"$LOG" 2>&1 &
+PID=$!
+trap 'kill "$PID" 2>/dev/null || true' EXIT
+
+waited=0
+until grep -q "Ready in" "$LOG" 2>/dev/null; do
+    kill -0 "$PID" 2>/dev/null || { echo "server exited before becoming ready"; tail -20 "$LOG"; exit 1; }
+    waited=$((waited + 1))
+    [ "$waited" -lt 60 ] || { echo "server never became ready"; tail -20 "$LOG"; exit 1; }
+    sleep 1
+done
+
+# The hook is evaluated on the request path, so make one request before judging.
+# Its status does not matter; there is no database here and a 500 is expected.
+wget -q -O /dev/null -T 5 http://127.0.0.1:3000/login 2>/dev/null || true
+sleep 2
+
+if grep -q "Failed to load external module" "$LOG"; then
+    echo "Standalone server cannot load its instrumentation hook:"
+    grep -m1 "Failed to load external module" "$LOG"
+    exit 1
+fi
+
+echo "Standalone smoke test passed."


### PR DESCRIPTION
Fixes #3150. Since #3149, self-hosted images start, apply migrations, log `✓ Ready`, and then 500 every request.

## Cause

meriyah publishes its ESM entry only through the `default` and `module-sync` export conditions. Tracing resolves it through `require`, so the standalone output gets `dist/meriyah.cjs` alone. At runtime `@sentry/nextjs` is in `serverExternalPackages`, so it loads from that traced output, reaches meriyah as ESM via `@apm-js-collab/code-transformer`, and cannot find `dist/meriyah.mjs`.

The truncated copy is not new. `@sentry/nextjs` 10.69.0 is what began importing it as ESM, which is why the gap only became reachable in #3149.

## Why not `outputFileTracingIncludes`

It is inert here. Since #2981 these are Turbopack builds, and Turbopack skips trace collection entirely:

```js
// next/dist/build/index.js
if (bundler !== _bundler.Bundler.Turbopack && !isGenerateMode && !buildTracesPromise) {
    const { collectBuildTraces } = require('./collect-build-traces');
```

`collect-build-traces` is what implements `outputFileTracingIncludes`, so setting it changes nothing and warns about nothing. I tried it first and confirmed it has no effect on the built image.

## Changes

1. `docker/Dockerfile.prod`: after the build, copy meriyah's ESM entries into the standalone tree. Deliberately narrow, because tracing omits files by design and a healthy image already has ~550 export targets that legitimately do not exist. A blanket repair would undo the point of tracing.
2. `docker/Dockerfile.prod` and `docker/scripts/smoke-standalone.sh`: boot the built server during the image build and fail if the instrumentation hook does not load. This is the durable half. The targeted copy is whack-a-mole on its own; the smoke test means the next occurrence fails the build instead of shipping.

## Why the smoke test boots the server

The existing check proves `next` resolves and stops there. Two cheaper checks look like they would cover this and do not:

* Asserting every `exports` target exists. ~550 false positives on a healthy image.
* `import("@sentry/nextjs")` by name. That resolves to the complete `pnpm deploy --prod` copy in `apps/web/node_modules`, which is intact even when the traced copy the server uses is not. I verified this passes on the broken image, so it would have shipped this bug.

Only running the built server exercises the path the runtime actually resolves. I checked whether a static
scan could work instead: the chunks contain just five literal absolute paths, all unrelated route entries,
so the store path is constructed at load time and cannot be asserted without booting.

## Verification

Against the published broken image `sha256:b59cfafc…`:

* the smoke test fails with the exact `Cannot find module .../meriyah/dist/meriyah.mjs`
* restoring only `meriyah.mjs` makes it pass, and `/login` returns 200 instead of 500

On this branch, built end to end with `docker/Dockerfile.prod`:

* the copy lands in `.next/standalone/.pnpm-store/v11/links/@/meriyah/6.1.4/2e61a82c…/node_modules/meriyah/dist/`, which is the path the chunks reference
* the smoke test passes as a build step
* running the resulting image against Postgres and Redis, `/login` returns 200 with zero `Cannot find module` lines in the log

I also confirmed the smoke test fails the build on this tree without the copy, so it is testing what it claims to.

## Note

The underlying mismatch, tracing resolving one export condition while the runtime uses another, looks like it belongs in Turbopack. This PR is the workaround plus a guard so it cannot ship silently again.
