### PR TITLE
onboarding: share the chat prompt input with the in-app assistant chat

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboardingChatPane.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboardingChatPane.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import Image from "next/image";
+import type { ChangeEvent } from "react";
 import { Fragment, useEffect, useRef, useState } from "react";
-import { ArrowRightIcon, ArrowUpIcon, CheckIcon } from "lucide-react";
+import { ArrowRightIcon, CheckIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ButtonLoader } from "@/components/Loading";
 import { Response } from "@/components/ai-elements/response";
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from "@/components/ai-elements/prompt-input";
 import type { OnboardingChatMessage } from "@/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig";
 import { cn } from "@/utils";
 
@@ -137,29 +143,30 @@ export function ChatOnboardingChatPane({
       </div>
 
       <div className="shrink-0 pb-5 pt-3">
-        <div className="flex items-center gap-2 rounded-2xl border bg-background py-2 pl-4 pr-2 shadow-sm">
-          <input
+        <PromptInput
+          onSubmit={(e) => {
+            e.preventDefault();
+            sendFreeform();
+          }}
+        >
+          <PromptInputTextarea
             value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                sendFreeform();
-              }
-            }}
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+              setInput(e.currentTarget.value)
+            }
             placeholder="Message"
-            className="min-w-0 flex-1 bg-transparent text-[15px] outline-none placeholder:text-muted-foreground/60"
+            disabled={inputDisabled}
+            className="pr-14"
           />
-          <Button
-            size="icon"
-            className="size-8 shrink-0 rounded-xl"
-            onClick={sendFreeform}
-            disabled={!input.trim() || busy || inputDisabled}
-            aria-label="Send message"
-          >
-            <ArrowUpIcon className="size-4" />
-          </Button>
-        </div>
+
+          <div className="absolute bottom-2 right-2">
+            <PromptInputSubmit
+              status={busy ? "submitted" : "ready"}
+              disabled={!input.trim() || busy || inputDisabled}
+              aria-label="Send message"
+            />
+          </div>
+        </PromptInput>
       </div>
     </div>
   );

--- a/apps/web/components/ai-elements/prompt-input.tsx
+++ b/apps/web/components/ai-elements/prompt-input.tsx
@@ -169,7 +169,9 @@ export const PromptInputSubmit = ({
   return (
     <Button
       className={cn(
-        "size-9 rounded-full bg-blue-500 text-white hover:bg-blue-600",
+        variant === "default" &&
+          size === "icon" &&
+          "size-9 rounded-full bg-blue-500 text-white hover:bg-blue-600",
         className,
       )}
       size={size}

--- a/apps/web/components/ai-elements/prompt-input.tsx
+++ b/apps/web/components/ai-elements/prompt-input.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/utils";
 import type { ChatStatus } from "ai";
-import { Loader2Icon, SendIcon, SquareIcon, XIcon } from "lucide-react";
+import { ArrowUpIcon, Loader2Icon, SquareIcon, XIcon } from "lucide-react";
 import type {
   ComponentProps,
   ChangeEvent,
@@ -25,7 +25,7 @@ export type PromptInputProps = HTMLAttributes<HTMLFormElement>;
 export const PromptInput = ({ className, ...props }: PromptInputProps) => (
   <form
     className={cn(
-      "w-full divide-y overflow-hidden rounded-xl border bg-background shadow-sm",
+      "relative w-full overflow-hidden rounded-2xl border bg-background shadow-sm",
       className,
     )}
     {...props}
@@ -96,7 +96,7 @@ export const PromptInputToolbar = ({
   ...props
 }: PromptInputToolbarProps) => (
   <div
-    className={cn("flex items-center justify-between p-1", className)}
+    className={cn("flex items-center justify-between border-t p-1", className)}
     {...props}
   />
 );
@@ -110,7 +110,7 @@ export const PromptInputTools = ({
   <div
     className={cn(
       "flex items-center gap-1",
-      "[&_button:first-child]:rounded-bl-xl",
+      "[&_button:first-child]:rounded-bl-2xl",
       className,
     )}
     {...props}
@@ -156,10 +156,10 @@ export const PromptInputSubmit = ({
   children,
   ...props
 }: PromptInputSubmitProps) => {
-  let Icon = <SendIcon className="size-4" />;
+  let Icon = <ArrowUpIcon className="size-5" />;
 
   if (status === "submitted") {
-    Icon = <Loader2Icon className="size-4 animate-spin" />;
+    Icon = <Loader2Icon className="size-5 animate-spin" />;
   } else if (status === "streaming") {
     Icon = <SquareIcon className="size-4" />;
   } else if (status === "error") {
@@ -168,7 +168,10 @@ export const PromptInputSubmit = ({
 
   return (
     <Button
-      className={cn("gap-1.5 rounded-lg", className)}
+      className={cn(
+        "size-9 rounded-full bg-blue-500 text-white hover:bg-blue-600",
+        className,
+      )}
       size={size}
       type="submit"
       variant={variant}

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -3,12 +3,10 @@
 import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  ArrowUpIcon,
   HistoryIcon,
   Loader2,
   PaperclipIcon,
   PlusIcon,
-  SquareIcon,
   XIcon,
 } from "lucide-react";
 import { Messages } from "./messages";
@@ -201,7 +199,6 @@ export function Chat({
           handleSubmit();
         }
       }}
-      className="relative divide-y-0 rounded-2xl"
     >
       {(attachments.length > 0 || uploadQueue.length > 0) && (
         <div className="flex gap-2 overflow-x-auto p-2 pb-0">
@@ -275,7 +272,6 @@ export function Chat({
           disabled={
             status === "ready" || status === "error" ? !hasContent : false
           }
-          className="h-9 w-9 rounded-full bg-blue-500 text-white hover:bg-blue-600"
           onClick={(e) => {
             if (status === "streaming" || status === "submitted") {
               analytics.captureAction("chat_generation_stopped", {
@@ -286,15 +282,7 @@ export function Chat({
               setMessages((messages) => messages);
             }
           }}
-        >
-          {status === "submitted" ? (
-            <Loader2 className="size-5 animate-spin" />
-          ) : status === "streaming" ? (
-            <SquareIcon className="size-4" />
-          ) : (
-            <ArrowUpIcon className="size-5" />
-          )}
-        </PromptInputSubmit>
+        />
       </div>
     </PromptInput>
   );


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260807-014432_pr-3174_d674c868e58a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The onboarding chat had its own hand-rolled input, which rendered a nested border around the field and let the send button overflow its container. It now uses the same `ai-elements` prompt input primitives as the in-app assistant chat, so there is one style to maintain instead of two.

- `PromptInput` is now `relative rounded-2xl` with no `divide-y`; `PromptInputToolbar` owns its own `border-t`
- `PromptInputSubmit` defaults to the round send button with arrow / spinner / stop icons by status, so `chat.tsx` no longer overrides styling or branches on icons itself
- Onboarding picks up autosizing, Shift+Enter for a newline, and IME-safe Enter handling
- Verified with Biome, a type check of the touched files, and `vitest run components/` (15 files, 78 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->