### PR TITLE
docker: Simplify standalone image smoke check

### DIFF
--- a/docker/scripts/smoke-standalone.sh
+++ b/docker/scripts/smoke-standalone.sh
@@ -6,11 +6,12 @@
 set -e
 
 main() {
+    trap cleanup EXIT
+    trap 'exit 1' HUP INT TERM
+
     LOG="$(mktemp)"
     node /app/apps/web/server.js >"$LOG" 2>&1 &
     PID=$!
-    trap cleanup EXIT
-    trap 'exit 1' HUP INT TERM
 
     deadline=$(($(date +%s) + 60))
     until probe_server; do
@@ -31,8 +32,8 @@ main() {
 
     sleep 2
 
-    if ! kill -0 "$PID" 2>/dev/null; then
-        echo "server exited after responding"
+    if ! probe_server; then
+        echo "server stopped responding after the initial request"
         tail -20 "$LOG"
         exit 1
     fi

--- a/docker/scripts/smoke-standalone.sh
+++ b/docker/scripts/smoke-standalone.sh
@@ -31,6 +31,20 @@ main() {
         sleep 1
     done
 
+    sleep 2
+
+    if ! wget -q -O /dev/null -T 2 http://127.0.0.1:3000/api/health; then
+        echo "server stopped responding after the initial health check"
+        tail -20 "$LOG"
+        exit 1
+    fi
+
+    if grep -q "Failed to load external module" "$LOG"; then
+        echo "Standalone server cannot load its instrumentation hook:"
+        tail -20 "$LOG"
+        exit 1
+    fi
+
     echo "Standalone smoke test passed."
 }
 

--- a/docker/scripts/smoke-standalone.sh
+++ b/docker/scripts/smoke-standalone.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Boot the standalone server and fail if it cannot load its instrumentation
-# hook. Resolving the package by name is not enough: `pnpm deploy` leaves a
-# complete copy in apps/web/node_modules that resolves fine even when the
-# traced copy the server actually uses is incomplete.
+# Boot the standalone server and exercise a request so broken runtime tracing
+# fails while the image is being built. Resolving the package by name is not
+# enough: `pnpm deploy` leaves a complete copy in apps/web/node_modules that
+# resolves fine even when the traced copy the server actually uses is incomplete.
 set -e
 
 main() {
@@ -13,16 +13,17 @@ main() {
     node /app/apps/web/server.js >"$LOG" 2>&1 &
     PID=$!
 
-    deadline=$(($(date +%s) + 60))
-    until probe_server; do
+    attempts=0
+    until wget -q -O /dev/null -T 2 http://127.0.0.1:3000/api/health; do
         if ! kill -0 "$PID" 2>/dev/null; then
             echo "server exited before responding"
             tail -20 "$LOG"
             exit 1
         fi
 
-        if [ "$(date +%s)" -ge "$deadline" ]; then
-            echo "server never responded"
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 60 ]; then
+            echo "server health check never passed"
             tail -20 "$LOG"
             exit 1
         fi
@@ -30,33 +31,7 @@ main() {
         sleep 1
     done
 
-    sleep 2
-
-    if ! probe_server; then
-        echo "server stopped responding after the initial request"
-        tail -20 "$LOG"
-        exit 1
-    fi
-
-    if grep -Eq "An error occurred while loading the instrumentation hook|Failed to load external module" "$LOG"; then
-        echo "Standalone server cannot load its instrumentation hook:"
-        tail -20 "$LOG"
-        exit 1
-    fi
-
     echo "Standalone smoke test passed."
-}
-
-probe_server() {
-    node -e '
-        const request = require("node:http").get("http://127.0.0.1:3000/login", (response) => {
-            response.destroy();
-            process.exit(0);
-        });
-
-        request.setTimeout(1_000, () => request.destroy(new Error("Request timed out")));
-        request.on("error", () => process.exit(1));
-    '
 }
 
 cleanup() {

--- a/docker/scripts/smoke-standalone.sh
+++ b/docker/scripts/smoke-standalone.sh
@@ -5,29 +5,65 @@
 # traced copy the server actually uses is incomplete.
 set -e
 
-LOG=/tmp/smoke-standalone.log
+main() {
+    LOG="$(mktemp)"
+    node /app/apps/web/server.js >"$LOG" 2>&1 &
+    PID=$!
+    trap cleanup EXIT
+    trap 'exit 1' HUP INT TERM
 
-node /app/apps/web/server.js >"$LOG" 2>&1 &
-PID=$!
-trap 'kill "$PID" 2>/dev/null || true' EXIT
+    deadline=$(($(date +%s) + 60))
+    until probe_server; do
+        if ! kill -0 "$PID" 2>/dev/null; then
+            echo "server exited before responding"
+            tail -20 "$LOG"
+            exit 1
+        fi
 
-waited=0
-until grep -q "Ready in" "$LOG" 2>/dev/null; do
-    kill -0 "$PID" 2>/dev/null || { echo "server exited before becoming ready"; tail -20 "$LOG"; exit 1; }
-    waited=$((waited + 1))
-    [ "$waited" -lt 60 ] || { echo "server never became ready"; tail -20 "$LOG"; exit 1; }
-    sleep 1
-done
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "server never responded"
+            tail -20 "$LOG"
+            exit 1
+        fi
 
-# The hook is evaluated on the request path, so make one request before judging.
-# Its status does not matter; there is no database here and a 500 is expected.
-wget -q -O /dev/null -T 5 http://127.0.0.1:3000/login 2>/dev/null || true
-sleep 2
+        sleep 1
+    done
 
-if grep -q "Failed to load external module" "$LOG"; then
-    echo "Standalone server cannot load its instrumentation hook:"
-    grep -m1 "Failed to load external module" "$LOG"
-    exit 1
-fi
+    sleep 2
 
-echo "Standalone smoke test passed."
+    if ! kill -0 "$PID" 2>/dev/null; then
+        echo "server exited after responding"
+        tail -20 "$LOG"
+        exit 1
+    fi
+
+    if grep -Eq "An error occurred while loading the instrumentation hook|Failed to load external module" "$LOG"; then
+        echo "Standalone server cannot load its instrumentation hook:"
+        tail -20 "$LOG"
+        exit 1
+    fi
+
+    echo "Standalone smoke test passed."
+}
+
+probe_server() {
+    node -e '
+        const request = require("node:http").get("http://127.0.0.1:3000/login", (response) => {
+            response.destroy();
+            process.exit(0);
+        });
+
+        request.setTimeout(1_000, () => request.destroy(new Error("Request timed out")));
+        request.on("error", () => process.exit(1));
+    '
+}
+
+cleanup() {
+    if [ -n "${PID:-}" ]; then
+        kill "$PID" 2>/dev/null || true
+        wait "$PID" 2>/dev/null || true
+    fi
+    rm -f "${LOG:-}"
+}
+
+main


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-100522_pr-3175_f8c04c33bac5/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Simplifies build-time validation for the packaged standalone server.

- require the lightweight health route to succeed during image creation
- detect early server exits and remove temporary artifacts
- add no production polling or runtime work
- validate shell syntax, route behavior, and HTTP status handling