### PR TITLE
gmail: Adapt batch retries to throttling

### DIFF
--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -5,13 +5,13 @@ import { isRetryableError } from "@/utils/gmail/retry";
 import { sleep } from "@/utils/sleep";
 import type { Logger } from "@/utils/logger";
 
-const GMAIL_BATCH_SIZE = 10;
+const GMAIL_BATCH_SIZE = 50;
+const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
 const MAX_BATCH_RETRIES = 3;
 const MAX_RETRY_JITTER_MS = 1000;
 
-// Gmail executes batch subrequests concurrently, so keep each request small
-// and sequential to avoid triggering the per-user concurrency limit. Retry only
-// failed items and preserve provider errors for account-level rate-limit mode.
+// Gmail recommends batches of 50 or fewer. Keep initial batches at that limit,
+// then reduce only rate-limited retries so successful items retain full throughput.
 export async function getBatchWithRetry<TRaw, TParsed>({
   ids,
   endpoint,
@@ -147,15 +147,23 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
     );
     const jitterMs = Math.floor(Math.random() * (MAX_RETRY_JITTER_MS + 1));
     await sleep(exponentialDelayMs + jitterMs);
-    const refetched = await getBatchChunkWithRetry({
-      ids: remainingIds,
-      endpoint,
-      accessToken,
-      parse,
-      retryCount: nextRetryCount,
-      retryError: lastRetryableError,
-      logger,
-    });
+    const retryChunks =
+      rateLimitedItemCount > 0
+        ? chunk(remainingIds, RATE_LIMIT_RETRY_BATCH_SIZE)
+        : [remainingIds];
+    const refetched: TParsed[] = [];
+    for (const idsChunk of retryChunks) {
+      const chunkResults = await getBatchChunkWithRetry({
+        ids: idsChunk,
+        endpoint,
+        accessToken,
+        parse,
+        retryCount: nextRetryCount,
+        retryError: lastRetryableError,
+        logger,
+      });
+      refetched.push(...chunkResults);
+    }
     return [...parsed, ...refetched];
   }
 

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -5,13 +5,12 @@ import { isRetryableError } from "@/utils/gmail/retry";
 import { sleep } from "@/utils/sleep";
 import type { Logger } from "@/utils/logger";
 
-const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
+const GMAIL_BATCH_SIZE = 10;
+const MAX_RETRY_JITTER_MS = 1000;
 
