### PR TITLE
homepage: Clarify trial credit card requirement

### DIFF
--- a/apps/web/app/(landing)/home/FAQs.tsx
+++ b/apps/web/app/(landing)/home/FAQs.tsx
@@ -81,7 +81,7 @@ const faqs: {
   {
     question: `Can I try ${BRAND_NAME} for free?`,
     answer:
-      "Absolutely, we have a 7 day free trial on all of our plans so you can try it out right away, no credit card needed!",
+      "Absolutely! All plans include a 7-day free trial. A credit card is required to start your trial, but you won't be charged until the trial ends. Cancel anytime during the trial to avoid being charged.",
   },
 ];
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-174629_pr-3190_ee1b477983bd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Correct the homepage FAQ so the trial terms match the checkout flow.

- state that all plans include a 7-day free trial and require a credit card
- clarify that customers can cancel during the trial to avoid a charge
- validate the edited TSX with Ultracite and git diff checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->