### PR TITLE
meeting recorder: Improve scheduling observability

### DIFF
--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -319,7 +319,14 @@ async function bookBot({
     data: { externalBotId, status: MeetingRecordingStatus.SCHEDULED },
   });
 
-  if (claimed.count === 0) {
+  if (claimed.count > 0) {
+    logger.info("Scheduled meeting bot", {
+      recordingId: recording.id,
+      externalBotId,
+      botProvider: recording.botProvider,
+      meetingStartTime: recording.meetingStartTime,
+    });
+  } else {
     logger.info("Another pass already booked this meeting", {
       recordingId: recording.id,
     });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260805-224858_pr-3168_9b91a82e4d35/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds structured observability after a meeting bot booking is durably claimed.

- Logs provider and recording identifiers with the scheduled start time.
- Preserves duplicate-booking cancellation behavior.
- Verified with focused meeting-recorder tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->