### PR TITLE
INB-322: Show processing while meeting recording continues

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/meeting-detail-state.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/meeting-detail-state.ts
@@ -2,6 +2,7 @@ import {
   MeetingProcessingStatus,
   MeetingRecordingStatus,
 } from "@/generated/prisma/enums";
+import { CAPTURED_MEETING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 
 export type MeetingDetailState =
   | "notes"
@@ -41,12 +42,7 @@ export function getMeetingDetailState({
 
   // Once the bot is in the call, the meeting is being captured even though
   // there is nothing to read yet, so "not recorded" would be wrong.
-  if (
-    recordingStatus === MeetingRecordingStatus.IN_CALL ||
-    recordingStatus === MeetingRecordingStatus.RECORDING ||
-    recordingStatus === MeetingRecordingStatus.CALL_ENDED ||
-    recordingStatus === MeetingRecordingStatus.DONE
-  ) {
+  if (recordingStatus && CAPTURED_MEETING_STATUSES.includes(recordingStatus)) {
     return "processing";
   }
 

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
@@ -27,6 +27,20 @@ describe("getRecordingStatusBadge", () => {
     ).toEqual({ label: "Not recorded", variant: "red" });
   });
 
+  it.each([
+    MeetingRecordingStatus.IN_CALL,
+    MeetingRecordingStatus.RECORDING,
+  ])("shows processing after the scheduled end while the recorder is still in progress (%s)", (status) => {
+    expect(
+      getRecordingStatusBadge({
+        status,
+        startTime: new Date("2026-07-30T16:00:00.000Z"),
+        endTime: new Date("2026-07-30T16:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Processing", variant: "secondary" });
+  });
+
   it("keeps actionable recorder progress visible while the meeting is ongoing", () => {
     expect(
       getRecordingStatusBadge({

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
@@ -2,6 +2,7 @@ import { MeetingRecordingStatus } from "@/generated/prisma/enums";
 import {
   NO_RECORDING_STATUSES,
   RECORDED_SECTION_STATUSES,
+  STILL_CAPTURING_STATUSES,
 } from "@/utils/meeting-recorder/recording-lifecycle";
 
 type StatusBadge = {
@@ -77,6 +78,11 @@ export function getRecordingStatusBadge({
 
   if (end <= now && status) {
     if (!RECORDED_SECTION_STATUSES.includes(status)) return null;
+    // A recorder still capturing past the scheduled end means the call ran
+    // long, so show the recording wrapping up rather than the stale live badge.
+    if (STILL_CAPTURING_STATUSES.includes(status)) {
+      return STATUS_BADGES[MeetingRecordingStatus.CALL_ENDED];
+    }
     if (NO_RECORDING_STATUSES.includes(status)) {
       return { label: "Not recorded", variant: "red" };
     }

--- a/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
@@ -49,9 +49,9 @@ describe("meeting recorder meetings route", () => {
           in: [
             MeetingRecordingStatus.JOINING,
             MeetingRecordingStatus.IN_WAITING_ROOM,
+            MeetingRecordingStatus.FAILED,
             MeetingRecordingStatus.IN_CALL,
             MeetingRecordingStatus.RECORDING,
-            MeetingRecordingStatus.FAILED,
             MeetingRecordingStatus.CALL_ENDED,
             MeetingRecordingStatus.DONE,
           ],

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -23,15 +23,29 @@ export const CHANGEABLE_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.SCHEDULED,
 ];
 
-// The bot engaged with the call (tried to join, reached it, or failed trying)
-// but delivered no media. A recording still in one of these states after the
-// meeting ended produced nothing.
+// The bot is in the call with capture still underway. A recording still in one
+// of these states after the meeting's scheduled end means the call ran long and
+// the recording is wrapping up, not missing.
+export const STILL_CAPTURING_STATUSES: MeetingRecordingStatus[] = [
+  MeetingRecordingStatus.IN_CALL,
+  MeetingRecordingStatus.RECORDING,
+];
+
+// The bot engaged with the call (tried to join, or failed trying) but delivered
+// no media. A recording still in one of these states after the meeting ended
+// produced nothing.
 export const NO_RECORDING_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.JOINING,
   MeetingRecordingStatus.IN_WAITING_ROOM,
-  MeetingRecordingStatus.IN_CALL,
-  MeetingRecordingStatus.RECORDING,
   MeetingRecordingStatus.FAILED,
+];
+
+// The bot made it into the call, so media exists or is still being captured.
+// Meetings in these states must never be presented as "not recorded".
+export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
+  ...STILL_CAPTURING_STATUSES,
+  MeetingRecordingStatus.CALL_ENDED,
+  MeetingRecordingStatus.DONE,
 ];
 
 // A booked bot is not a recorded meeting. The Recorded section only shows
@@ -39,8 +53,7 @@ export const NO_RECORDING_STATUSES: MeetingRecordingStatus[] = [
 // bookings are no-shows.
 export const RECORDED_SECTION_STATUSES: MeetingRecordingStatus[] = [
   ...NO_RECORDING_STATUSES,
-  MeetingRecordingStatus.CALL_ENDED,
-  MeetingRecordingStatus.DONE,
+  ...CAPTURED_MEETING_STATUSES,
 ];
 
 // Rank orders the lifecycle so replayed or out-of-order webhooks can only ever


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260811-090554_pr-3200_b7d6fdd208fd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Correct the meetings page to keep displaying Processing when capture continues beyond the scheduled end. Centralize active and captured lifecycle groupings so list badges and meeting details stay consistent.

- Treat IN_CALL and RECORDING as still capturing after the scheduled end.
- Preserve Recorded-section membership while distinguishing genuine no-recording states.
- Tests: 19 focused unit tests passed; Ultracite and diff checks passed.
- Performance: constant-size in-memory enum checks only; no new database or network calls and negligible hot-path risk.

Linear issue: https://linear.app/inbox-zero-ai/issue/INB-322/meetings-page-shows-not-recorded-status-while-recording-is-still-being

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->