### PR TITLE
rules: preserve explicit learned-pattern exclusions

### DIFF
--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -154,6 +154,58 @@ describe("saveLearnedPattern", () => {
     });
   });
 
+  it("should record label removal as the source of an exclusion", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "excluded@example.com",
+      ruleId: "rule-id",
+      exclude: true,
+      logger: createTestLogger(),
+      reason: "Label removed",
+      source: GroupItemSource.LABEL_REMOVED,
+    });
+
+    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          exclude: true,
+          source: GroupItemSource.LABEL_REMOVED,
+        }),
+      }),
+    );
+  });
+
+  it("should preserve the existing source for an inferred inclusion", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "sender@example.com",
+      ruleId: "rule-id",
+      logger: createTestLogger(),
+      source: GroupItemSource.AI,
+    });
+
+    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ source: undefined }),
+        create: expect.objectContaining({ source: GroupItemSource.AI }),
+      }),
+    );
+  });
+
   it("should handle duplicate group creation by finding existing group", async () => {
     const existingGroupId = "existing-group-id";
     vi.mocked(prisma.rule.findUnique)

--- a/apps/web/utils/rule/learned-patterns.ts
+++ b/apps/web/utils/rule/learned-patterns.ts
@@ -1,6 +1,6 @@
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
-import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
+import { type GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 
 /**
@@ -55,17 +55,15 @@ export async function saveLearnedPattern({
         value: from,
       },
     },
-    // Undefined fields are left untouched by Prisma, so a caller only overwrites what
-    // it actually knows. Inferred writers must not restate `source`, which records how
-    // the pattern was first learned and is what undoing a junk action keys off. An
-    // explicit user correction is not an inference and does claim the row, so undoing a
-    // junk action can never delete it.
+    // Undefined fields are left untouched by Prisma, so inferred inclusions do not
+    // overwrite how the pattern was first learned. Explicit exclusions claim the row
+    // so later cleanup cannot mistake a correction for spam learning.
     update: {
       exclude,
       reason,
       threadId,
       messageId,
-      source: source === GroupItemSource.USER ? source : undefined,
+      source: exclude === true ? source : undefined,
     },
     create: {
       groupId,

--- a/apps/web/utils/webhook/google/process-label-removed-event.test.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.test.ts
@@ -283,6 +283,7 @@ describe("process-label-removed-event", () => {
           type: GroupItemType.FROM,
           value: "sender@example.com",
           source: GroupItemSource.LABEL_ADDED,
+          exclude: false,
         },
       });
     });
@@ -343,6 +344,7 @@ describe("process-label-removed-event", () => {
           type: GroupItemType.FROM,
           value: "sender@example.com",
           source: GroupItemSource.LABEL_ADDED,
+          exclude: false,
         },
       });
 

--- a/apps/web/utils/webhook/google/process-label-removed-event.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.ts
@@ -74,7 +74,7 @@ export async function handleLabelRemovedEvent(
 
   // When SPAM label is removed (user moves email out of Junk),
   // undo any cold email pattern that was learned from marking as junk.
-  // Only removes patterns with source = LABEL_ADDED (preserves AI/USER patterns).
+  // Only removes active spam-learned patterns and preserves explicit exclusions.
   if (hasSpamRemoval) {
     await undoSpamLearning({ sender, emailAccountId, logger });
   }
@@ -144,7 +144,7 @@ async function learnFromRemovedLabel({
 /**
  * When the SPAM label is removed (user moves email out of Junk),
  * delete any cold email GroupItem that was created by the LABEL_ADDED handler.
- * Only removes patterns we created — preserves AI and USER patterns.
+ * Only removes active patterns we created and preserves explicit exclusions.
  */
 async function undoSpamLearning({
   sender,
@@ -172,6 +172,7 @@ async function undoSpamLearning({
       type: GroupItemType.FROM,
       value: sender,
       source: GroupItemSource.LABEL_ADDED,
+      exclude: false,
     },
   });
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-184006_pr-3191_39618a81afe4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keep explicit learned-pattern corrections authoritative throughout label and spam cleanup workflows.

- record exclusion provenance without overwriting inferred origins
- limit spam cleanup to active spam-learned patterns
- add regression coverage for correction and cleanup behavior

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->