### PR TITLE
chore: Add safe visual evidence guidance for UI PRs

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -46,6 +46,35 @@ Run focused validation appropriate to the changed files. Do not run builds or
 broad test suites when repository instructions prohibit them or the user did
 not request them.
 
+### Visual evidence for UI changes
+
+When the diff changes rendered UI and both states are practical to run, capture
+before-and-after evidence before publishing:
+
+1. Choose an explicit baseline such as production, a base-branch worktree, or a
+   preview deployment. Never infer a baseline from an unrelated local state.
+2. Render the same route, deterministic synthetic/demo state, and viewport in
+   both versions. Use the existing `agent-browser` skill (`diff url`,
+   `diff screenshot`, or matched screenshots), wait for fonts and loading states,
+   and capture the changed region rather than a full page unless the whole page
+   changed. Add a mobile pair when responsive behavior is part of the diff.
+3. Inspect both images for the intended change and accidental regressions.
+   Screenshots supplement focused tests; they do not replace interaction,
+   accessibility, or functional verification.
+4. Treat images as public before attaching them. Never capture customer data,
+   auth state, tokens, account IDs, or private service details. Do not upload to
+   anonymous or unapproved third-party hosts (including `0x0.st`), and do not
+   put credentials or bypass tokens in URLs or PR metadata.
+5. If an approved GitHub or first-party attachment path is available, add a
+   `Before | After` table to the PR body. Otherwise keep the artifacts local and
+   report their paths plus the exact attachment limitation; do not silently
+   publish them or add generated images to git without a repository convention.
+
+If a stable baseline, safe fixture, runnable browser, or approved attachment
+path is unavailable, do not fabricate evidence or block a non-visual fix. State
+what is missing in the PR and run the strongest non-visual verification
+available. Do not add a screenshot dependency solely for PR formatting.
+
 ## 2. Branch, commit, and push
 
 Create a dedicated branch when on the base branch or when the current branch


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260810-122255_pr-3196_4f900381ba41/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- add a bounded before/after evidence step for rendered UI changes
- reuse the repository's existing `agent-browser` tooling instead of adding a dependency
- require matched deterministic states and viewports, synthetic/demo data, and functional verification
- prohibit anonymous screenshot hosts and sensitive captures; degrade explicitly when no approved attachment path exists

## Source and rationale

Inspired by the workflow in https://x.com/hugorcd/status/2086471205998264699. The linked CLI demonstrates the review value of before/after PR screenshots, but its current `--markdown` path defaults to uploading images to `0x0.st`. Inbox Zero already has `agent-browser`, including URL and screenshot diff commands, so this adapts the useful review practice without adding the package or its external-upload default.

## Verification

- `git diff --check`
- static assertions confirmed all eight baseline, privacy, upload, test, and fallback guards
- scope check confirmed this changes one existing documentation-only skill file

## Expected signal

Across the next three UI PRs, reviewers should receive matched before/after evidence when a stable baseline and safe attachment path exist, with zero customer/auth data or anonymous-host uploads. Reassess after three UI PRs: keep the guidance if it surfaces at least one useful visual review observation or materially shortens visual review without creating attachment friction; otherwise simplify it.

No runtime code, dependency, production behavior, credential, data, deployment, or spend changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->