### PR TITLE
rules: apply the exclusion rule to bulk pattern saves too

### DIFF
--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -295,4 +295,56 @@ describe("saveLearnedPatterns", () => {
     expect(result).toEqual({ success: true });
     expect(prisma.groupItem.upsert).toHaveBeenCalledTimes(2);
   });
+
+  // Matches saveLearnedPattern: omitting exclude must not reset a stored exclusion,
+  // which would silently re-block a sender the user had corrected.
+  it("should leave exclude untouched when a pattern omits it", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
+
+    await saveLearnedPatterns({
+      emailAccountId: "email-account-id",
+      ruleName: "Test Rule",
+      patterns: [{ type: GroupItemType.FROM, value: "sender@example.com" }],
+      logger: createTestLogger(),
+    });
+
+    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { exclude: undefined },
+        create: expect.objectContaining({ exclude: false }),
+      }),
+    );
+  });
+
+  it("should still apply exclude when a pattern sets it", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
+
+    await saveLearnedPatterns({
+      emailAccountId: "email-account-id",
+      ruleName: "Test Rule",
+      patterns: [
+        {
+          type: GroupItemType.FROM,
+          value: "sender@example.com",
+          exclude: true,
+        },
+      ],
+      logger: createTestLogger(),
+    });
+
+    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { exclude: true },
+        create: expect.objectContaining({ exclude: true }),
+      }),
+    );
+  });
 });

--- a/apps/web/utils/rule/learned-patterns.ts
+++ b/apps/web/utils/rule/learned-patterns.ts
@@ -139,14 +139,16 @@ export async function saveLearnedPatterns({
             value: pattern.value,
           },
         },
+        // Same rule as saveLearnedPattern: a pattern that says nothing about exclude
+        // must not reset one, which would re-block a sender the user had corrected.
         update: {
-          exclude: pattern.exclude || false,
+          exclude: pattern.exclude,
         },
         create: {
           groupId,
           type: pattern.type,
           value: pattern.value,
-          exclude: pattern.exclude || false,
+          exclude: pattern.exclude ?? false,
         },
       });
     } catch (error) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-191924_pr-3192_d2c3eb1ed4a1/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Follow-up to #3075 and #3191.

## What

`saveLearnedPattern` no longer resets `exclude` for callers that omit it, so an inferred write can't silently un-exclude a sender the user corrected. The bulk variant in the same file was left with the original shape:

```ts
update: { exclude: pattern.exclude || false }
```

A pattern that says nothing about exclusion still clears a stored one. This makes the two functions agree.

## This is preventive, not a live fix

`saveLearnedPatterns` has exactly one caller, the assistant's learned-patterns tool, and it sets an explicit boolean at all four construction sites (`exclude: false` for includes, `exclude: true` for excludes). Nothing omits it today, so no user is affected.

I'm doing it anyway because the two functions are adjacent, are named a character apart, and are easy to reach for interchangeably. Leaving them with different semantics is what causes this bug the next time someone adds a caller, and the signature already advertises `exclude?: boolean` as optional.

## Deliberately not included

`saveLearnedPatterns` writes no `source` at all, so assistant-created rows land with `source: null`. That's safe under the current `undoSpamLearning` filter, which requires both `source: LABEL_ADDED` and `exclude: false`, so a null-source row is never deleted by it. Adding provenance would be a data-write change with its own reasoning, so it belongs in its own PR rather than riding along here.

## Tests

Written first and confirmed red. Reverting the fix to `pattern.exclude || false` fails `should leave exclude untouched when a pattern omits it`.

Full suite: 550 files passed, 105 skipped, 0 failed. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->