### PR TITLE
billing: Prevent duplicate checkout during plan changes

### DIFF
--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -357,12 +357,6 @@ function PriceTier({
 
             if (hasActiveStripeSubscription) {
               result = await getBillingPortalUrlAction({ tier: upgradeToTier });
-
-              if (!result?.data?.url) {
-                result = await generateCheckoutSessionAction({
-                  tier: upgradeToTier,
-                });
-              }
             } else {
               result = await generateCheckoutSessionAction({
                 tier: upgradeToTier,
@@ -370,7 +364,13 @@ function PriceTier({
             }
 
             if (!result?.data?.url || result?.serverError) {
-              captureException(new Error("Error creating checkout session"), {
+              const description =
+                result?.serverError ||
+                (hasActiveStripeSubscription
+                  ? `We couldn't open the plan change page. Your subscription has not been changed. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`
+                  : `Error creating checkout session. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`);
+
+              captureException(new Error("Error opening Stripe billing flow"), {
                 extra: {
                   tier: upgradeToTier,
                   frequency: frequency.value,
@@ -380,9 +380,7 @@ function PriceTier({
                 },
               });
               toastError({
-                description:
-                  result?.serverError ||
-                  `Error creating checkout session. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`,
+                description,
               });
               return;
             }

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -364,11 +364,10 @@ function PriceTier({
             }
 
             if (!result?.data?.url || result?.serverError) {
-              const description =
-                result?.serverError ||
-                (hasActiveStripeSubscription
-                  ? `We couldn't open the plan change page. Your subscription has not been changed. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`
-                  : `Error creating checkout session. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`);
+              const description = hasActiveStripeSubscription
+                ? `We couldn't open the plan change page. Your subscription has not been changed. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`
+                : result?.serverError ||
+                  `Error creating checkout session. Please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`;
 
               captureException(new Error("Error opening Stripe billing flow"), {
                 extra: {

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -1,12 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { updateStripeInvoiceEmailsAction } from "./premium";
+import {
+  generateCheckoutSessionAction,
+  updateStripeInvoiceEmailsAction,
+} from "./premium";
+
+const mocks = vi.hoisted(() => ({
+  createCheckoutSession: vi.fn(),
+}));
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
+}));
+vi.mock("@/ee/billing/stripe", () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: mocks.createCheckoutSession } },
+  }),
+}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: vi.fn() })),
+}));
+vi.mock("@/utils/posthog", () => ({
+  trackStripeCheckoutCreated: vi.fn(),
+  trackStripeCustomerCreated: vi.fn(),
 }));
 
 describe("updateStripeInvoiceEmailsAction", () => {
@@ -62,5 +81,35 @@ describe("updateStripeInvoiceEmailsAction", () => {
 
     expect(result?.serverError).toBe("Stripe billing account not found");
     expect(prisma.premium.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateCheckoutSessionAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not create a second checkout for an active Stripe subscription", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      utms: null,
+      _count: { emailAccounts: 2 },
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_active",
+        stripeSubscriptionStatus: "active",
+        users: [{ _count: { emailAccounts: 2 } }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await generateCheckoutSessionAction({
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(result?.serverError).toBe(
+      "You already have an existing subscription. Change your plan instead of starting a new subscription.",
+    );
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -135,26 +135,54 @@ describe("generateCheckoutSessionAction", () => {
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_test",
       url: "https://stripe.test",
     });
 
-    await generateCheckoutSessionAction({
-      tier: "BASIC_MONTHLY",
-    });
-    await generateCheckoutSessionAction({
-      tier: "BASIC_MONTHLY",
+    const results = await Promise.all([
+      generateCheckoutSessionAction({ tier: "BASIC_MONTHLY" }),
+      generateCheckoutSessionAction({ tier: "BASIC_MONTHLY" }),
+    ]);
+
+    expect(results.map((result) => result?.data?.url)).toEqual([
+      "https://stripe.test",
+      "https://stripe.test",
+    ]);
+    expect(mocks.createCheckoutSession).toHaveBeenCalledTimes(2);
+    expect(mocks.createCheckoutSession.mock.calls[0][1]).toEqual(
+      mocks.createCheckoutSession.mock.calls[1][1],
+    );
+  });
+
+  it("uses a new idempotency key when the checkout quantity changes", async () => {
+    let emailAccounts = 1;
+    prisma.user.findUnique.mockImplementation(
+      async () =>
+        ({
+          email: "user@example.com",
+          utms: null,
+          _count: { emailAccounts },
+          premium: {
+            id: "premium-1",
+            stripeCustomerId: "cus_test",
+            stripeSubscriptionId: null,
+            stripeSubscriptionStatus: null,
+            stripeEndedAt: null,
+            users: [{ _count: { emailAccounts } }],
+          },
+        }) as Awaited<ReturnType<typeof prisma.user.findUnique>>,
+    );
+    mocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_test",
+      url: "https://stripe.test",
     });
 
-    expect(mocks.createCheckoutSession).toHaveBeenCalledTimes(2);
-    expect(mocks.createCheckoutSession).toHaveBeenNthCalledWith(
-      1,
-      expect.anything(),
-      { idempotencyKey: "checkout:user-1:BASIC_MONTHLY:standard:new" },
-    );
-    expect(mocks.createCheckoutSession).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
-      { idempotencyKey: "checkout:user-1:BASIC_MONTHLY:standard:new" },
+    await generateCheckoutSessionAction({ tier: "BASIC_MONTHLY" });
+    emailAccounts = 2;
+    await generateCheckoutSessionAction({ tier: "BASIC_MONTHLY" });
+
+    expect(mocks.createCheckoutSession.mock.calls[0][1]).not.toEqual(
+      mocks.createCheckoutSession.mock.calls[1][1],
     );
   });
 
@@ -173,6 +201,7 @@ describe("generateCheckoutSessionAction", () => {
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createCheckoutSession.mockResolvedValue({
+      id: "cs_ended",
       url: "https://stripe.test",
     });
 

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -149,6 +149,9 @@ describe("generateCheckoutSessionAction", () => {
       "https://stripe.test",
     ]);
     expect(mocks.createCheckoutSession).toHaveBeenCalledTimes(2);
+    expect(mocks.createCheckoutSession.mock.calls[0][1]).toEqual({
+      idempotencyKey: expect.stringMatching(/^checkout:[a-f0-9]{64}$/),
+    });
     expect(mocks.createCheckoutSession.mock.calls[0][1]).toEqual(
       mocks.createCheckoutSession.mock.calls[1][1],
     );

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -89,7 +89,13 @@ describe("generateCheckoutSessionAction", () => {
     vi.clearAllMocks();
   });
 
-  it("does not create a second checkout for an active Stripe subscription", async () => {
+  it.each([
+    { status: "active", endedAt: null },
+    { status: "canceled", endedAt: null },
+  ])("does not create a second checkout for a $status Stripe subscription that has not ended", async ({
+    status,
+    endedAt,
+  }) => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
@@ -97,8 +103,9 @@ describe("generateCheckoutSessionAction", () => {
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
-        stripeSubscriptionId: "sub_active",
-        stripeSubscriptionStatus: "active",
+        stripeSubscriptionId: "sub_existing",
+        stripeSubscriptionStatus: status,
+        stripeEndedAt: endedAt,
         users: [{ _count: { emailAccounts: 2 } }],
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
@@ -111,5 +118,68 @@ describe("generateCheckoutSessionAction", () => {
       "You already have an existing subscription. Change your plan instead of starting a new subscription.",
     );
     expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("uses a stable idempotency key for concurrent checkout requests", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      utms: null,
+      _count: { emailAccounts: 2 },
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: null,
+        stripeSubscriptionStatus: null,
+        stripeEndedAt: null,
+        users: [{ _count: { emailAccounts: 2 } }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+    mocks.createCheckoutSession.mockResolvedValue({
+      url: "https://stripe.test",
+    });
+
+    await generateCheckoutSessionAction({
+      tier: "BASIC_MONTHLY",
+    });
+    await generateCheckoutSessionAction({
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(mocks.createCheckoutSession).toHaveBeenCalledTimes(2);
+    expect(mocks.createCheckoutSession).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      { idempotencyKey: "checkout:user-1:BASIC_MONTHLY:standard:new" },
+    );
+    expect(mocks.createCheckoutSession).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      { idempotencyKey: "checkout:user-1:BASIC_MONTHLY:standard:new" },
+    );
+  });
+
+  it("allows a new checkout after the previous subscription has ended", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      utms: null,
+      _count: { emailAccounts: 2 },
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_ended",
+        stripeSubscriptionStatus: "canceled",
+        stripeEndedAt: new Date(),
+        users: [{ _count: { emailAccounts: 2 } }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+    mocks.createCheckoutSession.mockResolvedValue({
+      url: "https://stripe.test",
+    });
+
+    const result = await generateCheckoutSessionAction({
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(result?.data).toEqual({ url: "https://stripe.test" });
   });
 });

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { createHash } from "node:crypto";
+import type Stripe from "stripe";
 import { z } from "zod";
 import { after } from "next/server";
 import { cookies } from "next/headers";
@@ -611,35 +613,36 @@ export const generateCheckoutSessionAction = actionClientUser
       }),
     };
 
+    const checkoutParams: Stripe.Checkout.SessionCreateParams = {
+      customer: stripeCustomerId,
+      success_url: `${env.NEXT_PUBLIC_BASE_URL}/api/stripe/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${env.NEXT_PUBLIC_BASE_URL}/premium`,
+      mode: "subscription",
+      subscription_data: {
+        trial_period_days: 7,
+        ...(Object.keys(conversionMetadata).length
+          ? {
+              metadata: conversionMetadata,
+            }
+          : {}),
+      },
+      line_items: [{ price: priceId, quantity }],
+      allow_promotion_codes: true,
+      payment_method_collection: "always",
+      metadata: {
+        dubCustomerId: userId,
+      },
+    };
+
     // ALWAYS create a checkout with a stripeCustomerId
-    const checkout = await stripe.checkout.sessions.create(
-      {
-        customer: stripeCustomerId,
-        success_url: `${env.NEXT_PUBLIC_BASE_URL}/api/stripe/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${env.NEXT_PUBLIC_BASE_URL}/premium`,
-        mode: "subscription",
-        subscription_data: {
-          trial_period_days: 7,
-          ...(Object.keys(conversionMetadata).length
-            ? {
-                metadata: conversionMetadata,
-              }
-            : {}),
-        },
-        line_items: [{ price: priceId, quantity }],
-        allow_promotion_codes: true,
-        payment_method_collection: "always",
-        metadata: {
-          dubCustomerId: userId,
-        },
-      },
-      {
-        idempotencyKey: `checkout:${userId}:${tier}:${offer || "standard"}:${user.premium?.stripeSubscriptionId || "new"}`,
-      },
-    );
+    const checkout = await stripe.checkout.sessions.create(checkoutParams, {
+      idempotencyKey: `checkout:${createHash("sha256")
+        .update(JSON.stringify(checkoutParams))
+        .digest("hex")}`,
+    });
 
     after(() =>
-      trackStripeCheckoutCreated(user.email, {
+      trackStripeCheckoutCreated(user.email, checkout.id, {
         billingProvider: "stripe",
         quantity,
         tier,

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -531,8 +531,6 @@ export const generateCheckoutSessionAction = actionClientUser
 
     if (!priceId) throw new SafeError("Unknown tier. Contact support.");
 
-    const stripe = getStripe();
-
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -543,6 +541,8 @@ export const generateCheckoutSessionAction = actionClientUser
           select: {
             id: true,
             stripeCustomerId: true,
+            stripeSubscriptionId: true,
+            stripeSubscriptionStatus: true,
             users: {
               select: { _count: { select: { emailAccounts: true } } },
             },
@@ -555,6 +555,18 @@ export const generateCheckoutSessionAction = actionClientUser
       throw new SafeError("User not found");
     }
 
+    if (
+      user.premium?.stripeSubscriptionId &&
+      !["canceled", "incomplete_expired"].includes(
+        user.premium.stripeSubscriptionStatus || "",
+      )
+    ) {
+      throw new SafeError(
+        "You already have an existing subscription. Change your plan instead of starting a new subscription.",
+      );
+    }
+
+    const stripe = getStripe();
     let stripeCustomerId = user.premium?.stripeCustomerId;
 
     if (!stripeCustomerId) {

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -543,6 +543,7 @@ export const generateCheckoutSessionAction = actionClientUser
             stripeCustomerId: true,
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
+            stripeEndedAt: true,
             users: {
               select: { _count: { select: { emailAccounts: true } } },
             },
@@ -557,9 +558,8 @@ export const generateCheckoutSessionAction = actionClientUser
 
     if (
       user.premium?.stripeSubscriptionId &&
-      !["canceled", "incomplete_expired"].includes(
-        user.premium.stripeSubscriptionStatus || "",
-      )
+      !user.premium.stripeEndedAt &&
+      user.premium.stripeSubscriptionStatus !== "incomplete_expired"
     ) {
       throw new SafeError(
         "You already have an existing subscription. Change your plan instead of starting a new subscription.",
@@ -612,26 +612,31 @@ export const generateCheckoutSessionAction = actionClientUser
     };
 
     // ALWAYS create a checkout with a stripeCustomerId
-    const checkout = await stripe.checkout.sessions.create({
-      customer: stripeCustomerId,
-      success_url: `${env.NEXT_PUBLIC_BASE_URL}/api/stripe/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${env.NEXT_PUBLIC_BASE_URL}/premium`,
-      mode: "subscription",
-      subscription_data: {
-        trial_period_days: 7,
-        ...(Object.keys(conversionMetadata).length
-          ? {
-              metadata: conversionMetadata,
-            }
-          : {}),
+    const checkout = await stripe.checkout.sessions.create(
+      {
+        customer: stripeCustomerId,
+        success_url: `${env.NEXT_PUBLIC_BASE_URL}/api/stripe/success?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${env.NEXT_PUBLIC_BASE_URL}/premium`,
+        mode: "subscription",
+        subscription_data: {
+          trial_period_days: 7,
+          ...(Object.keys(conversionMetadata).length
+            ? {
+                metadata: conversionMetadata,
+              }
+            : {}),
+        },
+        line_items: [{ price: priceId, quantity }],
+        allow_promotion_codes: true,
+        payment_method_collection: "always",
+        metadata: {
+          dubCustomerId: userId,
+        },
       },
-      line_items: [{ price: priceId, quantity }],
-      allow_promotion_codes: true,
-      payment_method_collection: "always",
-      metadata: {
-        dubCustomerId: userId,
+      {
+        idempotencyKey: `checkout:${userId}:${tier}:${offer || "standard"}:${user.premium?.stripeSubscriptionId || "new"}`,
       },
-    });
+    );
 
     after(() =>
       trackStripeCheckoutCreated(user.email, {

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/utils/prisma");
 import {
   FIRST_TIME_EVENTS,
   deletePosthogUser,
+  posthogCaptureEvent,
   trackFirstTimeEvent,
   trackProductFeedback,
   trackStripeCheckoutCreated,
@@ -322,5 +323,24 @@ describe("trackStripeCheckoutCreated", () => {
     expect(redis.del).toHaveBeenCalledWith(
       "posthog:stripe-checkout-created:cs_test",
     );
+  });
+});
+
+describe("posthogCaptureEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fail a delivered event when shutdown cleanup rejects", async () => {
+    const shutdownResult = Promise.reject(new Error("Shutdown unavailable"));
+    shutdownResult.catch(() => undefined);
+    const catchSpy = vi.spyOn(shutdownResult, "catch");
+    shutdownMock.mockReturnValueOnce(shutdownResult);
+
+    await expect(
+      posthogCaptureEvent("user@example.com", "Test event"),
+    ).resolves.toBe(true);
+
+    expect(catchSpy).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -27,6 +27,7 @@ vi.mock("posthog-node", () => ({
 
 vi.mock("@/utils/redis", () => ({
   redis: {
+    del: vi.fn(),
     set: vi.fn(),
   },
 }));
@@ -295,5 +296,29 @@ describe("trackStripeCheckoutCreated", () => {
       { nx: true, ex: 172_800 },
     );
     expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures when Redis is unavailable", async () => {
+    vi.mocked(redis.set).mockRejectedValue(new Error("Redis unavailable"));
+
+    await trackStripeCheckoutCreated("user@example.com", "cs_test", {
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+
+  it("releases the dedupe reservation when PostHog capture fails", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    shutdownMock.mockRejectedValueOnce(new Error("PostHog unavailable"));
+
+    await trackStripeCheckoutCreated("user@example.com", "cs_test", {
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(redis.del).toHaveBeenCalledWith(
+      "posthog:stripe-checkout-created:cs_test",
+    );
   });
 });

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -16,11 +16,13 @@ vi.mock("@/env", () => ({
 }));
 
 const captureMock = vi.fn();
-const shutdownMock = vi.fn().mockResolvedValue(undefined);
+const flushMock = vi.fn().mockResolvedValue(undefined);
+const shutdownMock = vi.fn();
 
 vi.mock("posthog-node", () => ({
   PostHog: class PostHogMock {
     capture = captureMock;
+    flush = flushMock;
     shutdown = shutdownMock;
   },
 }));
@@ -311,7 +313,7 @@ describe("trackStripeCheckoutCreated", () => {
 
   it("releases the dedupe reservation when PostHog capture fails", async () => {
     vi.mocked(redis.set).mockResolvedValue("OK");
-    shutdownMock.mockRejectedValueOnce(new Error("PostHog unavailable"));
+    flushMock.mockRejectedValueOnce(new Error("PostHog unavailable"));
 
     await trackStripeCheckoutCreated("user@example.com", "cs_test", {
       tier: "BASIC_MONTHLY",

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -38,6 +38,7 @@ import {
   deletePosthogUser,
   trackFirstTimeEvent,
   trackProductFeedback,
+  trackStripeCheckoutCreated,
   trackUserDeleted,
   trackUserDeletionRequested,
 } from "./posthog";
@@ -267,5 +268,32 @@ describe("trackProductFeedback", () => {
       properties: { feedback: "Still useful" },
       sendFeatureFlags: undefined,
     });
+  });
+});
+
+describe("trackStripeCheckoutCreated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures only once for a replayed Stripe Checkout Session", async () => {
+    vi.mocked(redis.set)
+      .mockResolvedValueOnce("OK")
+      .mockResolvedValueOnce(null);
+
+    await trackStripeCheckoutCreated("user@example.com", "cs_test", {
+      tier: "BASIC_MONTHLY",
+    });
+    await trackStripeCheckoutCreated("user@example.com", "cs_test", {
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(redis.set).toHaveBeenCalledTimes(2);
+    expect(redis.set).toHaveBeenCalledWith(
+      "posthog:stripe-checkout-created:cs_test",
+      "1",
+      { nx: true, ex: 172_800 },
+    );
+    expect(captureMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -149,8 +149,12 @@ export async function posthogCaptureEvent(
       properties,
       sendFeatureFlags,
     });
-    await client.shutdown();
-    return true;
+    try {
+      await client.flush();
+      return true;
+    } finally {
+      client.shutdown();
+    }
   } catch (error) {
     logger.error("Error capturing PostHog event", { error });
     return false;

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -153,7 +153,13 @@ export async function posthogCaptureEvent(
       await client.flush();
       return true;
     } finally {
-      client.shutdown();
+      try {
+        Promise.resolve(client.shutdown()).catch((error) => {
+          logger.error("Error shutting down PostHog client", { error });
+        });
+      } catch (error) {
+        logger.error("Error shutting down PostHog client", { error });
+      }
     }
   } catch (error) {
     logger.error("Error capturing PostHog event", { error });

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -139,7 +139,7 @@ export async function posthogCaptureEvent(
   try {
     if (!env.NEXT_PUBLIC_POSTHOG_KEY) {
       logger.warn("NEXT_PUBLIC_POSTHOG_KEY not set");
-      return;
+      return false;
     }
 
     const client = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY);
@@ -150,8 +150,10 @@ export async function posthogCaptureEvent(
       sendFeatureFlags,
     });
     await client.shutdown();
+    return true;
   } catch (error) {
     logger.error("Error capturing PostHog event", { error });
+    return false;
   }
 }
 
@@ -185,17 +187,36 @@ export async function trackStripeCheckoutCreated(
   checkoutSessionId: string,
   properties?: Properties,
 ) {
-  try {
-    const firstCapture = await redis.set(
-      `posthog:stripe-checkout-created:${checkoutSessionId}`,
-      "1",
-      { nx: true, ex: 172_800 },
-    );
-    if (!firstCapture) return;
+  const dedupeKey = `posthog:stripe-checkout-created:${checkoutSessionId}`;
+  let firstCapture: string | null;
 
-    return posthogCaptureEvent(email, "Stripe checkout created", properties);
+  try {
+    firstCapture = await redis.set(dedupeKey, "1", {
+      nx: true,
+      ex: 172_800,
+    });
   } catch (error) {
-    logger.error("Error tracking Stripe checkout creation", { error });
+    logger.error("Error deduplicating Stripe checkout creation event", {
+      error,
+    });
+    return posthogCaptureEvent(email, "Stripe checkout created", properties);
+  }
+
+  if (!firstCapture) return;
+
+  const captured = await posthogCaptureEvent(
+    email,
+    "Stripe checkout created",
+    properties,
+  );
+  if (captured) return;
+
+  try {
+    await redis.del(dedupeKey);
+  } catch (error) {
+    logger.error("Error releasing Stripe checkout creation event lock", {
+      error,
+    });
   }
 }
 

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -182,9 +182,21 @@ export async function trackStripeCustomerCreated(
 
 export async function trackStripeCheckoutCreated(
   email: string,
+  checkoutSessionId: string,
   properties?: Properties,
 ) {
-  return posthogCaptureEvent(email, "Stripe checkout created", properties);
+  try {
+    const firstCapture = await redis.set(
+      `posthog:stripe-checkout-created:${checkoutSessionId}`,
+      "1",
+      { nx: true, ex: 172_800 },
+    );
+    if (!firstCapture) return;
+
+    return posthogCaptureEvent(email, "Stripe checkout created", properties);
+  } catch (error) {
+    logger.error("Error tracking Stripe checkout creation", { error });
+  }
 }
 
 export async function trackStripeCheckoutCompleted(


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260807-022110_pr-3178_2d56dd628a37/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevent existing Stripe subscribers from being sent to a new checkout when a hosted plan-change session cannot be opened.

- keep active subscribers in the subscription-update flow and show a safe failure message
- reject new checkout creation while a non-terminal Stripe subscription exists
- add regression coverage for duplicate-checkout prevention

Validation: `pnpm test utils/actions/premium.test.ts` and focused Ultracite checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->