### PR TITLE
feat(mail): foundation for the redesigned mail tab

### DIFF
--- a/apps/web/app/api/labels/counts/route.test.ts
+++ b/apps/web/app/api/labels/counts/route.test.ts
@@ -1,0 +1,185 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetLabels,
+  mockGetLabelById,
+  mockGetInboxStats,
+  mockRedisGet,
+  mockRedisSet,
+  providerName,
+} = vi.hoisted(() => ({
+  mockGetLabels: vi.fn(),
+  mockGetLabelById: vi.fn(),
+  mockGetInboxStats: vi.fn(),
+  mockRedisGet: vi.fn(),
+  mockRedisSet: vi.fn(),
+  providerName: { current: "google" as "google" | "microsoft" },
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: (...args: unknown[]) => mockRedisGet(...args),
+    set: (...args: unknown[]) => mockRedisSet(...args),
+  },
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createScopedLogger } =
+    await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  const logger = createScopedLogger("test/labels-counts");
+
+  return {
+    withEmailProvider:
+      (
+        _name: string,
+        handler: (
+          request: NextRequest & Record<string, unknown>,
+        ) => Promise<Response>,
+      ) =>
+      (request: NextRequest) =>
+        handler(
+          Object.assign(request, {
+            auth: { emailAccountId: "email-account-id" },
+            logger,
+            emailProvider: {
+              get name() {
+                return providerName.current;
+              },
+              getLabels: mockGetLabels,
+              getLabelById: mockGetLabelById,
+              getInboxStats: mockGetInboxStats,
+            },
+          }),
+        ),
+  };
+});
+
+import { GET } from "./route";
+
+const request = () =>
+  new NextRequest("http://localhost:3000/api/labels/counts");
+
+function counts(body: { counts: Array<{ id: string }> }) {
+  return body.counts.map((count) => count.id);
+}
+
+describe("GET /api/labels/counts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    providerName.current = "google";
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockResolvedValue("OK");
+    mockGetLabels.mockResolvedValue([{ id: "Label_1", name: "Work" }]);
+    mockGetLabelById.mockImplementation(async (id: string) => ({
+      id,
+      name: id,
+      threadsTotal: 10,
+      threadsUnread: 3,
+    }));
+  });
+
+  it("returns unread and total counts per label and category", async () => {
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(counts(body)).toEqual([
+      "INBOX",
+      "DRAFT",
+      "SENT",
+      "CATEGORY_PERSONAL",
+      "CATEGORY_SOCIAL",
+      "CATEGORY_PROMOTIONS",
+      "CATEGORY_UPDATES",
+      "CATEGORY_FORUMS",
+      "Label_1",
+    ]);
+    expect(body.counts[0]).toEqual({
+      id: "INBOX",
+      name: "Inbox",
+      kind: "system",
+      total: 10,
+      unread: 3,
+    });
+    expect(body.counts.at(-1)).toMatchObject({
+      id: "Label_1",
+      name: "Work",
+      kind: "label",
+    });
+    expect(body.partial).toBe(false);
+  });
+
+  it("caches the response and serves later requests from the cache", async () => {
+    const first = await GET(request());
+    const firstBody = await first.json();
+
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      "label-counts:email-account-id",
+      firstBody,
+      { ex: 60 },
+    );
+
+    mockGetLabelById.mockClear();
+    mockGetLabels.mockClear();
+    mockRedisGet.mockResolvedValue(firstBody);
+
+    const second = await GET(request());
+
+    expect(await second.json()).toEqual(firstBody);
+    expect(mockGetLabels).not.toHaveBeenCalled();
+    expect(mockGetLabelById).not.toHaveBeenCalled();
+  });
+
+  it("keeps the other counts when a single label lookup fails", async () => {
+    mockGetLabelById.mockImplementation(async (id: string) => {
+      if (id === "CATEGORY_SOCIAL") throw new Error("Gmail is unhappy");
+      return { id, name: id, threadsTotal: 4, threadsUnread: 1 };
+    });
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(counts(body)).not.toContain("CATEGORY_SOCIAL");
+    expect(counts(body)).toContain("INBOX");
+    expect(body.partial).toBe(true);
+  });
+
+  it("degrades to an empty result when the provider fails", async () => {
+    mockGetLabels.mockRejectedValue(new Error("Gmail is down"));
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ counts: [], partial: true });
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it("still returns counts when the cache is unavailable", async () => {
+    mockRedisGet.mockRejectedValue(new Error("redis down"));
+    mockRedisSet.mockRejectedValue(new Error("redis down"));
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(counts(body)).toContain("INBOX");
+  });
+
+  it("returns inbox-only counts for Outlook", async () => {
+    providerName.current = "microsoft";
+    mockGetInboxStats.mockResolvedValue({ total: 7, unread: 2 });
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(body).toEqual({
+      counts: [
+        { id: "INBOX", name: "Inbox", kind: "system", total: 7, unread: 2 },
+      ],
+      partial: true,
+    });
+    expect(mockGetLabelById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/labels/counts/route.ts
+++ b/apps/web/app/api/labels/counts/route.ts
@@ -1,0 +1,172 @@
+import { NextResponse } from "next/server";
+import { withEmailProvider } from "@/utils/middleware";
+import { isGoogleProvider } from "@/utils/email/provider-types";
+import type { EmailProvider } from "@/utils/email/types";
+import { GmailLabel } from "@/utils/gmail/label";
+import type { Logger } from "@/utils/logger";
+import { redis } from "@/utils/redis";
+import { isDefined } from "@/utils/types";
+
+// The mail sidebar fills counts in after first paint, so this must degrade
+// rather than hang: a slow provider is worth less than an empty sidebar.
+export const maxDuration = 15;
+
+const CACHE_KEY_PREFIX = "label-counts";
+const CACHE_TTL_SECONDS = 60;
+const MAX_USER_LABELS = 100;
+
+type LabelCount = {
+  id: string;
+  name: string;
+  kind: "system" | "category" | "label";
+  /** Threads in the label, unread ones included */
+  total: number;
+  unread: number;
+};
+
+export type LabelCountsResponse = {
+  counts: LabelCount[];
+  /** Some counts are missing: a provider that can't report them, or a failed lookup */
+  partial: boolean;
+};
+
+const EMPTY_RESPONSE: LabelCountsResponse = { counts: [], partial: true };
+
+// Gmail's system labels the sidebar shows. Archived has no label of its own.
+const SYSTEM_LABELS = [
+  { id: GmailLabel.INBOX, name: "Inbox" },
+  { id: GmailLabel.DRAFT, name: "Drafts" },
+  { id: GmailLabel.SENT, name: "Sent" },
+];
+
+const CATEGORY_LABELS = [
+  { id: GmailLabel.PERSONAL, name: "Primary" },
+  { id: GmailLabel.SOCIAL, name: "Social" },
+  { id: GmailLabel.PROMOTIONS, name: "Promotions" },
+  { id: GmailLabel.UPDATES, name: "Updates" },
+  { id: GmailLabel.FORUMS, name: "Forums" },
+];
+
+export const GET = withEmailProvider(
+  "labels/counts",
+  async (request) => {
+    const { emailProvider, logger } = request;
+    const { emailAccountId } = request.auth;
+
+    const cached = await getCachedCounts(emailAccountId, logger);
+    if (cached) return NextResponse.json(cached);
+
+    const response = await getCounts({ emailProvider, logger });
+    if (response.counts.length) {
+      await setCachedCounts(emailAccountId, response, logger);
+    }
+
+    return NextResponse.json(response);
+  },
+  { requestTiming: {} },
+);
+
+async function getCounts({
+  emailProvider,
+  logger,
+}: {
+  emailProvider: EmailProvider;
+  logger: Logger;
+}): Promise<LabelCountsResponse> {
+  try {
+    if (isGoogleProvider(emailProvider.name)) {
+      return await getGmailCounts({ emailProvider, logger });
+    }
+
+    // Outlook has no per-category counts and its categories carry none either,
+    // so only the inbox is reported.
+    const { total, unread } = await emailProvider.getInboxStats();
+    return {
+      counts: [{ id: "INBOX", name: "Inbox", kind: "system", total, unread }],
+      partial: true,
+    };
+  } catch (error) {
+    logger.warn("Failed to fetch label counts", { error });
+    return EMPTY_RESPONSE;
+  }
+}
+
+async function getGmailCounts({
+  emailProvider,
+  logger,
+}: {
+  emailProvider: EmailProvider;
+  logger: Logger;
+}): Promise<LabelCountsResponse> {
+  const userLabels = await emailProvider.getLabels();
+
+  const targets: Array<Pick<LabelCount, "id" | "name" | "kind">> = [
+    ...SYSTEM_LABELS.map((label) => ({ ...label, kind: "system" as const })),
+    ...CATEGORY_LABELS.map((label) => ({
+      ...label,
+      kind: "category" as const,
+    })),
+    ...userLabels.slice(0, MAX_USER_LABELS).map((label) => ({
+      id: label.id,
+      name: label.name,
+      kind: "label" as const,
+    })),
+  ];
+
+  // Gmail's `labels.list` carries no counts, so each label needs its own
+  // `labels.get`. One failure must not cost us the rest of the sidebar.
+  const counts = (
+    await Promise.all(
+      targets.map(async (target) => {
+        try {
+          const label = await emailProvider.getLabelById(target.id);
+          if (!label) return null;
+          return {
+            ...target,
+            total: label.threadsTotal ?? 0,
+            unread: label.threadsUnread ?? 0,
+          };
+        } catch (error) {
+          logger.warn("Failed to fetch count for label", {
+            labelId: target.id,
+            error,
+          });
+          return null;
+        }
+      }),
+    )
+  ).filter(isDefined);
+
+  return {
+    counts,
+    partial:
+      counts.length < targets.length || userLabels.length > MAX_USER_LABELS,
+  };
+}
+
+function getCacheKey(emailAccountId: string) {
+  return `${CACHE_KEY_PREFIX}:${emailAccountId}`;
+}
+
+async function getCachedCounts(emailAccountId: string, logger: Logger) {
+  try {
+    return await redis.get<LabelCountsResponse>(getCacheKey(emailAccountId));
+  } catch (error) {
+    logger.warn("Failed to read cached label counts", { error });
+    return null;
+  }
+}
+
+async function setCachedCounts(
+  emailAccountId: string,
+  response: LabelCountsResponse,
+  logger: Logger,
+) {
+  try {
+    await redis.set(getCacheKey(emailAccountId), response, {
+      ex: CACHE_TTL_SECONDS,
+    });
+  } catch (error) {
+    logger.warn("Failed to cache label counts", { error });
+  }
+}

--- a/apps/web/app/api/labels/counts/route.ts
+++ b/apps/web/app/api/labels/counts/route.ts
@@ -148,7 +148,13 @@ async function getGmailCounts({
 
   const counts = settled
     .map(({ item, result }) => {
-      if (result.status === "fulfilled") return result.value;
+      if (result.status === "fulfilled") {
+        // The Gmail provider turns a failed lookup into a null rather than a
+        // rejection, so a null is a failure too — otherwise a transient miss
+        // gets frozen in the cache for a minute.
+        if (result.value === null) anyFailed = true;
+        return result.value;
+      }
       anyFailed = true;
       logger.warn("Failed to fetch count for label", {
         labelId: item.id,

--- a/apps/web/app/api/labels/counts/route.ts
+++ b/apps/web/app/api/labels/counts/route.ts
@@ -6,6 +6,7 @@ import { GmailLabel } from "@/utils/gmail/label";
 import type { Logger } from "@/utils/logger";
 import { redis } from "@/utils/redis";
 import { isDefined } from "@/utils/types";
+import { runWithBoundedConcurrency } from "@/utils/async";
 
 // The mail sidebar fills counts in after first paint, so this must degrade
 // rather than hang: a slow provider is worth less than an empty sidebar.
@@ -14,6 +15,7 @@ export const maxDuration = 15;
 const CACHE_KEY_PREFIX = "label-counts";
 const CACHE_TTL_SECONDS = 60;
 const MAX_USER_LABELS = 100;
+const LABEL_LOOKUP_CONCURRENCY = 8;
 
 type LabelCount = {
   id: string;
@@ -30,7 +32,15 @@ export type LabelCountsResponse = {
   partial: boolean;
 };
 
-const EMPTY_RESPONSE: LabelCountsResponse = { counts: [], partial: true };
+// `anyFailed` distinguishes "this provider can't report everything" from "a
+// lookup broke", so only the latter keeps a bad result out of the cache.
+type CountsResult = LabelCountsResponse & { anyFailed: boolean };
+
+const EMPTY_RESPONSE: CountsResult = {
+  counts: [],
+  partial: true,
+  anyFailed: true,
+};
 
 // Gmail's system labels the sidebar shows. Archived has no label of its own.
 const SYSTEM_LABELS = [
@@ -56,8 +66,12 @@ export const GET = withEmailProvider(
     const cached = await getCachedCounts(emailAccountId, logger);
     if (cached) return NextResponse.json(cached);
 
-    const response = await getCounts({ emailProvider, logger });
-    if (response.counts.length) {
+    const { anyFailed, ...response } = await getCounts({
+      emailProvider,
+      logger,
+    });
+    // A transient lookup failure must not be frozen in the cache for a minute.
+    if (response.counts.length && !anyFailed) {
       await setCachedCounts(emailAccountId, response, logger);
     }
 
@@ -72,7 +86,7 @@ async function getCounts({
 }: {
   emailProvider: EmailProvider;
   logger: Logger;
-}): Promise<LabelCountsResponse> {
+}): Promise<CountsResult> {
   try {
     if (isGoogleProvider(emailProvider.name)) {
       return await getGmailCounts({ emailProvider, logger });
@@ -84,6 +98,7 @@ async function getCounts({
     return {
       counts: [{ id: "INBOX", name: "Inbox", kind: "system", total, unread }],
       partial: true,
+      anyFailed: false,
     };
   } catch (error) {
     logger.warn("Failed to fetch label counts", { error });
@@ -97,7 +112,7 @@ async function getGmailCounts({
 }: {
   emailProvider: EmailProvider;
   logger: Logger;
-}): Promise<LabelCountsResponse> {
+}): Promise<CountsResult> {
   const userLabels = await emailProvider.getLabels();
 
   const targets: Array<Pick<LabelCount, "id" | "name" | "kind">> = [
@@ -114,33 +129,42 @@ async function getGmailCounts({
   ];
 
   // Gmail's `labels.list` carries no counts, so each label needs its own
-  // `labels.get`. One failure must not cost us the rest of the sidebar.
-  const counts = (
-    await Promise.all(
-      targets.map(async (target) => {
-        try {
-          const label = await emailProvider.getLabelById(target.id);
-          if (!label) return null;
-          return {
-            ...target,
-            total: label.threadsTotal ?? 0,
-            unread: label.threadsUnread ?? 0,
-          };
-        } catch (error) {
-          logger.warn("Failed to fetch count for label", {
-            labelId: target.id,
-            error,
-          });
-          return null;
-        }
-      }),
-    )
-  ).filter(isDefined);
+  // `labels.get`. Bounded so a label-heavy account doesn't fire a hundred
+  // requests at once, and one failure must not cost us the rest of the sidebar.
+  let anyFailed = false;
+  const settled = await runWithBoundedConcurrency({
+    items: targets,
+    concurrency: LABEL_LOOKUP_CONCURRENCY,
+    run: async (target) => {
+      const label = await emailProvider.getLabelById(target.id);
+      if (!label) return null;
+      return {
+        ...target,
+        total: label.threadsTotal ?? 0,
+        unread: label.threadsUnread ?? 0,
+      };
+    },
+  });
+
+  const counts = settled
+    .map(({ item, result }) => {
+      if (result.status === "fulfilled") return result.value;
+      anyFailed = true;
+      logger.warn("Failed to fetch count for label", {
+        labelId: item.id,
+        error: result.reason,
+      });
+      return null;
+    })
+    .filter(isDefined);
 
   return {
     counts,
+    // `partial` is also true for providers that simply can't report everything,
+    // so it can't gate caching on its own — see the failure flag below.
     partial:
       counts.length < targets.length || userLabels.length > MAX_USER_LABELS,
+    anyFailed,
   };
 }
 

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -5,23 +5,23 @@ import prisma from "@/utils/prisma";
 export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
 
 async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
-  const [emailAccount, splits] = await Promise.all([
-    prisma.emailAccount.findUnique({
-      where: { id: emailAccountId },
-      select: { mailLayout: true, mailHintBarDismissed: true },
-    }),
-    prisma.mailSplit.findMany({
-      where: { emailAccountId },
-      // createdAt breaks ties so tab order can't shuffle between requests
-      orderBy: [{ order: "asc" }, { createdAt: "asc" }],
-      select: { id: true, name: true, kind: true, value: true, order: true },
-    }),
-  ]);
+  const emailAccount = await prisma.emailAccount.findUnique({
+    where: { id: emailAccountId },
+    select: {
+      mailLayout: true,
+      mailHintBarDismissed: true,
+      mailSplits: {
+        // createdAt breaks ties so tab order can't shuffle between requests
+        orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+        select: { id: true, name: true, kind: true, value: true, order: true },
+      },
+    },
+  });
 
   return {
     layout: emailAccount?.mailLayout ?? null,
     hintBarDismissed: emailAccount?.mailHintBarDismissed ?? false,
-    splits,
+    splits: emailAccount?.mailSplits ?? [],
   };
 }
 

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -12,7 +12,8 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
     }),
     prisma.mailSplit.findMany({
       where: { emailAccountId },
-      orderBy: { order: "asc" },
+      // createdAt breaks ties so tab order can't shuffle between requests
+      orderBy: [{ order: "asc" }, { createdAt: "asc" }],
       select: { id: true, name: true, kind: true, value: true, order: true },
     }),
   ]);

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+
+export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
+
+async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
+  const [emailAccount, splits] = await Promise.all([
+    prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: { mailLayout: true, mailHintBarDismissed: true },
+    }),
+    prisma.mailSplit.findMany({
+      where: { emailAccountId },
+      orderBy: { order: "asc" },
+      select: { id: true, name: true, kind: true, value: true, order: true },
+    }),
+  ]);
+
+  return {
+    layout: emailAccount?.mailLayout ?? null,
+    hintBarDismissed: emailAccount?.mailHintBarDismissed ?? false,
+    splits,
+  };
+}
+
+export const GET = withEmailAccount("mail/settings", async (request) => {
+  const { emailAccountId } = request.auth;
+
+  try {
+    const result = await getMailSettings({ emailAccountId });
+    return NextResponse.json(result);
+  } catch (error) {
+    request.logger.error("Error fetching mail settings", { error });
+    return NextResponse.json(
+      { error: "Failed to fetch mail settings" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/threads/basic/route.ts
+++ b/apps/web/app/api/threads/basic/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
-import type { ThreadsResponse } from "@/app/api/threads/route";
+import type { EmailProvider } from "@/utils/email/types";
 import { threadsQuery } from "@/utils/threads/validation";
 import { EMAIL_PROVIDER_RATE_LIMIT_MESSAGE, SafeError } from "@/utils/error";
 import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
 
+// Straight from the provider — this route does no ExecutedRule join, so it
+// must not borrow the main threads type, which promises `plan` and `plans`.
 export type GetThreadsResponse = {
-  threads: ThreadsResponse["threads"];
+  threads: Awaited<ReturnType<EmailProvider["getThreadsWithQuery"]>>["threads"];
   nextPageToken?: string;
 };
 

--- a/apps/web/app/api/threads/batch/route.ts
+++ b/apps/web/app/api/threads/batch/route.ts
@@ -64,11 +64,14 @@ export const GET = withEmailProvider("threads/batch", async (request) => {
             );
             if (!filteredMessages.length) return null;
 
+            // This route doesn't join executed rules, but the shared response
+            // type promises them, so send the empty case rather than nothing.
             return {
               id: thread.id,
               messages: filteredMessages,
               snippet: thread.snippet,
               plan: undefined,
+              plans: [],
             };
           }),
       )

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -34,6 +34,39 @@ vi.mock("@/utils/middleware", () => ({
 
 import { GET } from "./route";
 
+function getMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "message-1",
+    threadId: "thread-1",
+    snippet: "snippet",
+    subject: "Subject",
+    date: "2024-01-01T00:00:00Z",
+    internalDate: "1704067200000",
+    labelIds: ["INBOX", "UNREAD"],
+    headers: { from: "sender@example.com", date: "2024-01-01T00:00:00Z" },
+    textHtml: "<p>body</p>",
+    textPlain: "body",
+    attachments: [{ attachmentId: "attachment-1" }],
+    inline: [],
+    historyId: "1",
+    ...overrides,
+  };
+}
+
+function getExecutedRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "executed-rule-1",
+    messageId: "message-1",
+    threadId: "thread-1",
+    rule: { id: "rule-1", name: "Newsletter" },
+    actionItems: [],
+    status: "APPLIED",
+    reason: "It's a newsletter",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
 describe("GET /api/threads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -74,6 +107,168 @@ describe("GET /api/threads", () => {
       }),
       maxResults: 50,
       pageToken: undefined,
+    });
+  });
+
+  describe("list view", () => {
+    beforeEach(() => {
+      mockGetThreadsWithQuery.mockResolvedValue({
+        threads: [
+          {
+            id: "thread-1",
+            snippet: "thread snippet",
+            messages: [getMessage()],
+          },
+        ],
+        nextPageToken: "next",
+      });
+      mockFindMany.mockResolvedValue([getExecutedRule()]);
+    });
+
+    it("returns message bodies and attachments by default", async () => {
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads"),
+      );
+      const body = await response.json();
+
+      expect(body.threads[0].messages[0]).toMatchObject({
+        textHtml: "<p>body</p>",
+        textPlain: "body",
+        attachments: [{ attachmentId: "attachment-1" }],
+      });
+    });
+
+    it("omits message bodies and attachments for view=list", async () => {
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads?view=list"),
+      );
+      const body = await response.json();
+
+      const [message] = body.threads[0].messages;
+      expect(message).toEqual({
+        id: "message-1",
+        threadId: "thread-1",
+        snippet: "snippet",
+        subject: "Subject",
+        date: "2024-01-01T00:00:00Z",
+        internalDate: "1704067200000",
+        labelIds: ["INBOX", "UNREAD"],
+        headers: { from: "sender@example.com", date: "2024-01-01T00:00:00Z" },
+      });
+      expect(body.threads[0]).toMatchObject({
+        id: "thread-1",
+        snippet: "thread snippet",
+      });
+      expect(body.threads[0].plan.rule.name).toBe("Newsletter");
+      expect(body.nextPageToken).toBe("next");
+    });
+
+    it("falls back to the full payload for an unknown view", async () => {
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads?view=nonsense"),
+      );
+      const body = await response.json();
+
+      expect(body.threads[0].messages[0].textHtml).toBe("<p>body</p>");
+    });
+  });
+
+  describe("rule attribution", () => {
+    it("returns every rule that fired on the thread", async () => {
+      mockGetThreadsWithQuery.mockResolvedValue({
+        threads: [{ id: "thread-1", snippet: "", messages: [getMessage()] }],
+      });
+      mockFindMany.mockResolvedValue([
+        getExecutedRule({
+          id: "executed-rule-2",
+          messageId: "message-2",
+          rule: { id: "rule-2", name: "Label as work" },
+          reason: "Work related",
+          createdAt: new Date("2024-01-02T00:00:00Z"),
+        }),
+        getExecutedRule(),
+      ]);
+
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads"),
+      );
+      const body = await response.json();
+
+      expect(body.threads[0].plans).toHaveLength(2);
+      expect(
+        body.threads[0].plans.map((plan: { id: string }) => plan.id),
+      ).toEqual(["executed-rule-2", "executed-rule-1"]);
+      expect(body.threads[0].plans[0]).toMatchObject({
+        rule: { id: "rule-2" },
+        reason: "Work related",
+        status: "APPLIED",
+        actionItems: [],
+      });
+      // `plan` stays the single most recent execution for existing consumers
+      expect(body.threads[0].plan.id).toBe("executed-rule-2");
+    });
+
+    it("keeps only the most recent execution of each rule", async () => {
+      mockGetThreadsWithQuery.mockResolvedValue({
+        threads: [{ id: "thread-1", snippet: "", messages: [getMessage()] }],
+      });
+      // Newest first, matching the route's `orderBy`
+      mockFindMany.mockResolvedValue([
+        getExecutedRule({
+          id: "executed-rule-newest",
+          messageId: "message-2",
+          reason: "Latest reason",
+          createdAt: new Date("2024-01-03T00:00:00Z"),
+        }),
+        getExecutedRule({ id: "executed-rule-oldest" }),
+      ]);
+
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads"),
+      );
+      const body = await response.json();
+
+      expect(body.threads[0].plans).toHaveLength(1);
+      expect(body.threads[0].plans[0]).toMatchObject({
+        id: "executed-rule-newest",
+        reason: "Latest reason",
+      });
+      expect(body.threads[0].plans[0].createdAt).toBeUndefined();
+    });
+
+    it("scopes executed rules to their own thread", async () => {
+      mockGetThreadsWithQuery.mockResolvedValue({
+        threads: [
+          { id: "thread-1", snippet: "", messages: [getMessage()] },
+          { id: "thread-2", snippet: "", messages: [getMessage()] },
+        ],
+      });
+      mockFindMany.mockResolvedValue([
+        getExecutedRule({ id: "executed-rule-2", threadId: "thread-2" }),
+        getExecutedRule(),
+      ]);
+
+      const response = await GET(
+        new NextRequest("http://localhost:3000/api/threads"),
+      );
+      const body = await response.json();
+
+      expect(
+        body.threads[0].plans.map((plan: { id: string }) => plan.id),
+      ).toEqual(["executed-rule-1"]);
+      expect(
+        body.threads[1].plans.map((plan: { id: string }) => plan.id),
+      ).toEqual(["executed-rule-2"]);
+    });
+
+    it("asks the database for the most recent executions first", async () => {
+      await GET(new NextRequest("http://localhost:3000/api/threads"));
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        }),
+      );
     });
   });
 });

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
-import { type ThreadsQuery, threadsQuery } from "@/utils/threads/validation";
+import {
+  type ThreadsQuery,
+  threadsQuery,
+  threadsView,
+} from "@/utils/threads/validation";
 import { isDefined } from "@/utils/types";
 import prisma from "@/utils/prisma";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
