### PR TITLE
meetings: Default recorder to all calls

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderOnboarding.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderOnboarding.tsx
@@ -77,7 +77,7 @@ export function MeetingRecorderOnboarding({
       features={features}
     >
       {hasCalendarConnected ? (
-        <Button onClick={() => setJoinRule(MeetingJoinRule.EXTERNAL_ONLY)}>
+        <Button onClick={() => setJoinRule(MeetingJoinRule.ALL)}>
           Get started
         </Button>
       ) : (

--- a/apps/web/app/(app)/[emailAccountId]/meetings/join-rule-options.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/join-rule-options.ts
@@ -1,12 +1,11 @@
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 
 export const JOIN_RULE_OPTIONS = [
+  { value: MeetingJoinRule.ALL, label: "Every call with a video link" },
   {
     value: MeetingJoinRule.EXTERNAL_ONLY,
     label: "Only calls with people outside my company",
-    badge: "Recommended",
   },
-  { value: MeetingJoinRule.ALL, label: "Every call with a video link" },
   { value: MeetingJoinRule.HOST_ONLY, label: "Only calls I organize" },
   { value: MeetingJoinRule.OFF, label: "Only the ones I turn on myself" },
 ];

--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -79,7 +79,7 @@ export default function Components() {
     "alice@example.com",
     "bob@example.com",
   ]);
-  const [joinRule, setJoinRule] = useState("external");
+  const [joinRule, setJoinRule] = useState("all");
   const [notifyByEmail, setNotifyByEmail] = useState(true);
   return (
     <Container>
@@ -905,12 +905,11 @@ export default function Components() {
               value={joinRule}
               onChange={setJoinRule}
               options={[
+                { value: "all", label: "Every call with a video link" },
                 {
                   value: "external",
                   label: "Only calls with people outside my company",
-                  badge: "Recommended",
                 },
-                { value: "all", label: "Every call with a video link" },
                 { value: "off", label: "Only the ones I turn on myself" },
               ]}
             />

--- a/apps/web/app/api/user/meeting-recorder/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/route.ts
@@ -30,8 +30,7 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
 
   return {
     enabled: emailAccount?.meetingRecorderEnabled ?? false,
-    joinRule:
-      emailAccount?.meetingRecorderJoinRule ?? MeetingJoinRule.EXTERNAL_ONLY,
+    joinRule: emailAccount?.meetingRecorderJoinRule ?? MeetingJoinRule.ALL,
     recapEmailEnabled: emailAccount?.meetingRecorderRecapEmailEnabled ?? true,
     followUpDraftEnabled:
       emailAccount?.meetingRecorderFollowUpDraftEnabled ?? true,

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
@@ -76,8 +76,7 @@ async function getData({
     meetings.map((meeting) => [meeting.calendarEventId, meeting]),
   );
 
-  const rule =
-    emailAccount?.meetingRecorderJoinRule ?? MeetingJoinRule.EXTERNAL_ONLY;
+  const rule = emailAccount?.meetingRecorderJoinRule ?? MeetingJoinRule.ALL;
 
   return {
     hasAccess,

--- a/apps/web/components/RadioCardGroup.tsx
+++ b/apps/web/components/RadioCardGroup.tsx
@@ -5,8 +5,6 @@ import { cn } from "@/utils";
 type RadioCardOption<T extends string> = {
   value: T;
   label: string;
-  /** Short qualifier shown next to the label, e.g. "Recommended". */
-  badge?: string;
 };
 
 /**
@@ -73,14 +71,7 @@ export function RadioCardGroup<T extends string>({
               )}
             />
 
-            <span className="flex items-center gap-2 text-sm">
-              {option.label}
-              {option.badge && (
-                <span className="text-xs text-muted-foreground">
-                  {option.badge}
-                </span>
-              )}
-            </span>
+            <span className="text-sm">{option.label}</span>
           </label>
         );
       })}

--- a/apps/web/prisma/migrations/20260810090000_default_meeting_recorder_all/migration.sql
+++ b/apps/web/prisma/migrations/20260810090000_default_meeting_recorder_all/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "EmailAccount"
+ALTER COLUMN "meetingRecorderJoinRule" SET DEFAULT 'ALL';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -162,7 +162,7 @@ model EmailAccount {
   meetingBriefsSendEmail        Boolean @default(true)
 
   meetingRecorderEnabled              Boolean         @default(false)
-  meetingRecorderJoinRule             MeetingJoinRule @default(EXTERNAL_ONLY)
+  meetingRecorderJoinRule             MeetingJoinRule @default(ALL)
   meetingRecorderRecapEmailEnabled    Boolean         @default(true)
   meetingRecorderFollowUpDraftEnabled Boolean         @default(true)
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260811-083435_pr-3201_35b9bba105ba/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Defaults the meeting recorder to all eligible calls after explicit activation.

- Selects and orders the all-calls option first while removing the recommendation badge.
- Aligns persisted and API fallback defaults without enabling recording at signup.
- Validated with focused meeting-recorder tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->