### PR TITLE
Bulk unsubscribe: align and filter suggested senders

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -19,8 +19,7 @@ import { DomainIcon } from "@/components/charts/DomainIcon";
 import { Progress } from "@/components/ui/progress";
 import { extractDomainFromEmail } from "@/utils/email";
 import { cn } from "@/utils";
-
-const LOW_READ_THRESHOLD = 30;
+import { isUnsubscribeSuggestion } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 
 export function BulkUnsubscribeDesktop({
   tableRows,
@@ -105,7 +104,7 @@ export function BulkUnsubscribeRowDesktop({
   readPercentage,
 }: RowProps) {
   const domain = extractDomainFromEmail(item.name) || item.name;
-  const isLowReadRate = readPercentage < LOW_READ_THRESHOLD;
+  const isSuggested = isUnsubscribeSuggestion(item);
 
   return (
     <TableRow
@@ -150,16 +149,16 @@ export function BulkUnsubscribeRowDesktop({
             value={readPercentage}
             className={cn(
               "h-1.5 w-16",
-              isLowReadRate ? "bg-amber-100 dark:bg-amber-950" : "bg-muted",
+              isSuggested ? "bg-amber-100 dark:bg-amber-950" : "bg-muted",
             )}
             innerClassName={
-              isLowReadRate ? "bg-amber-400" : "bg-slate-300 dark:bg-slate-500"
+              isSuggested ? "bg-amber-400" : "bg-slate-300 dark:bg-slate-500"
             }
           />
           <span
             className={cn(
               "font-medium",
-              isLowReadRate
+              isSuggested
                 ? "text-amber-600 dark:text-amber-400"
                 : "text-foreground/80",
             )}

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -34,6 +34,7 @@ import {
 import { createSearchParams } from "@/utils/url";
 import type { NewsletterFilterType } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
 import {
+  getSuggestedModeRows,
   isUnsubscribeSuggestion,
   SUGGESTION_READ_RATE_THRESHOLD,
 } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
@@ -247,12 +248,12 @@ export function BulkUnsubscribe() {
 
   // Data is now filtered, sorted, and limited by the backend
   const rows = data?.newsletters;
+  const [isSuggestedMode, setIsSuggestedMode] = useState(false);
 
   const {
     selected,
-    isAllSelected,
     onToggleSelect,
-    onToggleSelectAll,
+    onToggleSelectItems,
     selectItems,
     clearSelection,
     deselectItem,
@@ -263,17 +264,53 @@ export function BulkUnsubscribe() {
     [rows],
   );
 
-  const onSelectSuggested = useCallback(() => {
+  const visibleRows = useMemo(
+    () =>
+      isSuggestedMode
+        ? getSuggestedModeRows(rows ?? [], selected)
+        : (rows ?? []),
+    [isSuggestedMode, rows, selected],
+  );
+  const visibleRowIds = useMemo(
+    () => visibleRows.map((row) => row.name),
+    [visibleRows],
+  );
+  const isAllVisibleSelected =
+    visibleRows.length > 0 &&
+    visibleRows.every((row) => selected.get(row.name));
+  const isSomeVisibleSelected = visibleRows.some((row) =>
+    selected.get(row.name),
+  );
+
+  const onToggleSuggestedMode = useCallback(() => {
+    if (isSuggestedMode) {
+      setIsSuggestedMode(false);
+      return;
+    }
+
     selectItems(suggestedRows.map((row) => row.name));
+    setIsSuggestedMode(true);
     posthog?.capture("Clicked Select Suggested Unsubscribes", {
       count: suggestedRows.length,
     });
-  }, [selectItems, suggestedRows, posthog]);
+  }, [isSuggestedMode, selectItems, suggestedRows, posthog]);
+
+  const onToggleVisibleRow = useCallback(
+    (id: string, shiftKey = false) =>
+      onToggleSelect(id, shiftKey, visibleRowIds),
+    [onToggleSelect, visibleRowIds],
+  );
+
+  const onToggleSelectAllVisible = useCallback(
+    () => onToggleSelectItems(visibleRowIds),
+    [onToggleSelectItems, visibleRowIds],
+  );
 
   // Clear selection when filter changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally clearing selection when filter changes
   useEffect(() => {
     clearSelection();
+    setIsSuggestedMode(false);
   }, [filter]);
 
   // Deep link (e.g. from the inbox health email or onboarding):
@@ -292,6 +329,7 @@ export function BulkUnsubscribe() {
 
     hasAppliedSelectParamRef.current = true;
     selectItems(rows.filter(isUnsubscribeSuggestion).map((row) => row.name));
+    setIsSuggestedMode(true);
 
     const nextParams = new URLSearchParams(searchParams);
     nextParams.delete("select");
@@ -300,11 +338,8 @@ export function BulkUnsubscribe() {
     });
   }, [searchParams, rows, selectItems, router, pathname]);
 
-  const isSomeSelected =
-    Array.from(selected.values()).filter(Boolean).length > 0;
-
   // Backend now handles sorting, so we just map the rows in order
-  const tableRows = rows?.map((item) => {
+  const tableRows = visibleRows.map((item) => {
     const readPercentage =
       item.value > 0 ? (item.readEmails / item.value) * 100 : 0;
 
@@ -324,7 +359,7 @@ export function BulkUnsubscribe() {
         refetchPremium={refetchPremium}
         openPremiumModal={openModal}
         checked={selected.get(item.name) || false}
-        onToggleSelect={onToggleSelect}
+        onToggleSelect={onToggleVisibleRow}
         readPercentage={readPercentage}
         filter={filter}
       />
@@ -412,27 +447,29 @@ export function BulkUnsubscribe() {
             onSetDateDropdown={onSetDateDropdown}
           />
           <SearchBar onSearch={setSearch} />
-          {suggestedRows.length > 0 && (
+          {(suggestedRows.length > 0 || isSuggestedMode) && (
             <TooltipProvider delayDuration={200}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    variant="outline"
+                    variant={isSuggestedMode ? "secondary" : "outline"}
                     size="sm"
                     className="h-10"
-                    onClick={onSelectSuggested}
+                    aria-pressed={isSuggestedMode}
+                    onClick={onToggleSuggestedMode}
                   >
                     <SparklesIcon className="size-4 text-amber-500" />
                     <span className="ml-2">
-                      Select {suggestedRows.length} suggested
+                      {isSuggestedMode ? "Showing" : "Select"}{" "}
+                      {suggestedRows.length} suggested
                     </span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="max-w-xs">
-                    Selects senders you rarely read (under{" "}
-                    {SUGGESTION_READ_RATE_THRESHOLD}% read rate) so you can
-                    unsubscribe or archive them in one go.
+                    {isSuggestedMode
+                      ? "Shows suggested senders and any other senders you already selected. Click to show all senders."
+                      : `Selects and shows senders you rarely read (under ${SUGGESTION_READ_RATE_THRESHOLD}% read rate) so you can unsubscribe, block, or archive them in one go.`}
                   </p>
                 </TooltipContent>
               </Tooltip>
@@ -473,9 +510,9 @@ export function BulkUnsubscribe() {
                   sortDirection={sortDirection}
                   onSort={handleSort}
                   tableRows={tableRows}
-                  isAllSelected={isAllSelected}
-                  isSomeSelected={isSomeSelected}
-                  onToggleSelectAll={onToggleSelectAll}
+                  isAllSelected={isAllVisibleSelected}
+                  isSomeSelected={isSomeVisibleSelected}
+                  onToggleSelectAll={onToggleSelectAllVisible}
                 />
                 {/* Only show expand/collapse when there might be more results */}
                 {(expanded || (rows && rows.length >= 50)) && (

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { NewsletterStatus } from "@/generated/prisma/enums";
 import {
+  getSuggestedModeRows,
   getUnsubscribeSuggestions,
   isUnsubscribeSuggestion,
 } from "./suggestions";
@@ -100,5 +101,23 @@ describe("getUnsubscribeSuggestions", () => {
         requireAutomaticUnsubscribeLink: true,
       }),
     ).toEqual([automatic]);
+  });
+});
+
+describe("getSuggestedModeRows", () => {
+  it("shows suggestions and retains other selected senders", () => {
+    const suggested = { name: "suggested", value: 10, readEmails: 1 };
+    const selected = { name: "selected", value: 10, readEmails: 8 };
+    const hidden = { name: "hidden", value: 10, readEmails: 7 };
+
+    expect(
+      getSuggestedModeRows(
+        [suggested, selected, hidden],
+        new Map([
+          [selected.name, true],
+          [hidden.name, false],
+        ]),
+      ),
+    ).toEqual([suggested, selected]);
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
@@ -34,6 +34,14 @@ export function getUnsubscribeSuggestions<T extends UnsubscribeSuggestionItem>(
     .sort((a, b) => b.value - a.value);
 }
 
+export function getSuggestedModeRows<
+  T extends UnsubscribeSuggestionItem & { name: string },
+>(items: T[], selected: ReadonlyMap<string, boolean>): T[] {
+  return items.filter(
+    (item) => isUnsubscribeSuggestion(item) || selected.get(item.name),
+  );
+}
+
 export function hasAutomaticUnsubscribeLink(item: {
   unsubscribeLink?: string | null;
 }) {

--- a/apps/web/hooks/useToggleSelect.test.ts
+++ b/apps/web/hooks/useToggleSelect.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useToggleSelect } from "./useToggleSelect";
+
+const items = [{ id: "suggested-1" }, { id: "hidden" }, { id: "suggested-2" }];
+
+describe("useToggleSelect", () => {
+  it("limits select all to the supplied visible items", () => {
+    const { result } = renderHook(() => useToggleSelect(items));
+
+    act(() => {
+      result.current.onToggleSelectItems(["suggested-1", "suggested-2"]);
+    });
+
+    expect(result.current.selected.get("suggested-1")).toBe(true);
+    expect(result.current.selected.get("suggested-2")).toBe(true);
+    expect(result.current.selected.get("hidden")).toBeUndefined();
+  });
+
+  it("limits shift selection to the supplied visible items", () => {
+    const { result } = renderHook(() => useToggleSelect(items));
+    const visibleIds = ["suggested-1", "suggested-2"];
+
+    act(() => {
+      result.current.onToggleSelect("suggested-1", false, visibleIds);
+      result.current.onToggleSelect("suggested-2", true, visibleIds);
+    });
+
+    expect(result.current.selected.get("suggested-1")).toBe(true);
+    expect(result.current.selected.get("suggested-2")).toBe(true);
+    expect(result.current.selected.get("hidden")).toBeUndefined();
+  });
+});

--- a/apps/web/hooks/useToggleSelect.ts
+++ b/apps/web/hooks/useToggleSelect.ts
@@ -2,26 +2,30 @@ import { useState, useCallback, useRef } from "react";
 
 export function useToggleSelect(items: { id: string }[]) {
   const [selected, setSelected] = useState<Map<string, boolean>>(new Map());
-  const lastClickedIndexRef = useRef<number | null>(null);
+  const lastClickedIdRef = useRef<string | null>(null);
 
   const isAllSelected =
     !!items.length && items.every((item) => selected.get(item.id));
 
   const onToggleSelect = useCallback(
-    (id: string, shiftKey = false) => {
-      const currentIndex = items.findIndex((item) => item.id === id);
+    (id: string, shiftKey = false, selectableIds?: string[]) => {
+      const ids = selectableIds ?? items.map((item) => item.id);
+      const currentIndex = ids.indexOf(id);
+      const lastClickedIndex = lastClickedIdRef.current
+        ? ids.indexOf(lastClickedIdRef.current)
+        : -1;
 
-      if (shiftKey && lastClickedIndexRef.current !== null) {
+      if (shiftKey && currentIndex >= 0 && lastClickedIndex >= 0) {
         // Shift-click: select range between last clicked and current
-        const start = Math.min(lastClickedIndexRef.current, currentIndex);
-        const end = Math.max(lastClickedIndexRef.current, currentIndex);
+        const start = Math.min(lastClickedIndex, currentIndex);
+        const end = Math.max(lastClickedIndex, currentIndex);
 
         setSelected((prev) => {
           const newSelected = new Map(prev);
           for (let i = start; i <= end; i++) {
-            const item = items[i];
-            if (item) {
-              newSelected.set(item.id, true);
+            const itemId = ids[i];
+            if (itemId) {
+              newSelected.set(itemId, true);
             }
           }
           return newSelected;
@@ -31,22 +35,29 @@ export function useToggleSelect(items: { id: string }[]) {
         setSelected((prev) => new Map(prev).set(id, !prev.get(id)));
       }
 
-      lastClickedIndexRef.current = currentIndex;
+      lastClickedIdRef.current = id;
     },
     [items],
   );
 
-  const onToggleSelectAll = useCallback(() => {
-    const allSelected = items.every((item) => selected.get(item.id));
+  const onToggleSelectItems = useCallback(
+    (ids: string[]) => {
+      const allSelected = ids.every((id) => selected.get(id));
 
-    setSelected((prev) => {
-      const newSelected = new Map(prev);
-      for (const item of items) {
-        newSelected.set(item.id, !allSelected);
-      }
-      return newSelected;
-    });
-  }, [items, selected]);
+      setSelected((prev) => {
+        const newSelected = new Map(prev);
+        for (const id of ids) {
+          newSelected.set(id, !allSelected);
+        }
+        return newSelected;
+      });
+    },
+    [selected],
+  );
+
+  const onToggleSelectAll = useCallback(() => {
+    onToggleSelectItems(items.map((item) => item.id));
+  }, [items, onToggleSelectItems]);
 
   const selectItems = useCallback((ids: string[]) => {
     setSelected((prev) => {
@@ -60,7 +71,7 @@ export function useToggleSelect(items: { id: string }[]) {
 
   const clearSelection = useCallback(() => {
     setSelected(new Map());
-    lastClickedIndexRef.current = null;
+    lastClickedIdRef.current = null;
   }, []);
 
   const deselectItem = useCallback((id: string) => {
@@ -76,6 +87,7 @@ export function useToggleSelect(items: { id: string }[]) {
     isAllSelected,
     onToggleSelect,
     onToggleSelectAll,
+    onToggleSelectItems,
     selectItems,
     clearSelection,
     deselectItem,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-100704_pr-3181_23df102f4ad2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Make the suggested-sender action a reversible focused view and align its amber read-rate styling with the same 20% suggestion criteria.

- show suggested senders plus any previously selected senders while the mode is active
- scope select-all and shift-select to visible rows so hidden senders cannot be selected accidentally
- use the shared suggestion predicate for amber styling
- validate with 39 focused bulk-unsubscribe and selection tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->