### PR TITLE
fix: restore production build compatibility

### DIFF
--- a/apps/web/components/Banner.tsx
+++ b/apps/web/components/Banner.tsx
@@ -1,0 +1,24 @@
+import { UnicornScene } from "@/components/new-landing/UnicornScene";
+
+interface BannerProps {
+  children: React.ReactNode;
+  title: React.ReactNode;
+}
+
+export function Banner({ title, children }: BannerProps) {
+  return (
+    <div className="relative my-10 overflow-hidden rounded-3xl border border-[#E7E7E7A3] px-6 py-24 sm:py-32 lg:px-8">
+      <UnicornScene className="opacity-10" />
+      <div className="mx-auto max-w-2xl text-center">
+        <h2 className="font-title text-3xl text-gray-900 sm:text-4xl">
+          {title}
+        </h2>
+        {typeof children === "string" ? (
+          <p className="mt-6 text-lg leading-8 text-gray-600">{children}</p>
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -52,7 +52,11 @@ export function getEmailMessageCellLabels({
     });
 
   if (shouldShowArchivedLabel({ labelIds, provider, labels })) {
-    labels?.unshift({ id: OutlookLabel.ARCHIVE, name: "Archived" });
+    labels?.unshift({
+      id: OutlookLabel.ARCHIVE,
+      name: "Archived",
+      color: undefined,
+    });
   }
 
   return labels;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260811-082945_pr-3202_ac2b06c74671/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restores a shared UI dependency used by production routes and aligns generated label data with its updated display type.

- Restore the shared banner component required during route compilation.
- Include the optional color field for generated archived labels.
- Validate with focused tests, formatting checks, and a clean Node 24 production build.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->