-// Fetches a Gmail batch and handles per-item errors: throws on 401, retries
-// retryable items (re-fetching only the missing ids, in smaller chunks when
-// rate-limited), and drops non-retryable items with a warning. Without this,
-// per-item batch errors are returned as-is and silently treated as
-// valid-but-empty results, so threads/messages disappear under partial failure.
+// Gmail executes batch subrequests concurrently, so keep each request small
+// and sequential to avoid triggering the per-user concurrency limit. Retry only
+// failed items and preserve provider errors for account-level rate-limit mode.
 export async function getBatchWithRetry<TRaw, TParsed>({
   ids,
   endpoint,
@@ -31,8 +30,45 @@ export async function getBatchWithRetry<TRaw, TParsed>({
 }): Promise<TParsed[]> {
   if (!accessToken) throw new Error("No access token");
 
+  const results: TParsed[] = [];
+  for (const idsChunk of chunk(ids, GMAIL_BATCH_SIZE)) {
+    const chunkResults = await getBatchChunkWithRetry<TRaw, TParsed>({
+      ids: idsChunk,
+      endpoint,
+      accessToken,
+      parse,
+      logger,
+      retryCount,
+      retryError,
+    });
+    results.push(...chunkResults);
+  }
+
+  return results;
+}
+
+async function getBatchChunkWithRetry<TRaw, TParsed>({
+  ids,
+  endpoint,
+  accessToken,
+  parse,
+  logger,
+  retryCount,
+  retryError,
+}: {
+  ids: string[];
+  endpoint: string;
+  accessToken: string;
+  parse: (item: TRaw) => TParsed;
+  logger: Logger;
+  retryCount: number;
+  retryError?: BatchError["error"];
+}): Promise<TParsed[]> {
   if (retryCount > 3) {
-    logger.warn("Too many batch retries", { ids, retryCount });
+    logger.warn("Too many Gmail batch retries", {
+      batchSize: ids.length,
+      retryCount,
+    });
     if (!retryError) throw new Error("Gmail batch retry limit exceeded");
     // Preserve the provider error so account-level rate-limit protection can pause follow-on calls.
     throw new Error(retryError.message, { cause: retryError });
@@ -50,8 +86,9 @@ export async function getBatchWithRetry<TRaw, TParsed>({
   }
 
   const missingIds = new Set<string>();
-  let shouldRetryInSmallerBatches = false;
   let lastRetryableError = retryError;
+  let retryableItemCount = 0;
+  let rateLimitedItemCount = 0;
 
   const parsed = batch
     .map((item, i) => {
@@ -67,7 +104,6 @@ export async function getBatchWithRetry<TRaw, TParsed>({
 
         if (!retryable) {
           logger.warn("Skipping batch item due to non-retryable error", {
-            id: ids[i],
             code,
             reason,
             errorMessage,
@@ -75,13 +111,8 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           return;
         }
 
-        logger.warn("Error fetching batch item, adding to retry queue", {
-          id: ids[i],
-          code,
-          errorMessage,
-          reason,
-        });
-        if (isRateLimit) shouldRetryInSmallerBatches = true;
+        retryableItemCount++;
+        if (isRateLimit) rateLimitedItemCount++;
         if (isRateLimit || !lastRetryableError) {
           lastRetryableError = item.error;
         }
@@ -95,69 +126,30 @@ export async function getBatchWithRetry<TRaw, TParsed>({
 
   if (missingIds.size > 0) {
     const remainingIds = Array.from(missingIds);
-    logger.info("Missing batch items", {
-      missingIds: remainingIds,
-      retryMode: shouldRetryInSmallerBatches ? "chunked" : "batch",
+    logger.warn("Retrying Gmail batch items", {
+      batchSize: ids.length,
+      retryableItemCount,
+      rateLimitedItemCount,
+      retryCount: retryCount + 1,
     });
     const nextRetryCount = retryCount + 1;
-    await sleep(1000 * nextRetryCount);
-    const refetched = shouldRetryInSmallerBatches
-      ? await getBatchWithRetryInChunks({
-          ids: remainingIds,
-          endpoint,
-          accessToken,
-          parse,
-          retryCount: nextRetryCount,
-          retryError: lastRetryableError,
-          logger,
-        })
-      : await getBatchWithRetry({
-          ids: remainingIds,
-          endpoint,
-          accessToken,
-          parse,
-          retryCount: nextRetryCount,
-          retryError: lastRetryableError,
-          logger,
-        });
+    const exponentialDelayMs = Math.min(
+      1000 * 2 ** (nextRetryCount - 1),
+      10_000,
+    );
+    const jitterMs = Math.floor(Math.random() * (MAX_RETRY_JITTER_MS + 1));
+    await sleep(exponentialDelayMs + jitterMs);
+    const refetched = await getBatchChunkWithRetry({
+      ids: remainingIds,
+      endpoint,
+      accessToken,
+      parse,
+      retryCount: nextRetryCount,
+      retryError: lastRetryableError,
+      logger,
+    });
     return [...parsed, ...refetched];
   }
 
   return parsed;
-}
-
-async function getBatchWithRetryInChunks<TRaw, TParsed>({
-  ids,
-  endpoint,
-  accessToken,
-  parse,
-  retryCount,
-  retryError,
-  logger,
-}: {
-  ids: string[];
-  endpoint: string;
-  accessToken: string;
-  parse: (item: TRaw) => TParsed;
-  retryCount: number;
-  retryError?: BatchError["error"];
-  logger: Logger;
-}): Promise<TParsed[]> {
-  const chunked = chunk(ids, RATE_LIMIT_RETRY_BATCH_SIZE);
-  const results: TParsed[] = [];
-
-  for (const idsChunk of chunked) {
-    const chunkResults = await getBatchWithRetry<TRaw, TParsed>({
-      ids: idsChunk,
-      endpoint,
-      accessToken,
-      parse,
-      retryCount,
-      retryError,
-      logger,
-    });
-    results.push(...chunkResults);
-  }
-
-  return results;
 }

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -6,6 +6,7 @@ import { sleep } from "@/utils/sleep";
 import type { Logger } from "@/utils/logger";
 
 const GMAIL_BATCH_SIZE = 10;
+const MAX_BATCH_RETRIES = 3;
 const MAX_RETRY_JITTER_MS = 1000;
 
 // Gmail executes batch subrequests concurrently, so keep each request small
@@ -64,15 +65,13 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
   retryCount: number;
   retryError?: BatchError["error"];
 }): Promise<TParsed[]> {
-  if (retryCount > 3) {
-    logger.warn("Too many Gmail batch retries", {
+  if (retryCount > MAX_BATCH_RETRIES)
+    throwBatchRetryLimit({
       batchSize: ids.length,
       retryCount,
+      retryError,
+      logger,
     });
-    if (!retryError) throw new Error("Gmail batch retry limit exceeded");
-    // Preserve the provider error so account-level rate-limit protection can pause follow-on calls.
-    throw new Error(retryError.message, { cause: retryError });
-  }
 
   const batch: (TRaw | BatchError)[] = await getBatch(
     ids,
@@ -126,13 +125,22 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
 
   if (missingIds.size > 0) {
     const remainingIds = Array.from(missingIds);
+    const nextRetryCount = retryCount + 1;
+
+    if (nextRetryCount > MAX_BATCH_RETRIES)
+      throwBatchRetryLimit({
+        batchSize: remainingIds.length,
+        retryCount: nextRetryCount,
+        retryError: lastRetryableError,
+        logger,
+      });
+
     logger.warn("Retrying Gmail batch items", {
       batchSize: ids.length,
       retryableItemCount,
       rateLimitedItemCount,
-      retryCount: retryCount + 1,
+      retryCount: nextRetryCount,
     });
-    const nextRetryCount = retryCount + 1;
     const exponentialDelayMs = Math.min(
       1000 * 2 ** (nextRetryCount - 1),
       10_000,
@@ -152,4 +160,22 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
   }
 
   return parsed;
+}
+
+function throwBatchRetryLimit({
+  batchSize,
+  retryCount,
+  retryError,
+  logger,
+}: {
+  batchSize: number;
+  retryCount: number;
+  retryError?: BatchError["error"];
+  logger: Logger;
+}): never {
+  logger.warn("Too many Gmail batch retries", { batchSize, retryCount });
+  if (!retryError) throw new Error("Gmail batch retry limit exceeded");
+
+  // Preserve the provider error so account-level rate-limit protection can pause follow-on calls.
+  throw new Error(retryError.message, { cause: retryError });
 }

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -85,6 +85,7 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
   }
 
   const missingIds = new Set<string>();
+  const rateLimitedIds = new Set<string>();
   let lastRetryableError = retryError;
   let retryableItemCount = 0;
   let rateLimitedItemCount = 0;
@@ -111,7 +112,10 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
         }
 
         retryableItemCount++;
-        if (isRateLimit) rateLimitedItemCount++;
+        if (isRateLimit) {
+          rateLimitedItemCount++;
+          rateLimitedIds.add(ids[i]);
+        }
         if (isRateLimit || !lastRetryableError) {
           lastRetryableError = item.error;
         }
@@ -147,10 +151,13 @@ async function getBatchChunkWithRetry<TRaw, TParsed>({
     );
     const jitterMs = Math.floor(Math.random() * (MAX_RETRY_JITTER_MS + 1));
     await sleep(exponentialDelayMs + jitterMs);
-    const retryChunks =
-      rateLimitedItemCount > 0
-        ? chunk(remainingIds, RATE_LIMIT_RETRY_BATCH_SIZE)
-        : [remainingIds];
+    const nonRateLimitedIds = remainingIds.filter(
+      (id) => !rateLimitedIds.has(id),
+    );
+    const retryChunks = [
+      ...chunk(nonRateLimitedIds, GMAIL_BATCH_SIZE),
+      ...chunk(Array.from(rateLimitedIds), RATE_LIMIT_RETRY_BATCH_SIZE),
+    ];
     const refetched: TParsed[] = [];
     for (const idsChunk of retryChunks) {
       const chunkResults = await getBatchChunkWithRetry({

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -5,13 +5,13 @@ import { isRetryableError } from "@/utils/gmail/retry";
 import { sleep } from "@/utils/sleep";
 import type { Logger } from "@/utils/logger";
 
-const GMAIL_BATCH_SIZE = 50;
+const GMAIL_BATCH_SIZE = 25;
 const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
 const MAX_BATCH_RETRIES = 3;
 const MAX_RETRY_JITTER_MS = 1000;
 
-// Gmail recommends batches of 50 or fewer. Keep initial batches at that limit,
-// then reduce only rate-limited retries so successful items retain full throughput.
+// Gmail counts each subrequest toward per-user concurrency. Leave headroom for
+// other account activity, then reduce rate-limited retries even further.
 export async function getBatchWithRetry<TRaw, TParsed>({
   ids,
   endpoint,

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -109,9 +109,9 @@ describe("getMessagesBatch", () => {
     expect(getBatch).toHaveBeenCalledTimes(2);
   });
 
-  it("splits large Gmail batches into sequential requests before Gmail throttles them", async () => {
+  it("keeps initial Gmail batches within the recommended size", async () => {
     const messageIds = Array.from(
-      { length: 25 },
+      { length: 100 },
       (_, index) => `id${index + 1}`,
     );
     const accessToken = "token";
@@ -136,16 +136,16 @@ describe("getMessagesBatch", () => {
 
     const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
-    expect(result).toHaveLength(25);
+    expect(result).toHaveLength(100);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
-      10, 10, 5,
+      50, 50,
     ]);
     expect(maxActiveBatchRequests).toBe(1);
   });
 
-  it("retries only rate-limited items within each safe batch", async () => {
+  it("retries only rate-limited items in smaller sequential batches", async () => {
     const messageIds = Array.from(
-      { length: 12 },
+      { length: 55 },
       (_, index) => `id${index + 1}`,
     );
     const accessToken = "token";
@@ -154,8 +154,8 @@ describe("getMessagesBatch", () => {
 
     vi.mocked(getBatch)
       .mockResolvedValueOnce(
-        messageIds.slice(0, 10).map((id, index) =>
-          index < 5
+        messageIds.slice(0, 50).map((id, index) =>
+          index < 35
             ? {
                 id,
                 threadId: `${id}-thread`,
@@ -172,14 +172,21 @@ describe("getMessagesBatch", () => {
         ),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(5, 10).map((id) => ({
+        messageIds.slice(35, 45).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
         })),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(10).map((id) => ({
+        messageIds.slice(45, 50).map((id) => ({
+          id,
+          threadId: `${id}-thread`,
+          payload: { headers: [] },
+        })),
+      )
+      .mockResolvedValueOnce(
+        messageIds.slice(50).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
@@ -188,10 +195,10 @@ describe("getMessagesBatch", () => {
 
     const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
-    expect(result).toHaveLength(12);
-    expect(getBatch).toHaveBeenCalledTimes(3);
+    expect(result).toHaveLength(55);
+    expect(getBatch).toHaveBeenCalledTimes(4);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
-      10, 5, 2,
+      50, 10, 5, 5,
     ]);
     expect(
       warnSpy.mock.calls.filter(
@@ -201,9 +208,9 @@ describe("getMessagesBatch", () => {
       [
         "Retrying Gmail batch items",
         {
-          batchSize: 10,
-          rateLimitedItemCount: 5,
-          retryableItemCount: 5,
+          batchSize: 50,
+          rateLimitedItemCount: 15,
+          retryableItemCount: 15,
           retryCount: 1,
         },
       ],

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -218,6 +218,67 @@ describe("getMessagesBatch", () => {
     expect(sleep).toHaveBeenCalledWith(1500);
   });
 
+  it("keeps non-rate-limited failures separate from smaller rate-limit retries", async () => {
+    const messageIds = Array.from(
+      { length: 50 },
+      (_, index) => `id${index + 1}`,
+    );
+    const accessToken = "token";
+
+    vi.mocked(getBatch)
+      .mockResolvedValueOnce(
+        messageIds.map((id, index) => {
+          if (index < 35) {
+            return {
+              id,
+              threadId: `${id}-thread`,
+              payload: { headers: [] },
+            };
+          }
+
+          return {
+            error:
+              index < 47
+                ? {
+                    code: 500,
+                    message: "Backend error",
+                    errors: [{ reason: "backendError" }],
+                    status: "INTERNAL",
+                  }
+                : {
+                    code: 429,
+                    message: "Too many concurrent requests for user",
+                    errors: [{ reason: "rateLimitExceeded" }],
+                    status: "RESOURCE_EXHAUSTED",
+                  },
+          };
+        }),
+      )
+      .mockResolvedValueOnce(
+        messageIds.slice(35, 47).map((id) => ({
+          id,
+          threadId: `${id}-thread`,
+          payload: { headers: [] },
+        })),
+      )
+      .mockResolvedValueOnce(
+        messageIds.slice(47).map((id) => ({
+          id,
+          threadId: `${id}-thread`,
+          payload: { headers: [] },
+        })),
+      );
+
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
+
+    expect(result).toHaveLength(50);
+    expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids)).toEqual([
+      messageIds,
+      messageIds.slice(35, 47),
+      messageIds.slice(47),
+    ]);
+  });
+
   it("throws when rate-limited batch items exhaust all retries", async () => {
     const rateLimitError = {
       error: {

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -109,7 +109,7 @@ describe("getMessagesBatch", () => {
     expect(getBatch).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps initial Gmail batches within the recommended size", async () => {
+  it("uses conservative sequential initial Gmail batches", async () => {
     const messageIds = Array.from(
       { length: 100 },
       (_, index) => `id${index + 1}`,
@@ -138,7 +138,7 @@ describe("getMessagesBatch", () => {
 
     expect(result).toHaveLength(100);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
-      50, 50,
+      25, 25, 25, 25,
     ]);
     expect(maxActiveBatchRequests).toBe(1);
   });
@@ -154,8 +154,8 @@ describe("getMessagesBatch", () => {
 
     vi.mocked(getBatch)
       .mockResolvedValueOnce(
-        messageIds.slice(0, 50).map((id, index) =>
-          index < 35
+        messageIds.slice(0, 25).map((id, index) =>
+          index < 10
             ? {
                 id,
                 threadId: `${id}-thread`,
@@ -172,14 +172,21 @@ describe("getMessagesBatch", () => {
         ),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(35, 45).map((id) => ({
+        messageIds.slice(10, 20).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
         })),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(45, 50).map((id) => ({
+        messageIds.slice(20, 25).map((id) => ({
+          id,
+          threadId: `${id}-thread`,
+          payload: { headers: [] },
+        })),
+      )
+      .mockResolvedValueOnce(
+        messageIds.slice(25, 50).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
@@ -196,9 +203,9 @@ describe("getMessagesBatch", () => {
     const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
     expect(result).toHaveLength(55);
-    expect(getBatch).toHaveBeenCalledTimes(4);
+    expect(getBatch).toHaveBeenCalledTimes(5);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
-      50, 10, 5, 5,
+      25, 10, 5, 25, 5,
     ]);
     expect(
       warnSpy.mock.calls.filter(
@@ -208,7 +215,7 @@ describe("getMessagesBatch", () => {
       [
         "Retrying Gmail batch items",
         {
-          batchSize: 50,
+          batchSize: 25,
           rateLimitedItemCount: 15,
           retryableItemCount: 15,
           retryCount: 1,
@@ -220,7 +227,7 @@ describe("getMessagesBatch", () => {
 
   it("keeps non-rate-limited failures separate from smaller rate-limit retries", async () => {
     const messageIds = Array.from(
-      { length: 50 },
+      { length: 25 },
       (_, index) => `id${index + 1}`,
     );
     const accessToken = "token";
@@ -228,7 +235,7 @@ describe("getMessagesBatch", () => {
     vi.mocked(getBatch)
       .mockResolvedValueOnce(
         messageIds.map((id, index) => {
-          if (index < 35) {
+          if (index < 10) {
             return {
               id,
               threadId: `${id}-thread`,
@@ -238,7 +245,7 @@ describe("getMessagesBatch", () => {
 
           return {
             error:
-              index < 47
+              index < 22
                 ? {
                     code: 500,
                     message: "Backend error",
@@ -255,14 +262,14 @@ describe("getMessagesBatch", () => {
         }),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(35, 47).map((id) => ({
+        messageIds.slice(10, 22).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
         })),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(47).map((id) => ({
+        messageIds.slice(22).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
@@ -271,11 +278,11 @@ describe("getMessagesBatch", () => {
 
     const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
-    expect(result).toHaveLength(50);
+    expect(result).toHaveLength(25);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids)).toEqual([
       messageIds,
-      messageIds.slice(35, 47),
-      messageIds.slice(47),
+      messageIds.slice(10, 22),
+      messageIds.slice(22),
     ]);
   });
 

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getMessagesBatch,
   hasPreviousCommunicationsWithSenderOrDomain,
@@ -14,6 +14,10 @@ vi.mock("@/utils/sleep", () => ({
 vi.mock("gmail-api-parse-message", () => ({
   default: vi.fn((m) => m),
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("getMessagesBatch", () => {
   const logger = createTestLogger();
@@ -146,7 +150,7 @@ describe("getMessagesBatch", () => {
     );
     const accessToken = "token";
     const warnSpy = vi.spyOn(logger, "warn");
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
 
     vi.mocked(getBatch)
       .mockResolvedValueOnce(
@@ -205,8 +209,6 @@ describe("getMessagesBatch", () => {
       ],
     ]);
     expect(sleep).toHaveBeenCalledWith(1500);
-    warnSpy.mockRestore();
-    randomSpy.mockRestore();
   });
 
   it("throws when rate-limited batch items exhaust all retries", async () => {
@@ -245,6 +247,7 @@ describe("getMessagesBatch", () => {
     });
 
     expect(getBatch).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -5,6 +5,7 @@ import {
 } from "./message";
 import { getBatch } from "@/utils/gmail/batch";
 import { createTestLogger } from "@/__tests__/helpers";
+import { sleep } from "@/utils/sleep";
 
 vi.mock("@/utils/gmail/batch");
 vi.mock("@/utils/sleep", () => ({
@@ -104,26 +105,70 @@ describe("getMessagesBatch", () => {
     expect(getBatch).toHaveBeenCalledTimes(2);
   });
 
-  it("should retry rate-limited messages in smaller chunks", async () => {
+  it("splits large Gmail batches into sequential requests before Gmail throttles them", async () => {
+    const messageIds = Array.from(
+      { length: 25 },
+      (_, index) => `id${index + 1}`,
+    );
+    const accessToken = "token";
+    let activeBatchRequests = 0;
+    let maxActiveBatchRequests = 0;
+
+    vi.mocked(getBatch).mockImplementation(async (ids) => {
+      activeBatchRequests++;
+      maxActiveBatchRequests = Math.max(
+        maxActiveBatchRequests,
+        activeBatchRequests,
+      );
+      await Promise.resolve();
+      activeBatchRequests--;
+
+      return ids.map((id) => ({
+        id,
+        threadId: `${id}-thread`,
+        payload: { headers: [] },
+      }));
+    });
+
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
+
+    expect(result).toHaveLength(25);
+    expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
+      10, 10, 5,
+    ]);
+    expect(maxActiveBatchRequests).toBe(1);
+  });
+
+  it("retries only rate-limited items within each safe batch", async () => {
     const messageIds = Array.from(
       { length: 12 },
       (_, index) => `id${index + 1}`,
     );
     const accessToken = "token";
+    const warnSpy = vi.spyOn(logger, "warn");
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
 
     vi.mocked(getBatch)
       .mockResolvedValueOnce(
-        messageIds.map(() => ({
-          error: {
-            code: 429,
-            message: "Too many concurrent requests for user",
-            errors: [{ reason: "rateLimitExceeded" }],
-            status: "RESOURCE_EXHAUSTED",
-          },
-        })),
+        messageIds.slice(0, 10).map((id, index) =>
+          index < 5
+            ? {
+                id,
+                threadId: `${id}-thread`,
+                payload: { headers: [] },
+              }
+            : {
+                error: {
+                  code: 429,
+                  message: "Too many concurrent requests for user",
+                  errors: [{ reason: "rateLimitExceeded" }],
+                  status: "RESOURCE_EXHAUSTED",
+                },
+              },
+        ),
       )
       .mockResolvedValueOnce(
-        messageIds.slice(0, 10).map((id) => ({
+        messageIds.slice(5, 10).map((id) => ({
           id,
           threadId: `${id}-thread`,
           payload: { headers: [] },
@@ -142,8 +187,26 @@ describe("getMessagesBatch", () => {
     expect(result).toHaveLength(12);
     expect(getBatch).toHaveBeenCalledTimes(3);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
-      12, 10, 2,
+      10, 5, 2,
     ]);
+    expect(
+      warnSpy.mock.calls.filter(
+        ([message]) => message === "Retrying Gmail batch items",
+      ),
+    ).toEqual([
+      [
+        "Retrying Gmail batch items",
+        {
+          batchSize: 10,
+          rateLimitedItemCount: 5,
+          retryableItemCount: 5,
+          retryCount: 1,
+        },
+      ],
+    ]);
+    expect(sleep).toHaveBeenCalledWith(1500);
+    warnSpy.mockRestore();
+    randomSpy.mockRestore();
   });
 
   it("throws when rate-limited batch items exhaust all retries", async () => {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260810-112624_pr-3194_ad5d50a2ac8e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Use conservative Gmail batches for normal throughput, then reduce only rate-limited retry work.

- process initial message and thread fetches in sequential batches of up to 25
- preserve successful items and retry only retryable failures
- retry rate-limited items in sequential batches of 10 with exponential backoff and jitter
- aggregate retry logs and preserve provider errors for account-level protection

Validation:
- `pnpm exec ultracite check apps/web/utils/gmail/batch-with-retry.ts apps/web/utils/gmail/message.test.ts`
- `pnpm test utils/gmail/message.test.ts utils/gmail/thread.test.ts`
- `pnpm test utils/gmail`