### PR TITLE
fix(analytics): target public conversion callback

### DIFF
--- a/apps/web/utils/analytics/server-conversion-events.test.ts
+++ b/apps/web/utils/analytics/server-conversion-events.test.ts
@@ -74,6 +74,7 @@ describe("trackServerConversionEvent", () => {
       expect.any(Object),
       undefined,
       undefined,
+      { destinationUrl: "https://example.com/rill" },
     );
 
     const body = publishToQstashMock.mock.calls[0]?.[1];
@@ -171,6 +172,7 @@ describe("trackServerConversionEvent", () => {
       expect.any(Object),
       undefined,
       { "x-conversion-analytics-secret": "secret_test" },
+      { destinationUrl: "https://example.com/rill" },
     );
   });
 

--- a/apps/web/utils/analytics/server-conversion-events.ts
+++ b/apps/web/utils/analytics/server-conversion-events.ts
@@ -76,6 +76,9 @@ export async function trackServerConversionEvent({
       },
       undefined,
       headers,
+      {
+        destinationUrl: `${env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, "")}${path}`,
+      },
     );
   } catch (error) {
     logger.error("Server conversion tracking failed", {

--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -88,6 +88,34 @@ describe("publishToQstash", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("uses an explicit destination instead of the internal base URL", async () => {
+    const fetchMock = setupFetchMock();
+    const upstash = await loadUpstashModule({ qstashToken: "token" });
+
+    await upstash.publishToQstash(
+      "/rill",
+      { id: "evt_paid" },
+      undefined,
+      { "x-conversion-analytics-secret": "secret_test" },
+      { destinationUrl: "https://public.example.com/rill" },
+    );
+
+    expect(mockPublishJSON).toHaveBeenCalledOnce();
+    const request = mockPublishJSON.mock.calls[0]?.[0];
+    expect(request).toEqual(
+      expect.objectContaining({
+        url: "https://public.example.com/rill",
+        body: { id: "evt_paid" },
+        retries: 3,
+      }),
+    );
+    expect(request?.headers.get("x-conversion-analytics-secret")).toBe(
+      "secret_test",
+    );
+    expect(request?.headers.get("Retry-After")).toBe("10");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("forwards custom delivery headers", async () => {
     const fetchMock = setupFetchMock();
     const upstash = await loadUpstashModule({ qstashToken: "token" });
@@ -133,6 +161,34 @@ describe("publishToQstash", () => {
       "https://worker.example.com/api/process",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("falls back to an explicit destination when QStash is unavailable", async () => {
+    const fetchMock = setupFetchMock();
+    const upstash = await loadUpstashModule({ qstashToken: undefined });
+
+    await upstash.publishToQstash(
+      "/rill",
+      { id: "evt_paid" },
+      undefined,
+      { "x-conversion-analytics-secret": "secret_test" },
+      { destinationUrl: "https://public.example.com/rill" },
+    );
+
+    expect(mockPublishJSON).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://public.example.com/rill");
+    expect(request).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ id: "evt_paid" }),
+      }),
+    );
+    expect(request?.headers.get("x-conversion-analytics-secret")).toBe(
+      "secret_test",
+    );
+    expect(request?.headers.get("x-api-key")).toBe("internal-api-key");
   });
 
   it("falls back when the QStash callback URL resolves to loopback", async () => {

--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -188,7 +188,8 @@ describe("publishToQstash", () => {
     expect(request?.headers.get("x-conversion-analytics-secret")).toBe(
       "secret_test",
     );
-    expect(request?.headers.get("x-api-key")).toBe("internal-api-key");
+    expect(request?.headers.get("x-api-key")).toBeNull();
+    expect(request?.headers.get("x-inbox-zero-caller-id")).toBeNull();
   });
 
   it("falls back when the QStash callback URL resolves to loopback", async () => {

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -7,13 +7,17 @@ import { isSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
 
 const logger = createScopedLogger("upstash");
 
-function getQstashClient() {
+type PublishToQstashOptions = {
+  destinationUrl?: string;
+};
+
+function getQstashClient(callbackUrl: string = getQstashCallbackBaseUrl()) {
   if (!env.QSTASH_TOKEN) return null;
-  if (!isSafeExternalHttpUrl(getQstashCallbackBaseUrl())) {
+  if (!isSafeExternalHttpUrl(callbackUrl)) {
     logger.warn(
       "Qstash callback URL is not externally reachable; using fallback",
       {
-        qstashCallbackBaseUrl: getQstashCallbackBaseUrl(),
+        qstashCallbackUrl: callbackUrl,
       },
     );
     return null;
@@ -26,13 +30,15 @@ export async function publishToQstash<T>(
   body: T,
   flowControl?: FlowControl,
   headers?: HeadersInit,
+  options?: PublishToQstashOptions,
 ) {
   const requestHeaders = createHeaders(headers);
   requestHeaders.set("Retry-After", "10");
 
-  const client = getQstashClient();
+  const qstashUrl =
+    options?.destinationUrl ?? `${getQstashCallbackBaseUrl()}${path}`;
+  const client = getQstashClient(qstashUrl);
   if (client) {
-    const qstashUrl = `${getQstashCallbackBaseUrl()}${path}`;
     return client.publishJSON({
       url: qstashUrl,
       body,
@@ -42,7 +48,8 @@ export async function publishToQstash<T>(
     });
   }
 
-  const fallbackUrl = `${getInternalApiUrl()}${path}`;
+  const fallbackUrl =
+    options?.destinationUrl ?? `${getInternalApiUrl()}${path}`;
   return fallbackPublishToQstash(fallbackUrl, body, requestHeaders);
 }
 

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -50,7 +50,12 @@ export async function publishToQstash<T>(
 
   const fallbackUrl =
     options?.destinationUrl ?? `${getInternalApiUrl()}${path}`;
-  return fallbackPublishToQstash(fallbackUrl, body, requestHeaders);
+  return fallbackPublishToQstash(
+    fallbackUrl,
+    body,
+    requestHeaders,
+    !options?.destinationUrl,
+  );
 }
 
 export async function bulkPublishToQstash<T>({
@@ -147,13 +152,16 @@ async function fallbackPublishToQstash<T>(
   url: string,
   body: T,
   headers?: HeadersInit,
+  includeInternalApiHeaders = true,
 ) {
   logger.warn("Qstash client not found");
 
   const internalHeaders = createHeaders(headers);
   internalHeaders.set("Content-Type", "application/json");
-  for (const [key, value] of Object.entries(getInternalApiHeaders())) {
-    internalHeaders.set(key, value);
+  if (includeInternalApiHeaders) {
+    for (const [key, value] of Object.entries(getInternalApiHeaders())) {
+      internalHeaders.set(key, value);
+    }
   }
 
   after(async () => {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-171045_pr-3186_f3e665a82c35/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Routes server-side conversion events through the public callback path so the delivery service can reach the destination.

- supports an explicit public delivery destination
- prevents internal fallback credentials from reaching custom destinations
- adds focused coverage for queued and fallback delivery

Validation: `pnpm test utils/upstash/index.test.ts utils/analytics/server-conversion-events.test.ts`