@@ -29,6 +33,7 @@ export const GET = withEmailProvider(
     const after = searchParams.get("after");
     const before = searchParams.get("before");
     const isUnread = searchParams.get("isUnread");
+    const view = threadsView.parse(searchParams.get("view"));
 
     const query = threadsQuery.parse({
       limit,
@@ -49,7 +54,9 @@ export const GET = withEmailProvider(
         emailAccountId,
         emailProvider,
       });
-      return NextResponse.json(threads);
+      return NextResponse.json(
+        view === "list" ? toListThreads(threads) : threads,
+      );
     } catch (error) {
       request.logger.error("Error fetching threads", {
         error,
@@ -65,6 +72,9 @@ export const GET = withEmailProvider(
 );
 
 export type ThreadsResponse = Awaited<ReturnType<typeof getThreads>>;
+
+/** Slim rows for the mail list: `?view=list`. No message bodies or attachments. */
+export type ThreadsListResponse = ReturnType<typeof toListThreads>;
 
 async function getThreads({
   query,
@@ -83,7 +93,7 @@ async function getThreads({
   });
 
   const threadIds = threads.map((t) => t.id);
-  const plans = await prisma.executedRule.findMany({
+  const executedRules = await prisma.executedRule.findMany({
     where: {
       emailAccountId,
       threadId: { in: threadIds },
@@ -104,31 +114,77 @@ async function getThreads({
       },
       status: true,
       reason: true,
+      createdAt: true,
     },
+    // Newest first so the per-rule aggregation below keeps the latest execution
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
   });
 
   // Process threads with plans and categories
-  const threadsWithPlans = await Promise.all(
-    threads.map(async (thread) => {
-      const plan = plans.find((p) => p.threadId === thread.id);
+  const threadsWithPlans = threads.map((thread) => {
+    const plans = aggregateThreadPlans(
+      executedRules.filter(
+        (executedRule) => executedRule.threadId === thread.id,
+      ),
+    );
 
-      // Filter out ignored senders from the already parsed messages
-      const filteredMessages = thread.messages.filter((message) => {
-        if (!message.headers?.from) return true; // Keep messages without from field
-        return !isIgnoredSender(message.headers.from);
-      });
+    // Filter out ignored senders from the already parsed messages
+    const filteredMessages = thread.messages.filter((message) => {
+      if (!message.headers?.from) return true; // Keep messages without from field
+      return !isIgnoredSender(message.headers.from);
+    });
 
-      return {
-        id: thread.id,
-        messages: filteredMessages,
-        snippet: thread.snippet,
-        plan,
-      };
-    }),
-  );
+    return {
+      id: thread.id,
+      messages: filteredMessages,
+      snippet: thread.snippet,
+      plan: plans.at(0),
+      plans,
+    };
+  });
 
   return {
     threads: threadsWithPlans.filter(isDefined),
+    nextPageToken,
+  };
+}
+
+// `ExecutedRule` is per message, so a thread can hold several rows for the same
+// rule. Keep the most recent execution of each rule, newest first. Rows whose
+// rule was deleted collapse into a single entry.
+function aggregateThreadPlans<
+  T extends { createdAt: Date; rule: { id: string } | null },
+>(executedRules: T[]): Omit<T, "createdAt">[] {
+  const latestByRule = new Map<string, Omit<T, "createdAt">>();
+
+  for (const executedRule of executedRules) {
+    const key = executedRule.rule?.id ?? "deleted-rule";
+    if (latestByRule.has(key)) continue;
+    const { createdAt: _createdAt, ...plan } = executedRule;
+    latestByRule.set(key, plan);
+  }
+
+  return [...latestByRule.values()];
+}
+
+function toListThreads({ threads, nextPageToken }: ThreadsResponse) {
+  return {
+    threads: threads.map((thread) => ({
+      id: thread.id,
+      snippet: thread.snippet,
+      plan: thread.plan,
+      plans: thread.plans,
+      messages: thread.messages.map((message) => ({
+        id: message.id,
+        threadId: message.threadId,
+        snippet: message.snippet,
+        subject: message.subject,
+        date: message.date,
+        internalDate: message.internalDate,
+        labelIds: message.labelIds,
+        headers: message.headers,
+      })),
+    })),
     nextPageToken,
   };
 }

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ArchiveIcon, Loader2Icon } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { useAtomValue } from "jotai";
 import {
   CommandDialog,
@@ -21,6 +21,13 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { useCommandPaletteCommands } from "@/hooks/useCommandPaletteCommands";
 import { fuzzySearch } from "@/lib/commands/fuzzy-search";
 import type { Command, CommandSection } from "@/lib/commands/types";
+import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
+import {
+  buildShortcutPaletteCommands,
+  type ShortcutHandlers,
+  type ShortcutScope,
+} from "@/lib/shortcuts/registry";
 
 const SECTION_ORDER: CommandSection[] = [
   "actions",
@@ -38,7 +45,20 @@ const SECTION_LABELS: Record<CommandSection, string> = {
   settings: "Settings",
 };
 
+// This component is mounted app-wide, and its archive/close bindings act on
+// whatever email is displayed, so the mail scope is enabled everywhere for now.
+// The mail redesign moves mail scope activation onto the mail route.
+const SHORTCUT_SCOPES: ShortcutScope[] = ["global", "mail"];
+
 export function CommandK() {
+  return (
+    <ShortcutsProvider scopes={SHORTCUT_SCOPES}>
+      <CommandPalette />
+    </ShortcutsProvider>
+  );
+}
+
+function CommandPalette() {
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState("");
 
@@ -61,26 +81,24 @@ export function CommandK() {
     }
   }, [refreshEmailList, threadId, showEmail, emailAccountId]);
 
-  // build action commands that include archive and compose
-  const actionCommands = React.useMemo<Command[]>(() => {
-    const actions: Command[] = [];
+  const shortcutHandlers = React.useMemo<ShortcutHandlers>(
+    () => ({
+      commandPalette: () => setOpen((prev) => !prev),
+      compose: onOpenComposeModal,
+      archive: threadId ? onArchive : undefined,
+      // While the palette is open, Escape belongs to the dialog.
+      close: open || !threadId ? undefined : () => showEmail(null),
+    }),
+    [threadId, open, onArchive, onOpenComposeModal, showEmail],
+  );
 
-    if (threadId) {
-      actions.unshift({
-        id: "archive",
-        label: "Archive",
-        description: "Archive current email",
-        icon: ArchiveIcon,
-        shortcut: "E",
-        section: "actions",
-        priority: 0,
-        keywords: ["archive", "remove", "delete"],
-        action: () => onArchive(),
-      });
-    }
+  useShortcuts(shortcutHandlers);
 
-    return actions;
-  }, [threadId, onArchive]);
+  // the registry decides which shortcuts surface as palette entries
+  const actionCommands = React.useMemo<Command[]>(
+    () => buildShortcutPaletteCommands(shortcutHandlers),
+    [shortcutHandlers],
+  );
 
   // combine action commands with dynamic commands
   const allCommands = React.useMemo(
@@ -138,53 +156,6 @@ export function CommandK() {
     }),
     [],
   );
-
-  // keyboard shortcuts
-  React.useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      // cmd+k to toggle palette
-      if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen((prev) => !prev);
-        return;
-      }
-
-      // don't handle other shortcuts when palette is open
-      if (open) return;
-
-      // escape to close email preview
-      if (e.key === "Escape") {
-        if (threadId) {
-          e.preventDefault();
-          showEmail(null);
-        }
-        return;
-      }
-
-      // only handle shortcuts when focus is on body
-      if (document?.activeElement?.tagName !== "BODY") return;
-
-      // e for archive
-      if ((e.key === "e" || e.key === "E") && !(e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        onArchive();
-        return;
-      }
-
-      // c for compose
-      if ((e.key === "c" || e.key === "C") && !(e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        onOpenComposeModal();
-        return;
-      }
-    };
-
-    document.addEventListener("keydown", down);
-
-    return () => {
-      document.removeEventListener("keydown", down);
-    };
-  }, [open, onArchive, onOpenComposeModal, threadId, showEmail]);
 
   return (
     <CommandDialog

--- a/apps/web/components/Kbd.tsx
+++ b/apps/web/components/Kbd.tsx
@@ -1,0 +1,29 @@
+import type * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/utils";
+
+const kbdVariants = cva(
+  "inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[5px] border px-1 font-mono text-[10px] font-medium leading-none",
+  {
+    variants: {
+      variant: {
+        default: "border-border bg-muted text-muted-foreground",
+        // Sits on a coloured/gradient surface, where a token background would
+        // read as a hole rather than a key
+        onColor: "border-white/30 bg-white/20 text-white",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export function Kbd({
+  className,
+  variant,
+  ...props
+}: React.HTMLAttributes<HTMLElement> & VariantProps<typeof kbdVariants>) {
+  return <kbd className={cn(kbdVariants({ variant, className }))} {...props} />;
+}

--- a/apps/web/components/email-list/types.ts
+++ b/apps/web/components/email-list/types.ts
@@ -7,6 +7,7 @@ export type Thread = {
   messages: FullThread["messages"];
   snippet: FullThread["snippet"];
   plan: FullThread["plan"];
+  plans: FullThread["plans"];
 };
 
 export type Executing = Record<string, boolean>;

--- a/apps/web/components/new-landing/common/Button.tsx
+++ b/apps/web/components/new-landing/common/Button.tsx
@@ -35,7 +35,8 @@ export function Button({
       variants: {
         variant: {
           primary: [
-            "bg-gradient-to-b from-[#2965EC] to-[#5C89F8] text-white button-gradient-border shadow-[0px_2px_10.1px_0px_#4B83FD33] hover:shadow-[0px_2px_10.1px_0px_#4B83FD44]",
+            // The 1px gradient border comes from the wrapper below, not from here
+            "bg-gradient-to-b from-[#2965EC] to-[#5C89F8] text-white shadow-[0px_2px_10.1px_0px_#4B83FD33] hover:shadow-[0px_2px_10.1px_0px_#4B83FD44]",
             "relative overflow-hidden z-10",
             "before:absolute before:inset-0 before:bg-gradient-to-b before:from-[#285EE5] before:to-[#5380F2] before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-200 before:z-0",
           ],

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -27,6 +27,8 @@ const buttonVariants = cva(
         red: "bg-red-100 text-red-900 hover:bg-red-100/80 dark:bg-red-800 dark:text-red-50 dark:hover:bg-red-800/80",
         blue: "bg-blue-100 text-blue-900 hover:bg-blue-100/80 dark:bg-blue-800 dark:text-blue-50 dark:hover:bg-blue-800/80",
         primaryBlack: "bg-primary text-primary-foreground hover:bg-primary/90",
+        gradient:
+          "border border-[hsl(var(--button-gradient-border))] [background-image:var(--button-gradient)] text-white transition-shadow shadow-[0_2px_10.1px_hsl(var(--button-gradient-shadow)/0.2)] hover:shadow-[0_2px_14px_hsl(var(--button-gradient-shadow)/0.32)]",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/apps/web/hooks/useLabelCounts.ts
+++ b/apps/web/hooks/useLabelCounts.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import useSWR from "swr";
+import type { LabelCountsResponse } from "@/app/api/labels/counts/route";
+
+/**
+ * Unread/total counts per label and Gmail category for the mail sidebar.
+ * Deliberately not blocking: the sidebar renders without counts and fills in.
+ */
+export function useLabelCounts() {
+  const { data, error, isLoading, mutate } = useSWR<LabelCountsResponse>(
+    "/api/labels/counts",
+    { shouldRetryOnError: false },
+  );
+
+  const countsById = useMemo(
+    () => new Map((data?.counts ?? []).map((count) => [count.id, count])),
+    [data?.counts],
+  );
+
+  return {
+    countsById,
+    isPartial: data?.partial ?? true,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/apps/web/hooks/useMailSettings.ts
+++ b/apps/web/hooks/useMailSettings.ts
@@ -1,0 +1,6 @@
+import useSWR from "swr";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
+
+export function useMailSettings() {
+  return useSWR<MailSettingsResponse>("/api/mail/settings");
+}

--- a/apps/web/lib/shortcuts/ShortcutsProvider.tsx
+++ b/apps/web/lib/shortcuts/ShortcutsProvider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { HotkeysProvider, useHotkeysContext } from "react-hotkeys-hook";
+import type { ShortcutScope } from "@/lib/shortcuts/registry";
+
+/**
+ * Enables the given shortcut scopes for everything it wraps. Bindings from
+ * other scopes stay registered but inert, so mail keys do nothing elsewhere.
+ *
+ * Pass a stable `scopes` array (a module constant) — it drives an effect.
+ */
+export function ShortcutsProvider({
+  scopes,
+  children,
+}: {
+  scopes: readonly ShortcutScope[];
+  children: ReactNode;
+}) {
+  return (
+    <HotkeysProvider initiallyActiveScopes={[...scopes]}>
+      <ActiveScopes scopes={scopes} />
+      {children}
+    </HotkeysProvider>
+  );
+}
+
+function ActiveScopes({ scopes }: { scopes: readonly ShortcutScope[] }) {
+  const { activeScopes, enableScope, disableScope } = useHotkeysContext();
+
+  useEffect(() => {
+    for (const scope of scopes) {
+      if (!activeScopes.includes(scope)) enableScope(scope);
+    }
+    for (const scope of activeScopes) {
+      if (!scopes.includes(scope as ShortcutScope)) disableScope(scope);
+    }
+  }, [scopes, activeScopes, enableScope, disableScope]);
+
+  return null;
+}

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertNoShortcutConflicts,
+  buildShortcutPaletteCommands,
+  createSequencePrefixTracker,
+  findShortcutConflicts,
+  formatShortcutKeys,
+  getShortcut,
+  getShortcutGroups,
+  isTypingTarget,
+  SEQUENCE_TIMEOUT_MS,
+  type ShortcutEntry,
+  SHORTCUTS,
+} from "./registry";
+
+describe("shortcut registry", () => {
+  it("gives every key a single owner", () => {
+    expect(findShortcutConflicts(SHORTCUTS)).toEqual([]);
+  });
+
+  it("lists every shortcut in exactly one help group", () => {
+    const grouped = getShortcutGroups(["global", "mail"]).flatMap(
+      ({ shortcuts }) => shortcuts,
+    );
+
+    expect(grouped).toHaveLength(SHORTCUTS.length);
+    expect(new Set(grouped.map((entry) => entry.id)).size).toBe(
+      SHORTCUTS.length,
+    );
+  });
+
+  it("leaves mail shortcuts out of a global-only surface", () => {
+    const grouped = getShortcutGroups(["global"]).flatMap(
+      ({ shortcuts }) => shortcuts,
+    );
+
+    expect(grouped.every((entry) => entry.scope === "global")).toBe(true);
+    expect(grouped.map((entry) => entry.id)).toContain("commandPalette");
+  });
+
+  it("renders keys the way the help dialog and palette show them", () => {
+    expect(formatShortcutKeys(getShortcut("next"))).toBe("J / ↓");
+    expect(formatShortcutKeys(getShortcut("commandPalette"))).toBe("⌘K");
+    expect(formatShortcutKeys(getShortcut("send"))).toBe("⌘↵");
+    expect(formatShortcutKeys(getShortcut("backToApp"))).toBe("G A");
+    expect(formatShortcutKeys(getShortcut("delete"))).toBe("#");
+  });
+});
+
+describe("findShortcutConflicts", () => {
+  it("flags two shortcuts owning the same key in one scope", () => {
+    const conflicts = findShortcutConflicts([
+      buildEntry({ id: "archive", keys: ["e"] }),
+      buildEntry({ id: "expand", keys: ["e"] }),
+    ]);
+
+    expect(conflicts).toEqual([{ key: "e", ids: ["archive", "expand"] }]);
+  });
+
+  it("flags a global shortcut colliding with a mail shortcut", () => {
+    const conflicts = findShortcutConflicts([
+      buildEntry({ id: "compose", keys: ["c"], scope: "global" }),
+      buildEntry({ id: "categorize", keys: ["c"], scope: "mail" }),
+    ]);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].ids).toEqual(["compose", "categorize"]);
+  });
+
+  it("flags a plain binding that swallows a sequence prefix", () => {
+    const conflicts = findShortcutConflicts([
+      buildEntry({ id: "backToApp", keys: ["g>a"] }),
+      buildEntry({ id: "goToInbox", keys: ["g"] }),
+    ]);
+
+    expect(conflicts).toEqual([{ key: "g", ids: ["backToApp", "goToInbox"] }]);
+  });
+
+  it("lets two sequences share a prefix", () => {
+    const conflicts = findShortcutConflicts([
+      buildEntry({ id: "backToApp", keys: ["g>a"] }),
+      buildEntry({ id: "goToInbox", keys: ["g>i"] }),
+    ]);
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("throws naming both shortcuts", () => {
+    expect(() =>
+      assertNoShortcutConflicts([
+        buildEntry({ id: "archive", keys: ["e"] }),
+        buildEntry({ id: "expand", keys: ["e"] }),
+      ]),
+    ).toThrow(/archive, expand/);
+  });
+});
+
+describe("isTypingTarget", () => {
+  it.each(["input", "textarea", "select"])("guards <%s>", (tagName) => {
+    expect(isTypingTarget(document.createElement(tagName))).toBe(true);
+  });
+
+  it("guards contenteditable, including nested nodes", () => {
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    const child = document.createElement("span");
+    editable.append(child);
+    document.body.append(editable);
+
+    expect(isTypingTarget(editable)).toBe(true);
+    expect(isTypingTarget(child)).toBe(true);
+
+    editable.remove();
+  });
+
+  it("guards elements that behave like a text box", () => {
+    const element = document.createElement("div");
+    element.setAttribute("role", "textbox");
+
+    expect(isTypingTarget(element)).toBe(true);
+  });
+
+  it("lets shortcuts through for everything else", () => {
+    expect(isTypingTarget(document.createElement("button"))).toBe(false);
+    expect(isTypingTarget(document.body)).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+  });
+});
+
+describe("createSequencePrefixTracker", () => {
+  it("keeps the prefix pending inside the window", () => {
+    let now = 0;
+    const tracker = createSequencePrefixTracker(() => now);
+
+    tracker.start("g");
+    now = SEQUENCE_TIMEOUT_MS - 1;
+
+    expect(tracker.pendingPrefix()).toBe("g");
+  });
+
+  it("drops the prefix once the window closes", () => {
+    let now = 0;
+    const tracker = createSequencePrefixTracker(() => now);
+
+    tracker.start("g");
+    now = SEQUENCE_TIMEOUT_MS;
+
+    expect(tracker.pendingPrefix()).toBeNull();
+  });
+
+  it("drops the prefix when the sequence is abandoned", () => {
+    const tracker = createSequencePrefixTracker();
+
+    tracker.start("g");
+    tracker.clear();
+
+    expect(tracker.pendingPrefix()).toBeNull();
+  });
+
+  it("marks the press that completed the sequence", () => {
+    const tracker = createSequencePrefixTracker();
+    const completing = new KeyboardEvent("keydown", { key: "a" });
+
+    tracker.start("g");
+    tracker.resolve(completing);
+
+    expect(tracker.pendingPrefix()).toBeNull();
+    expect(tracker.wasResolvedBy(completing)).toBe(true);
+    expect(
+      tracker.wasResolvedBy(new KeyboardEvent("keydown", { key: "a" })),
+    ).toBe(false);
+  });
+});
+
+describe("buildShortcutPaletteCommands", () => {
+  it("surfaces a shortcut once its handler is registered", () => {
+    expect(buildShortcutPaletteCommands({})).toEqual([]);
+
+    const archive = vi.fn();
+    const [command, ...rest] = buildShortcutPaletteCommands({ archive });
+
+    expect(rest).toEqual([]);
+    expect(command).toMatchObject({
+      id: "archive",
+      label: "Archive",
+      section: "actions",
+      shortcut: "E",
+    });
+
+    command.action();
+    expect(archive).toHaveBeenCalledOnce();
+  });
+
+  it("leaves shortcuts without palette metadata out", () => {
+    const commands = buildShortcutPaletteCommands({ compose: vi.fn() });
+
+    expect(commands.map((command) => command.id)).not.toContain("compose");
+  });
+});
+
+function buildEntry(overrides: Partial<ShortcutEntry>): ShortcutEntry {
+  return {
+    id: "test",
+    keys: ["t"],
+    scope: "mail",
+    group: "Triage",
+    label: "Test",
+    ...overrides,
+  };
+}

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -57,8 +57,6 @@ export type ShortcutEntry = {
   palette?: ShortcutPalette;
   /** Fallback when no handler is injected at the call site. */
   action?: ShortcutHandler;
-  /** Extra runtime guard evaluated when the keys match. */
-  when?: (event: KeyboardEvent) => boolean;
 };
 
 const SHORTCUT_DEFINITIONS = [

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -1,0 +1,479 @@
+import { ArchiveIcon, type LucideIcon } from "lucide-react";
+import type { Command, CommandSection } from "@/lib/commands/types";
+import { createClientLogger } from "@/utils/logger-client";
+
+const logger = createClientLogger("shortcuts");
+
+/**
+ * `global` bindings are active anywhere the app mounts a `ShortcutsProvider`.
+ * `mail` bindings are only active where the mail scope is enabled, so they are
+ * inert on the rest of the app.
+ */
+export type ShortcutScope = "global" | "mail";
+
+/** Display order of the `?` help dialog sections. */
+export const SHORTCUT_GROUPS = [
+  "Navigate",
+  "Triage",
+  "View",
+  "Assistant & rules",
+] as const;
+
+export type ShortcutGroup = (typeof SHORTCUT_GROUPS)[number];
+
+/** `g` then `a`: the second key has to land inside this window. */
+export const SEQUENCE_TIMEOUT_MS = 900;
+
+/** react-hotkeys-hook's sequence separator: `g>a` is "press g, then a". */
+export const SEQUENCE_SPLIT_KEY = ">";
+
+export type ShortcutHandler = (event?: KeyboardEvent) => void;
+
+export type ShortcutHandlers = Partial<Record<ShortcutId, ShortcutHandler>>;
+
+type ShortcutPalette = {
+  section: CommandSection;
+  description?: string;
+  keywords?: readonly string[];
+  priority?: number;
+  icon?: LucideIcon;
+};
+
+export type ShortcutEntry = {
+  id: string;
+  /**
+   * react-hotkeys-hook hotkey strings, matched against `event.key` so they
+   * follow the character the user typed rather than the physical key.
+   */
+  keys: readonly string[];
+  scope: ShortcutScope;
+  group: ShortcutGroup;
+  label: string;
+  /** Overrides the keys rendered in the help dialog and the palette. */
+  display?: readonly string[];
+  /** Fires even while typing. Only for modifier combos and Escape. */
+  allowWhileTyping?: boolean;
+  /** Present means the entry shows in ⌘K once a handler is registered. */
+  palette?: ShortcutPalette;
+  /** Fallback when no handler is injected at the call site. */
+  action?: ShortcutHandler;
+  /** Extra runtime guard evaluated when the keys match. */
+  when?: (event: KeyboardEvent) => boolean;
+};
+
+const SHORTCUT_DEFINITIONS = [
+  {
+    id: "next",
+    keys: ["j", "arrowdown"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Next message",
+  },
+  {
+    id: "previous",
+    keys: ["k", "arrowup"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Previous message",
+  },
+  {
+    id: "open",
+    keys: ["enter"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Open message",
+  },
+  {
+    id: "backToList",
+    keys: ["u"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Back to the list",
+  },
+  {
+    id: "nextSplit",
+    keys: ["tab"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Next split",
+  },
+  {
+    id: "backToApp",
+    keys: ["g>a"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Back to the app",
+  },
+  {
+    id: "commandPalette",
+    keys: ["mod+k"],
+    scope: "global",
+    group: "Navigate",
+    label: "Command palette",
+    allowWhileTyping: true,
+  },
+  {
+    id: "select",
+    keys: ["x"],
+    scope: "mail",
+    group: "Triage",
+    label: "Select",
+  },
+  {
+    id: "extendSelectionDown",
+    keys: ["shift+arrowdown", "shift+j"],
+    scope: "mail",
+    group: "Triage",
+    label: "Extend the selection down",
+  },
+  {
+    id: "extendSelectionUp",
+    keys: ["shift+arrowup", "shift+k"],
+    scope: "mail",
+    group: "Triage",
+    label: "Extend the selection up",
+  },
+  {
+    id: "archive",
+    keys: ["e"],
+    scope: "mail",
+    group: "Triage",
+    label: "Archive",
+    palette: {
+      section: "actions",
+      description: "Archive current email",
+      keywords: ["archive", "remove", "delete"],
+      priority: 0,
+      icon: ArchiveIcon,
+    },
+  },
+  {
+    // `#` sits behind shift on US layouts and in front of it on others.
+    id: "delete",
+    keys: ["shift+#", "#", "backspace"],
+    display: ["#"],
+    scope: "mail",
+    group: "Triage",
+    label: "Delete",
+  },
+  {
+    id: "reply",
+    keys: ["r"],
+    scope: "mail",
+    group: "Triage",
+    label: "Reply",
+  },
+  {
+    id: "replyAll",
+    keys: ["a"],
+    scope: "mail",
+    group: "Triage",
+    label: "Reply all",
+  },
+  {
+    id: "moreActions",
+    keys: ["m"],
+    scope: "mail",
+    group: "Triage",
+    label: "More actions",
+  },
+  {
+    id: "undo",
+    keys: ["z"],
+    scope: "mail",
+    group: "Triage",
+    label: "Undo last action",
+  },
+  {
+    id: "toggleLayout",
+    keys: ["v"],
+    scope: "mail",
+    group: "View",
+    label: "List view / split view",
+  },
+  {
+    id: "focusMode",
+    keys: ["f"],
+    scope: "mail",
+    group: "View",
+    label: "Focus mode (full screen)",
+  },
+  {
+    id: "close",
+    keys: ["escape"],
+    scope: "mail",
+    group: "View",
+    label: "Exit focus / close overlay",
+    allowWhileTyping: true,
+  },
+  {
+    id: "help",
+    keys: ["shift+?", "?"],
+    display: ["?"],
+    scope: "mail",
+    group: "View",
+    label: "Keyboard shortcuts",
+  },
+  {
+    id: "compose",
+    keys: ["c"],
+    scope: "global",
+    group: "Assistant & rules",
+    label: "New message",
+  },
+  {
+    id: "send",
+    keys: ["mod+enter"],
+    scope: "mail",
+    group: "Assistant & rules",
+    label: "Send reply",
+    allowWhileTyping: true,
+  },
+] as const satisfies readonly ShortcutEntry[];
+
+export type ShortcutId = (typeof SHORTCUT_DEFINITIONS)[number]["id"];
+
+/** The single source of truth behind key handling, `?` help and ⌘K. */
+export const SHORTCUTS: readonly ShortcutEntry[] = SHORTCUT_DEFINITIONS;
+
+const SHORTCUTS_BY_ID = new Map(SHORTCUTS.map((entry) => [entry.id, entry]));
+
+export type ShortcutConflict = {
+  key: string;
+  ids: string[];
+};
+
+type ShortcutKeyOwner = {
+  id: string;
+  scope: ShortcutScope;
+  viaPrefix: boolean;
+};
+
+export function getShortcut(id: ShortcutId): ShortcutEntry {
+  const entry = SHORTCUTS_BY_ID.get(id);
+  if (!entry) throw new Error(`Unknown shortcut: ${id}`);
+  return entry;
+}
+
+export function getShortcutsForScopes(
+  scopes: readonly ShortcutScope[],
+): ShortcutEntry[] {
+  return SHORTCUTS.filter((entry) => scopes.includes(entry.scope));
+}
+
+/** Feeds the `?` help dialog so it can never drift from the handlers. */
+export function getShortcutGroups(
+  scopes: readonly ShortcutScope[],
+): { group: ShortcutGroup; shortcuts: ShortcutEntry[] }[] {
+  const entries = getShortcutsForScopes(scopes);
+
+  return SHORTCUT_GROUPS.map((group) => ({
+    group,
+    shortcuts: entries.filter((entry) => entry.group === group),
+  })).filter(({ shortcuts }) => shortcuts.length > 0);
+}
+
+/** The keys as shown to the user, e.g. `⌘K`, `J / ↓`, `G A`. */
+export function formatShortcutKeys(entry: ShortcutEntry): string {
+  const keys = entry.display ?? entry.keys;
+  return keys.map(formatKey).join(" / ");
+}
+
+export function getShortcutHint(id: ShortcutId): string {
+  return formatShortcutKeys(getShortcut(id));
+}
+
+/** Feeds ⌘K: an entry appears once its handler is registered. */
+export function buildShortcutPaletteCommands(
+  handlers: ShortcutHandlers,
+): Command[] {
+  const commands: (Command & { priority: number })[] = [];
+
+  for (const entry of SHORTCUTS) {
+    const palette = entry.palette;
+    if (!palette) continue;
+
+    const handler = handlers[entry.id as ShortcutId] ?? entry.action;
+    if (!handler) continue;
+
+    commands.push({
+      id: entry.id,
+      label: entry.label,
+      description: palette.description,
+      icon: palette.icon,
+      shortcut: formatShortcutKeys(entry),
+      section: palette.section,
+      priority: palette.priority ?? 50,
+      keywords: palette.keywords ? [...palette.keywords] : undefined,
+      action: () => handler(),
+    });
+  }
+
+  return commands.sort((a, b) => a.priority - b.priority);
+}
+
+/**
+ * Two entries owning the same key fire both handlers. Scopes that are never
+ * active together are allowed to reuse a key; `global` is active alongside
+ * everything, so it never can.
+ */
+export function findShortcutConflicts(
+  entries: readonly ShortcutEntry[],
+): ShortcutConflict[] {
+  const owners = new Map<string, ShortcutKeyOwner[]>();
+
+  for (const entry of entries) {
+    for (const key of entry.keys) {
+      addOwner(owners, key, entry, false);
+      // Reserve the sequence prefix: a plain `g` binding would swallow `g>a`.
+      const [prefix] = key.split(SEQUENCE_SPLIT_KEY);
+      if (prefix !== key) addOwner(owners, prefix, entry, true);
+    }
+  }
+
+  const conflicts: ShortcutConflict[] = [];
+
+  for (const [key, keyOwners] of owners) {
+    const clashing = keyOwners.filter((owner) =>
+      keyOwners.some(
+        (other) =>
+          other.id !== owner.id &&
+          scopesOverlap(owner.scope, other.scope) &&
+          // Two sequences may share a prefix (`g>a` and `g>i`).
+          !(owner.viaPrefix && other.viaPrefix),
+      ),
+    );
+    if (clashing.length > 1) {
+      conflicts.push({ key, ids: clashing.map((owner) => owner.id) });
+    }
+  }
+
+  return conflicts;
+}
+
+export function assertNoShortcutConflicts(
+  entries: readonly ShortcutEntry[],
+): void {
+  const conflicts = findShortcutConflicts(entries);
+  if (conflicts.length === 0) return;
+  throw new Error(`Conflicting shortcuts: ${describeConflicts(conflicts)}`);
+}
+
+/** Bindings stay inert while the user is typing, unless they're a ⌘ combo. */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  if (!element?.tagName) return false;
+
+  const tagName = element.tagName.toUpperCase();
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+    return true;
+  }
+  if (element.isContentEditable) return true;
+  if (element.getAttribute?.("role") === "textbox") return true;
+
+  return !!element.closest?.(
+    "[contenteditable]:not([contenteditable='false'])",
+  );
+}
+
+/**
+ * Tracks a pending sequence prefix (`g`) so the plain binding for the second
+ * key (`a` = reply all) stays quiet while a sequence is in flight.
+ */
+export function createSequencePrefixTracker(now: () => number = Date.now) {
+  let prefix: string | null = null;
+  let startedAt = 0;
+  let resolvedBy: KeyboardEvent | null = null;
+
+  return {
+    start(key: string) {
+      prefix = key;
+      startedAt = now();
+      resolvedBy = null;
+    },
+    pendingPrefix(): string | null {
+      if (prefix && now() - startedAt >= SEQUENCE_TIMEOUT_MS) prefix = null;
+      return prefix;
+    },
+    /**
+     * A completed sequence and the plain binding for its last key are matched
+     * by the same event, in an order we do not control.
+     */
+    resolve(event: KeyboardEvent) {
+      prefix = null;
+      resolvedBy = event;
+    },
+    wasResolvedBy(event: KeyboardEvent): boolean {
+      return resolvedBy === event;
+    },
+    clear() {
+      prefix = null;
+    },
+  };
+}
+
+// A conflicting registry is a bug, not a runtime condition: fail loudly while
+// developing, and report it rather than crash a production session.
+if (process.env.NODE_ENV === "production") {
+  const conflicts = findShortcutConflicts(SHORTCUTS);
+  if (conflicts.length > 0) {
+    logger.error("Conflicting shortcuts", {
+      conflicts: describeConflicts(conflicts),
+    });
+  }
+} else {
+  assertNoShortcutConflicts(SHORTCUTS);
+}
+
+const KEY_SYMBOLS: Record<string, string> = {
+  mod: "⌘",
+  meta: "⌘",
+  ctrl: "⌃",
+  alt: "⌥",
+  shift: "⇧",
+  enter: "↵",
+  escape: "Esc",
+  tab: "Tab",
+  backspace: "⌫",
+  space: "Space",
+  arrowup: "↑",
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+};
+
+function formatKey(key: string): string {
+  return key
+    .split(SEQUENCE_SPLIT_KEY)
+    .map((step) =>
+      step
+        .split("+")
+        .map((token) => KEY_SYMBOLS[token] ?? token.toUpperCase())
+        .join(""),
+    )
+    .join(" ");
+}
+
+function addOwner(
+  owners: Map<string, ShortcutKeyOwner[]>,
+  key: string,
+  entry: ShortcutEntry,
+  viaPrefix: boolean,
+) {
+  const existing = owners.get(key);
+  if (viaPrefix && existing?.some((owner) => owner.id === entry.id)) return;
+
+  const owner = { id: entry.id, scope: entry.scope, viaPrefix };
+  if (existing) existing.push(owner);
+  else owners.set(key, [owner]);
+}
+
+function scopesOverlap(a: ShortcutScope, b: ShortcutScope): boolean {
+  return a === b || a === "global" || b === "global";
+}
+
+function describeConflicts(conflicts: ShortcutConflict[]): string {
+  return conflicts
+    .map(({ key, ids }) => `${key} (${ids.join(", ")})`)
+    .join("; ");
+}

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -72,6 +72,20 @@ describe("useShortcuts", () => {
     expect(replyAll).not.toHaveBeenCalled();
   });
 
+  it("lets an abandoned sequence prefix through to the next shortcut", () => {
+    const backToApp = vi.fn();
+    const next = vi.fn();
+    renderShortcuts({ backToApp, next });
+
+    // `g` starts a sequence that `j` doesn't complete, so `j` must still move
+    // rather than being eaten by the dangling prefix.
+    press({ key: "g", code: "KeyG" });
+    press({ key: "j", code: "KeyJ" });
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(backToApp).not.toHaveBeenCalled();
+  });
+
   it("treats A on its own as reply all", () => {
     const backToApp = vi.fn();
     const replyAll = vi.fn();

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ShortcutHandlers, ShortcutScope } from "./registry";
+import { ShortcutsProvider } from "./ShortcutsProvider";
+import { useShortcuts } from "./useShortcuts";
+
+const MAIL_SCOPES: ShortcutScope[] = ["global", "mail"];
+const GLOBAL_SCOPES: ShortcutScope[] = ["global"];
+
+afterEach(cleanup);
+
+describe("useShortcuts", () => {
+  it("runs the handler for a mail shortcut while the mail scope is active", () => {
+    const archive = vi.fn();
+    renderShortcuts({ archive });
+
+    press({ key: "e", code: "KeyE" });
+
+    expect(archive).toHaveBeenCalledOnce();
+  });
+
+  it("leaves mail shortcuts inert outside the mail scope", () => {
+    const archive = vi.fn();
+    const commandPalette = vi.fn();
+    renderShortcuts({ archive, commandPalette }, GLOBAL_SCOPES);
+
+    press({ key: "e", code: "KeyE" });
+    press({ key: "k", code: "KeyK", ctrlKey: true });
+
+    expect(archive).not.toHaveBeenCalled();
+    expect(commandPalette).toHaveBeenCalledOnce();
+  });
+
+  it("stays quiet while the user is typing", () => {
+    const archive = vi.fn();
+    const send = vi.fn();
+    renderShortcuts({ archive, send });
+
+    press({ key: "e", code: "KeyE" }, screen.getByRole("textbox"));
+
+    expect(archive).not.toHaveBeenCalled();
+
+    // ⌘/ctrl combos are the exception: sending happens from the composer
+    press(
+      { key: "Enter", code: "Enter", ctrlKey: true },
+      screen.getByRole("textbox"),
+    );
+
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("ignores modified presses of a plain shortcut", () => {
+    const archive = vi.fn();
+    renderShortcuts({ archive });
+
+    press({ key: "e", code: "KeyE", metaKey: true });
+
+    expect(archive).not.toHaveBeenCalled();
+  });
+
+  it("treats G then A as back to the app rather than reply all", () => {
+    const backToApp = vi.fn();
+    const replyAll = vi.fn();
+    renderShortcuts({ backToApp, replyAll });
+
+    press({ key: "g", code: "KeyG" });
+    press({ key: "a", code: "KeyA" });
+
+    expect(backToApp).toHaveBeenCalledOnce();
+    expect(replyAll).not.toHaveBeenCalled();
+  });
+
+  it("treats A on its own as reply all", () => {
+    const backToApp = vi.fn();
+    const replyAll = vi.fn();
+    renderShortcuts({ backToApp, replyAll });
+
+    press({ key: "a", code: "KeyA" });
+
+    expect(replyAll).toHaveBeenCalledOnce();
+    expect(backToApp).not.toHaveBeenCalled();
+  });
+
+  it("does not bind keys that have no handler", () => {
+    const archive = vi.fn();
+    renderShortcuts({ archive });
+
+    const event = press({ key: "z", code: "KeyZ" });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+function renderShortcuts(
+  handlers: ShortcutHandlers,
+  scopes: ShortcutScope[] = MAIL_SCOPES,
+) {
+  return render(
+    <ShortcutsProvider scopes={scopes}>
+      <Bindings handlers={handlers} />
+      <textarea />
+    </ShortcutsProvider>,
+  );
+}
+
+function Bindings({ handlers }: { handlers: ShortcutHandlers }) {
+  useShortcuts(handlers);
+  return null;
+}
+
+function press(init: KeyboardEventInit, target: Element = document.body) {
+  const event = new KeyboardEvent("keydown", { bubbles: true, ...init });
+  fireEvent(target, event);
+  return event;
+}

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -95,8 +95,6 @@ function useShortcutBucket(
       }
 
       const { entry } = target;
-      if (entry.when && !entry.when(event)) return;
-
       const handler =
         handlersRef.current[entry.id as ShortcutId] ?? entry.action;
       handler?.(event);

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -79,10 +79,19 @@ function useShortcutBucket(
       const pendingPrefix = sequence.pendingPrefix();
       if (isSequence(hotkeysEvent)) {
         sequence.resolve(event);
-      } else if (pendingPrefix || sequence.wasResolvedBy(event)) {
+      } else if (sequence.wasResolvedBy(event)) {
         // A sequence owns this press: `a` belongs to `g>a`, not to reply all.
         sequence.clear();
         return;
+      } else if (pendingPrefix) {
+        // An abandoned prefix must not eat the next key: after `g`, a `j` still
+        // moves. Only suppress when the press really does complete a sequence,
+        // since then the `g>a` hotkey fires for the same keydown.
+        const completesSequence = bucket.targets.has(
+          `${pendingPrefix}${SEQUENCE_SPLIT_KEY}${hotkeysEvent.hotkey}`,
+        );
+        sequence.clear();
+        if (completesSequence) return;
       }
 
       const { entry } = target;

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -1,0 +1,165 @@
+"use client";
+
+import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
+import { type HotkeyCallback, useHotkeys } from "react-hotkeys-hook";
+import {
+  createSequencePrefixTracker,
+  isTypingTarget,
+  SEQUENCE_SPLIT_KEY,
+  SEQUENCE_TIMEOUT_MS,
+  type ShortcutEntry,
+  type ShortcutHandlers,
+  type ShortcutId,
+  type ShortcutScope,
+  SHORTCUTS,
+} from "@/lib/shortcuts/registry";
+
+type HotkeysEvent = Parameters<HotkeyCallback>[1];
+
+type SequenceTracker = ReturnType<typeof createSequencePrefixTracker>;
+
+type ShortcutTarget =
+  | { type: "entry"; entry: ShortcutEntry }
+  | { type: "prefix"; key: string };
+
+type ShortcutBucket = {
+  scope: ShortcutScope;
+  allowWhileTyping: boolean;
+  /** Comma separated hotkeys, the shape react-hotkeys-hook expects. */
+  keys: string;
+  targets: Map<string, ShortcutTarget>;
+};
+
+// react-hotkeys-hook takes scope and typing behaviour per hook, so bindings are
+// registered as one hook per combination rather than one hook per shortcut.
+const BUCKET_SPECS = [
+  { scope: "global", allowWhileTyping: false },
+  { scope: "global", allowWhileTyping: true },
+  { scope: "mail", allowWhileTyping: false },
+  { scope: "mail", allowWhileTyping: true },
+] as const satisfies readonly {
+  scope: ShortcutScope;
+  allowWhileTyping: boolean;
+}[];
+
+/**
+ * Binds the registry entries the caller supplies a handler for. A shortcut with
+ * no handler stays unbound, so its key keeps its browser default.
+ */
+export function useShortcuts(handlers: ShortcutHandlers): void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  const [sequence] = useState(createSequencePrefixTracker);
+
+  const signature = activeShortcutIds(handlers).join(",");
+  const buckets = useMemo(() => buildBuckets(signature), [signature]);
+
+  useShortcutBucket(buckets[0], handlersRef, sequence);
+  useShortcutBucket(buckets[1], handlersRef, sequence);
+  useShortcutBucket(buckets[2], handlersRef, sequence);
+  useShortcutBucket(buckets[3], handlersRef, sequence);
+}
+
+function useShortcutBucket(
+  bucket: ShortcutBucket,
+  handlersRef: RefObject<ShortcutHandlers>,
+  sequence: SequenceTracker,
+) {
+  const onHotkey = useCallback<HotkeyCallback>(
+    (event, hotkeysEvent) => {
+      const target = resolveTarget(bucket, event, hotkeysEvent);
+      if (!target) return;
+
+      if (target.type === "prefix") {
+        sequence.start(target.key);
+        return;
+      }
+
+      const pendingPrefix = sequence.pendingPrefix();
+      if (isSequence(hotkeysEvent)) {
+        sequence.resolve(event);
+      } else if (pendingPrefix || sequence.wasResolvedBy(event)) {
+        // A sequence owns this press: `a` belongs to `g>a`, not to reply all.
+        sequence.clear();
+        return;
+      }
+
+      const { entry } = target;
+      if (entry.when && !entry.when(event)) return;
+
+      const handler =
+        handlersRef.current[entry.id as ShortcutId] ?? entry.action;
+      handler?.(event);
+    },
+    [bucket, handlersRef, sequence],
+  );
+
+  const preventDefault = useCallback(
+    (event: KeyboardEvent, hotkeysEvent: HotkeysEvent) => {
+      const target = resolveTarget(bucket, event, hotkeysEvent);
+      return !!target && target.type === "entry";
+    },
+    [bucket],
+  );
+
+  useHotkeys(bucket.keys, onHotkey, {
+    scopes: [bucket.scope],
+    // Hotkeys are matched on the typed character so they survive keyboard
+    // layouts that move `#` or `?`.
+    useKey: true,
+    enableOnFormTags: bucket.allowWhileTyping,
+    enableOnContentEditable: bucket.allowWhileTyping,
+    sequenceTimeoutMs: SEQUENCE_TIMEOUT_MS,
+    preventDefault,
+  });
+}
+
+function activeShortcutIds(handlers: ShortcutHandlers): string[] {
+  return SHORTCUTS.filter(
+    (entry) => handlers[entry.id as ShortcutId] ?? entry.action,
+  ).map((entry) => entry.id);
+}
+
+function buildBuckets(signature: string): ShortcutBucket[] {
+  const activeIds = new Set(signature ? signature.split(",") : []);
+
+  return BUCKET_SPECS.map((spec) => {
+    const targets = new Map<string, ShortcutTarget>();
+
+    for (const entry of SHORTCUTS) {
+      if (!activeIds.has(entry.id)) continue;
+      if (entry.scope !== spec.scope) continue;
+      if (!!entry.allowWhileTyping !== spec.allowWhileTyping) continue;
+
+      for (const key of entry.keys) {
+        targets.set(key, { type: "entry", entry });
+
+        const [prefix] = key.split(SEQUENCE_SPLIT_KEY);
+        if (prefix !== key && !targets.has(prefix)) {
+          targets.set(prefix, { type: "prefix", key: prefix });
+        }
+      }
+    }
+
+    return {
+      scope: spec.scope,
+      allowWhileTyping: spec.allowWhileTyping,
+      keys: [...targets.keys()].join(","),
+      targets,
+    };
+  });
+}
+
+function resolveTarget(
+  bucket: ShortcutBucket,
+  event: KeyboardEvent,
+  hotkeysEvent: HotkeysEvent,
+): ShortcutTarget | undefined {
+  if (!bucket.allowWhileTyping && isTypingTarget(event.target)) return;
+  return bucket.targets.get(hotkeysEvent.hotkey);
+}
+
+function isSequence(hotkeysEvent: HotkeysEvent): boolean {
+  return hotkeysEvent.hotkey.includes(SEQUENCE_SPLIT_KEY);
+}

--- a/apps/web/prisma/migrations/20260811120000_add_mail_splits_and_prefs/migration.sql
+++ b/apps/web/prisma/migrations/20260811120000_add_mail_splits_and_prefs/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "MailLayout" AS ENUM ('LIST', 'SPLIT');
 
 -- CreateEnum
-CREATE TYPE "MailSplitKind" AS ENUM ('ALL', 'UNREAD', 'LABEL', 'CATEGORY');
+CREATE TYPE "MailSplitKind" AS ENUM ('INBOX', 'UNREAD', 'LABEL', 'CATEGORY');
 
 -- AlterTable
 ALTER TABLE "EmailAccount" ADD COLUMN     "mailHintBarDismissed" BOOLEAN NOT NULL DEFAULT false,

--- a/apps/web/prisma/migrations/20260811120000_add_mail_splits_and_prefs/migration.sql
+++ b/apps/web/prisma/migrations/20260811120000_add_mail_splits_and_prefs/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "MailLayout" AS ENUM ('LIST', 'SPLIT');
+
+-- CreateEnum
+CREATE TYPE "MailSplitKind" AS ENUM ('ALL', 'UNREAD', 'LABEL', 'CATEGORY');
+
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN     "mailHintBarDismissed" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "mailLayout" "MailLayout" NOT NULL DEFAULT 'LIST';
+
+-- CreateTable
+CREATE TABLE "MailSplit" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "kind" "MailSplitKind" NOT NULL,
+    "value" TEXT,
+    "order" INTEGER NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "MailSplit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MailSplit_emailAccountId_order_idx" ON "MailSplit"("emailAccountId", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MailSplit_emailAccountId_name_key" ON "MailSplit"("emailAccountId", "name");
+
+-- AddForeignKey
+ALTER TABLE "MailSplit" ADD CONSTRAINT "MailSplit_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -233,7 +233,7 @@ model EmailAccount {
 }
 
 // A saved filter shown as a tab above the mail list. `value` holds the label id for
-// LABEL splits and the provider category for CATEGORY splits; it is unused for ALL/UNREAD.
+// LABEL splits and the provider category for CATEGORY splits; it is unused for INBOX/UNREAD.
 model MailSplit {
   id        String        @id @default(cuid())
   createdAt DateTime      @default(now())

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -102,8 +102,8 @@ model User {
   emailAccounts EmailAccount[]
 
   // Referral relationships
-  referralsMade    Referral[]     @relation("ReferrerUser")
-  referralReceived Referral?      @relation("ReferredUser")
+  referralsMade    Referral[]        @relation("ReferrerUser")
+  referralReceived Referral?         @relation("ReferredUser")
   scimProviders    ScimProvider[]
   mobilePushTokens MobilePushToken[]
 }
@@ -156,6 +156,9 @@ model EmailAccount {
   draftCleanupDays          Int?                 @default(14)
   allowHiddenAiDraftLinks   Boolean              @default(false)
   rulesRevision             Int                  @default(0)
+
+  mailLayout           MailLayout @default(LIST)
+  mailHintBarDismissed Boolean    @default(false)
 
   meetingBriefingsEnabled       Boolean @default(false)
   meetingBriefingsMinutesBefore Int     @default(240) // 4 hours in minutes
@@ -220,12 +223,31 @@ model EmailAccount {
   filingFolders          FilingFolder[]
   apiKeys                ApiKey[]
   classificationFeedback ClassificationFeedback[]
+  mailSplits             MailSplit[]
 
   @@index([userId])
   @@index([lastSummaryEmailAt])
   @@index([lastInboxHealthEmailAt])
   @@index([watchEmailsSubscriptionId])
   @@index([watchEmailsSubscriptionHistory(ops: JsonbPathOps)], type: Gin)
+}
+
+// A saved filter shown as a tab above the mail list. `value` holds the label id for
+// LABEL splits and the provider category for CATEGORY splits; it is unused for ALL/UNREAD.
+model MailSplit {
+  id        String        @id @default(cuid())
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  name      String
+  kind      MailSplitKind
+  value     String?
+  order     Int
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  @@unique([emailAccountId, name])
+  @@index([emailAccountId, order])
 }
 
 model Organization {
@@ -1174,8 +1196,8 @@ model ChatMessage {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  role  String
-  parts Json
+  role     String
+  parts    Json
   metadata Json?
   // attachments Json?
 
@@ -1400,27 +1422,27 @@ model MeetingRecording {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  botProvider          String   @default("recall")
+  botProvider           String    @default("recall")
   // Null between claiming the row and the provider call returning.
-  externalBotId        String?
+  externalBotId         String?
   // Last display name successfully sent to the provider.
-  botName              String?
+  botName               String?
   // Set when the provider reports the recording is ready.
-  externalRecordingId  String?
+  externalRecordingId   String?
   // Claim for the create-transcript call, kept separate from the id above so a
   // failed call does not have to choose between losing the recording id and
   // losing the claim. The sweep retries a claim that goes stale.
   transcriptRequestedAt DateTime?
-  externalTranscriptId String?
+  externalTranscriptId  String?
   // Raw join URL including credentials (Zoom pwd etc.) - what the bot joins with.
-  meetingUrl           String
+  meetingUrl            String
   // Dedup key only, never sent to the provider.
-  normalizedMeetingUrl String
+  normalizedMeetingUrl  String
   // Account-scoped normalizedMeetingUrl while the recording can still be
   // scheduled, and cleared once it reaches a terminal state. Account scoping
   // prevents a calendar link from becoming cross-tenant transcript access.
-  activeKey            String?
-  meetingStartTime     DateTime
+  activeKey             String?
+  meetingStartTime      DateTime
 
   status              MeetingRecordingStatus @default(PENDING)
   failureReason       String?
@@ -1865,6 +1887,18 @@ enum Frequency {
   WEEKLY
   // MONTHLY
   // ANNUALLY
+}
+
+enum MailLayout {
+  LIST
+  SPLIT
+}
+
+enum MailSplitKind {
+  ALL
+  UNREAD
+  LABEL
+  CATEGORY
 }
 
 enum DraftReplyConfidence {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1895,7 +1895,7 @@ enum MailLayout {
 }
 
 enum MailSplitKind {
-  ALL
+  INBOX
   UNREAD
   LABEL
   CATEGORY

--- a/apps/web/store/archive-queue.test.ts
+++ b/apps/web/store/archive-queue.test.ts
@@ -37,6 +37,10 @@ function blockOn(threadId: string) {
 const archivedThreadIds = () =>
   mockArchiveThreadAction.mock.calls.map(([, input]) => input.threadId);
 
+// The queue state is persisted, and ArchiveProgress reads it to draw the bar.
+const persistedTotalThreads = () =>
+  JSON.parse(localStorage.getItem("gmailActionQueue") ?? "{}").totalThreads;
+
 describe("cancelQueuedThreads", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -106,6 +110,30 @@ describe("cancelQueuedThreads", () => {
     await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
 
     expect(archivedThreadIds()).not.toContain("thread-2");
+  });
+
+  it("does not count a deduplicated re-enqueue towards progress", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails } = await import("./archive-queue");
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+    await archiveEmails({
+      threadIds: ["thread-2"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+
+    // ArchiveProgress uses totalThreads as its denominator, so counting work
+    // that was never enqueued would leave the bar stuck short of 100%.
+    expect(persistedTotalThreads()).toBe(2);
+
+    release();
   });
 
   it("reports a thread already sent to the provider as not cancelled", async () => {

--- a/apps/web/store/archive-queue.test.ts
+++ b/apps/web/store/archive-queue.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockArchiveThreadAction = vi.fn();
+const mockTrashThreadAction = vi.fn();
+const mockMarkReadThreadAction = vi.fn();
+
+vi.mock("@/utils/actions/mail", () => ({
+  archiveThreadAction: (...args: Parameters<typeof mockArchiveThreadAction>) =>
+    mockArchiveThreadAction(...args),
+  trashThreadAction: (...args: Parameters<typeof mockTrashThreadAction>) =>
+    mockTrashThreadAction(...args),
+  markReadThreadAction: (
+    ...args: Parameters<typeof mockMarkReadThreadAction>
+  ) => mockMarkReadThreadAction(...args),
+}));
+
+// Keeps the first thread mid-flight so the rest of the batch stays queued
+// behind it (the email action queue runs one thread at a time).
+function blockOn(threadId: string) {
+  let release: () => void = () => {};
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  const implementation = async (
+    _emailAccountId: string,
+    { threadId: id }: { threadId: string },
+  ) => {
+    if (id === threadId) await blocked;
+  };
+
+  return { release, implementation };
+}
+
+const archivedThreadIds = () =>
+  mockArchiveThreadAction.mock.calls.map(([, input]) => input.threadId);
+
+describe("cancelQueuedThreads", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockArchiveThreadAction.mockResolvedValue(undefined);
+    mockTrashThreadAction.mockResolvedValue(undefined);
+  });
+
+  it("stops a queued thread from ever reaching the provider", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+    const onSuccess = vi.fn();
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2"],
+      onSuccess,
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    const result = cancelQueuedThreads({
+      threadIds: ["thread-2"],
+      actionType: "archive",
+    });
+
+    expect(result).toEqual({ cancelled: ["thread-2"], notCancelled: [] });
+
+    release();
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledWith("thread-1"));
+
+    expect(archivedThreadIds()).toEqual(["thread-1"]);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a thread already sent to the provider as not cancelled", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+    const onSuccess = vi.fn();
+
+    await archiveEmails({
+      threadIds: ["thread-1"],
+      onSuccess,
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    const result = cancelQueuedThreads({
+      threadIds: ["thread-1"],
+      actionType: "archive",
+    });
+
+    expect(result).toEqual({ cancelled: [], notCancelled: ["thread-1"] });
+
+    // the in-flight archive still completes; the caller has to undo it server-side
+    release();
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledWith("thread-1"));
+  });
+
+  it("splits a batch into cancelled and still-in-flight threads", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+    const onSuccess = vi.fn();
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2", "thread-3"],
+      onSuccess,
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    const result = cancelQueuedThreads({
+      threadIds: ["thread-1", "thread-2", "thread-3"],
+      actionType: "archive",
+    });
+
+    expect(result).toEqual({
+      cancelled: ["thread-2", "thread-3"],
+      notCancelled: ["thread-1"],
+    });
+
+    release();
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalledWith("thread-1"));
+
+    expect(archivedThreadIds()).toEqual(["thread-1"]);
+  });
+
+  it("clears cancelled threads from the queue progress state", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2", "thread-3"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    cancelQueuedThreads({
+      threadIds: ["thread-2", "thread-3"],
+      actionType: "archive",
+    });
+
+    const { activeThreads, totalThreads } = readPersistedQueueState();
+    expect(Object.keys(activeThreads)).toEqual(["archive-thread-1"]);
+    expect(totalThreads).toBe(1);
+
+    release();
+  });
+
+  it("only cancels threads queued for the requested action", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    expect(
+      cancelQueuedThreads({ threadIds: ["thread-2"], actionType: "delete" }),
+    ).toEqual({ cancelled: [], notCancelled: ["thread-2"] });
+
+    expect(
+      cancelQueuedThreads({ threadIds: ["thread-2"], actionType: "archive" }),
+    ).toEqual({ cancelled: ["thread-2"], notCancelled: [] });
+
+    release();
+  });
+
+  it("returns unknown and empty thread ids as not cancelled", async () => {
+    const { cancelQueuedThreads } = await import("./archive-queue");
+
+    expect(
+      cancelQueuedThreads({ threadIds: [], actionType: "archive" }),
+    ).toEqual({ cancelled: [], notCancelled: [] });
+
+    expect(
+      cancelQueuedThreads({
+        threadIds: ["never-queued"],
+        actionType: "delete",
+      }),
+    ).toEqual({ cancelled: [], notCancelled: ["never-queued"] });
+  });
+});
+
+// The queue atom isn't exported; it persists to localStorage on every write,
+// which is the same state the progress UI reads through `useQueueState`.
+function readPersistedQueueState() {
+  return JSON.parse(localStorage.getItem("gmailActionQueue") ?? "{}") as {
+    activeThreads: Record<string, unknown>;
+    totalThreads: number;
+  };
+}

--- a/apps/web/store/archive-queue.test.ts
+++ b/apps/web/store/archive-queue.test.ts
@@ -76,6 +76,38 @@ describe("cancelQueuedThreads", () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels a thread that was queued twice before it ran", async () => {
+    const { release, implementation } = blockOn("thread-1");
+    mockArchiveThreadAction.mockImplementation(implementation);
+
+    const { archiveEmails, cancelQueuedThreads } = await import(
+      "./archive-queue"
+    );
+
+    await archiveEmails({
+      threadIds: ["thread-1", "thread-2"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+    // A second enqueue of the same thread must not orphan the first job, or
+    // cancelling would report success while the orphan still archived it.
+    await archiveEmails({
+      threadIds: ["thread-2"],
+      onSuccess: vi.fn(),
+      emailAccountId: "account-1",
+    });
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    expect(
+      cancelQueuedThreads({ threadIds: ["thread-2"], actionType: "archive" }),
+    ).toEqual({ cancelled: ["thread-2"], notCancelled: [] });
+
+    release();
+    await vi.waitFor(() => expect(archivedThreadIds()).toEqual(["thread-1"]));
+
+    expect(archivedThreadIds()).not.toContain("thread-2");
+  });
+
   it("reports a thread already sent to the provider as not cancelled", async () => {
     const { release, implementation } = blockOn("thread-1");
     mockArchiveThreadAction.mockImplementation(implementation);

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -10,18 +10,33 @@ import {
 import { exponentialBackoff, sleep } from "@/utils/sleep";
 import { useAtomValue } from "jotai";
 
-type ActionType = "archive" | "delete" | "markRead";
+export type QueueActionType = "archive" | "delete" | "markRead";
+
+type QueueKey = `${QueueActionType}-${string}`;
 
 type QueueItem = {
   threadId: string;
-  actionType: ActionType;
+  actionType: QueueActionType;
   labelId?: string;
 };
 
 type QueueState = {
-  activeThreads: Record<`${ActionType}-${string}`, QueueItem>;
+  activeThreads: Record<QueueKey, QueueItem>;
   totalThreads: number;
 };
+
+type QueuedJobStatus = "pending" | "running" | "cancelled";
+
+type QueuedJob = {
+  threadId: string;
+  actionType: QueueActionType;
+  status: QueuedJobStatus;
+};
+
+// p-queue can't remove a task once it's been added, so cancellation is tracked
+// here instead: a cancelled job returns immediately when its turn comes up.
+// Only holds jobs that haven't finished yet.
+const queuedJobs = new Map<QueueKey, QueuedJob>();
 
 // some users were somehow getting null for activeThreads, this should fix it
 const createStorage = () => {
@@ -68,7 +83,7 @@ const addThreadsToQueue = ({
   onError,
   emailAccountId,
 }: {
-  actionType: ActionType;
+  actionType: QueueActionType;
   threadIds: string[];
   labelId?: string;
   onSuccess?: (threadId: string) => void;
@@ -77,7 +92,7 @@ const addThreadsToQueue = ({
 }) => {
   const threads = Object.fromEntries(
     threadIds.map((threadId) => [
-      `${actionType}-${threadId}`,
+      getQueueKey(actionType, threadId),
       { threadId, actionType, labelId },
     ]),
   );
@@ -156,7 +171,7 @@ export const deleteEmails = async ({
   });
 };
 
-function removeThreadFromQueue(threadId: string, actionType: ActionType) {
+function removeThreadFromQueue(threadId: string, actionType: QueueActionType) {
   jotaiStore.set(queueAtom, (prev) => {
     const remainingThreads = Object.fromEntries(
       Object.entries(prev.activeThreads).filter(
@@ -183,7 +198,7 @@ export function processQueue({
   onError?: (threadId: string) => void;
   emailAccountId: string;
 }) {
-  const actionMap: Record<ActionType, ActionFunction> = {
+  const actionMap: Record<QueueActionType, ActionFunction> = {
     archive: ({ threadId, labelId }) =>
       archiveThreadAction(emailAccountId, { threadId, labelId }),
     delete: ({ threadId }) => trashThreadAction(emailAccountId, { threadId }),
@@ -192,41 +207,97 @@ export function processQueue({
   };
 
   emailActionQueue.addAll(
-    Object.entries(threads).map(
-      ([_key, { threadId, actionType, labelId }]) =>
-        async () => {
-          try {
-            await pRetry(
-              async (attemptCount) => {
-                // biome-ignore lint/suspicious/noConsole: frontend
-                console.log(
-                  `Queue: ${actionType}. Processing ${threadId}${attemptCount > 1 ? ` (attempt ${attemptCount})` : ""}`,
-                );
+    Object.values(threads).map(({ threadId, actionType, labelId }) => {
+      const key = getQueueKey(actionType, threadId);
+      const job: QueuedJob = { threadId, actionType, status: "pending" };
+      queuedJobs.set(key, job);
 
-                const result = await actionMap[actionType]({
-                  threadId,
-                  labelId,
-                });
+      return async () => {
+        // cancelled while it was still waiting its turn, so nothing was sent
+        if (job.status === "cancelled") return;
+        job.status = "running";
 
-                // when Gmail API returns a rate limit error, throw an error so it can be retried
-                if (result?.serverError) {
-                  await sleep(exponentialBackoff(attemptCount, 1000));
-                  throw new Error(result.serverError);
-                }
-                onSuccess?.(threadId);
-              },
-              { retries: 3 },
-            );
-          } catch {
-            // all retries failed
-            onError?.(threadId);
-          }
+        try {
+          await pRetry(
+            async (attemptCount) => {
+              // biome-ignore lint/suspicious/noConsole: frontend
+              console.log(
+                `Queue: ${actionType}. Processing ${threadId}${attemptCount > 1 ? ` (attempt ${attemptCount})` : ""}`,
+              );
 
-          // remove completed thread from activeThreads
-          removeThreadFromQueue(threadId, actionType);
-        },
-    ),
+              const result = await actionMap[actionType]({
+                threadId,
+                labelId,
+              });
+
+              // when Gmail API returns a rate limit error, throw an error so it can be retried
+              if (result?.serverError) {
+                await sleep(exponentialBackoff(attemptCount, 1000));
+                throw new Error(result.serverError);
+              }
+              onSuccess?.(threadId);
+            },
+            { retries: 3 },
+          );
+        } catch {
+          // all retries failed
+          onError?.(threadId);
+        }
+
+        if (queuedJobs.get(key) === job) queuedJobs.delete(key);
+
+        // remove completed thread from activeThreads
+        removeThreadFromQueue(threadId, actionType);
+      };
+    }),
   );
+}
+
+/**
+ * Undo support: drops threads that are still waiting in the queue so the action
+ * never reaches the provider. Threads already sent can't be pulled back — the
+ * caller must reverse those itself (e.g. unarchive/untrash).
+ */
+export function cancelQueuedThreads({
+  threadIds,
+  actionType,
+}: {
+  threadIds: string[];
+  actionType: QueueActionType;
+}): { cancelled: string[]; notCancelled: string[] } {
+  const cancelled: string[] = [];
+  const notCancelled: string[] = [];
+
+  for (const threadId of new Set(threadIds)) {
+    const key = getQueueKey(actionType, threadId);
+    const job = queuedJobs.get(key);
+
+    if (job?.status === "pending") {
+      job.status = "cancelled";
+      queuedJobs.delete(key);
+      cancelled.push(threadId);
+    } else {
+      notCancelled.push(threadId);
+    }
+  }
+
+  if (cancelled.length) {
+    jotaiStore.set(queueAtom, (prev) => {
+      const activeThreads: QueueState["activeThreads"] = {
+        ...prev.activeThreads,
+      };
+      for (const threadId of cancelled) {
+        delete activeThreads[getQueueKey(actionType, threadId)];
+      }
+
+      return {
+        activeThreads,
+        totalThreads: Math.max(0, prev.totalThreads - cancelled.length),
+      };
+    });
+  }
+
+  return { cancelled, notCancelled };
 }
 
 export const resetTotalThreads = () => {
@@ -235,3 +306,7 @@ export const resetTotalThreads = () => {
     totalThreads: 0,
   }));
 };
+
+function getQueueKey(actionType: QueueActionType, threadId: string): QueueKey {
+  return `${actionType}-${threadId}`;
+}

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -91,10 +91,20 @@ const addThreadsToQueue = ({
   emailAccountId: string;
 }) => {
   const threads = Object.fromEntries(
-    threadIds.map((threadId) => [
-      getQueueKey(actionType, threadId),
-      { threadId, actionType, labelId },
-    ]),
+    threadIds
+      // Re-enqueuing a thread that is already queued would orphan the first
+      // job: cancellation only reaches the newest one, so the orphan would
+      // still reach the provider while undo believed it had been cancelled.
+      // Filtered here rather than at job creation so the progress totals below
+      // count only the work actually enqueued.
+      .filter((threadId) => {
+        const existing = queuedJobs.get(getQueueKey(actionType, threadId));
+        return !existing || existing.status === "cancelled";
+      })
+      .map((threadId) => [
+        getQueueKey(actionType, threadId),
+        { threadId, actionType, labelId },
+      ]),
   );
 
   jotaiStore.set(queueAtom, (prev) => ({
@@ -207,16 +217,8 @@ export function processQueue({
   };
 
   emailActionQueue.addAll(
-    Object.values(threads).flatMap(({ threadId, actionType, labelId }) => {
+    Object.values(threads).map(({ threadId, actionType, labelId }) => {
       const key = getQueueKey(actionType, threadId);
-
-      // Re-enqueuing a thread that is already queued would orphan the first
-      // job: cancellation only reaches the newest one, so the orphan would
-      // still reach the provider while undo believed it had been cancelled.
-      // The duplicate is redundant anyway — same action, same thread.
-      const existing = queuedJobs.get(key);
-      if (existing && existing.status !== "cancelled") return [];
-
       const job: QueuedJob = { threadId, actionType, status: "pending" };
       queuedJobs.set(key, job);
 

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -207,8 +207,16 @@ export function processQueue({
   };
 
   emailActionQueue.addAll(
-    Object.values(threads).map(({ threadId, actionType, labelId }) => {
+    Object.values(threads).flatMap(({ threadId, actionType, labelId }) => {
       const key = getQueueKey(actionType, threadId);
+
+      // Re-enqueuing a thread that is already queued would orphan the first
+      // job: cancellation only reaches the newest one, so the orphan would
+      // still reach the provider while undo believed it had been cancelled.
+      // The duplicate is redundant anyway — same action, same thread.
+      const existing = queuedJobs.get(key);
+      if (existing && existing.status !== "cancelled") return [];
+
       const job: QueuedJob = { threadId, actionType, status: "pending" };
       queuedJobs.set(key, job);
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -20,6 +20,9 @@
 
     --border: 214.3 31.8% 91.4%; /* slate-200 */
     --input: 214.3 31.8% 91.4%; /* slate-200 */
+    /* Heavier rule weight than --border. Defined here only so it never resolves
+       to nothing outside the Mail route; the Mail palette overrides it. */
+    --border-strong: 212.7 26.8% 83.9%; /* slate-300 */
 
     --primary: 222.2 47.4% 11.2%; /* slate-900 */
     --primary-foreground: 210 40% 98%; /* slate-50 */
@@ -72,6 +75,7 @@
     --destructive-foreground: 0 85.7% 97.3%;
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
+    --border-strong: 240 3.7% 22%;
     --ring: 240 4.9% 83.9%;
     --chart-1: oklch(0.7 0.2 250);
     --chart-2: oklch(0.6 0.22 250);
@@ -86,6 +90,69 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 240 4.9% 83.9%;
+  }
+}
+
+@layer base {
+  /*
+   * Warm-neutral palette for the Mail route, scoped so the rest of the app keeps
+   * today's cool-slate tokens while the new design language is proven out.
+   * Intended to be promoted to `:root` in a follow-up PR, at which point this
+   * block and the `data-theme` attribute go away.
+   *
+   * Dark mode deliberately has no Mail variant — it inherits `.dark` unchanged.
+   */
+  :root[data-theme="mail"]:not(.dark) {
+    --background: 0 0% 99.2%; /* #FDFDFD */
+    --foreground: 0 0% 14.1%; /* #242424 */
+
+    --muted: 0 0% 96.5%; /* #F6F6F6 */
+    --muted-foreground: 0 0% 51.8%; /* #848484 */
+
+    --popover: 0 0% 100%; /* #FFFFFF */
+    --popover-foreground: 0 0% 14.1%;
+
+    --card: 0 0% 100%; /* #FFFFFF */
+    --card-foreground: 0 0% 14.1%;
+
+    --border: 0 0% 93.7%; /* #EFEFEF */
+    --input: 0 0% 93.7%;
+    /* Second, heavier rule weight used for column dividers and field outlines */
+    --border-strong: 0 0% 90.2%; /* #E6E6E6 */
+
+    --primary: 221.2 83.2% 53.3%; /* #2563EB */
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 0 0% 96.5%;
+    --secondary-foreground: 0 0% 23.9%; /* #3D3D3D */
+
+    --accent: 0 0% 96.5%;
+    --accent-foreground: 0 0% 14.1%;
+
+    --ring: 221.2 83.2% 53.3%;
+
+    --radius: 0.5rem;
+
+    --sidebar-background: 0 0% 98.4%; /* #FBFBFB */
+    --sidebar-foreground: 0 0% 23.9%;
+    --sidebar-primary: 221.2 83.2% 53.3%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 0 0% 96.5%;
+    --sidebar-accent-foreground: 0 0% 14.1%;
+    --sidebar-border: 0 0% 93.7%;
+    --sidebar-ring: 221.2 83.2% 53.3%;
+  }
+}
+
+@layer base {
+  /*
+   * The gradient button reads identically in every theme, so its values live
+   * outside the theme blocks rather than being redefined per palette.
+   */
+  :root {
+    --button-gradient: linear-gradient(180deg, #2965ec, #5c89f8);
+    --button-gradient-border: 220.9 83.4% 64.5%; /* #5989F0 */
+    --button-gradient-shadow: 221.1 97.8% 64.3%; /* #4B83FD */
   }
 }
 

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -145,6 +145,8 @@ module.exports = {
             150: "#E7E0CB",
             200: "#E7DBB9",
             500: "#D8A40C",
+            // Readable on the 50 tint; the 500 fails contrast as chip text
+            600: "#B5870A",
           },
           brown: {
             50: "#FEEDE0",
@@ -165,6 +167,8 @@ module.exports = {
             100: "#E5F9FF",
             200: "#D0F4FF",
             500: "#49D1FA",
+            // Readable on the 100 tint; the 500 fails contrast as chip text
+            700: "#0E86AC",
           },
           gray: {
             50: "#FFFFFF",
@@ -172,6 +176,7 @@ module.exports = {
             150: "#EEEEEE",
             200: "#E6E6E6",
             500: "#8E8E8E",
+            550: "#6D6E70",
             600: "#525252",
           },
         },

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -7,7 +7,6 @@ import {
   createMailSplitBody,
   deleteMailSplitBody,
   renameMailSplitBody,
-  reorderMailSplitsBody,
   updateMailPreferencesBody,
 } from "@/utils/actions/mail-split.validation";
 
@@ -30,13 +29,21 @@ export const createMailSplitAction = actionClient
       });
       if (duplicate) throw new SafeError(`You already have a "${name}" split.`);
 
+      // Derived from the highest order rather than the count: deleting a split
+      // from the middle would otherwise hand the next one a duplicate order.
+      const last = await prisma.mailSplit.findFirst({
+        where: { emailAccountId },
+        orderBy: { order: "desc" },
+        select: { order: true },
+      });
+
       const split = await prisma.mailSplit.create({
         data: {
           emailAccountId,
           name,
           kind,
           value: value ?? null,
-          order: existing,
+          order: (last?.order ?? -1) + 1,
         },
       });
 
@@ -61,23 +68,6 @@ export const deleteMailSplitAction = actionClient
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
     // deleteMany rather than delete so another account's id can never be removed
     await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
-  });
-
-export const reorderMailSplitsAction = actionClient
-  .metadata({ name: "reorderMailSplits" })
-  .inputSchema(reorderMailSplitsBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { ids } }) => {
-    const owned = await prisma.mailSplit.findMany({
-      where: { emailAccountId, id: { in: ids } },
-      select: { id: true },
-    });
-    if (owned.length !== ids.length) throw new SafeError("Split not found");
-
-    await prisma.$transaction(
-      ids.map((id, order) =>
-        prisma.mailSplit.update({ where: { id }, data: { order } }),
-      ),
-    );
   });
 
 export const updateMailPreferencesAction = actionClient

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -1,0 +1,101 @@
+"use server";
+
+import prisma from "@/utils/prisma";
+import { actionClient } from "@/utils/actions/safe-action";
+import { SafeError } from "@/utils/error";
+import {
+  createMailSplitBody,
+  deleteMailSplitBody,
+  renameMailSplitBody,
+  reorderMailSplitsBody,
+  updateMailPreferencesBody,
+} from "@/utils/actions/mail-split.validation";
+
+const MAX_SPLITS = 12;
+
+export const createMailSplitAction = actionClient
+  .metadata({ name: "createMailSplit" })
+  .inputSchema(createMailSplitBody)
+  .action(
+    async ({ ctx: { emailAccountId }, parsedInput: { name, kind, value } }) => {
+      const existing = await prisma.mailSplit.count({
+        where: { emailAccountId },
+      });
+      if (existing >= MAX_SPLITS)
+        throw new SafeError(`You can only have ${MAX_SPLITS} splits.`);
+
+      const duplicate = await prisma.mailSplit.findUnique({
+        where: { emailAccountId_name: { emailAccountId, name } },
+        select: { id: true },
+      });
+      if (duplicate) throw new SafeError(`You already have a "${name}" split.`);
+
+      const split = await prisma.mailSplit.create({
+        data: {
+          emailAccountId,
+          name,
+          kind,
+          value: value ?? null,
+          order: existing,
+        },
+      });
+
+      return { split };
+    },
+  );
+
+export const renameMailSplitAction = actionClient
+  .metadata({ name: "renameMailSplit" })
+  .inputSchema(renameMailSplitBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id, name } }) => {
+    const { count } = await prisma.mailSplit.updateMany({
+      where: { id, emailAccountId },
+      data: { name },
+    });
+    if (!count) throw new SafeError("Split not found");
+  });
+
+export const deleteMailSplitAction = actionClient
+  .metadata({ name: "deleteMailSplit" })
+  .inputSchema(deleteMailSplitBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
+    // deleteMany rather than delete so another account's id can never be removed
+    await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
+  });
+
+export const reorderMailSplitsAction = actionClient
+  .metadata({ name: "reorderMailSplits" })
+  .inputSchema(reorderMailSplitsBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { ids } }) => {
+    const owned = await prisma.mailSplit.findMany({
+      where: { emailAccountId, id: { in: ids } },
+      select: { id: true },
+    });
+    if (owned.length !== ids.length) throw new SafeError("Split not found");
+
+    await prisma.$transaction(
+      ids.map((id, order) =>
+        prisma.mailSplit.update({ where: { id }, data: { order } }),
+      ),
+    );
+  });
+
+export const updateMailPreferencesAction = actionClient
+  .metadata({ name: "updateMailPreferences" })
+  .inputSchema(updateMailPreferencesBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { layout, hintBarDismissed },
+    }) => {
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: {
+          ...(layout === undefined ? {} : { mailLayout: layout }),
+          ...(hintBarDismissed === undefined
+            ? {}
+            : { mailHintBarDismissed: hintBarDismissed }),
+        },
+      });
+    },
+  );

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+
+// LABEL splits carry a provider label id; CATEGORY splits carry a provider category
+// (e.g. CATEGORY_PERSONAL). ALL and UNREAD need no value.
+const requiresValue = (kind: MailSplitKind) =>
+  kind === MailSplitKind.LABEL || kind === MailSplitKind.CATEGORY;
+
+export const createMailSplitBody = z
+  .object({
+    name: z.string().trim().min(1).max(60),
+    kind: z.nativeEnum(MailSplitKind),
+    value: z.string().trim().min(1).nullish(),
+  })
+  .refine((data) => !requiresValue(data.kind) || !!data.value, {
+    message: "Label and category splits need a value",
+    path: ["value"],
+  });
+export type CreateMailSplitBody = z.infer<typeof createMailSplitBody>;
+
+export const renameMailSplitBody = z.object({
+  id: z.string(),
+  name: z.string().trim().min(1).max(60),
+});
+export type RenameMailSplitBody = z.infer<typeof renameMailSplitBody>;
+
+export const deleteMailSplitBody = z.object({ id: z.string() });
+export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
+
+export const reorderMailSplitsBody = z.object({
+  ids: z.array(z.string()).min(1),
+});
+export type ReorderMailSplitsBody = z.infer<typeof reorderMailSplitsBody>;
+
+export const updateMailPreferencesBody = z
+  .object({
+    layout: z.nativeEnum(MailLayout).optional(),
+    hintBarDismissed: z.boolean().optional(),
+  })
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: "Nothing to update",
+  });
+export type UpdateMailPreferencesBody = z.infer<
+  typeof updateMailPreferencesBody
+>;

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 
 // LABEL splits carry a provider label id; CATEGORY splits carry a provider category
-// (e.g. CATEGORY_PERSONAL). ALL and UNREAD need no value.
+// (e.g. CATEGORY_PERSONAL). INBOX and UNREAD need no value.
 const requiresValue = (kind: MailSplitKind) =>
   kind === MailSplitKind.LABEL || kind === MailSplitKind.CATEGORY;
 

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -27,11 +27,6 @@ export type RenameMailSplitBody = z.infer<typeof renameMailSplitBody>;
 export const deleteMailSplitBody = z.object({ id: z.string() });
 export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 
-export const reorderMailSplitsBody = z.object({
-  ids: z.array(z.string()).min(1),
-});
-export type ReorderMailSplitsBody = z.infer<typeof reorderMailSplitsBody>;
-
 export const updateMailPreferencesBody = z
   .object({
     layout: z.nativeEnum(MailLayout).optional(),

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -6,6 +6,11 @@ import { sendEmailBody } from "@/utils/gmail/mail";
 import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
 import { createEmailProvider } from "@/utils/email/provider";
+import {
+  removeThreadLabelBody,
+  unarchiveThreadBody,
+  untrashThreadBody,
+} from "@/utils/actions/mail.validation";
 
 const isStatusOk = (status: number) => status >= 200 && status < 300;
 
@@ -38,6 +43,29 @@ export const archiveThreadAction = actionClient
     },
   );
 
+export const unarchiveThreadAction = actionClient
+  .metadata({ name: "unarchiveThread" })
+  .inputSchema(unarchiveThreadBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, provider, logger },
+      parsedInput: { threadId },
+    }) => {
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider,
+        logger,
+      });
+
+      try {
+        await emailProvider.unarchiveThread(threadId);
+      } catch (error) {
+        logger.error("Failed to unarchive thread", { error });
+        throw new SafeError("Failed to unarchive email. Please try again.");
+      }
+    },
+  );
+
 export const trashThreadAction = actionClient
   .metadata({ name: "trashThread" })
   .inputSchema(z.object({ threadId: z.string() }))
@@ -57,6 +85,29 @@ export const trashThreadAction = actionClient
       } catch (error) {
         logger.error("Failed to trash thread", { error });
         throw new SafeError("Failed to delete email. Please try again.");
+      }
+    },
+  );
+
+export const untrashThreadAction = actionClient
+  .metadata({ name: "untrashThread" })
+  .inputSchema(untrashThreadBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, provider, logger },
+      parsedInput: { threadId },
+    }) => {
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider,
+        logger,
+      });
+
+      try {
+        await emailProvider.untrashThread(threadId);
+      } catch (error) {
+        logger.error("Failed to untrash thread", { error });
+        throw new SafeError("Failed to restore email. Please try again.");
       }
     },
   );
@@ -82,6 +133,29 @@ export const markReadThreadAction = actionClient
         throw new SafeError(
           `Failed to mark email as ${read ? "read" : "unread"}. Please try again.`,
         );
+      }
+    },
+  );
+
+export const removeThreadLabelAction = actionClient
+  .metadata({ name: "removeThreadLabel" })
+  .inputSchema(removeThreadLabelBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, provider, logger },
+      parsedInput: { threadId, labelId },
+    }) => {
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider,
+        logger,
+      });
+
+      try {
+        await emailProvider.removeThreadLabel(threadId, labelId);
+      } catch (error) {
+        logger.error("Failed to remove thread label", { error });
+        throw new SafeError("Failed to remove label. Please try again.");
       }
     },
   );

--- a/apps/web/utils/actions/mail.validation.ts
+++ b/apps/web/utils/actions/mail.validation.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const unarchiveThreadBody = z.object({ threadId: z.string() });
+export type UnarchiveThreadBody = z.infer<typeof unarchiveThreadBody>;
+
+export const untrashThreadBody = z.object({ threadId: z.string() });
+export type UntrashThreadBody = z.infer<typeof untrashThreadBody>;
+
+export const removeThreadLabelBody = z.object({
+  threadId: z.string(),
+  labelId: z.string(),
+});
+export type RemoveThreadLabelBody = z.infer<typeof removeThreadLabelBody>;

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -187,6 +187,7 @@ export class GmailProvider implements EmailProvider {
         type: label.type!,
         color: label.color || undefined,
         threadsTotal: label.threadsTotal || undefined,
+        threadsUnread: label.threadsUnread || undefined,
       };
     } catch {
       return null;

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -29,6 +29,8 @@ export interface EmailLabel {
   messageListVisibility?: string;
   name: string;
   threadsTotal?: number;
+  // Only populated by providers that report per-label counts (Gmail `labels.get`)
+  threadsUnread?: number;
   type: string;
 }
 

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -11,7 +11,7 @@ function split(
 
 describe("mailSplitToThreadsQuery", () => {
   it("scopes the default split to the inbox", () => {
-    expect(mailSplitToThreadsQuery(split(MailSplitKind.ALL))).toEqual({
+    expect(mailSplitToThreadsQuery(split(MailSplitKind.INBOX))).toEqual({
       type: "inbox",
     });
   });

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+
+function split(
+  kind: MailSplitKind,
+  value: string | null = null,
+): Parameters<typeof mailSplitToThreadsQuery>[0] {
+  return { id: "split-1", name: "Test split", kind, value };
+}
+
+describe("mailSplitToThreadsQuery", () => {
+  it("scopes the default split to the inbox", () => {
+    expect(mailSplitToThreadsQuery(split(MailSplitKind.ALL))).toEqual({
+      type: "inbox",
+    });
+  });
+
+  it("asks the server for unread rather than filtering loaded pages", () => {
+    expect(mailSplitToThreadsQuery(split(MailSplitKind.UNREAD))).toEqual({
+      type: "inbox",
+      isUnread: true,
+    });
+  });
+
+  it("queries by label id, not by label name", () => {
+    expect(
+      mailSplitToThreadsQuery(split(MailSplitKind.LABEL, "Label_42")),
+    ).toEqual({ labelId: "Label_42" });
+  });
+
+  it("passes a provider category through as the type", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split(MailSplitKind.CATEGORY, "CATEGORY_PERSONAL"),
+      ),
+    ).toEqual({ type: "CATEGORY_PERSONAL" });
+  });
+
+  it.each([
+    MailSplitKind.LABEL,
+    MailSplitKind.CATEGORY,
+  ])("throws rather than silently querying the whole inbox when %s has no value", (kind) => {
+    expect(() => mailSplitToThreadsQuery(split(kind))).toThrow(
+      /has no (label|category)/,
+    );
+  });
+});

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -14,7 +14,7 @@ export type MailSplit = {
  */
 export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
   switch (split.kind) {
-    case MailSplitKind.ALL:
+    case MailSplitKind.INBOX:
       return { type: "inbox" };
     case MailSplitKind.UNREAD:
       return { type: "inbox", isUnread: true };

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -1,0 +1,29 @@
+import { MailSplitKind } from "@/generated/prisma/enums";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+
+export type MailSplit = {
+  id: string;
+  name: string;
+  kind: MailSplitKind;
+  value: string | null;
+};
+
+/**
+ * Every split is its own server query. Filtering a paginated list client-side would
+ * only ever search the pages already loaded, which silently under-reports.
+ */
+export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
+  switch (split.kind) {
+    case MailSplitKind.ALL:
+      return { type: "inbox" };
+    case MailSplitKind.UNREAD:
+      return { type: "inbox", isUnread: true };
+    case MailSplitKind.LABEL:
+      if (!split.value) throw new Error(`Split "${split.name}" has no label`);
+      return { labelId: split.value };
+    case MailSplitKind.CATEGORY:
+      if (!split.value)
+        throw new Error(`Split "${split.name}" has no category`);
+      return { type: split.value };
+  }
+}

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -14,3 +14,7 @@ export const threadsQuery = z.object({
   isUnread: z.coerce.boolean().nullish(),
 });
 export type ThreadsQuery = z.infer<typeof threadsQuery>;
+
+// Opt-in slim response for list rows. Anything unrecognised falls back to the
+// full response so a bad param can never drop data a caller depends on.
+export const threadsView = z.enum(["full", "list"]).catch("full");


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260811-142641_pr-3204_450d5629bd36/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Foundation for the Mail tab redesign. **Everything here is additive and opt-in — no user-visible behaviour changes.** The redesigned screen itself lands in a follow-up PR stacked on this one.

## Why

The Mail tab is being rebuilt from a new design mock. It's the first product surface to adopt the design language that currently only exists on the marketing pages. Mail is reachable by URL only (it has no `SideNav` entry), so the risk here is low.

This PR lands the pieces the new screen needs, separately from the screen, so the schema and API changes get reviewed on their own.

## What's in here

### Scoped theme (`styles/globals.css`)
A warm-neutral palette redefining the **existing** shadcn vars under `:root[data-theme="mail"]:not(.dark)`. The `:root` and `.dark` blocks are untouched, so nothing outside the Mail route moves. The attribute is applied above `<body>` so Radix portals (dropdowns, dialogs, tooltips) inherit it rather than rendering with the old palette on top of the new screen.

Dark mode deliberately has no Mail variant — it inherits `.dark` unchanged. The redesign still applies in dark; only the warm tuning is light-only.

Once the look is proven, promoting this app-wide is moving the block to `:root` and deleting the attribute.

### Shared primitives
- `gradient` button variant in `components/ui/button.tsx`, built to the mock's spec. No existing variant changed.
- `components/Kbd.tsx` — keyboard key chip, with an `onColor` variant for use inside coloured buttons.
- Three chip foregrounds added to `tailwind.config.js` (`new-cyan-700`, `new-gray-550`, `new-yellow-600`). The rest of the chip palette already existed under `new-*`.
- `--border-strong`: a second, heavier rule weight. Defined in `:root`/`.dark` too so it never resolves to nothing outside Mail.

### Keyboard shortcut registry (`lib/shortcuts/`)
One declarative array drives the key handler, the help dialog, and the ⌘K palette entries, so the documented shortcuts can't drift from the ones that actually work. `CommandK`'s inline `e`/`c` handlers move into it — those already targeted the displayed mail thread, so this is consolidation, not new behaviour. Includes a dev-time check that two shortcuts never claim the same key in one scope.

### Splits and mail preferences
- New `MailSplit` model (a saved filter shown as a tab above the list), plus `mailLayout` and `mailHintBarDismissed` on `EmailAccount`.
- Server actions to create/rename/delete/reorder splits and update preferences. Ownership-scoped throughout (`updateMany`/`deleteMany` filtered by `emailAccountId`), so an id belonging to another account can't be touched.
- `GET /api/mail/settings` + `useMailSettings`.
- `utils/mail/split-query.ts` maps a split to a `ThreadsQuery`. **Each split is its own server query.** Filtering a paginated list client-side only ever searches the pages already loaded — the existing "Planned" tab has that bug today, and the new splits must not inherit it.

### Threads API
- **`?view=list`** — opt-in slim payload for list rows: no `textHtml`, `textPlain` or attachments. The default response is unchanged, so existing consumers (`no-reply`, `stats/NewsletterModal`) are unaffected. An unrecognised `view` falls back to the full payload, so a typo can't silently drop data.
- **Multi-rule attribution.** `runRules()` returns `RunRulesResult[]` — several rules genuinely can fire on one message — but the route kept only the first match, with no `orderBy`, so which one you got was arbitrary. There's now a `plans` array alongside the existing `plan`, deduped per rule keeping the most recent execution. `plan` is still present and is now deterministically the most recent rather than arbitrary.
- **`GET /api/labels/counts`** — thread totals and unread counts per label/category for the sidebar, cached 60s. Degrades rather than fails: a per-label lookup failure drops that entry and flags the response `partial`; total failure returns `200` with empty counts so the sidebar can never be broken by it.

### Undo
`unarchiveThreadAction`, `untrashThreadAction`, `removeThreadLabelAction` — the provider methods existed for both Gmail and Outlook but nothing exposed them.

`cancelQueuedThreads()` in `store/archive-queue.ts` lets an undo cancel a job that hasn't reached the provider yet, returning which ids still need reversing. The queue usually drains in under a second, so both paths matter for undo to feel reliable.

## Notes for review

- `EmailLabel` gained an optional `threadsUnread`; `GmailProvider.getLabelById` populates it from the `users.labels.get` call it already makes, so there's no extra API cost. Outlook leaves it undefined.
- The counts endpoint fans out to one `users.labels.get` per label (capped at 100) on a cache miss. Acceptable at a 60s TTL, but it's the piece most worth a second opinion.
- The migration was hand-written rather than generated, then verified by applying all migrations to a throwaway database and diffing against the schema — no difference.

## Testing

- `utils/mail/split-query.test.ts` — split → query mapping, including that a label split with no value throws rather than silently querying the whole inbox
- `store/archive-queue.test.ts` — queued vs in-flight cancellation, partial batches, progress-state cleanup
- `app/api/threads/route.test.ts` — slim payload omits bodies, default payload unchanged, attribution dedupes per rule
- `app/api/labels/counts/route.test.ts` — caching and per-label failure tolerance
- `lib/shortcuts/` — conflict detection, typing guard, key sequences


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->