### PR TITLE
site: link to AI email assistant directory

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -46,6 +46,11 @@ export const footerNavigation = {
       name: "Best AI Email Assistants",
       href: "/blog/post/best-ai-email-assistants",
     },
+    {
+      name: "AI Email Assistant Directory",
+      href: "https://aiemailassistants.com",
+      target: "_blank",
+    },
     { name: "vs Fyxer.ai", href: "/best-fyxer-alternative" },
     { name: "vs Superhuman", href: "/best-superhuman-alternative" },
     { name: "vs Shortwave", href: "/best-shortwave-alternative" },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260809-194424_pr-3193_b38209b11c6e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- add a contextual link to AIEmailAssistants.com in the existing Compare footer section
- use a descriptive anchor instead of implying third-party recognition
- keep the directory link clean for referral and canonical attribution

## Validation

- `pnpm exec biome check apps/web/app/\(landing\)/home/Footer.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->