### PR TITLE
Add all free tools to the site footer

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -60,6 +60,7 @@ export const footerNavigation = {
     },
   ],
   tools: [
+    { name: "All Free Email Tools", href: "/tools" },
     {
       name: "Email Deliverability Checker",
       href: "/tools/email-deliverability-checker",
@@ -71,6 +72,10 @@ export const footerNavigation = {
       href: "/tools/email-signature-generator",
     },
     { name: "Meeting Cost Calculator", href: "/tools/meeting-cost-calculator" },
+    {
+      name: "Team Email Cost Calculator",
+      href: "/tools/email-cost-calculator",
+    },
   ],
   support: [
     { name: "Pricing", href: "/pricing" },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260810-201456_pr-3199_80d823ce6bdd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- link the free email tools directory from the main site footer
- add the team email cost calculator alongside the existing free tools

## Validation
- `git diff --check`

This is a link-only footer update; no application behavior changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->