### PR TITLE
INB-323: Fix meeting summary structured output

### DIFF
--- a/apps/web/__tests__/eval/meeting-follow-up-draft.test.ts
+++ b/apps/web/__tests__/eval/meeting-follow-up-draft.test.ts
@@ -25,6 +25,7 @@ const ROLLOUT_SUMMARY: MeetingSummary = {
     {
       description:
         "Tell the customers who already have the fifteenth in writing",
+      owner: null,
     },
   ],
   openQuestions: ["Who owns the migration webinar?"],
@@ -45,6 +46,7 @@ const UNRESOLVED_PRICING_SUMMARY: MeetingSummary = {
   openQuestions: [
     "Do they pay for all forty people or only the fifteen daily users?",
   ],
+  nextSteps: null,
 };
 
 describe.runIf(shouldRunEval)("meeting-follow-up-draft eval", () => {

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -52,7 +52,11 @@ export function getEmailMessageCellLabels({
     });
 
   if (shouldShowArchivedLabel({ labelIds, provider, labels })) {
-    labels?.unshift({ id: OutlookLabel.ARCHIVE, name: "Archived" });
+    labels?.unshift({
+      id: OutlookLabel.ARCHIVE,
+      name: "Archived",
+      color: undefined,
+    });
   }
 
   return labels;

--- a/apps/web/utils/ai/meeting-recorder/summarize-meeting.test.ts
+++ b/apps/web/utils/ai/meeting-recorder/summarize-meeting.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { getEmailAccount } from "@/__tests__/helpers";
+import { aiSummarizeMeeting } from "@/utils/ai/meeting-recorder/summarize-meeting";
+
+const { createGenerateObjectMock, generateObjectMock, getModelForUseCaseMock } =
+  vi.hoisted(() => ({
+    createGenerateObjectMock: vi.fn(),
+    generateObjectMock: vi.fn(),
+    getModelForUseCaseMock: vi.fn(),
+  }));
+
+vi.mock("@/utils/llms/index", () => ({
+  createGenerateObject: createGenerateObjectMock,
+}));
+
+vi.mock("@/utils/llms/use-cases", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/llms/use-cases")>(
+    "@/utils/llms/use-cases",
+  );
+
+  return {
+    ...actual,
+    getModelForUseCase: getModelForUseCaseMock,
+  };
+});
+
+describe("aiSummarizeMeeting", () => {
+  it("asks the model for a schema strict structured-output providers accept", async () => {
+    createGenerateObjectMock.mockReturnValue(generateObjectMock);
+    getModelForUseCaseMock.mockReturnValue({});
+    const object = {
+      overview: "The team reviewed the launch.",
+      keyDecisions: [],
+      actionItems: [
+        { description: "Prepare the launch checklist", owner: null },
+      ],
+      openQuestions: [],
+      nextSteps: [],
+    };
+    generateObjectMock.mockResolvedValue({ object });
+
+    const summary = await aiSummarizeMeeting({
+      emailAccount: getEmailAccount(),
+      eventTitle: "Launch planning",
+      attendees: [],
+      transcript: [
+        {
+          speakerName: "Speaker",
+          isHost: true,
+          startTime: 0,
+          endTime: 1,
+          text: "Let's prepare the launch checklist.",
+        },
+      ],
+    });
+
+    const { schema } = generateObjectMock.mock.calls[0][0];
+    const jsonSchema = z.toJSONSchema(schema) as {
+      properties: Record<
+        string,
+        { items?: { properties: Record<string, unknown>; required?: string[] } }
+      >;
+      required?: string[];
+    };
+
+    // Strict structured-output providers reject any property left optional, so
+    // every declared property must be required at each level.
+    expect([...(jsonSchema.required ?? [])].sort()).toEqual(
+      Object.keys(jsonSchema.properties).sort(),
+    );
+    const actionItem = jsonSchema.properties.actionItems.items;
+    expect([...(actionItem?.required ?? [])].sort()).toEqual(
+      Object.keys(actionItem?.properties ?? {}).sort(),
+    );
+
+    expect(summary).toEqual(object);
+  });
+});

--- a/apps/web/utils/ai/meeting-recorder/summarize-meeting.test.ts
+++ b/apps/web/utils/ai/meeting-recorder/summarize-meeting.test.ts
@@ -1,7 +1,10 @@
+import { asSchema } from "ai";
 import { describe, expect, it, vi } from "vitest";
-import { z } from "zod";
 import { getEmailAccount } from "@/__tests__/helpers";
