### PR TITLE
docs: Clarify public repository guidance

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -27,6 +27,8 @@ continue until the latest commit has clean reviews and checks.
 - Use public-safe metadata. Never expose non-public personal data, account IDs,
   tokens, secrets, or other sensitive information. Public GitHub identities
   already present on the PR may be referenced when needed for specific replies.
+- Mention related work in private repositories or services only generically,
+  such as "updated the marketing repository," without internal details.
 
 ## 1. Inspect and review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
 ## Change Philosophy
 - Prefer the simplest, most readable change; only keep backwards compatibility when explicitly requested.
 - Do not optimize for migration paths: refactor call sites directly, including larger coordinated changes when clarity improves.
+- This is a public repository. Never include non-public data or internal details from private repositories or services in repository content or GitHub metadata; describe related private work only generically (for example, “updated the marketing repository”).
 
 ## LLM Features
 - Stay AI-first: fix general failure modes, not exact eval wording, and avoid brittle keyword or regex rules unless the product needs a hard guard.


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-104555_pr-3184_97027dbe862f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Clarifies repository guidance for handling non-public context in public metadata.

- Add repository-wide confidentiality guidance
- Reinforce public-safe PR descriptions
- Validation: `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->