-import { aiSummarizeMeeting } from "@/utils/ai/meeting-recorder/summarize-meeting";
+import {
+  aiSummarizeMeeting,
+  parseMeetingSummary,
+} from "@/utils/ai/meeting-recorder/summarize-meeting";
 
 const { createGenerateObjectMock, generateObjectMock, getModelForUseCaseMock } =
   vi.hoisted(() => ({
@@ -56,10 +59,16 @@ describe("aiSummarizeMeeting", () => {
     });
 
     const { schema } = generateObjectMock.mock.calls[0][0];
-    const jsonSchema = z.toJSONSchema(schema) as {
+    const jsonSchema = (await Promise.resolve(asSchema(schema).jsonSchema)) as {
       properties: Record<
         string,
-        { items?: { properties: Record<string, unknown>; required?: string[] } }
+        {
+          anyOf?: Array<{ type?: string }>;
+          items?: {
+            properties: Record<string, { anyOf?: Array<{ type?: string }> }>;
+            required?: string[];
+          };
+        }
       >;
       required?: string[];
     };
@@ -73,7 +82,34 @@ describe("aiSummarizeMeeting", () => {
     expect([...(actionItem?.required ?? [])].sort()).toEqual(
       Object.keys(actionItem?.properties ?? {}).sort(),
     );
+    expect(jsonSchema.properties.openQuestions.anyOf).toContainEqual({
+      type: "null",
+    });
+    expect(jsonSchema.properties.nextSteps.anyOf).toContainEqual({
+      type: "null",
+    });
+    expect(actionItem?.properties.owner.anyOf).toContainEqual({
+      type: "null",
+    });
 
     expect(summary).toEqual(object);
+  });
+
+  it("parses summaries stored before optional fields became nullable", () => {
+    expect(
+      parseMeetingSummary({
+        overview: "The team reviewed the launch.",
+        keyDecisions: [],
+        actionItems: [{ description: "Prepare the launch checklist" }],
+      }),
+    ).toEqual({
+      overview: "The team reviewed the launch.",
+      keyDecisions: [],
+      actionItems: [
+        { description: "Prepare the launch checklist", owner: null },
+      ],
+      openQuestions: null,
+      nextSteps: null,
+    });
   });
 });

--- a/apps/web/utils/ai/meeting-recorder/summarize-meeting.ts
+++ b/apps/web/utils/ai/meeting-recorder/summarize-meeting.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createGenerateObject } from "@/utils/llms/index";
+import { strictOptional } from "@/utils/llms/strict-optional";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createScopedLogger } from "@/utils/logger";
@@ -24,6 +25,10 @@ Rules:
 
 Return your response in JSON format.`;
 
+// Strict structured-output providers require every declared property to be
+// required, so optional fields are required-but-nullable via strictOptional.
+// Its `value ?? null` preprocess also keeps previously stored summaries
+// parseable: fields absent in old rows come back as null.
 const summarySchema = z.object({
   overview: z
     .string()
@@ -35,21 +40,18 @@ const summarySchema = z.object({
     .array(
       z.object({
         description: z.string(),
-        owner: z
-          .string()
-          .optional()
-          .describe("Only set when the transcript shows who took this on"),
+        owner: strictOptional(z.string()).describe(
+          "Only set when the transcript shows who took this on",
+        ),
       }),
     )
     .describe("Concrete follow-up work agreed in the meeting"),
-  openQuestions: z
-    .array(z.string())
-    .optional()
-    .describe("Questions raised but left unresolved"),
-  nextSteps: z
-    .array(z.string())
-    .optional()
-    .describe("What happens next, including any agreed timing"),
+  openQuestions: strictOptional(z.array(z.string())).describe(
+    "Questions raised but left unresolved",
+  ),
+  nextSteps: strictOptional(z.array(z.string())).describe(
+    "What happens next, including any agreed timing",
+  ),
 });
 
 export type MeetingSummary = z.infer<typeof summarySchema>;

--- a/apps/web/utils/meeting-recorder/send-recap.test.ts
+++ b/apps/web/utils/meeting-recorder/send-recap.test.ts
@@ -52,6 +52,8 @@ describe("sendMeetingRecapEmail", () => {
         overview: "Discussed the plan.",
         keyDecisions: [],
         actionItems: [],
+        openQuestions: null,
+        nextSteps: null,
       },
       followUpDraftCreated: false,
       logger: {

--- a/packages/resend/emails/meeting-recap.tsx
+++ b/packages/resend/emails/meeting-recap.tsx
@@ -12,15 +12,15 @@ import {
 
 export type MeetingRecapActionItem = {
   description: string;
-  owner?: string;
+  owner?: string | null;
 };
 
 export type MeetingRecapContent = {
   overview: string;
   keyDecisions: string[];
   actionItems: MeetingRecapActionItem[];
-  openQuestions?: string[];
-  nextSteps?: string[];
+  openQuestions?: string[] | null;
+  nextSteps?: string[] | null;
 };
 
 export type MeetingRecapEmailProps = {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260811-090351_pr-3203_f631a57f9da8/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix meeting note generation when strict structured-output providers reject optional schema properties. Meeting summaries now encode optional values as nullable while preserving compatibility with older stored summaries.

- Make all generated JSON Schema properties required for provider compatibility.
- Update recap types and fixtures for nullable summary fields.
- Tests: 4 focused unit tests passed across 3 files; Ultracite checked all changed files.
- Performance: constant-time schema preprocessing only; no new database or network calls and no meaningful hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-323/meeting-notes-not-generated-only-transcript-available