### PR TITLE
feat(mail): rebuild the mail screen on the new design

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/app/(app)/[emailAccountId]/mail/HintBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/HintBar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import { Kbd } from "@/components/Kbd";
+import { getShortcutHint, type ShortcutId } from "@/lib/shortcuts/registry";
+import { cn } from "@/utils";
+
+// The shortcuts worth advertising. Everything else lives behind `?`.
+const HINTS: { id: ShortcutId; label: string }[] = [
+  { id: "next", label: "move" },
+  { id: "select", label: "select" },
+  { id: "archive", label: "archive" },
+  { id: "reply", label: "reply" },
+  { id: "toggleLayout", label: "view" },
+  { id: "help", label: "shortcuts" },
+];
+
+export type HintBarProps = {
+  status?: string;
+  onDismiss: () => void;
+  className?: string;
+};
+
+/**
+ * A keyboard-first screen is invisible without this: it's the only thing that
+ * tells someone the shortcuts exist. Dismissible, because it stops earning its
+ * space once you know them.
+ */
+export function HintBar({ status, onDismiss, className }: HintBarProps) {
+  return (
+    <footer
+      className={cn(
+        "flex h-9 shrink-0 items-center gap-4 overflow-x-auto border-t border-border bg-sidebar px-4 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      {HINTS.map((hint) => (
+        <span key={hint.id} className="flex shrink-0 items-center gap-1.5">
+          <Kbd>{getShortcutHint(hint.id)}</Kbd>
+          {hint.label}
+        </span>
+      ))}
+
+      <div className="flex-1" />
+
+      {status ? <span className="shrink-0">{status}</span> : null}
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Hide keyboard shortcut hints"
+        className="-mr-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </footer>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ColumnsIcon, RowsIcon, SearchIcon, SparklesIcon } from "lucide-react";
+import { Kbd } from "@/components/Kbd";
+import { Tooltip } from "@/components/Tooltip";
+import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { cn } from "@/utils";
+
+export type ListToolbarProps = {
+  layout: MailLayoutMode;
+  onOpenSearch: () => void;
+  onToggleLayout: () => void;
+  onToggleAssistant: () => void;
+};
+
+export function ListToolbar({
+  layout,
+  onOpenSearch,
+  onToggleLayout,
+  onToggleAssistant,
+}: ListToolbarProps) {
+  const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-2">
+      {/* Opens the command palette rather than searching mail — it navigates
+          and runs actions, and promising search we don't have would mislead. */}
+      <button
+        type="button"
+        onClick={onOpenSearch}
+        className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors hover:border-[hsl(var(--border-strong))] hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <SearchIcon className="size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-left">
+          Search or jump to…
+        </span>
+        <Kbd>{getShortcutHint("commandPalette")}</Kbd>
+      </button>
+
+      <Tooltip content="Switch list / split view">
+        <button
+          type="button"
+          onClick={onToggleLayout}
+          aria-label="Switch list or split view"
+          className={toolbarButton}
+        >
+          <LayoutIcon className="size-3.5" />
+          <Kbd>{getShortcutHint("toggleLayout")}</Kbd>
+        </button>
+      </Tooltip>
+
+      <Tooltip content="Assistant">
+        <button
+          type="button"
+          onClick={onToggleAssistant}
+          aria-label="Toggle the assistant"
+          className={cn(toolbarButton, "px-0 w-8 justify-center")}
+        >
+          <SparklesIcon className="size-3.5" />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+const toolbarButton =
+  "flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { chipColorForLabel } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import type { ChipColor } from "@/app/(app)/[emailAccountId]/mail/types";
+
+const PALETTE: ChipColor[] = [
+  "blue",
+  "green",
+  "purple",
+  "orange",
+  "red",
+  "gray",
+  "cyan",
+  "yellow",
+];
+
+describe("chipColorForLabel", () => {
+  it("gives product labels their fixed colour, however they are cased", () => {
+    expect(chipColorForLabel("To Reply")).toBe("blue");
+    expect(chipColorForLabel("to reply")).toBe("blue");
+    expect(chipColorForLabel("  Cold Email  ")).toBe("red");
+    expect(chipColorForLabel("Newsletter")).toBe("gray");
+    expect(chipColorForLabel("Awaiting Reply")).toBe("cyan");
+  });
+
+  it("keeps an unknown label on one colour across calls", () => {
+    const names = ["Acme Corp", "shipping", "🚀 launch", "", "a"];
+
+    for (const name of names) {
+      const color = chipColorForLabel(name);
+      expect(PALETTE).toContain(color);
+      expect(chipColorForLabel(name)).toBe(color);
+    }
+  });
+
+  it("spreads unknown labels over the palette rather than collapsing to one", () => {
+    const colors = new Set(
+      Array.from({ length: 60 }, (_, index) =>
+        chipColorForLabel(`label-${index}`),
+      ),
+    );
+
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
+  it("does not treat labels that merely contain a known name as known", () => {
+    expect(chipColorForLabel("Newsletters")).not.toBe(
+      chipColorForLabel("Newsletter"),
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
@@ -32,6 +32,14 @@ describe("chipColorForLabel", () => {
     }
   });
 
+  it("keeps an unknown label on one colour however the provider cases it", () => {
+    const color = chipColorForLabel("Acme Corp");
+
+    expect(chipColorForLabel("acme corp")).toBe(color);
+    expect(chipColorForLabel("ACME CORP")).toBe(color);
+    expect(chipColorForLabel("  Acme Corp  ")).toBe(color);
+  });
+
   it("spreads unknown labels over the palette rather than collapsing to one", () => {
     const colors = new Set(
       Array.from({ length: 60 }, (_, index) =>

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
@@ -1,17 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { chipColorForLabel } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
-import type { ChipColor } from "@/app/(app)/[emailAccountId]/mail/types";
-
-const PALETTE: ChipColor[] = [
-  "blue",
-  "green",
-  "purple",
-  "orange",
-  "red",
-  "gray",
-  "cyan",
-  "yellow",
-];
+import {
+  CHIP_COLORS,
+  chipColorForLabel,
+} from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 
 describe("chipColorForLabel", () => {
   it("gives product labels their fixed colour, however they are cased", () => {
@@ -27,7 +18,7 @@ describe("chipColorForLabel", () => {
 
     for (const name of names) {
       const color = chipColorForLabel(name);
-      expect(PALETTE).toContain(color);
+      expect(CHIP_COLORS).toContain(color);
       expect(chipColorForLabel(name)).toBe(color);
     }
   });

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
@@ -2,13 +2,10 @@
 
 import Link from "next/link";
 import { XIcon } from "lucide-react";
-import type { ChipColor } from "@/app/(app)/[emailAccountId]/mail/types";
 import { cn } from "@/utils";
 
 export type MailLabelChipProps = {
   name: string;
-  /** Defaults to `chipColorForLabel(name)` so a label reads the same everywhere. */
-  color?: ChipColor;
   /** Interactive: the chip navigates to that label's view. */
   href?: string;
   /** Interactive: reveals a `×` on hover that removes the label. */
@@ -17,12 +14,12 @@ export type MailLabelChipProps = {
 };
 
 /**
- * A label pill. Rows pass neither `href` nor `onRemove` and get an inert chip;
- * the reader passes both and gets a link with a hover remove affordance.
+ * A label pill. Its colour comes from the name, so a label reads the same
+ * everywhere. Without `href` or `onRemove` the chip is inert; each adds its own
+ * affordance — a link on the name, and a `×` revealed on hover.
  */
 export function MailLabelChip({
   name,
-  color,
   href,
   onRemove,
   className,
@@ -31,7 +28,7 @@ export function MailLabelChip({
     <span
       className={cn(
         "group/chip inline-flex min-w-0 max-w-full items-center gap-0.5 whitespace-nowrap rounded-md border px-1.5 py-px text-xs leading-4",
-        CHIP_CLASSES[color ?? chipColorForLabel(name)],
+        CHIP_CLASSES[chipColorForLabel(name)],
         className,
       )}
     >
@@ -60,8 +57,14 @@ export function MailLabelChip({
   );
 }
 
-/** bg / border / text, light-scoped: the Mail palette has no dark variant. */
-const CHIP_CLASSES: Record<ChipColor, string> = {
+/**
+ * The chip palette, and the only place it is spelled out: `ChipColor` and
+ * `CHIP_COLORS` both derive from these keys, so a new colour is picked up by the
+ * hash the moment it is added here.
+ *
+ * bg / border / text, light-scoped: the Mail palette has no dark variant.
+ */
+const CHIP_CLASSES = {
   blue: "bg-new-blue-50 border-new-blue-150 text-primary",
   green: "bg-new-green-50 border-new-green-150 text-new-green-600",
   purple: "bg-new-purple-50 border-new-purple-200 text-new-purple-600",
@@ -72,16 +75,10 @@ const CHIP_CLASSES: Record<ChipColor, string> = {
   yellow: "bg-new-yellow-50 border-new-yellow-150 text-new-yellow-600",
 };
 
-const CHIP_COLORS: readonly ChipColor[] = [
-  "blue",
-  "green",
-  "purple",
-  "orange",
-  "red",
-  "gray",
-  "cyan",
-  "yellow",
-];
+type ChipColor = keyof typeof CHIP_CLASSES;
+
+/** The colours the hash can land on. Exported so tests assert against the palette itself. */
+export const CHIP_COLORS = Object.keys(CHIP_CLASSES) as ChipColor[];
 
 /** Lowercased, so a label keeps its colour however the provider cases it. */
 const NAMED_CHIP_COLORS: Record<string, ChipColor> = {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { XIcon } from "lucide-react";
+import type { ChipColor } from "@/app/(app)/[emailAccountId]/mail/types";
+import { cn } from "@/utils";
+
+export type MailLabelChipProps = {
+  name: string;
+  /** Defaults to `chipColorForLabel(name)` so a label reads the same everywhere. */
+  color?: ChipColor;
+  /** Interactive: the chip navigates to that label's view. */
+  href?: string;
+  /** Interactive: reveals a `×` on hover that removes the label. */
+  onRemove?: () => void;
+  className?: string;
+};
+
+/**
+ * A label pill. Rows pass neither `href` nor `onRemove` and get an inert chip;
+ * the reader passes both and gets a link with a hover remove affordance.
+ */
+export function MailLabelChip({
+  name,
+  color,
+  href,
+  onRemove,
+  className,
+}: MailLabelChipProps) {
+  return (
+    <span
+      className={cn(
+        "group/chip inline-flex min-w-0 max-w-full items-center gap-0.5 whitespace-nowrap rounded-md border px-1.5 py-px text-xs leading-4",
+        CHIP_CLASSES[color ?? chipColorForLabel(name)],
+        className,
+      )}
+    >
+      {href ? (
+        <Link className="truncate hover:underline" href={href}>
+          {name}
+        </Link>
+      ) : (
+        <span className="truncate">{name}</span>
+      )}
+      {onRemove ? (
+        <button
+          aria-label={`Remove ${name} label`}
+          className="-mr-0.5 shrink-0 rounded-sm opacity-0 transition-opacity focus-visible:opacity-100 group-hover/chip:opacity-100"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove();
+          }}
+          type="button"
+        >
+          <XIcon className="size-3" />
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+/** bg / border / text, light-scoped: the Mail palette has no dark variant. */
+const CHIP_CLASSES: Record<ChipColor, string> = {
+  blue: "bg-new-blue-50 border-new-blue-150 text-primary",
+  green: "bg-new-green-50 border-new-green-150 text-new-green-600",
+  purple: "bg-new-purple-50 border-new-purple-200 text-new-purple-600",
+  orange: "bg-new-orange-50 border-new-orange-150 text-new-orange-600",
+  red: "bg-new-red-50 border-new-red-150 text-new-red-500",
+  gray: "bg-new-gray-100 border-new-gray-150 text-new-gray-550",
+  cyan: "bg-new-cyan-100 border-new-cyan-200 text-new-cyan-700",
+  yellow: "bg-new-yellow-50 border-new-yellow-150 text-new-yellow-600",
+};
+
+const CHIP_COLORS: readonly ChipColor[] = [
+  "blue",
+  "green",
+  "purple",
+  "orange",
+  "red",
+  "gray",
+  "cyan",
+  "yellow",
+];
+
+/** Lowercased, so a label keeps its colour however the provider cases it. */
+const NAMED_CHIP_COLORS: Record<string, ChipColor> = {
+  "to reply": "blue",
+  notification: "green",
+  receipt: "orange",
+  "cold email": "red",
+  newsletter: "gray",
+  actioned: "orange",
+  "awaiting reply": "cyan",
+  calendar: "yellow",
+  "customer feedback": "purple",
+};
+
+/**
+ * The colour a label wears. Product labels have a fixed colour; everything else
+ * hashes into the palette so a user's own label keeps one colour forever rather
+ * than flickering between renders.
+ */
+export function chipColorForLabel(name: string): ChipColor {
+  const named = NAMED_CHIP_COLORS[name.trim().toLowerCase()];
+  if (named) return named;
+
+  // djb2
+  let hash = 5381;
+  for (let index = 0; index < name.length; index++) {
+    hash = (hash * 33 + name.charCodeAt(index)) % 0xff_ff_ff;
+  }
+
+  return CHIP_COLORS[hash % CHIP_COLORS.length];
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
@@ -36,11 +36,11 @@ export function MailLabelChip({
       )}
     >
       {href ? (
-        <Link className="truncate hover:underline" href={href}>
+        <Link className="min-w-0 truncate hover:underline" href={href}>
           {name}
         </Link>
       ) : (
-        <span className="truncate">{name}</span>
+        <span className="min-w-0 truncate">{name}</span>
       )}
       {onRemove ? (
         <button
@@ -102,13 +102,16 @@ const NAMED_CHIP_COLORS: Record<string, ChipColor> = {
  * than flickering between renders.
  */
 export function chipColorForLabel(name: string): ChipColor {
-  const named = NAMED_CHIP_COLORS[name.trim().toLowerCase()];
+  // Hash the same normalized key the named lookup uses, so a label doesn't
+  // change colour when the provider varies its casing or padding.
+  const key = name.trim().toLowerCase();
+  const named = NAMED_CHIP_COLORS[key];
   if (named) return named;
 
   // djb2
   let hash = 5381;
-  for (let index = 0; index < name.length; index++) {
-    hash = (hash * 33 + name.charCodeAt(index)) % 0xff_ff_ff;
+  for (let index = 0; index < key.length; index++) {
+    hash = (hash * 33 + key.charCodeAt(index)) % 0xff_ff_ff;
   }
 
   return CHIP_COLORS[hash % CHIP_COLORS.length];

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -27,6 +27,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useSetAtom } from "jotai";
 import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { isGoogleProvider } from "@/utils/email/provider-types";
 import { useEmail } from "@/providers/EmailProvider";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
@@ -61,7 +62,10 @@ const CATEGORY_OPTIONS = [
 ];
 
 export function MailShell() {
-  const { emailAccountId, userEmail } = useAccount();
+  const { emailAccountId, userEmail, provider } = useAccount();
+  // Gmail categories have no Outlook equivalent, so they're hidden rather than
+  // rendered as rows and split options that can never match anything.
+  const showCategories = isGoogleProvider(provider);
   const { userLabels } = useEmail();
   const { visibleLabels } = useSplitLabels();
   const { countsById } = useLabelCounts();
@@ -289,7 +293,7 @@ export function MailShell() {
         value: null,
         group: "state",
       },
-      ...CATEGORY_OPTIONS.map((category) => ({
+      ...(showCategories ? CATEGORY_OPTIONS : []).map((category) => ({
         id: `category:${category.value}`,
         name: category.name,
         kind: MailSplitKind.CATEGORY,
@@ -304,7 +308,7 @@ export function MailShell() {
         group: "label" as const,
       })),
     ],
-    [visibleLabels],
+    [visibleLabels, showCategories],
   );
 
   const onCreateSplit = useCallback(
@@ -353,6 +357,7 @@ export function MailShell() {
             hrefFor={hrefFor}
             labels={visibleLabels}
             countsById={countsById}
+            showCategories={showCategories}
             backToAppHref={prefixPath(emailAccountId, "/automation")}
             onCompose={openCompose}
             onCreateLabel={onCreateLabel}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useQueryState } from "nuqs";
 import { toast } from "sonner";
 import { HintBar } from "@/app/(app)/[emailAccountId]/mail/HintBar";
+import { ListToolbar } from "@/app/(app)/[emailAccountId]/mail/ListToolbar";
 import { MailSidebar } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import type { MailNavTarget } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { RuleAttributionMenu } from "@/app/(app)/[emailAccountId]/mail/RuleAttributionMenu";
@@ -22,6 +23,9 @@ import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-a
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
+import { useSidebar } from "@/components/ui/sidebar";
+import { useSetAtom } from "jotai";
+import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useEmail } from "@/providers/EmailProvider";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
@@ -64,6 +68,8 @@ export function MailShell() {
   const { data: settings, mutate: mutateSettings } = useMailSettings();
   const { onOpen: openCompose } = useComposeModal();
   const { setInput: setChatInput } = useChat();
+  const { toggleSidebar } = useSidebar();
+  const setPaletteOpen = useSetAtom(commandPaletteOpenAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
   const { threadId: sidePanelThreadId } = useDisplayedEmail();
@@ -365,6 +371,12 @@ export function MailShell() {
                   "flex min-h-0 min-w-0 flex-1 flex-col"
             }
           >
+            <ListToolbar
+              layout={layout}
+              onOpenSearch={() => setPaletteOpen(true)}
+              onToggleLayout={toggleLayout}
+              onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
+            />
             {!isScoped && (
               <SplitTabs
                 splits={splits}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useQueryState } from "nuqs";
+import { toast } from "sonner";
+import { HintBar } from "@/app/(app)/[emailAccountId]/mail/HintBar";
+import { MailSidebar } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
+import type { MailNavTarget } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
+import { RuleAttributionMenu } from "@/app/(app)/[emailAccountId]/mail/RuleAttributionMenu";
+import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
+import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
+import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
+import type {
+  NewSplitDraft,
+  NewSplitOption,
+} from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
+import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
+import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
+import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
+import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
+import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
+import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
+import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import { useChat } from "@/providers/ChatProvider";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { useEmail } from "@/providers/EmailProvider";
+import { useComposeModal } from "@/providers/ComposeModalProvider";
+import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
+import { useLabelCounts } from "@/hooks/useLabelCounts";
+import { useSplitLabels } from "@/hooks/useLabels";
+import { useMailSettings } from "@/hooks/useMailSettings";
+import { useThread } from "@/hooks/useThread";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
+import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
+import {
+  createMailSplitAction,
+  deleteMailSplitAction,
+  updateMailPreferencesAction,
+} from "@/utils/actions/mail-split";
+import { createLabelAction } from "@/utils/actions/mail";
+import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+import { prefixPath } from "@/utils/path";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+
+// Always present, never deletable. Everything else is a saved split.
+const BUILT_IN_SPLITS: MailSplitTab[] = [
+  { id: "all", name: "All", deletable: false },
+  { id: "unread", name: "Unread", deletable: false },
+];
+
+const CATEGORY_OPTIONS = [
+  { name: "Personal", value: "CATEGORY_PERSONAL" },
+  { name: "Social", value: "CATEGORY_SOCIAL" },
+  { name: "Updates", value: "CATEGORY_UPDATES" },
+  { name: "Forums", value: "CATEGORY_FORUMS" },
+  { name: "Promotions", value: "CATEGORY_PROMOTIONS" },
+];
+
+export function MailShell() {
+  const { emailAccountId, userEmail } = useAccount();
+  const { userLabels } = useEmail();
+  const { visibleLabels } = useSplitLabels();
+  const { countsById } = useLabelCounts();
+  const { data: settings, mutate: mutateSettings } = useMailSettings();
+  const { onOpen: openCompose } = useComposeModal();
+  const { setInput: setChatInput } = useChat();
+  // The side panel viewer owns the triage keys while it's open, so this screen
+  // stands down rather than both archiving the same keystroke.
+  const { threadId: sidePanelThreadId } = useDisplayedEmail();
+
+  const [openThreadId, setOpenThreadId] = useQueryState("thread-id");
+  const [activeSplitId, setActiveSplitId] = useQueryState("split", {
+    defaultValue: "all",
+  });
+  const [scopeType] = useQueryState("type");
+  const [scopeLabelId] = useQueryState("labelId");
+
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [isFocusMode, setIsFocusMode] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [replyToMessageId, setReplyToMessageId] = useState<string>();
+  const [layoutOverride, setLayoutOverride] = useState<MailLayoutMode>();
+  const [hintBarHidden, setHintBarHidden] = useState(false);
+
+  const layout: MailLayoutMode =
+    layoutOverride ??
+    (settings?.layout === MailLayout.SPLIT ? "split" : "list");
+
+  // A sidebar selection scopes the whole list, which replaces the split tabs —
+  // splits are a way of slicing the inbox, not of slicing an arbitrary view.
+  const isScoped = Boolean(
+    scopeLabelId || (scopeType && scopeType !== "inbox"),
+  );
+
+  const splits: MailSplitTab[] = useMemo(
+    () => [
+      ...BUILT_IN_SPLITS,
+      ...(settings?.splits ?? []).map((split) => ({
+        id: split.id,
+        name: split.name,
+        deletable: true,
+      })),
+    ],
+    [settings?.splits],
+  );
+
+  const query: ThreadsQuery = useMemo(() => {
+    if (scopeLabelId) return { labelId: scopeLabelId };
+    if (scopeType && scopeType !== "inbox") return { type: scopeType };
+    if (activeSplitId === "unread") return { type: "inbox", isUnread: true };
+
+    const saved = settings?.splits?.find((split) => split.id === activeSplitId);
+    if (saved) return mailSplitToThreadsQuery(saved);
+
+    return { type: "inbox" };
+  }, [scopeLabelId, scopeType, activeSplitId, settings?.splits]);
+
+  const {
+    threads,
+    isLoading,
+    hasMore,
+    isLoadingMore,
+    loadMore,
+    removeThreads,
+    restoreThreads,
+  } = useMailThreads(query);
+
+  const orderedIds = useMemo(() => threads.map((t) => t.id), [threads]);
+  const selection = useThreadSelection(orderedIds);
+  const { archive, trash, undo } = useThreadActions({
+    emailAccountId,
+    removeThreads,
+    restoreThreads,
+  });
+
+  const clampedIndex = Math.min(focusedIndex, Math.max(0, threads.length - 1));
+  const focusedThread = threads[clampedIndex];
+  const openThread = threads.find((t) => t.id === openThreadId);
+
+  const { data: openThreadData, mutate: refetchOpenThread } = useThread(
+    { id: openThreadId ?? "" },
+    { includeDrafts: true },
+  );
+  const openMessages = openThreadId ? openThreadData?.thread.messages : [];
+
+  const hrefFor = useCallback(
+    (target: MailNavTarget) =>
+      prefixPath(
+        emailAccountId,
+        target.kind === "label"
+          ? `/mail?type=label&labelId=${encodeURIComponent(target.labelId)}`
+          : `/mail?type=${encodeURIComponent(target.type)}`,
+      ),
+    [emailAccountId],
+  );
+
+  const runOn = useCallback(
+    (action: (ids: string[]) => void) => {
+      const ids = selection.targetIds(focusedThread?.id);
+      if (!ids.length) return;
+      if (openThreadId && ids.includes(openThreadId)) setOpenThreadId(null);
+      selection.clear();
+      action(ids);
+    },
+    [selection, focusedThread?.id, openThreadId, setOpenThreadId],
+  );
+
+  const openAt = useCallback(
+    (index: number) => {
+      const thread = threads[index];
+      if (!thread) return;
+      setFocusedIndex(index);
+      setReplyToMessageId(undefined);
+      setOpenThreadId(thread.id);
+    },
+    [threads, setOpenThreadId],
+  );
+
+  const move = useCallback(
+    (delta: number) => {
+      const next = Math.min(
+        Math.max(0, clampedIndex + delta),
+        Math.max(0, threads.length - 1),
+      );
+      setFocusedIndex(next);
+      // In split view the reader tracks the cursor; in list view it doesn't,
+      // so J/K browses the list without yanking you out of what you're reading.
+      if (layout === "split" && threads[next])
+        setOpenThreadId(threads[next].id);
+    },
+    [clampedIndex, threads, layout, setOpenThreadId],
+  );
+
+  const extendSelection = useCallback(
+    (delta: number) => {
+      const next = Math.min(
+        Math.max(0, clampedIndex + delta),
+        Math.max(0, threads.length - 1),
+      );
+      selection.extendTo(next, clampedIndex);
+      setFocusedIndex(next);
+    },
+    [clampedIndex, threads.length, selection],
+  );
+
+  const toggleLayout = useCallback(() => {
+    const next: MailLayoutMode = layout === "split" ? "list" : "split";
+    setLayoutOverride(next);
+    updateMailPreferencesAction(emailAccountId, {
+      layout: next === "split" ? MailLayout.SPLIT : MailLayout.LIST,
+    });
+  }, [layout, emailAccountId]);
+
+  const handlers: ShortcutHandlers = useMemo(() => {
+    if (sidePanelThreadId) return {};
+    return {
+      next: () => move(1),
+      previous: () => move(-1),
+      open: () => openAt(clampedIndex),
+      backToList: () => {
+        setIsFocusMode(false);
+        setOpenThreadId(null);
+      },
+      nextSplit: () => {
+        const index = splits.findIndex((s) => s.id === activeSplitId);
+        const next = splits[(index + 1) % splits.length];
+        if (next) setActiveSplitId(next.id);
+      },
+      select: () => selection.toggle(clampedIndex),
+      // The cursor travels with the extension; without that, every repeat
+      // re-extends from the same row and the range never grows.
+      extendSelectionDown: () => extendSelection(1),
+      extendSelectionUp: () => extendSelection(-1),
+      archive: () => runOn(archive),
+      delete: () => runOn(trash),
+      reply: () => {
+        if (!openThreadId && focusedThread) setOpenThreadId(focusedThread.id);
+        setReplyToMessageId(openMessages?.at(-1)?.id);
+      },
+      moreActions: () => setIsMenuOpen((open) => !open),
+      undo: () => undo(),
+      toggleLayout,
+      focusMode: () => setIsFocusMode((on) => !on),
+      close: () => {
+        if (isFocusMode) setIsFocusMode(false);
+        else if (selection.hasSelection) selection.clear();
+        else if (layout === "list") setOpenThreadId(null);
+      },
+      help: () => setIsHelpOpen(true),
+    };
+  }, [
+    sidePanelThreadId,
+    move,
+    openAt,
+    clampedIndex,
+    splits,
+    activeSplitId,
+    setActiveSplitId,
+    selection,
+    extendSelection,
+    runOn,
+    archive,
+    trash,
+    openThreadId,
+    focusedThread,
+    openMessages,
+    setOpenThreadId,
+    undo,
+    toggleLayout,
+    isFocusMode,
+    layout,
+  ]);
+
+  useShortcuts(handlers);
+
+  const newSplitOptions: NewSplitOption[] = useMemo(
+    () => [
+      {
+        id: "state:unread",
+        name: "Unread",
+        kind: MailSplitKind.UNREAD,
+        value: null,
+        group: "state",
+      },
+      ...CATEGORY_OPTIONS.map((category) => ({
+        id: `category:${category.value}`,
+        name: category.name,
+        kind: MailSplitKind.CATEGORY,
+        value: category.value,
+        group: "category" as const,
+      })),
+      ...visibleLabels.map((label) => ({
+        id: `label:${label.id}`,
+        name: label.name,
+        kind: MailSplitKind.LABEL,
+        value: label.id,
+        group: "label" as const,
+      })),
+    ],
+    [visibleLabels],
+  );
+
+  const onCreateSplit = useCallback(
+    async (draft: NewSplitDraft) => {
+      const result = await createMailSplitAction(emailAccountId, draft);
+      if (result?.serverError) {
+        toast.error(result.serverError);
+        return;
+      }
+      mutateSettings();
+    },
+    [emailAccountId, mutateSettings],
+  );
+
+  const onDeleteSplit = useCallback(
+    async (splitId: string) => {
+      if (activeSplitId === splitId) setActiveSplitId("all");
+      await deleteMailSplitAction(emailAccountId, { id: splitId });
+      mutateSettings();
+    },
+    [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
+  );
+
+  const onCreateLabel = useCallback(
+    async (name: string) => {
+      const result = await createLabelAction(emailAccountId, { name });
+      if (result?.serverError) toast.error(result.serverError);
+      else toast.success(`Label "${name}" created`);
+    },
+    [emailAccountId],
+  );
+
+  const showList = !isFocusMode && (layout === "split" || !openThreadId);
+  const showReader = layout === "split" || Boolean(openThreadId);
+  const showHintBar =
+    !hintBarHidden && !settings?.hintBarDismissed && !isFocusMode;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      <div className="flex min-h-0 flex-1">
+        {!isFocusMode && (
+          <MailSidebar
+            className="hidden lg:flex"
+            activeType={scopeLabelId ? null : (scopeType ?? "inbox")}
+            activeLabelId={scopeLabelId}
+            hrefFor={hrefFor}
+            labels={visibleLabels}
+            countsById={countsById}
+            backToAppHref={prefixPath(emailAccountId, "/automation")}
+            onCompose={openCompose}
+            onCreateLabel={onCreateLabel}
+            onOpenShortcuts={() => setIsHelpOpen(true)}
+          />
+        )}
+
+        {showList && (
+          <section
+            className={
+              layout === "split"
+                ? "flex min-h-0 w-[clamp(258px,32vw,400px)] shrink-0 flex-col border-r border-border"
+                : // min-w-0 matters: a flex item won't shrink below its content
+                  // width without it, so long snippets would widen the column
+                  // past the viewport instead of truncating.
+                  "flex min-h-0 min-w-0 flex-1 flex-col"
+            }
+          >
+            {!isScoped && (
+              <SplitTabs
+                splits={splits}
+                activeSplitId={activeSplitId}
+                onSelect={setActiveSplitId}
+                onDelete={onDeleteSplit}
+                newSplitOptions={newSplitOptions}
+                onCreateSplit={onCreateSplit}
+              />
+            )}
+            <ThreadList
+              threads={threads}
+              layout={layout}
+              userEmail={userEmail}
+              userLabels={userLabels}
+              focusedIndex={clampedIndex}
+              isSelected={selection.isSelected}
+              selectedCount={selection.selectedCount}
+              onOpenThread={openAt}
+              onToggleSelect={selection.toggle}
+              onSelectRangeTo={selection.selectRangeTo}
+              onArchiveSelected={() => runOn(archive)}
+              onDeleteSelected={() => runOn(trash)}
+              onClearSelection={selection.clear}
+              emptyTitle={isLoading ? "Loading…" : "Nothing in this view"}
+              showLoadMore={hasMore}
+              isLoadingMore={Boolean(isLoadingMore)}
+              onLoadMore={loadMore}
+            />
+          </section>
+        )}
+
+        {showReader && (
+          <ThreadReader
+            thread={openThread ?? null}
+            messages={openMessages ?? []}
+            userEmail={userEmail}
+            userLabels={userLabels}
+            layout={layout}
+            isFocusMode={isFocusMode}
+            position={
+              openThread
+                ? { index: clampedIndex + 1, total: threads.length }
+                : undefined
+            }
+            labelHref={(labelId) => hrefFor({ kind: "label", labelId })}
+            onBack={() => {
+              setIsFocusMode(false);
+              setOpenThreadId(null);
+            }}
+            onArchive={() => runOn(archive)}
+            onDelete={() => runOn(trash)}
+            onReply={() => setReplyToMessageId(openMessages?.at(-1)?.id)}
+            onToggleFocusMode={() => setIsFocusMode((on) => !on)}
+            refetch={refetchOpenThread}
+            autoOpenReplyForMessageId={replyToMessageId}
+            menu={
+              <RuleAttributionMenu
+                plans={openThread?.plans ?? []}
+                message={openMessages?.at(-1) ?? null}
+                setChatInput={setChatInput}
+                open={isMenuOpen}
+                onOpenChange={setIsMenuOpen}
+              />
+            }
+          />
+        )}
+      </div>
+
+      {showHintBar && (
+        <HintBar
+          status={`${threads.length} in view`}
+          onDismiss={() => {
+            setHintBarHidden(true);
+            updateMailPreferencesAction(emailAccountId, {
+              hintBarDismissed: true,
+            });
+          }}
+        />
+      )}
+
+      <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -106,7 +106,14 @@ export function MailShell() {
     (patch: UpdateMailPreferencesBody) => {
       mutateSettings(
         async (current) => {
-          await updateMailPreferencesAction(emailAccountId, patch);
+          const result = await updateMailPreferencesAction(
+            emailAccountId,
+            patch,
+          );
+          // Thrown so SWR rolls the optimistic value back rather than leaving
+          // the UI showing a preference the server never accepted.
+          if (result?.serverError || result?.validationErrors)
+            throw new Error(getActionErrorMessage(result));
           return current;
         },
         {
@@ -119,7 +126,11 @@ export function MailShell() {
           revalidate: false,
           rollbackOnError: true,
         },
-      );
+      ).catch((error) => {
+        toast.error(
+          error instanceof Error ? error.message : "Couldn't save that",
+        );
+      });
     },
     [emailAccountId, mutateSettings],
   );
@@ -196,7 +207,12 @@ export function MailShell() {
     { id: readerThreadId },
     { includeDrafts: true },
   );
-  const openMessages = openThreadData?.thread.messages ?? NO_MESSAGES;
+  // Withheld until the deferred id catches up, so a fast J/K can't pair the new
+  // thread's header with the previous thread's body.
+  const openMessages =
+    readerThreadId === openThreadId
+      ? (openThreadData?.thread.messages ?? NO_MESSAGES)
+      : NO_MESSAGES;
 
   const hrefFor = useCallback(
     (target: MailNavTarget) =>

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import { useQueryState } from "nuqs";
 import { toast } from "sonner";
 import { HintBar } from "@/app/(app)/[emailAccountId]/mail/HintBar";
 import { ListToolbar } from "@/app/(app)/[emailAccountId]/mail/ListToolbar";
-import { MailSidebar } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
+import {
+  MAIL_CATEGORIES,
+  MailSidebar,
+} from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import type { MailNavTarget } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { RuleAttributionMenu } from "@/app/(app)/[emailAccountId]/mail/RuleAttributionMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
@@ -18,6 +21,7 @@ import type {
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
 import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
+import type { ThreadMessage } from "@/components/email-list/types";
 import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
@@ -42,24 +46,26 @@ import {
   deleteMailSplitAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
-import { createLabelAction } from "@/utils/actions/mail";
+import type { UpdateMailPreferencesBody } from "@/utils/actions/mail-split.validation";
+import {
+  createLabelAction,
+  removeThreadLabelAction,
+} from "@/utils/actions/mail";
 import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+import { getActionErrorMessage } from "@/utils/error";
 import { prefixPath } from "@/utils/path";
+import { LoadingContent } from "@/components/LoadingContent";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 
-// Always present, never deletable. Everything else is a saved split.
-const BUILT_IN_SPLITS: MailSplitTab[] = [
-  { id: "all", name: "All", deletable: false },
-  { id: "unread", name: "Unread", deletable: false },
-];
+// Always present, never deletable. Everything else is a saved split. They carry
+// a kind so built-ins and saved splits resolve through one mapping.
+const BUILT_IN_SPLITS = [
+  { id: "all", name: "All", kind: MailSplitKind.INBOX, value: null },
+  { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD, value: null },
+] as const;
 
-const CATEGORY_OPTIONS = [
-  { name: "Personal", value: "CATEGORY_PERSONAL" },
-  { name: "Social", value: "CATEGORY_SOCIAL" },
-  { name: "Updates", value: "CATEGORY_UPDATES" },
-  { name: "Forums", value: "CATEGORY_FORUMS" },
-  { name: "Promotions", value: "CATEGORY_PROMOTIONS" },
-];
+// Module-level so an "empty" reader doesn't hand children a new array each render.
+const NO_MESSAGES: ThreadMessage[] = [];
 
 export function MailShell() {
   const { emailAccountId, userEmail, provider } = useAccount();
@@ -67,7 +73,7 @@ export function MailShell() {
   // rendered as rows and split options that can never match anything.
   const showCategories = isGoogleProvider(provider);
   const { userLabels } = useEmail();
-  const { visibleLabels } = useSplitLabels();
+  const { visibleLabels, mutate: mutateLabels } = useSplitLabels();
   const { countsById } = useLabelCounts();
   const { data: settings, mutate: mutateSettings } = useMailSettings();
   const { onOpen: openCompose } = useComposeModal();
@@ -90,22 +96,51 @@ export function MailShell() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
-  const [layoutOverride, setLayoutOverride] = useState<MailLayoutMode>();
-  const [hintBarHidden, setHintBarHidden] = useState(false);
 
   const layout: MailLayoutMode =
-    layoutOverride ??
-    (settings?.layout === MailLayout.SPLIT ? "split" : "list");
+    settings?.layout === MailLayout.SPLIT ? "split" : "list";
+
+  // Written through the SWR cache rather than mirrored in local state, so the
+  // preference has one source of truth and every reader sees the new value.
+  const savePreferences = useCallback(
+    (patch: UpdateMailPreferencesBody) => {
+      mutateSettings(
+        async (current) => {
+          await updateMailPreferencesAction(emailAccountId, patch);
+          return current;
+        },
+        {
+          optimisticData: (current) => ({
+            layout: patch.layout ?? current?.layout ?? null,
+            hintBarDismissed:
+              patch.hintBarDismissed ?? current?.hintBarDismissed ?? false,
+            splits: current?.splits ?? [],
+          }),
+          revalidate: false,
+          rollbackOnError: true,
+        },
+      );
+    },
+    [emailAccountId, mutateSettings],
+  );
 
   // A sidebar selection scopes the whole list, which replaces the split tabs —
   // splits are a way of slicing the inbox, not of slicing an arbitrary view.
-  const isScoped = Boolean(
-    scopeLabelId || (scopeType && scopeType !== "inbox"),
-  );
+  // Resolved once so the tab bar and the fetched rows can't disagree.
+  const scopeQuery: ThreadsQuery | null = useMemo(() => {
+    if (scopeLabelId) return { labelId: scopeLabelId };
+    if (scopeType && scopeType !== "inbox") return { type: scopeType };
+    return null;
+  }, [scopeLabelId, scopeType]);
+  const isScoped = scopeQuery !== null;
 
   const splits: MailSplitTab[] = useMemo(
     () => [
-      ...BUILT_IN_SPLITS,
+      ...BUILT_IN_SPLITS.map((split) => ({
+        id: split.id,
+        name: split.name,
+        deletable: false,
+      })),
       ...(settings?.splits ?? []).map((split) => ({
         id: split.id,
         name: split.name,
@@ -116,19 +151,20 @@ export function MailShell() {
   );
 
   const query: ThreadsQuery = useMemo(() => {
-    if (scopeLabelId) return { labelId: scopeLabelId };
-    if (scopeType && scopeType !== "inbox") return { type: scopeType };
-    if (activeSplitId === "unread") return { type: "inbox", isUnread: true };
+    if (scopeQuery) return scopeQuery;
 
-    const saved = settings?.splits?.find((split) => split.id === activeSplitId);
-    if (saved) return mailSplitToThreadsQuery(saved);
+    const active =
+      settings?.splits?.find((split) => split.id === activeSplitId) ??
+      BUILT_IN_SPLITS.find((split) => split.id === activeSplitId) ??
+      BUILT_IN_SPLITS[0];
 
-    return { type: "inbox" };
-  }, [scopeLabelId, scopeType, activeSplitId, settings?.splits]);
+    return mailSplitToThreadsQuery(active);
+  }, [scopeQuery, activeSplitId, settings?.splits]);
 
   const {
     threads,
     isLoading,
+    error,
     hasMore,
     isLoadingMore,
     loadMore,
@@ -144,15 +180,23 @@ export function MailShell() {
     restoreThreads,
   });
 
-  const clampedIndex = Math.min(focusedIndex, Math.max(0, threads.length - 1));
+  const clampIndex = useCallback(
+    (index: number) =>
+      Math.min(Math.max(0, index), Math.max(0, threads.length - 1)),
+    [threads.length],
+  );
+  const clampedIndex = clampIndex(focusedIndex);
   const focusedThread = threads[clampedIndex];
   const openThread = threads.find((t) => t.id === openThreadId);
 
+  // Deferred so holding J/K in split view doesn't fire a full-thread provider
+  // fetch for every row the cursor passes over — only the row you settle on.
+  const readerThreadId = useDeferredValue(openThreadId);
   const { data: openThreadData, mutate: refetchOpenThread } = useThread(
-    { id: openThreadId ?? "" },
+    { id: readerThreadId },
     { includeDrafts: true },
   );
-  const openMessages = openThreadId ? openThreadData?.thread.messages : [];
+  const openMessages = openThreadData?.thread.messages ?? NO_MESSAGES;
 
   const hrefFor = useCallback(
     (target: MailNavTarget) =>
@@ -163,6 +207,11 @@ export function MailShell() {
           : `/mail?type=${encodeURIComponent(target.type)}`,
       ),
     [emailAccountId],
+  );
+
+  const labelHref = useCallback(
+    (labelId: string) => hrefFor({ kind: "label", labelId }),
+    [hrefFor],
   );
 
   const runOn = useCallback(
@@ -189,40 +238,38 @@ export function MailShell() {
 
   const move = useCallback(
     (delta: number) => {
-      const next = Math.min(
-        Math.max(0, clampedIndex + delta),
-        Math.max(0, threads.length - 1),
-      );
+      const next = clampIndex(clampedIndex + delta);
       setFocusedIndex(next);
       // In split view the reader tracks the cursor; in list view it doesn't,
       // so J/K browses the list without yanking you out of what you're reading.
       if (layout === "split" && threads[next])
         setOpenThreadId(threads[next].id);
     },
-    [clampedIndex, threads, layout, setOpenThreadId],
+    [clampIndex, clampedIndex, threads, layout, setOpenThreadId],
   );
 
   const extendSelection = useCallback(
     (delta: number) => {
-      const next = Math.min(
-        Math.max(0, clampedIndex + delta),
-        Math.max(0, threads.length - 1),
-      );
+      const next = clampIndex(clampedIndex + delta);
       selection.extendTo(next, clampedIndex);
       setFocusedIndex(next);
     },
-    [clampedIndex, threads.length, selection],
+    [clampIndex, clampedIndex, selection],
   );
 
   const toggleLayout = useCallback(() => {
-    const next: MailLayoutMode = layout === "split" ? "list" : "split";
-    setLayoutOverride(next);
-    updateMailPreferencesAction(emailAccountId, {
-      layout: next === "split" ? MailLayout.SPLIT : MailLayout.LIST,
+    savePreferences({
+      layout: layout === "split" ? MailLayout.LIST : MailLayout.SPLIT,
     });
-  }, [layout, emailAccountId]);
+  }, [layout, savePreferences]);
 
-  const handlers: ShortcutHandlers = useMemo(() => {
+  const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
+  const archiveTargets = useCallback(() => runOn(archive), [runOn, archive]);
+  const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
+
+  // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
+  // when the set of handled ids changes, so a stable identity buys nothing.
+  const handlers: ShortcutHandlers = (() => {
     if (sidePanelThreadId) return {};
     return {
       next: () => move(1),
@@ -242,8 +289,8 @@ export function MailShell() {
       // re-extends from the same row and the range never grows.
       extendSelectionDown: () => extendSelection(1),
       extendSelectionUp: () => extendSelection(-1),
-      archive: () => runOn(archive),
-      delete: () => runOn(trash),
+      archive: archiveTargets,
+      delete: trashTargets,
       reply: () => {
         if (!openThreadId && focusedThread) setOpenThreadId(focusedThread.id);
         setReplyToMessageId(openMessages?.at(-1)?.id);
@@ -259,28 +306,7 @@ export function MailShell() {
       },
       help: () => setIsHelpOpen(true),
     };
-  }, [
-    sidePanelThreadId,
-    move,
-    openAt,
-    clampedIndex,
-    splits,
-    activeSplitId,
-    setActiveSplitId,
-    selection,
-    extendSelection,
-    runOn,
-    archive,
-    trash,
-    openThreadId,
-    focusedThread,
-    openMessages,
-    setOpenThreadId,
-    undo,
-    toggleLayout,
-    isFocusMode,
-    layout,
-  ]);
+  })();
 
   useShortcuts(handlers);
 
@@ -293,11 +319,11 @@ export function MailShell() {
         value: null,
         group: "state",
       },
-      ...(showCategories ? CATEGORY_OPTIONS : []).map((category) => ({
-        id: `category:${category.value}`,
+      ...(showCategories ? MAIL_CATEGORIES : []).map((category) => ({
+        id: `category:${category.type}`,
         name: category.name,
         kind: MailSplitKind.CATEGORY,
-        value: category.value,
+        value: category.type,
         group: "category" as const,
       })),
       ...visibleLabels.map((label) => ({
@@ -314,8 +340,8 @@ export function MailShell() {
   const onCreateSplit = useCallback(
     async (draft: NewSplitDraft) => {
       const result = await createMailSplitAction(emailAccountId, draft);
-      if (result?.serverError) {
-        toast.error(result.serverError);
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
         return;
       }
       mutateSettings();
@@ -326,7 +352,13 @@ export function MailShell() {
   const onDeleteSplit = useCallback(
     async (splitId: string) => {
       if (activeSplitId === splitId) setActiveSplitId("all");
-      await deleteMailSplitAction(emailAccountId, { id: splitId });
+      const result = await deleteMailSplitAction(emailAccountId, {
+        id: splitId,
+      });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return;
+      }
       mutateSettings();
     },
     [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
@@ -335,16 +367,37 @@ export function MailShell() {
   const onCreateLabel = useCallback(
     async (name: string) => {
       const result = await createLabelAction(emailAccountId, { name });
-      if (result?.serverError) toast.error(result.serverError);
-      else toast.success(`Label "${name}" created`);
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return;
+      }
+      // Without this the label the user just typed doesn't appear until an
+      // unrelated revalidation happens to run.
+      await mutateLabels();
+      toast.success(`Label "${name}" created`);
     },
-    [emailAccountId],
+    [emailAccountId, mutateLabels],
+  );
+
+  const onRemoveLabel = useCallback(
+    async (labelId: string) => {
+      if (!openThreadId) return;
+      const result = await removeThreadLabelAction(emailAccountId, {
+        threadId: openThreadId,
+        labelId,
+      });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return;
+      }
+      refetchOpenThread();
+    },
+    [emailAccountId, openThreadId, refetchOpenThread],
   );
 
   const showList = !isFocusMode && (layout === "split" || !openThreadId);
   const showReader = layout === "split" || Boolean(openThreadId);
-  const showHintBar =
-    !hintBarHidden && !settings?.hintBarDismissed && !isFocusMode;
+  const showHintBar = !settings?.hintBarDismissed && !isFocusMode;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
@@ -361,7 +414,7 @@ export function MailShell() {
             backToAppHref={prefixPath(emailAccountId, "/automation")}
             onCompose={openCompose}
             onCreateLabel={onCreateLabel}
-            onOpenShortcuts={() => setIsHelpOpen(true)}
+            onOpenShortcuts={openShortcuts}
           />
         )}
 
@@ -392,25 +445,30 @@ export function MailShell() {
                 onCreateSplit={onCreateSplit}
               />
             )}
-            <ThreadList
-              threads={threads}
-              layout={layout}
-              userEmail={userEmail}
-              userLabels={userLabels}
-              focusedIndex={clampedIndex}
-              isSelected={selection.isSelected}
-              selectedCount={selection.selectedCount}
-              onOpenThread={openAt}
-              onToggleSelect={selection.toggle}
-              onSelectRangeTo={selection.selectRangeTo}
-              onArchiveSelected={() => runOn(archive)}
-              onDeleteSelected={() => runOn(trash)}
-              onClearSelection={selection.clear}
-              emptyTitle={isLoading ? "Loading…" : "Nothing in this view"}
-              showLoadMore={hasMore}
-              isLoadingMore={Boolean(isLoadingMore)}
-              onLoadMore={loadMore}
-            />
+            <LoadingContent
+              loading={isLoading && !threads.length}
+              error={error}
+            >
+              <ThreadList
+                threads={threads}
+                layout={layout}
+                userEmail={userEmail}
+                userLabels={userLabels}
+                focusedIndex={clampedIndex}
+                isSelected={selection.isSelected}
+                selectedCount={selection.selectedCount}
+                onOpenThread={openAt}
+                onToggleSelect={selection.toggle}
+                onSelectRangeTo={selection.selectRangeTo}
+                onArchiveSelected={archiveTargets}
+                onDeleteSelected={trashTargets}
+                onClearSelection={selection.clear}
+                emptyTitle="Nothing in this view"
+                showLoadMore={hasMore}
+                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMore}
+              />
+            </LoadingContent>
           </section>
         )}
 
@@ -427,13 +485,14 @@ export function MailShell() {
                 ? { index: clampedIndex + 1, total: threads.length }
                 : undefined
             }
-            labelHref={(labelId) => hrefFor({ kind: "label", labelId })}
+            labelHref={labelHref}
+            onRemoveLabel={onRemoveLabel}
             onBack={() => {
               setIsFocusMode(false);
               setOpenThreadId(null);
             }}
-            onArchive={() => runOn(archive)}
-            onDelete={() => runOn(trash)}
+            onArchive={archiveTargets}
+            onDelete={trashTargets}
             onReply={() => setReplyToMessageId(openMessages?.at(-1)?.id)}
             onToggleFocusMode={() => setIsFocusMode((on) => !on)}
             refetch={refetchOpenThread}
@@ -454,12 +513,7 @@ export function MailShell() {
       {showHintBar && (
         <HintBar
           status={`${threads.length} in view`}
-          onDismiss={() => {
-            setHintBarHidden(true);
-            updateMailPreferencesAction(emailAccountId, {
-              hintBarDismissed: true,
-            });
-          }}
+          onDismiss={() => savePreferences({ hintBarDismissed: true })}
         />
       )}
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -40,6 +40,8 @@ export type MailSidebarProps = {
   labels: EmailLabel[];
   /** Keyed by provider label id. Arrives after first paint; may be empty. */
   countsById: Map<string, LabelCount>;
+  /** Gmail-only concept, so Outlook accounts hide the section entirely. */
+  showCategories: boolean;
   backToAppHref: string;
   backToAppLabel?: string;
   onBackToApp?: () => void;
@@ -71,6 +73,7 @@ export function MailSidebar({
   hrefFor,
   labels,
   countsById,
+  showCategories,
   backToAppHref,
   backToAppLabel = "Inbox Zero",
   onBackToApp,
@@ -135,20 +138,24 @@ export function MailSidebar({
           ))}
         </nav>
 
-        <GroupHeading>Categories</GroupHeading>
-        <nav className="flex flex-col gap-px">
-          {CATEGORY_ITEMS.map(({ name, type, Icon }) => (
-            <NavRow
-              key={type}
-              href={hrefFor({ kind: "type", type })}
-              active={!activeLabelId && activeType === type}
-              onSelect={() => onSelectView?.({ kind: "type", type })}
-              icon={<Icon className="size-3.5 shrink-0" />}
-              name={name}
-              count={displayCount(countsById.get(type))}
-            />
-          ))}
-        </nav>
+        {showCategories && (
+          <>
+            <GroupHeading>Categories</GroupHeading>
+            <nav className="flex flex-col gap-px">
+              {CATEGORY_ITEMS.map(({ name, type, Icon }) => (
+                <NavRow
+                  key={type}
+                  href={hrefFor({ kind: "type", type })}
+                  active={!activeLabelId && activeType === type}
+                  onSelect={() => onSelectView?.({ kind: "type", type })}
+                  icon={<Icon className="size-3.5 shrink-0" />}
+                  name={name}
+                  count={displayCount(countsById.get(type))}
+                />
+              ))}
+            </nav>
+          </>
+        )}
 
         <GroupHeading
           action={

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -9,6 +9,7 @@ import {
   FileIcon,
   InboxIcon,
   KeyboardIcon,
+  type LucideIcon,
   MegaphoneIcon,
   MessagesSquareIcon,
   PenLineIcon,
@@ -23,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import type { EmailLabel } from "@/providers/email-label-types";
+import { GmailLabel } from "@/utils/gmail/label";
 import { cn } from "@/utils";
 
 /** Where a sidebar row navigates. Mirrors the mail page's `?type=` query shape. */
@@ -43,10 +45,7 @@ export type MailSidebarProps = {
   /** Gmail-only concept, so Outlook accounts hide the section entirely. */
   showCategories: boolean;
   backToAppHref: string;
-  backToAppLabel?: string;
-  onBackToApp?: () => void;
   onCompose: () => void;
-  onSelectView?: (target: MailNavTarget) => void;
   onCreateLabel: (name: string) => void;
   onOpenShortcuts: () => void;
   className?: string;
@@ -59,13 +58,17 @@ const SYSTEM_ITEMS = [
   { name: "Archived", type: "archive", countId: null, Icon: ArchiveIcon },
 ] as const;
 
-const CATEGORY_ITEMS = [
-  { name: "Personal", type: "CATEGORY_PERSONAL", Icon: UserIcon },
-  { name: "Social", type: "CATEGORY_SOCIAL", Icon: Users2Icon },
-  { name: "Updates", type: "CATEGORY_UPDATES", Icon: BellIcon },
-  { name: "Forums", type: "CATEGORY_FORUMS", Icon: MessagesSquareIcon },
-  { name: "Promotions", type: "CATEGORY_PROMOTIONS", Icon: MegaphoneIcon },
-] as const;
+export const MAIL_CATEGORIES: {
+  name: string;
+  type: string;
+  Icon: LucideIcon;
+}[] = [
+  { name: "Personal", type: GmailLabel.PERSONAL, Icon: UserIcon },
+  { name: "Social", type: GmailLabel.SOCIAL, Icon: Users2Icon },
+  { name: "Updates", type: GmailLabel.UPDATES, Icon: BellIcon },
+  { name: "Forums", type: GmailLabel.FORUMS, Icon: MessagesSquareIcon },
+  { name: "Promotions", type: GmailLabel.PROMOTIONS, Icon: MegaphoneIcon },
+];
 
 export function MailSidebar({
   activeType,
@@ -75,10 +78,7 @@ export function MailSidebar({
   countsById,
   showCategories,
   backToAppHref,
-  backToAppLabel = "Inbox Zero",
-  onBackToApp,
   onCompose,
-  onSelectView,
   onCreateLabel,
   onOpenShortcuts,
   className,
@@ -104,11 +104,10 @@ export function MailSidebar({
     >
       <Link
         href={backToAppHref}
-        onClick={onBackToApp}
         className="mb-2.5 flex shrink-0 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <ArrowLeftIcon className="size-3.5 shrink-0" />
-        <span className="flex-1 truncate">{backToAppLabel}</span>
+        <span className="flex-1 truncate">Inbox Zero</span>
         <Kbd>{getShortcutHint("backToApp")}</Kbd>
       </Link>
 
@@ -129,7 +128,6 @@ export function MailSidebar({
               key={type}
               href={hrefFor({ kind: "type", type })}
               active={!activeLabelId && activeType === type}
-              onSelect={() => onSelectView?.({ kind: "type", type })}
               icon={<Icon className="size-4 shrink-0" />}
               name={name}
               count={countId ? displayCount(countsById.get(countId)) : null}
@@ -142,12 +140,11 @@ export function MailSidebar({
           <>
             <GroupHeading>Categories</GroupHeading>
             <nav className="flex flex-col gap-px">
-              {CATEGORY_ITEMS.map(({ name, type, Icon }) => (
+              {MAIL_CATEGORIES.map(({ name, type, Icon }) => (
                 <NavRow
                   key={type}
                   href={hrefFor({ kind: "type", type })}
                   active={!activeLabelId && activeType === type}
-                  onSelect={() => onSelectView?.({ kind: "type", type })}
                   icon={<Icon className="size-3.5 shrink-0" />}
                   name={name}
                   count={displayCount(countsById.get(type))}
@@ -178,9 +175,6 @@ export function MailSidebar({
               key={label.id}
               href={hrefFor({ kind: "label", labelId: label.id })}
               active={activeLabelId === label.id}
-              onSelect={() =>
-                onSelectView?.({ kind: "label", labelId: label.id })
-              }
               icon={
                 <span
                   className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
@@ -255,7 +249,6 @@ function GroupHeading({
 function NavRow({
   href,
   active,
-  onSelect,
   icon,
   name,
   count,
@@ -263,7 +256,6 @@ function NavRow({
 }: {
   href: string;
   active: boolean;
-  onSelect?: () => void;
   icon: ReactNode;
   name: string;
   count: number | null;
@@ -272,7 +264,6 @@ function NavRow({
   return (
     <Link
       href={href}
-      onClick={onSelect}
       aria-current={active ? "page" : undefined}
       className={cn(
         "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -283,16 +274,18 @@ function NavRow({
     >
       {icon}
       <span className="flex-1 truncate">{name}</span>
-      {count !== null &&
-        (emphasizeCount ? (
-          <span className="shrink-0 rounded-full bg-primary/10 px-1.5 py-px font-medium text-primary text-xs">
-            {count}
-          </span>
-        ) : (
-          <span className="shrink-0 text-muted-foreground text-xs">
-            {count}
-          </span>
-        ))}
+      {count !== null && (
+        <span
+          className={cn(
+            "shrink-0 text-xs",
+            emphasizeCount
+              ? "rounded-full bg-primary/10 px-1.5 py-px font-medium text-primary"
+              : "text-muted-foreground",
+          )}
+        >
+          {count}
+        </span>
+      )}
     </Link>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { type FormEvent, type ReactNode, useState } from "react";
+import Link from "next/link";
+import {
+  ArchiveIcon,
+  ArrowLeftIcon,
+  BellIcon,
+  FileIcon,
+  InboxIcon,
+  KeyboardIcon,
+  MegaphoneIcon,
+  MessagesSquareIcon,
+  PenLineIcon,
+  PlusIcon,
+  SendIcon,
+  UserIcon,
+  Users2Icon,
+} from "lucide-react";
+import type { LabelCount } from "@/app/api/labels/counts/route";
+import { Kbd } from "@/components/Kbd";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import type { EmailLabel } from "@/providers/email-label-types";
+import { cn } from "@/utils";
+
+/** Where a sidebar row navigates. Mirrors the mail page's `?type=` query shape. */
+export type MailNavTarget =
+  | { kind: "type"; type: string }
+  | { kind: "label"; labelId: string };
+
+export type MailSidebarProps = {
+  /** `?type=` of the current view — `inbox` when nothing is selected. */
+  activeType: string | null;
+  /** `?labelId=` of the current view, when a user label is open. */
+  activeLabelId: string | null;
+  /** Builds the href for a row so the sidebar never owns routing. */
+  hrefFor: (target: MailNavTarget) => string;
+  labels: EmailLabel[];
+  /** Keyed by provider label id. Arrives after first paint; may be empty. */
+  countsById: Map<string, LabelCount>;
+  backToAppHref: string;
+  backToAppLabel?: string;
+  onBackToApp?: () => void;
+  onCompose: () => void;
+  onSelectView?: (target: MailNavTarget) => void;
+  onCreateLabel: (name: string) => void;
+  onOpenShortcuts: () => void;
+  className?: string;
+};
+
+const SYSTEM_ITEMS = [
+  { name: "Inbox", type: "inbox", countId: "INBOX", Icon: InboxIcon },
+  { name: "Drafts", type: "draft", countId: "DRAFT", Icon: FileIcon },
+  { name: "Sent", type: "sent", countId: "SENT", Icon: SendIcon },
+  { name: "Archived", type: "archive", countId: null, Icon: ArchiveIcon },
+] as const;
+
+const CATEGORY_ITEMS = [
+  { name: "Personal", type: "CATEGORY_PERSONAL", Icon: UserIcon },
+  { name: "Social", type: "CATEGORY_SOCIAL", Icon: Users2Icon },
+  { name: "Updates", type: "CATEGORY_UPDATES", Icon: BellIcon },
+  { name: "Forums", type: "CATEGORY_FORUMS", Icon: MessagesSquareIcon },
+  { name: "Promotions", type: "CATEGORY_PROMOTIONS", Icon: MegaphoneIcon },
+] as const;
+
+export function MailSidebar({
+  activeType,
+  activeLabelId,
+  hrefFor,
+  labels,
+  countsById,
+  backToAppHref,
+  backToAppLabel = "Inbox Zero",
+  onBackToApp,
+  onCompose,
+  onSelectView,
+  onCreateLabel,
+  onOpenShortcuts,
+  className,
+}: MailSidebarProps) {
+  const [isAddingLabel, setIsAddingLabel] = useState(false);
+  const [newLabelName, setNewLabelName] = useState("");
+
+  const submitNewLabel = (event: FormEvent) => {
+    event.preventDefault();
+    const name = newLabelName.trim();
+    if (!name) return;
+    onCreateLabel(name);
+    setNewLabelName("");
+    setIsAddingLabel(false);
+  };
+
+  return (
+    <aside
+      className={cn(
+        "flex w-[236px] shrink-0 flex-col overflow-hidden border-border border-r bg-sidebar px-2.5 pt-3 pb-2.5",
+        className,
+      )}
+    >
+      <Link
+        href={backToAppHref}
+        onClick={onBackToApp}
+        className="mb-2.5 flex shrink-0 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <ArrowLeftIcon className="size-3.5 shrink-0" />
+        <span className="flex-1 truncate">{backToAppLabel}</span>
+        <Kbd>{getShortcutHint("backToApp")}</Kbd>
+      </Link>
+
+      <Button
+        variant="gradient"
+        onClick={onCompose}
+        className="mb-3.5 w-full shrink-0 justify-start gap-2 rounded-xl px-3"
+      >
+        <PenLineIcon className="size-4 shrink-0" />
+        <span className="flex-1 text-left">Compose</span>
+        <Kbd variant="onColor">{getShortcutHint("compose")}</Kbd>
+      </Button>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <nav className="flex flex-col gap-px">
+          {SYSTEM_ITEMS.map(({ name, type, countId, Icon }) => (
+            <NavRow
+              key={type}
+              href={hrefFor({ kind: "type", type })}
+              active={!activeLabelId && activeType === type}
+              onSelect={() => onSelectView?.({ kind: "type", type })}
+              icon={<Icon className="size-4 shrink-0" />}
+              name={name}
+              count={countId ? displayCount(countsById.get(countId)) : null}
+              emphasizeCount
+            />
+          ))}
+        </nav>
+
+        <GroupHeading>Categories</GroupHeading>
+        <nav className="flex flex-col gap-px">
+          {CATEGORY_ITEMS.map(({ name, type, Icon }) => (
+            <NavRow
+              key={type}
+              href={hrefFor({ kind: "type", type })}
+              active={!activeLabelId && activeType === type}
+              onSelect={() => onSelectView?.({ kind: "type", type })}
+              icon={<Icon className="size-3.5 shrink-0" />}
+              name={name}
+              count={displayCount(countsById.get(type))}
+            />
+          ))}
+        </nav>
+
+        <GroupHeading
+          action={
+            <button
+              type="button"
+              onClick={() => setIsAddingLabel((open) => !open)}
+              aria-expanded={isAddingLabel}
+              aria-label="Create label"
+              className="rounded-md p-0.5 text-muted-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <PlusIcon className="size-3.5" />
+            </button>
+          }
+        >
+          Labels
+        </GroupHeading>
+        <nav className="flex flex-col gap-px">
+          {labels.map((label) => (
+            <NavRow
+              key={label.id}
+              href={hrefFor({ kind: "label", labelId: label.id })}
+              active={activeLabelId === label.id}
+              onSelect={() =>
+                onSelectView?.({ kind: "label", labelId: label.id })
+              }
+              icon={
+                <span
+                  className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
+                  style={
+                    label.color?.backgroundColor
+                      ? { backgroundColor: label.color.backgroundColor }
+                      : undefined
+                  }
+                />
+              }
+              name={label.name}
+              count={displayCount(countsById.get(label.id))}
+            />
+          ))}
+        </nav>
+
+        {isAddingLabel && (
+          <form onSubmit={submitNewLabel} className="flex gap-1.5 px-2.5 py-2">
+            <Input
+              value={newLabelName}
+              onChange={(event) => setNewLabelName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") setIsAddingLabel(false);
+              }}
+              placeholder="Label name"
+              aria-label="New label name"
+              autoFocus
+              className="h-7 min-w-0 flex-1 px-2 text-xs"
+            />
+            <Button
+              type="submit"
+              variant="gradient"
+              size="xs-2"
+              disabled={!newLabelName.trim()}
+            >
+              Add
+            </Button>
+          </form>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onOpenShortcuts}
+        className="mt-2 flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <KeyboardIcon className="size-3.5 shrink-0" />
+        <span className="flex-1 text-left">Keyboard shortcuts</span>
+        <Kbd>{getShortcutHint("help")}</Kbd>
+      </button>
+    </aside>
+  );
+}
+
+function GroupHeading({
+  children,
+  action,
+}: {
+  children: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 px-2.5 pt-4 pb-1.5">
+      <span className="flex-1 font-medium text-muted-foreground text-xs">
+        {children}
+      </span>
+      {action}
+    </div>
+  );
+}
+
+function NavRow({
+  href,
+  active,
+  onSelect,
+  icon,
+  name,
+  count,
+  emphasizeCount,
+}: {
+  href: string;
+  active: boolean;
+  onSelect?: () => void;
+  icon: ReactNode;
+  name: string;
+  count: number | null;
+  emphasizeCount?: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onSelect}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        active
+          ? "bg-background font-medium text-foreground shadow-sm ring-1 ring-border"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      {icon}
+      <span className="flex-1 truncate">{name}</span>
+      {count !== null &&
+        (emphasizeCount ? (
+          <span className="shrink-0 rounded-full bg-primary/10 px-1.5 py-px font-medium text-primary text-xs">
+            {count}
+          </span>
+        ) : (
+          <span className="shrink-0 text-muted-foreground text-xs">
+            {count}
+          </span>
+        ))}
+    </Link>
+  );
+}
+
+/**
+ * Drafts are never unread, so the only number worth showing there is the total.
+ * A zero is noise, so it renders as nothing at all.
+ */
+function displayCount(count: LabelCount | undefined): number | null {
+  if (!count) return null;
+  const value = count.id === "DRAFT" ? count.total : count.unread;
+  return value > 0 ? value : null;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailThemeScope.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailThemeScope.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Applies the Mail palette by stamping `data-theme="mail"` on the document root.
+ *
+ * It has to be the root rather than a wrapper element: Radix renders dropdowns,
+ * dialogs and tooltips into a portal on <body>, so a wrapper-scoped theme would
+ * leave every popover painted in the app's default palette on top of this screen.
+ *
+ * next-themes drives dark mode through a class, so an attribute doesn't collide.
+ */
+export function MailThemeScope() {
+  useEffect(() => {
+    const { documentElement } = document;
+    const previous = documentElement.dataset.theme;
+    documentElement.dataset.theme = "mail";
+
+    return () => {
+      if (previous === undefined) delete documentElement.dataset.theme;
+      else documentElement.dataset.theme = previous;
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/utils";
+
+/** Display grouping only — "To reply" is a LABEL split that belongs under State. */
+export type NewSplitOptionGroup = "state" | "category" | "label";
+
+export type NewSplitOption = {
+  /** Unique across every group; identifies the choice, not the split. */
+  id: string;
+  name: string;
+  kind: MailSplitKind;
+  /** Label id or category key the split filters on. `null` for ALL/UNREAD. */
+  value: string | null;
+  group: NewSplitOptionGroup;
+};
+
+export type NewSplitDraft = {
+  name: string;
+  kind: MailSplitKind;
+  value: string | null;
+};
+
+export type NewSplitPopoverProps = {
+  options: NewSplitOption[];
+  onCreate: (draft: NewSplitDraft) => void;
+  isCreating?: boolean;
+  align?: "start" | "center" | "end";
+  className?: string;
+};
+
+const GROUP_TITLES: { group: NewSplitOptionGroup; title: string }[] = [
+  { group: "state", title: "State" },
+  { group: "category", title: "Category" },
+  { group: "label", title: "Label" },
+];
+
+export function NewSplitPopover({
+  options,
+  onCreate,
+  isCreating,
+  align = "start",
+  className,
+}: NewSplitPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+
+  const selected = options.find((option) => option.id === selectedId);
+
+  const changeOpen = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setSelectedId(null);
+      setName("");
+    }
+  };
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!selected) return;
+    onCreate({
+      name: name.trim() || selected.name,
+      kind: selected.kind,
+      value: selected.value,
+    });
+    changeOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={changeOpen}>
+      <PopoverTrigger
+        aria-label="New split"
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className,
+        )}
+      >
+        <PlusIcon className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent align={align} className="w-80 p-3 text-foreground">
+        <form onSubmit={submit}>
+          <p className="mb-2.5 font-medium text-foreground text-xs">
+            New split
+          </p>
+
+          <div className="mb-3 flex flex-col gap-2.5">
+            {GROUP_TITLES.map(({ group, title }) => {
+              const groupOptions = options.filter(
+                (option) => option.group === group,
+              );
+              if (!groupOptions.length) return null;
+
+              return (
+                <fieldset key={group} className="flex flex-col gap-1.5">
+                  <legend className="text-muted-foreground text-xs">
+                    {title}
+                  </legend>
+                  <div className="flex flex-wrap gap-1.5">
+                    {groupOptions.map((option) => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        aria-pressed={option.id === selectedId}
+                        onClick={() => {
+                          setSelectedId(option.id);
+                          setName(option.name);
+                        }}
+                        className={cn(
+                          "rounded-full border px-2.5 py-0.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          option.id === selectedId
+                            ? "border-primary/30 bg-primary/10 text-primary"
+                            : "border-border bg-muted text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {option.name}
+                      </button>
+                    ))}
+                  </div>
+                </fieldset>
+              );
+            })}
+          </div>
+
+          <p className="mb-2.5 rounded-lg border border-border bg-muted px-2.5 py-2 text-muted-foreground text-xs">
+            {summarize(selected)}
+          </p>
+
+          <Input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Name this split"
+            aria-label="Split name"
+            className="mb-2.5 h-8 text-xs"
+          />
+
+          <div className="flex gap-2">
+            <Button
+              type="submit"
+              variant="gradient"
+              size="xs-2"
+              disabled={!selected}
+              loading={isCreating}
+            >
+              Add split
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs-2"
+              onClick={() => changeOpen(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function summarize(option: NewSplitOption | undefined): string {
+  if (!option) return "Pick what this split should contain";
+  switch (option.kind) {
+    case MailSplitKind.ALL:
+      return "Shows everything in this view";
+    case MailSplitKind.UNREAD:
+      return "Shows unread mail";
+    case MailSplitKind.CATEGORY:
+      return `Shows mail in the ${option.name} category`;
+    default:
+      return `Shows mail labelled ${option.name}`;
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -172,8 +172,8 @@ export function NewSplitPopover({
 function summarize(option: NewSplitOption | undefined): string {
   if (!option) return "Pick what this split should contain";
   switch (option.kind) {
-    case MailSplitKind.ALL:
-      return "Shows everything in this view";
+    case MailSplitKind.INBOX:
+      return "Shows everything in the inbox";
     case MailSplitKind.UNREAD:
       return "Shows unread mail";
     case MailSplitKind.CATEGORY:

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -34,9 +34,6 @@ export type NewSplitDraft = {
 export type NewSplitPopoverProps = {
   options: NewSplitOption[];
   onCreate: (draft: NewSplitDraft) => void;
-  isCreating?: boolean;
-  align?: "start" | "center" | "end";
-  className?: string;
 };
 
 const GROUP_TITLES: { group: NewSplitOptionGroup; title: string }[] = [
@@ -45,13 +42,7 @@ const GROUP_TITLES: { group: NewSplitOptionGroup; title: string }[] = [
   { group: "label", title: "Label" },
 ];
 
-export function NewSplitPopover({
-  options,
-  onCreate,
-  isCreating,
-  align = "start",
-  className,
-}: NewSplitPopoverProps) {
+export function NewSplitPopover({ options, onCreate }: NewSplitPopoverProps) {
   const [open, setOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -81,14 +72,11 @@ export function NewSplitPopover({
     <Popover open={open} onOpenChange={changeOpen}>
       <PopoverTrigger
         aria-label="New split"
-        className={cn(
-          "flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          className,
-        )}
+        className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <PlusIcon className="size-3.5" />
       </PopoverTrigger>
-      <PopoverContent align={align} className="w-80 p-3 text-foreground">
+      <PopoverContent align="start" className="w-80 p-3 text-foreground">
         <form onSubmit={submit}>
           <p className="mb-2.5 font-medium text-foreground text-xs">
             New split
@@ -150,7 +138,6 @@ export function NewSplitPopover({
               variant="gradient"
               size="xs-2"
               disabled={!selected}
-              loading={isCreating}
             >
               Add split
             </Button>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  ArchiveIcon,
+  ArrowLeftIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  ReplyIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
+import { Kbd } from "@/components/Kbd";
+import { Button } from "@/components/ui/button";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+
+export type ReaderToolbarProps = {
+  subject: string;
+  /** Display name of the other party. Falls back to the address when absent. */
+  senderName: string;
+  senderEmail: string;
+  labels: { id: string; name: string }[];
+  /**
+   * Chips navigate to a label's view and nothing else: a label carries no
+   * reason, because several rules — or none at all — can put one on a thread.
+   * The "why" is rule-scoped and lives in `menu`.
+   */
+  labelHref: (labelId: string) => string;
+  onRemoveLabel?: (labelId: string) => void;
+  layout: MailLayoutMode;
+  isFocusMode: boolean;
+  /** 1-based position of the open thread in the list, for the "N of M" readout. */
+  position?: { index: number; total: number };
+  onBack: () => void;
+  onArchive: () => void;
+  onReply: () => void;
+  onDelete: () => void;
+  onToggleFocusMode: () => void;
+  /** The ⋯ dropdown, i.e. `RuleAttributionMenu`, composed by the shell. */
+  menu?: ReactNode;
+};
+
+/**
+ * The reader's header: what the thread is, and what you can do to it.
+ * In `list` layout the list is hidden behind the reader, so it also carries the
+ * way back and the position in the list.
+ */
+export function ReaderToolbar({
+  subject,
+  senderName,
+  senderEmail,
+  labels,
+  labelHref,
+  onRemoveLabel,
+  layout,
+  isFocusMode,
+  position,
+  onBack,
+  onArchive,
+  onReply,
+  onDelete,
+  onToggleFocusMode,
+  menu,
+}: ReaderToolbarProps) {
+  const showBackBar = layout === "list" && !isFocusMode;
+  const FocusIcon = isFocusMode ? MinimizeIcon : MaximizeIcon;
+
+  return (
+    <div>
+      {showBackBar ? (
+        <div className="-mx-1 sticky top-0 z-10 mb-4 flex items-center gap-3 bg-background px-1 py-2">
+          <Button onClick={onBack} size="xs-2" variant="outline">
+            <ArrowLeftIcon className="mr-1.5 size-3.5" />
+            Back
+            <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
+          </Button>
+          {position ? (
+            <span className="font-mono text-muted-foreground text-xs">
+              {`${position.index} of ${position.total}`}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-start gap-x-4 gap-y-3 border-border border-b pb-4">
+        <div className="min-w-56 flex-1">
+          <h1 className="font-title font-medium text-2xl text-foreground leading-tight tracking-tight">
+            {subject}
+          </h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground text-sm">
+              {senderName}
+            </span>
+            {senderEmail && senderEmail !== senderName ? (
+              <span className="text-muted-foreground text-sm">
+                {senderEmail}
+              </span>
+            ) : null}
+            {labels.map((label) => (
+              <MailLabelChip
+                href={labelHref(label.id)}
+                key={label.id}
+                name={label.name}
+                onRemove={
+                  onRemoveLabel ? () => onRemoveLabel(label.id) : undefined
+                }
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="ml-auto flex flex-wrap items-center gap-1.5">
+          <Button onClick={onArchive} size="xs-2" variant="outline">
+            <ArchiveIcon className="mr-1.5 size-3.5" />
+            Archive
+            <Kbd className="ml-1.5">{getShortcutHint("archive")}</Kbd>
+          </Button>
+          <Button onClick={onReply} size="xs-2" variant="outline">
+            <ReplyIcon className="mr-1.5 size-3.5" />
+            Reply
+            <Kbd className="ml-1.5">{getShortcutHint("reply")}</Kbd>
+          </Button>
+          <Button
+            aria-label={`Delete (${getShortcutHint("delete")})`}
+            className="h-7 w-7 hover:border-destructive/30 hover:bg-destructive/5 hover:text-destructive"
+            onClick={onDelete}
+            size="icon"
+            title={`Delete (${getShortcutHint("delete")})`}
+            variant="outline"
+          >
+            <Trash2Icon className="size-3.5" />
+          </Button>
+          <Button
+            aria-label={`${isFocusMode ? "Exit focus mode" : "Focus mode"} (${getShortcutHint("focusMode")})`}
+            aria-pressed={isFocusMode}
+            className="h-7 w-7"
+            onClick={onToggleFocusMode}
+            size="icon"
+            title={`${isFocusMode ? "Exit focus mode" : "Focus mode"} (${getShortcutHint("focusMode")})`}
+            variant="outline"
+          >
+            <FocusIcon className="size-3.5" />
+          </Button>
+          {menu}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
@@ -9,8 +9,6 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
@@ -33,29 +31,17 @@ export type RuleAttributionMenuProps = {
   setChatInput: (input: string) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onMarkUnread?: () => void;
-  onMuteThread?: () => void;
-  onUnsubscribe?: () => void;
 };
 
-/** The reader's ⋯ menu: why the thread looks the way it does, and thread-level actions. */
+/** The reader's ⋯ menu: why the thread looks the way it does. */
 export function RuleAttributionMenu({
   plans,
   message,
   setChatInput,
   open,
   onOpenChange,
-  onMarkUnread,
-  onMuteThread,
-  onUnsubscribe,
 }: RuleAttributionMenuProps) {
-  const threadActions = [
-    { label: "Mark as unread", onSelect: onMarkUnread },
-    { label: "Mute thread", onSelect: onMuteThread },
-    { label: "Unsubscribe", onSelect: onUnsubscribe },
-  ].filter((action) => Boolean(action.onSelect));
-
-  if (plans.length === 0 && threadActions.length === 0) return null;
+  if (!plans.length) return null;
 
   const hint = getShortcutHint("moreActions");
 
@@ -81,16 +67,6 @@ export function RuleAttributionMenu({
             plan={plan}
             setChatInput={setChatInput}
           />
-        ))}
-
-        {plans.length > 0 && threadActions.length > 0 ? (
-          <DropdownMenuSeparator />
-        ) : null}
-
-        {threadActions.map((action) => (
-          <DropdownMenuItem key={action.label} onSelect={action.onSelect}>
-            {action.label}
-          </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
@@ -156,9 +132,12 @@ function RuleAttribution({
 }
 
 /**
- * The list payload drops `ExecutedRule.createdAt`, which the fix dialog only
- * uses to group results into batches. One rule is one batch, so a constant
- * stands in rather than inventing an execution time.
+ * `ThreadPlan` has no `createdAt`: the list route uses it to pick each rule's
+ * latest execution and then drops it. `ResultsDisplay`, inside `FixWithChat`,
+ * still requires one — but only as the key it groups and orders batches by, and
+ * never renders it. Each menu entry passes a single result, so grouping has
+ * nothing to do and any constant serves; a sentinel is honest about the
+ * execution time being unknown here, where a real date would be invented.
  */
 const FIX_RESULT_BATCH = new Date(0);
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { MoreHorizontalIcon } from "lucide-react";
+import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
+import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
+import type { ParsedMessage } from "@/utils/types";
+
+type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
+
+export type RuleAttributionMenuProps = {
+  /**
+   * Every rule that fired on the thread, newest first. Attribution is
+   * rule-scoped, not label-scoped: one entry per rule, each with its own reason,
+   * the actions it applied, and its own way to correct it.
+   */
+  plans: ThreadPlan[];
+  /** The message the fix flow reasons about — the thread's latest message. */
+  message: ParsedMessage | null;
+  /** `setInput` from `useChat()`: the fix flow seeds the assistant with it. */
+  setChatInput: (input: string) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onMarkUnread?: () => void;
+  onMuteThread?: () => void;
+  onUnsubscribe?: () => void;
+};
+
+/** The reader's ⋯ menu: why the thread looks the way it does, and thread-level actions. */
+export function RuleAttributionMenu({
+  plans,
+  message,
+  setChatInput,
+  open,
+  onOpenChange,
+  onMarkUnread,
+  onMuteThread,
+  onUnsubscribe,
+}: RuleAttributionMenuProps) {
+  const threadActions = [
+    { label: "Mark as unread", onSelect: onMarkUnread },
+    { label: "Mute thread", onSelect: onMuteThread },
+    { label: "Unsubscribe", onSelect: onUnsubscribe },
+  ].filter((action) => Boolean(action.onSelect));
+
+  if (plans.length === 0 && threadActions.length === 0) return null;
+
+  const hint = getShortcutHint("moreActions");
+
+  return (
+    <DropdownMenu onOpenChange={onOpenChange} open={open}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label={`More actions (${hint})`}
+          className="h-7 w-7"
+          size="icon"
+          title={`More actions (${hint})`}
+          variant="outline"
+        >
+          <MoreHorizontalIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-80">
+        {plans.map((plan) => (
+          <RuleAttribution
+            key={plan.id}
+            message={message}
+            plan={plan}
+            setChatInput={setChatInput}
+          />
+        ))}
+
+        {plans.length > 0 && threadActions.length > 0 ? (
+          <DropdownMenuSeparator />
+        ) : null}
+
+        {threadActions.map((action) => (
+          <DropdownMenuItem key={action.label} onSelect={action.onSelect}>
+            {action.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function RuleAttribution({
+  plan,
+  message,
+  setChatInput,
+}: {
+  plan: ThreadPlan;
+  message: ParsedMessage | null;
+  setChatInput: (input: string) => void;
+}) {
+  const actions = getVisibleActions(plan.actionItems);
+  const labels = actions.filter(
+    (action) => action.type === ActionType.LABEL && action.label,
+  );
+  const otherActions = actions.filter(
+    (action) => action.type !== ActionType.LABEL,
+  );
+
+  return (
+    <div className="border-border border-b px-2 py-2.5 last:border-b-0">
+      <div className="text-muted-foreground text-xs">
+        {plan.status === ExecutedRuleStatus.APPLIED ? "Applied by" : "Matched"}{" "}
+        <span className="font-medium text-foreground">
+          {plan.rule?.name ?? "a deleted rule"}
+        </span>
+      </div>
+
+      {plan.reason ? (
+        <p className="mt-1.5 text-foreground text-xs leading-relaxed">
+          {plan.reason}
+        </p>
+      ) : null}
+
+      {labels.length > 0 || otherActions.length > 0 ? (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          {labels.map((action) => (
+            <MailLabelChip key={action.id} name={action.label ?? ""} />
+          ))}
+          {otherActions.map((action) => (
+            <span className="text-muted-foreground text-xs" key={action.id}>
+              {ACTION_TYPE_LABELS[action.type]}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {message ? (
+        <div className="mt-2.5">
+          <FixWithChat
+            message={message}
+            results={toFixResults(plan)}
+            setInput={setChatInput}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The list payload drops `ExecutedRule.createdAt`, which the fix dialog only
+ * uses to group results into batches. One rule is one batch, so a constant
+ * stands in rather than inventing an execution time.
+ */
+const FIX_RESULT_BATCH = new Date(0);
+
+function toFixResults(plan: ThreadPlan): FixWithChatResults {
+  return [
+    {
+      rule: plan.rule,
+      actionItems: plan.actionItems,
+      reason: plan.reason,
+      status: plan.status,
+      createdAt: FIX_RESULT_BATCH,
+    },
+  ];
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/Kbd";
+
+export type SelectionBarProps = {
+  selectedCount: number;
+  onArchive: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+};
+
+/** The band above the list. Rendered only while the selection is non-empty. */
+export function SelectionBar({
+  selectedCount,
+  onArchive,
+  onDelete,
+  onClear,
+}: SelectionBarProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-primary/20 border-b bg-primary/5 px-3.5 py-2">
+      <span
+        aria-live="polite"
+        className="font-medium text-primary text-xs"
+      >{`${selectedCount} selected`}</span>
+
+      <div className="flex-1" />
+
+      <Button onClick={onArchive} size="xs-2" variant="outline">
+        Archive
+        <Kbd className="ml-1.5">{getShortcutHint("archive")}</Kbd>
+      </Button>
+      <Button
+        className="hover:border-destructive/30 hover:bg-destructive/5 hover:text-destructive"
+        onClick={onDelete}
+        size="xs-2"
+        variant="outline"
+      >
+        Delete
+        <Kbd className="ml-1.5">{getShortcutHint("delete")}</Kbd>
+      </Button>
+      <Button onClick={onClear} size="xs-2" variant="ghost">
+        Clear
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ShortcutsDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ShortcutsDialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Kbd } from "@/components/Kbd";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  formatShortcutKeys,
+  getShortcutGroups,
+  type ShortcutScope,
+} from "@/lib/shortcuts/registry";
+
+const SCOPES: readonly ShortcutScope[] = ["global", "mail"];
+
+export type ShortcutsDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * Rendered straight from the shortcut registry, so a binding can never be
+ * documented here without also being bound — or bound without being documented.
+ */
+export function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  const groups = getShortcutGroups(SCOPES);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Everything here works without the mouse.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          {groups.map(({ group, shortcuts }) => (
+            <div key={group} className="flex flex-col gap-2">
+              <div className="text-xs font-semibold text-primary">{group}</div>
+              {shortcuts.map((shortcut) => (
+                <div key={shortcut.id} className="flex items-center gap-3">
+                  <Kbd className="min-w-9">{formatShortcutKeys(shortcut)}</Kbd>
+                  <span className="text-sm text-foreground">
+                    {shortcut.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -24,7 +24,6 @@ export type SplitTabsProps = {
   onDelete: (splitId: string) => void;
   newSplitOptions: NewSplitOption[];
   onCreateSplit: (draft: NewSplitDraft) => void;
-  isCreatingSplit?: boolean;
   className?: string;
 };
 
@@ -35,7 +34,6 @@ export function SplitTabs({
   onDelete,
   newSplitOptions,
   onCreateSplit,
-  isCreatingSplit,
   className,
 }: SplitTabsProps) {
   return (
@@ -75,11 +73,7 @@ export function SplitTabs({
         );
       })}
 
-      <NewSplitPopover
-        options={newSplitOptions}
-        onCreate={onCreateSplit}
-        isCreating={isCreatingSplit}
-      />
+      <NewSplitPopover options={newSplitOptions} onCreate={onCreateSplit} />
 
       <div className="flex-1" />
       <Kbd title="Next split">{getShortcutHint("nextSplit")}</Kbd>

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import {
+  type NewSplitDraft,
+  type NewSplitOption,
+  NewSplitPopover,
+} from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
+import { Kbd } from "@/components/Kbd";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { cn } from "@/utils";
+
+export type MailSplitTab = {
+  id: string;
+  name: string;
+  /** Built-in splits (e.g. All) can't be removed. */
+  deletable: boolean;
+};
+
+export type SplitTabsProps = {
+  splits: MailSplitTab[];
+  activeSplitId: string | null;
+  onSelect: (splitId: string) => void;
+  onDelete: (splitId: string) => void;
+  newSplitOptions: NewSplitOption[];
+  onCreateSplit: (draft: NewSplitDraft) => void;
+  isCreatingSplit?: boolean;
+  className?: string;
+};
+
+export function SplitTabs({
+  splits,
+  activeSplitId,
+  onSelect,
+  onDelete,
+  newSplitOptions,
+  onCreateSplit,
+  isCreatingSplit,
+  className,
+}: SplitTabsProps) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1", className)}>
+      {splits.map((split) => {
+        const active = split.id === activeSplitId;
+
+        return (
+          <div
+            key={split.id}
+            className={cn(
+              "flex items-center gap-1 rounded-full py-0.5 pr-1 pl-2.5 text-xs",
+              active
+                ? "bg-primary/10 font-medium text-primary"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect(split.id)}
+              aria-current={active ? "true" : undefined}
+              className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {split.name}
+            </button>
+            {active && split.deletable && (
+              <button
+                type="button"
+                onClick={() => onDelete(split.id)}
+                aria-label={`Remove the ${split.name} split`}
+                className="rounded-full p-0.5 text-primary/60 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <XIcon className="size-3" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      <NewSplitPopover
+        options={newSplitOptions}
+        onCreate={onCreateSplit}
+        isCreating={isCreatingSplit}
+      />
+
+      <div className="flex-1" />
+      <Kbd title="Next split">{getShortcutHint("nextSplit")}</Kbd>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
 import { SelectionBar } from "@/app/(app)/[emailAccountId]/mail/SelectionBar";
 import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
 import type {
@@ -15,7 +14,7 @@ export type ThreadListProps = {
   layout: MailLayoutMode;
   userEmail: string;
   userLabels: EmailLabels;
-  /** The row `J`/`K` sits on. `-1` when nothing is focused. */
+  /** The row `J`/`K` sits on. */
   focusedIndex: number;
   isSelected: (threadId: string) => boolean;
   selectedCount: number;
@@ -26,8 +25,6 @@ export type ThreadListProps = {
   onDeleteSelected: () => void;
   onClearSelection: () => void;
   emptyTitle: string;
-  /** Rendered under the empty state, e.g. a "Back to Inbox" button. */
-  emptyAction?: ReactNode;
   showLoadMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
@@ -48,7 +45,6 @@ export function ThreadList({
   onDeleteSelected,
   onClearSelection,
   emptyTitle,
-  emptyAction,
   showLoadMore,
   isLoadingMore,
   onLoadMore,
@@ -69,7 +65,6 @@ export function ThreadList({
             <div className="mt-1.5 text-muted-foreground text-xs">
               Nothing here right now.
             </div>
-            {emptyAction ? <div className="mt-3.5">{emptyAction}</div> : null}
           </div>
         ) : (
           <>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SelectionBar } from "@/app/(app)/[emailAccountId]/mail/SelectionBar";
+import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
+import type {
+  ListThread,
+  MailLayoutMode,
+} from "@/app/(app)/[emailAccountId]/mail/types";
+import { Button } from "@/components/ui/button";
+import type { EmailLabels } from "@/providers/email-label-types";
+
+export type ThreadListProps = {
+  threads: ListThread[];
+  layout: MailLayoutMode;
+  userEmail: string;
+  userLabels: EmailLabels;
+  /** The row `J`/`K` sits on. `-1` when nothing is focused. */
+  focusedIndex: number;
+  isSelected: (threadId: string) => boolean;
+  selectedCount: number;
+  onOpenThread: (index: number) => void;
+  onToggleSelect: (index: number) => void;
+  onSelectRangeTo: (index: number) => void;
+  onArchiveSelected: () => void;
+  onDeleteSelected: () => void;
+  onClearSelection: () => void;
+  emptyTitle: string;
+  /** Rendered under the empty state, e.g. a "Back to Inbox" button. */
+  emptyAction?: ReactNode;
+  showLoadMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+};
+
+export function ThreadList({
+  threads,
+  layout,
+  userEmail,
+  userLabels,
+  focusedIndex,
+  isSelected,
+  selectedCount,
+  onOpenThread,
+  onToggleSelect,
+  onSelectRangeTo,
+  onArchiveSelected,
+  onDeleteSelected,
+  onClearSelection,
+  emptyTitle,
+  emptyAction,
+  showLoadMore,
+  isLoadingMore,
+  onLoadMore,
+}: ThreadListProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <SelectionBar
+        onArchive={onArchiveSelected}
+        onClear={onClearSelection}
+        onDelete={onDeleteSelected}
+        selectedCount={selectedCount}
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        {threads.length === 0 ? (
+          <div className="px-6 py-12 text-center">
+            <div className="text-foreground text-sm">{emptyTitle}</div>
+            <div className="mt-1.5 text-muted-foreground text-xs">
+              Nothing here right now.
+            </div>
+            {emptyAction ? <div className="mt-3.5">{emptyAction}</div> : null}
+          </div>
+        ) : (
+          <>
+            <div aria-label="Conversations" aria-multiselectable role="listbox">
+              {threads.map((thread, index) => (
+                <ThreadRow
+                  hasAnySelection={selectedCount > 0}
+                  index={index}
+                  isFocused={index === focusedIndex}
+                  isSelected={isSelected(thread.id)}
+                  key={thread.id}
+                  layout={layout}
+                  onOpen={onOpenThread}
+                  onSelectRangeTo={onSelectRangeTo}
+                  onToggleSelect={onToggleSelect}
+                  thread={thread}
+                  userEmail={userEmail}
+                  userLabels={userLabels}
+                />
+              ))}
+            </div>
+
+            {showLoadMore ? (
+              <div className="flex justify-center px-4 py-5">
+                <Button
+                  loading={isLoadingMore}
+                  onClick={onLoadMore}
+                  size="sm"
+                  variant="outline"
+                >
+                  Load more
+                </Button>
+              </div>
+            ) : (
+              <div className="px-4 pt-5 pb-10 text-center text-muted-foreground text-xs">
+                That's everything in this view
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MailIcon } from "lucide-react";
+import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
+import type {
+  ListThread,
+  MailLayoutMode,
+} from "@/app/(app)/[emailAccountId]/mail/types";
+import { EmailThread } from "@/components/email-list/EmailThread";
+import type { ThreadMessage } from "@/components/email-list/types";
+import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
+import type { EmailLabels } from "@/providers/email-label-types";
+import {
+  extractEmailAddress,
+  extractNameFromEmail,
+  participant,
+} from "@/utils/email";
+
+export type ThreadReaderProps = {
+  /** The row that is open. `null` renders the empty state. */
+  thread: ListThread | null;
+  /**
+   * The open thread's full messages. The list payload has no bodies, so this
+   * arrives from a second fetch; the header renders before it lands.
+   */
+  messages: ThreadMessage[];
+  userEmail: string;
+  userLabels: EmailLabels;
+  layout: MailLayoutMode;
+  isFocusMode: boolean;
+  /** 1-based position of the open thread in the list. */
+  position?: { index: number; total: number };
+  labelHref: (labelId: string) => string;
+  onRemoveLabel?: (labelId: string) => void;
+  onBack: () => void;
+  onArchive: () => void;
+  onReply: () => void;
+  onDelete: () => void;
+  onToggleFocusMode: () => void;
+  /** Refreshes the open thread after a reply is sent or a draft changes. */
+  refetch: () => void;
+  onSendSuccess?: (messageId: string, threadId: string) => void;
+  /**
+   * Set by the reply action. Left unset the composer still opens on its own for
+   * a message that already has an AI draft.
+   */
+  autoOpenReplyForMessageId?: string;
+  /** The ⋯ dropdown, i.e. `RuleAttributionMenu`, composed by the shell. */
+  menu?: ReactNode;
+  emptyTitle?: string;
+};
+
+export function ThreadReader({
+  thread,
+  messages,
+  userEmail,
+  userLabels,
+  layout,
+  isFocusMode,
+  position,
+  labelHref,
+  onRemoveLabel,
+  onBack,
+  onArchive,
+  onReply,
+  onDelete,
+  onToggleFocusMode,
+  refetch,
+  onSendSuccess,
+  autoOpenReplyForMessageId,
+  menu,
+  emptyTitle = "Nothing selected",
+}: ThreadReaderProps) {
+  const headerMessage = thread?.messages.at(-1);
+
+  if (!thread || !headerMessage) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+        <MailIcon className="size-6 text-muted-foreground" />
+        <div className="text-foreground text-sm">{emptyTitle}</div>
+        <div className="text-muted-foreground text-xs">
+          Pick another view, or head back to the inbox.
+        </div>
+      </div>
+    );
+  }
+
+  const sender = participant(headerMessage, userEmail);
+  const labels =
+    getEmailMessageCellLabels({
+      labelIds: headerMessage.labelIds,
+      userLabels,
+    }) ?? [];
+
+  return (
+    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-background">
+      <div className={readerMeasure({ layout, isFocusMode })}>
+        <ReaderToolbar
+          isFocusMode={isFocusMode}
+          labelHref={labelHref}
+          labels={labels}
+          layout={layout}
+          menu={menu}
+          onArchive={onArchive}
+          onBack={onBack}
+          onDelete={onDelete}
+          onRemoveLabel={onRemoveLabel}
+          onReply={onReply}
+          onToggleFocusMode={onToggleFocusMode}
+          position={position}
+          senderEmail={extractEmailAddress(sender)}
+          senderName={extractNameFromEmail(sender)}
+          subject={headerMessage.headers.subject}
+        />
+
+        {messages.length > 0 ? (
+          // `EmailThread` brings its own panel chrome, which the reader replaces
+          // with a plain measure column.
+          <div className="[&>div]:bg-transparent [&>div]:p-0 [&>div>ul]:mt-0">
+            <EmailThread
+              autoOpenReplyForMessageId={autoOpenReplyForMessageId}
+              key={thread.id}
+              messages={messages}
+              onSendSuccess={onSendSuccess}
+              refetch={refetch}
+              showReplyButton
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** A readable measure, centred whenever the reader owns the full width. */
+function readerMeasure({
+  layout,
+  isFocusMode,
+}: {
+  layout: MailLayoutMode;
+  isFocusMode: boolean;
+}) {
+  // ~860px: the mock's measure, and about as wide as an email body stays legible.
+  if (isFocusMode) return "mx-auto w-full max-w-[54rem] px-10 py-10";
+  if (layout === "split") return "px-6 py-5";
+  return "mx-auto w-full max-w-[54rem] px-6 py-5";
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -40,7 +40,6 @@ export type ThreadReaderProps = {
   onToggleFocusMode: () => void;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
   refetch: () => void;
-  onSendSuccess?: (messageId: string, threadId: string) => void;
   /**
    * Set by the reply action. Left unset the composer still opens on its own for
    * a message that already has an AI draft.
@@ -48,7 +47,6 @@ export type ThreadReaderProps = {
   autoOpenReplyForMessageId?: string;
   /** The ⋯ dropdown, i.e. `RuleAttributionMenu`, composed by the shell. */
   menu?: ReactNode;
-  emptyTitle?: string;
 };
 
 export function ThreadReader({
@@ -67,10 +65,8 @@ export function ThreadReader({
   onDelete,
   onToggleFocusMode,
   refetch,
-  onSendSuccess,
   autoOpenReplyForMessageId,
   menu,
-  emptyTitle = "Nothing selected",
 }: ThreadReaderProps) {
   const headerMessage = thread?.messages.at(-1);
 
@@ -78,7 +74,7 @@ export function ThreadReader({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 px-6 py-16 text-center">
         <MailIcon className="size-6 text-muted-foreground" />
-        <div className="text-foreground text-sm">{emptyTitle}</div>
+        <div className="text-foreground text-sm">Nothing selected</div>
         <div className="text-muted-foreground text-xs">
           Pick another view, or head back to the inbox.
         </div>
@@ -115,14 +111,14 @@ export function ThreadReader({
         />
 
         {messages.length > 0 ? (
-          // `EmailThread` brings its own panel chrome, which the reader replaces
-          // with a plain measure column.
+          // Workaround: `EmailThread` bakes in its own panel chrome, so the
+          // reader strips it from the outside to get a plain measure column.
+          // Fixing it properly means giving `EmailThread` a chrome-less mode.
           <div className="[&>div]:bg-transparent [&>div]:p-0 [&>div>ul]:mt-0">
             <EmailThread
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
               key={thread.id}
               messages={messages}
-              onSendSuccess={onSendSuccess}
               refetch={refetch}
               showReplyButton
             />

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { memo, useMemo } from "react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type {
-  ListMessage,
   ListThread,
   MailLayoutMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
@@ -15,6 +15,9 @@ import { cn } from "@/utils";
 import { internalDateToDate } from "@/utils/date";
 import { extractNameFromEmail, participant } from "@/utils/email";
 import { decodeSnippet } from "@/utils/gmail/decode";
+import { GmailLabel } from "@/utils/gmail/label";
+
+const SELECT_HINT = getShortcutHint("select");
 
 export type ThreadRowProps = {
   thread: ListThread;
@@ -32,7 +35,7 @@ export type ThreadRowProps = {
   onSelectRangeTo: (index: number) => void;
 };
 
-export function ThreadRow({
+export const ThreadRow = memo(function ThreadRow({
   thread,
   index,
   layout,
@@ -46,20 +49,27 @@ export function ThreadRow({
   onSelectRangeTo,
 }: ThreadRowProps) {
   const message = thread.messages.at(-1);
+
+  const labels = useMemo(
+    () =>
+      getEmailMessageCellLabels({
+        labelIds: message?.labelIds,
+        userLabels,
+      }) ?? [],
+    [message?.labelIds, userLabels],
+  );
+
   if (!message) return null;
 
-  const isUnread = message.labelIds?.includes(UNREAD_LABEL) ?? false;
-  const isDraft = message.labelIds?.includes(DRAFT_LABEL) ?? false;
+  // Both providers normalise to these ids, so this is not a provider branch.
+  const isUnread = message.labelIds?.includes(GmailLabel.UNREAD) ?? false;
+  const isDraft = message.labelIds?.includes(GmailLabel.DRAFT) ?? false;
   const isWide = layout === "list";
 
   const sender = extractNameFromEmail(participant(message, userEmail));
   const subject = message.headers.subject;
   const snippet = decodeSnippet(thread.snippet || message.snippet);
-  const chips =
-    getEmailMessageCellLabels({
-      labelIds: message.labelIds,
-      userLabels,
-    })?.slice(0, isWide ? 3 : 2) ?? [];
+  const chips = labels.slice(0, isWide ? 3 : 2);
 
   const checkbox = (
     <Checkbox
@@ -77,7 +87,7 @@ export function ThreadRow({
         if (event.shiftKey) onSelectRangeTo(index);
         else onToggleSelect(index);
       }}
-      title={`Select (${getShortcutHint("select")})`}
+      title={`Select (${SELECT_HINT})`}
     />
   );
 
@@ -97,7 +107,13 @@ export function ThreadRow({
     </span>
   );
 
-  const date = <ThreadRowDate message={message} />;
+  // `EmailDate` is shared with the old list, which sets a heavier type ramp.
+  const date = (
+    <EmailDate
+      className="font-normal text-xs"
+      date={internalDateToDate(message.internalDate)}
+    />
+  );
   const draftMarker = isDraft ? (
     <span className="shrink-0 text-primary text-sm">Draft</span>
   ) : null;
@@ -204,20 +220,7 @@ export function ThreadRow({
       )}
     </div>
   );
-}
-
-// Both providers normalise to these ids, so this is not a provider branch.
-const UNREAD_LABEL = "UNREAD";
-const DRAFT_LABEL = "DRAFT";
-
-/** `EmailDate` is shared with the old list, which sets a heavier type ramp. */
-function ThreadRowDate({ message }: { message: ListMessage }) {
-  return (
-    <div className="[&>div]:font-normal [&>div]:text-xs">
-      <EmailDate date={internalDateToDate(message.internalDate)} />
-    </div>
-  );
-}
+});
 
 function rowBackground({
   isSelected,

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -112,7 +112,9 @@ export function ThreadRow({
           : "items-start gap-2 px-3.5 py-2.5",
         rowBackground({ isSelected, isFocused }),
         isFocused &&
-          "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary before:content-['']",
+          // Inset so the marker reads as a marker rather than a border, and so
+          // the first row's doesn't run into the tab bar above it.
+          "before:absolute before:inset-y-1 before:left-0 before:w-0.5 before:rounded-full before:bg-primary before:content-['']",
       )}
       onClick={(event) => {
         if (event.shiftKey) onSelectRangeTo(index);

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import type {
+  ListMessage,
+  ListThread,
+  MailLayoutMode,
+} from "@/app/(app)/[emailAccountId]/mail/types";
+import { EmailDate } from "@/components/email-list/EmailDate";
+import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { EmailLabels } from "@/providers/email-label-types";
+import { cn } from "@/utils";
+import { internalDateToDate } from "@/utils/date";
+import { extractNameFromEmail, participant } from "@/utils/email";
+import { decodeSnippet } from "@/utils/gmail/decode";
+
+export type ThreadRowProps = {
+  thread: ListThread;
+  /** Position in the rendered list — selection and focus are index-addressed. */
+  index: number;
+  layout: MailLayoutMode;
+  userEmail: string;
+  userLabels: EmailLabels;
+  isFocused: boolean;
+  isSelected: boolean;
+  /** Keeps every checkbox visible once the list has a selection. */
+  hasAnySelection: boolean;
+  onOpen: (index: number) => void;
+  onToggleSelect: (index: number) => void;
+  onSelectRangeTo: (index: number) => void;
+};
+
+export function ThreadRow({
+  thread,
+  index,
+  layout,
+  userEmail,
+  userLabels,
+  isFocused,
+  isSelected,
+  hasAnySelection,
+  onOpen,
+  onToggleSelect,
+  onSelectRangeTo,
+}: ThreadRowProps) {
+  const message = thread.messages.at(-1);
+  if (!message) return null;
+
+  const isUnread = message.labelIds?.includes(UNREAD_LABEL) ?? false;
+  const isDraft = message.labelIds?.includes(DRAFT_LABEL) ?? false;
+  const isWide = layout === "list";
+
+  const sender = extractNameFromEmail(participant(message, userEmail));
+  const subject = message.headers.subject;
+  const snippet = decodeSnippet(thread.snippet || message.snippet);
+  const chips =
+    getEmailMessageCellLabels({
+      labelIds: message.labelIds,
+      userLabels,
+    })?.slice(0, isWide ? 3 : 2) ?? [];
+
+  const checkbox = (
+    <Checkbox
+      aria-label={`Select conversation from ${sender}`}
+      checked={isSelected}
+      className={cn(
+        "size-3.5 shrink-0 rounded border-input transition-opacity [&_svg]:size-2.5",
+        isSelected || hasAnySelection
+          ? "opacity-100"
+          : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100",
+        isWide ? null : "mt-0.5",
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (event.shiftKey) onSelectRangeTo(index);
+        else onToggleSelect(index);
+      }}
+      title={`Select (${getShortcutHint("select")})`}
+    />
+  );
+
+  const unreadDot = (
+    <span
+      className={cn(
+        "flex w-1.5 shrink-0 justify-center",
+        isWide ? "items-center" : "pt-1.5",
+      )}
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full",
+          isUnread ? "bg-primary" : "bg-transparent",
+        )}
+      />
+    </span>
+  );
+
+  const date = <ThreadRowDate message={message} />;
+  const draftMarker = isDraft ? (
+    <span className="shrink-0 text-primary text-sm">Draft</span>
+  ) : null;
+
+  return (
+    <div
+      aria-selected={isSelected}
+      className={cn(
+        "group relative flex cursor-pointer border-b border-border/60 outline-none",
+        isWide
+          ? "items-center gap-3 py-2.5 pr-5 pl-3"
+          : "items-start gap-2 px-3.5 py-2.5",
+        rowBackground({ isSelected, isFocused }),
+        isFocused &&
+          "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary before:content-['']",
+      )}
+      onClick={(event) => {
+        if (event.shiftKey) onSelectRangeTo(index);
+        else onOpen(index);
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        onOpen(index);
+      }}
+      role="option"
+      tabIndex={isFocused ? 0 : -1}
+    >
+      {checkbox}
+      {unreadDot}
+
+      {isWide ? (
+        <>
+          <div className="flex w-48 shrink-0 items-baseline overflow-hidden whitespace-nowrap">
+            <span
+              className={cn(
+                "truncate text-foreground text-sm",
+                isUnread && "font-semibold",
+              )}
+            >
+              {sender}
+            </span>
+          </div>
+          <div className="flex min-w-0 flex-1 items-center gap-2.5">
+            {chips.map((label) => (
+              <MailLabelChip key={label.id} name={label.name} />
+            ))}
+            <span
+              className={cn(
+                "max-w-[46%] shrink-0 truncate whitespace-nowrap text-sm",
+                isUnread
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              {subject}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground text-sm">
+              {snippet}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {draftMarker}
+            <div className="w-16 text-right">{date}</div>
+          </div>
+        </>
+      ) : (
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className={cn(
+                "min-w-0 flex-1 truncate text-foreground text-sm",
+                isUnread && "font-semibold",
+              )}
+            >
+              {sender}
+            </span>
+            {draftMarker}
+            <div className="ml-auto shrink-0">{date}</div>
+          </div>
+          <div
+            className={cn(
+              "truncate text-sm",
+              isUnread
+                ? "font-medium text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            {subject}
+          </div>
+          <div className="truncate text-muted-foreground text-xs">
+            {snippet}
+          </div>
+          {chips.length ? (
+            <div className="flex flex-wrap gap-1 pt-1">
+              {chips.map((label) => (
+                <MailLabelChip key={label.id} name={label.name} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Both providers normalise to these ids, so this is not a provider branch.
+const UNREAD_LABEL = "UNREAD";
+const DRAFT_LABEL = "DRAFT";
+
+/** `EmailDate` is shared with the old list, which sets a heavier type ramp. */
+function ThreadRowDate({ message }: { message: ListMessage }) {
+  return (
+    <div className="[&>div]:font-normal [&>div]:text-xs">
+      <EmailDate date={internalDateToDate(message.internalDate)} />
+    </div>
+  );
+}
+
+function rowBackground({
+  isSelected,
+  isFocused,
+}: {
+  isSelected: boolean;
+  isFocused: boolean;
+}) {
+  if (isSelected) return "bg-primary/10";
+  if (isFocused) return "bg-primary/5";
+  return "bg-background hover:bg-muted/50";
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
@@ -1,18 +1,16 @@
 import { MailThemeScope } from "@/app/(app)/[emailAccountId]/mail/MailThemeScope";
 import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
-import type { ShortcutScope } from "@/lib/shortcuts/registry";
-
-// CommandK's provider only wraps its own palette, so the mail screen needs its
-// own for react-hotkeys-hook to have any active scope to bind against.
-const SCOPES: readonly ShortcutScope[] = ["global", "mail"];
+import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
 
 export default function MailLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // CommandK's provider only wraps its own palette, so the mail screen needs its
+  // own for react-hotkeys-hook to have any active scope to bind against.
   return (
-    <ShortcutsProvider scopes={SCOPES}>
+    <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
       <MailThemeScope />
       {children}
     </ShortcutsProvider>

--- a/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
@@ -1,0 +1,20 @@
+import { MailThemeScope } from "@/app/(app)/[emailAccountId]/mail/MailThemeScope";
+import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
+import type { ShortcutScope } from "@/lib/shortcuts/registry";
+
+// CommandK's provider only wraps its own palette, so the mail screen needs its
+// own for react-hotkeys-hook to have any active scope to bind against.
+const SCOPES: readonly ShortcutScope[] = ["global", "mail"];
+
+export default function MailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ShortcutsProvider scopes={SCOPES}>
+      <MailThemeScope />
+      {children}
+    </ShortcutsProvider>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/page.tsx
@@ -1,110 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, use } from "react";
-import useSWRInfinite from "swr/infinite";
-import { useSetAtom } from "jotai";
-import { List } from "@/components/email-list/EmailList";
-import { LoadingContent } from "@/components/LoadingContent";
-import type { ThreadsQuery } from "@/utils/threads/validation";
-import type { ThreadsResponse } from "@/app/api/threads/route";
-import { refetchEmailListAtom } from "@/store/email";
+import { MailShell } from "@/app/(app)/[emailAccountId]/mail/MailShell";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { EmailProvider } from "@/providers/EmailProvider";
-import { createSearchParams } from "@/utils/url";
 
-export default function Mail(props: {
-  searchParams: Promise<{ type?: string; labelId?: string }>;
-}) {
-  const searchParams = use(props.searchParams);
-
-  const getKey = (
-    pageIndex: number,
-    previousPageData: ThreadsResponse | null,
-  ) => {
-    if (previousPageData && !previousPageData.nextPageToken) return null;
-
-    const query: ThreadsQuery = {};
-
-    // Handle different query params
-    if (searchParams.type === "label" && searchParams.labelId) {
-      query.labelId = searchParams.labelId;
-    } else if (searchParams.type) {
-      query.type = searchParams.type;
-    }
-
-    // Append nextPageToken for subsequent pages
-    if (pageIndex > 0 && previousPageData?.nextPageToken) {
-      query.nextPageToken = previousPageData.nextPageToken;
-    }
-    const queryParams = createSearchParams(query);
-
-    return `/api/threads?${queryParams.toString()}`;
-  };
-
-  const { data, size, setSize, isLoading, error, mutate } =
-    useSWRInfinite<ThreadsResponse>(getKey, {
-      keepPreviousData: true,
-      dedupingInterval: 1000,
-      revalidateOnFocus: false,
-    });
-
-  const allThreads = data ? data.flatMap((page) => page.threads) : [];
-  const isLoadingMore =
-    isLoading || (size > 0 && data && typeof data[size - 1] === "undefined");
-  const showLoadMore = data ? !!data[data.length - 1]?.nextPageToken : false;
-
-  // store `refetch` in the atom so we can refresh the list upon archive via command k
-  // TODO is this the best way to do this?
-  const refetch = useCallback(
-    (options?: { removedThreadIds?: string[] }) => {
-      mutate(
-        (currentData) => {
-          if (!currentData) return currentData;
-          if (!options?.removedThreadIds) return currentData;
-
-          return currentData.map((page) => ({
-            ...page,
-            threads: page.threads.filter(
-              (t) => !options?.removedThreadIds?.includes(t.id),
-            ),
-          }));
-        },
-        {
-          rollbackOnError: true,
-          populateCache: true,
-          revalidate: false,
-        },
-      );
-    },
-    [mutate],
-  );
-
-  // Set up the refetch function in the atom store
-  const setRefetchEmailList = useSetAtom(refetchEmailListAtom);
-  useEffect(() => {
-    setRefetchEmailList({ refetch });
-  }, [refetch, setRefetchEmailList]);
-
-  const handleLoadMore = useCallback(() => {
-    setSize((size) => size + 1);
-  }, [setSize]);
-
+export default function Mail() {
   return (
     <EmailProvider>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <PermissionsCheck />
-        <LoadingContent loading={isLoading && !data} error={error}>
-          {allThreads && (
-            <List
-              emails={allThreads}
-              refetch={refetch}
-              type={searchParams.type}
-              showLoadMore={showLoadMore}
-              handleLoadMore={handleLoadMore}
-              isLoadingMore={isLoadingMore}
-            />
-          )}
-        </LoadingContent>
+        <MailShell />
       </div>
     </EmailProvider>
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/types.ts
@@ -1,0 +1,24 @@
+import type { ThreadsListResponse } from "@/app/api/threads/route";
+
+export type ListThread = ThreadsListResponse["threads"][number];
+export type ListMessage = ListThread["messages"][number];
+
+/** One rule that fired on a thread, with the reason it matched. */
+export type ThreadPlan = NonNullable<ListThread["plans"]>[number];
+
+/** Split view is the two-column list + reader; list view gives the list the full width. */
+export type MailLayoutMode = "list" | "split";
+
+/**
+ * The label chip palette. Names map to a colour so a chip looks the same
+ * everywhere it appears, rather than inheriting the provider's own colour.
+ */
+export type ChipColor =
+  | "blue"
+  | "green"
+  | "purple"
+  | "orange"
+  | "red"
+  | "gray"
+  | "cyan"
+  | "yellow";

--- a/apps/web/app/(app)/[emailAccountId]/mail/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/types.ts
@@ -8,17 +8,3 @@ export type ThreadPlan = NonNullable<ListThread["plans"]>[number];
 
 /** Split view is the two-column list + reader; list view gives the list the full width. */
 export type MailLayoutMode = "list" | "split";
-
-/**
- * The label chip palette. Names map to a colour so a chip looks the same
- * everywhere it appears, rather than inheriting the provider's own colour.
- */
-export type ChipColor =
-  | "blue"
-  | "green"
-  | "purple"
-  | "orange"
-  | "red"
-  | "gray"
-  | "cyan"
-  | "yellow";

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
+
+const pages = vi.hoisted(() => ({
+  current: [{ threads: [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }] }],
+}));
+
+// Stands in for the SWR cache: `mutate(fn)` applies fn to the current pages.
+vi.mock("swr/infinite", () => ({
+  default: () => ({
+    data: pages.current,
+    size: 1,
+    setSize: vi.fn(),
+    isLoading: false,
+    error: undefined,
+    mutate: (updater: unknown) => {
+      if (typeof updater === "function") {
+        pages.current = (updater as (p: unknown) => typeof pages.current)(
+          pages.current,
+        );
+      }
+      return Promise.resolve(pages.current);
+    },
+  }),
+}));
+
+const ids = () => pages.current[0].threads.map((thread) => thread.id);
+
+function setup() {
+  pages.current = [
+    { threads: [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }] },
+  ];
+  return renderHook((query) => useMailThreads(query), {
+    initialProps: { type: "inbox" } as { type: string },
+  });
+}
+
+describe("useMailThreads restore ordering", () => {
+  it("puts a row back where it was", () => {
+    const { result } = setup();
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["b"]);
+    });
+    expect(ids()).toEqual(["a", "c", "d"]);
+
+    act(() => result.current.restoreThreads(removal, ["b"]));
+    expect(ids()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps position when a later batch removed a row above it", () => {
+    const { result } = setup();
+
+    let first!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      first = result.current.removeThreads(["c"]);
+    });
+    act(() => {
+      result.current.removeThreads(["a"]);
+    });
+    expect(ids()).toEqual(["b", "d"]);
+
+    // `c` sat after `b`, so it must land between b and d — not at its old index.
+    act(() => result.current.restoreThreads(first, ["c"]));
+    expect(ids()).toEqual(["b", "c", "d"]);
+  });
+
+  it("restores a row that was first back to the front", () => {
+    const { result } = setup();
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["a"]);
+    });
+    act(() => result.current.restoreThreads(removal, ["a"]));
+
+    expect(ids()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("restores a contiguous batch in order", () => {
+    const { result } = setup();
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["b", "c"]);
+    });
+    expect(ids()).toEqual(["a", "d"]);
+
+    act(() => result.current.restoreThreads(removal, ["b", "c"]));
+    expect(ids()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("restores only the threads asked for", () => {
+    const { result } = setup();
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["b", "c"]);
+    });
+
+    // A failed reversal must leave its row out of the list.
+    act(() => result.current.restoreThreads(removal, ["b"]));
+    expect(ids()).toEqual(["a", "b", "d"]);
+  });
+
+  it("refuses to restore into a different split", () => {
+    const { result, rerender } = setup();
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["b"]);
+    });
+
+    rerender({ type: "CATEGORY_PROMOTIONS" });
+    act(() => result.current.restoreThreads(removal, ["b"]));
+
+    expect(ids()).toEqual(["a", "c", "d"]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -67,9 +67,8 @@ export function useMailThreads(query: ThreadsQuery) {
     threads,
     isLoading,
     error,
-    hasMore: data ? Boolean(data.at(-1)?.nextPageToken) : false,
-    isLoadingMore:
-      isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),
+    hasMore: Boolean(data?.at(-1)?.nextPageToken),
+    isLoadingMore: isLoading || (size > 0 && !data?.[size - 1]),
     loadMore: useCallback(() => setSize((current) => current + 1), [setSize]),
     removeThreads,
     restoreThreads,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -1,11 +1,17 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import useSWRInfinite from "swr/infinite";
 import type { ThreadsListResponse } from "@/app/api/threads/route";
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { createSearchParams } from "@/utils/url";
+
+type RemovedThread = { thread: ListThread; pageIndex: number; index: number };
+
+// Only the most recent removals can still be undone, so the retained rows are
+// capped rather than accumulating for the whole session.
+const MAX_RETAINED_REMOVALS = 200;
 
 /**
  * One SWR key per split, so switching splits reads from cache instead of
@@ -42,26 +48,72 @@ export function useMailThreads(query: ThreadsQuery) {
     [data],
   );
 
+  // Rows are kept so an undo can put back exactly what it removed. Revalidating
+  // instead would also resurrect rows that a *different* batch is still
+  // archiving, since the server hasn't caught up with those yet.
+  const removed = useRef(new Map<string, RemovedThread>());
+
   const removeThreads = useCallback(
     (threadIds: string[]) => {
       if (!threadIds.length) return;
-      const removed = new Set(threadIds);
+      const targets = new Set(threadIds);
 
       // Optimistic: drop the rows now and don't revalidate, so triage keeps its
       // rhythm instead of the list flickering back after every archive.
       mutate(
         (pages) =>
-          pages?.map((page) => ({
+          pages?.map((page, pageIndex) => ({
             ...page,
-            threads: page.threads.filter((thread) => !removed.has(thread.id)),
+            threads: page.threads.filter((thread, index) => {
+              if (!targets.has(thread.id)) return true;
+              removed.current.set(thread.id, { thread, pageIndex, index });
+              return false;
+            }),
           })),
         { revalidate: false, populateCache: true, rollbackOnError: true },
       );
+
+      while (removed.current.size > MAX_RETAINED_REMOVALS) {
+        const oldest = removed.current.keys().next().value;
+        if (oldest === undefined) break;
+        removed.current.delete(oldest);
+      }
     },
     [mutate],
   );
 
-  const restoreThreads = useCallback(() => mutate(), [mutate]);
+  const restoreThreads = useCallback(
+    (threadIds: string[]) => {
+      const restoring = threadIds
+        .map((id) => removed.current.get(id))
+        .filter((entry): entry is RemovedThread => entry !== undefined);
+      if (!restoring.length) return;
+
+      for (const entry of restoring) removed.current.delete(entry.thread.id);
+
+      mutate(
+        (pages) =>
+          pages?.map((page, pageIndex) => {
+            const forPage = restoring
+              .filter((entry) => entry.pageIndex === pageIndex)
+              .sort((a, b) => a.index - b.index);
+            if (!forPage.length) return page;
+
+            const threads = [...page.threads];
+            for (const entry of forPage) {
+              threads.splice(
+                Math.min(entry.index, threads.length),
+                0,
+                entry.thread,
+              );
+            }
+            return { ...page, threads };
+          }),
+        { revalidate: false, populateCache: true },
+      );
+    },
+    [mutate],
+  );
 
   return {
     threads,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import useSWRInfinite from "swr/infinite";
 import type { ThreadsListResponse } from "@/app/api/threads/route";
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
@@ -9,9 +9,15 @@ import { createSearchParams } from "@/utils/url";
 
 type RemovedThread = { thread: ListThread; pageIndex: number; index: number };
 
-// Only the most recent removals can still be undone, so the retained rows are
-// capped rather than accumulating for the whole session.
-const MAX_RETAINED_REMOVALS = 200;
+/**
+ * The rows one `removeThreads` call took out, and the view they came from.
+ * Returned to the caller so an undo can put back exactly those rows — and only
+ * while the list is still showing the split they were removed from.
+ */
+export type ThreadRemoval = {
+  cacheKey: string;
+  entries: Map<string, RemovedThread>;
+};
 
 /**
  * One SWR key per split, so switching splits reads from cache instead of
@@ -19,6 +25,13 @@ const MAX_RETAINED_REMOVALS = 200;
  * filtering pages that happen to be loaded.
  */
 export function useMailThreads(query: ThreadsQuery) {
+  // Identifies the split these rows belong to, so a restore can't drop them
+  // into a different split's cache after the user switches tabs.
+  const cacheKey = useMemo(
+    () => createSearchParams({ ...query, view: "list" }).toString(),
+    [query],
+  );
+
   const getKey = useCallback(
     (pageIndex: number, previousPageData: ThreadsListResponse | null) => {
       if (previousPageData && !previousPageData.nextPageToken) return null;
@@ -48,48 +61,49 @@ export function useMailThreads(query: ThreadsQuery) {
     [data],
   );
 
-  // Rows are kept so an undo can put back exactly what it removed. Revalidating
-  // instead would also resurrect rows that a *different* batch is still
-  // archiving, since the server hasn't caught up with those yet.
-  const removed = useRef(new Map<string, RemovedThread>());
-
   const removeThreads = useCallback(
-    (threadIds: string[]) => {
-      if (!threadIds.length) return;
+    (threadIds: string[]): ThreadRemoval => {
+      const entries = new Map<string, RemovedThread>();
       const targets = new Set(threadIds);
 
       // Optimistic: drop the rows now and don't revalidate, so triage keeps its
-      // rhythm instead of the list flickering back after every archive.
-      mutate(
-        (pages) =>
-          pages?.map((page, pageIndex) => ({
-            ...page,
-            threads: page.threads.filter((thread, index) => {
-              if (!targets.has(thread.id)) return true;
-              removed.current.set(thread.id, { thread, pageIndex, index });
-              return false;
-            }),
-          })),
-        { revalidate: false, populateCache: true, rollbackOnError: true },
-      );
-
-      while (removed.current.size > MAX_RETAINED_REMOVALS) {
-        const oldest = removed.current.keys().next().value;
-        if (oldest === undefined) break;
-        removed.current.delete(oldest);
+      // rhythm instead of the list flickering back after every archive. The
+      // rows come back with the handle so an undo can reinstate them without a
+      // refetch — which would also resurrect rows another batch is still
+      // archiving, since the server hasn't caught up with those yet.
+      if (threadIds.length) {
+        mutate(
+          (pages) =>
+            pages?.map((page, pageIndex) => ({
+              ...page,
+              threads: page.threads.filter((thread, index) => {
+                if (!targets.has(thread.id)) return true;
+                entries.set(thread.id, { thread, pageIndex, index });
+                return false;
+              }),
+            })),
+          { revalidate: false, populateCache: true, rollbackOnError: true },
+        );
       }
+
+      return { cacheKey, entries };
     },
-    [mutate],
+    [mutate, cacheKey],
   );
 
   const restoreThreads = useCallback(
-    (threadIds: string[]) => {
+    (removal: ThreadRemoval, threadIds: string[]) => {
+      // The entries describe positions within the split they were removed from.
+      // If the user has since switched splits, putting them back here would
+      // show rows that don't match this view's query.
+      if (removal.cacheKey !== cacheKey) return;
+
       const restoring = threadIds
-        .map((id) => removed.current.get(id))
+        .map((id) => removal.entries.get(id))
         .filter((entry): entry is RemovedThread => entry !== undefined);
       if (!restoring.length) return;
 
-      for (const entry of restoring) removed.current.delete(entry.thread.id);
+      for (const entry of restoring) removal.entries.delete(entry.thread.id);
 
       mutate(
         (pages) =>
@@ -112,7 +126,7 @@ export function useMailThreads(query: ThreadsQuery) {
         { revalidate: false, populateCache: true },
       );
     },
-    [mutate],
+    [mutate, cacheKey],
   );
 
   return {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -7,7 +7,17 @@ import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { createSearchParams } from "@/utils/url";
 
-type RemovedThread = { thread: ListThread; pageIndex: number; index: number };
+type RemovedThread = {
+  thread: ListThread;
+  pageIndex: number;
+  index: number;
+  /**
+   * Id of the row that preceded this one, or null if it was first. Anchoring to
+   * a neighbour rather than the raw index keeps the row in place when a later
+   * batch removes something above it before this one is undone.
+   */
+  afterId: string | null;
+};
 
 /**
  * The rows one `removeThreads` call took out, and the view they came from.
@@ -74,14 +84,25 @@ export function useMailThreads(query: ThreadsQuery) {
       if (threadIds.length) {
         mutate(
           (pages) =>
-            pages?.map((page, pageIndex) => ({
-              ...page,
-              threads: page.threads.filter((thread, index) => {
-                if (!targets.has(thread.id)) return true;
-                entries.set(thread.id, { thread, pageIndex, index });
-                return false;
-              }),
-            })),
+            pages?.map((page, pageIndex) => {
+              let previousKeptId: string | null = null;
+              return {
+                ...page,
+                threads: page.threads.filter((thread, index) => {
+                  if (!targets.has(thread.id)) {
+                    previousKeptId = thread.id;
+                    return true;
+                  }
+                  entries.set(thread.id, {
+                    thread,
+                    pageIndex,
+                    index,
+                    afterId: previousKeptId,
+                  });
+                  return false;
+                }),
+              };
+            }),
           { revalidate: false, populateCache: true, rollbackOnError: true },
         );
       }
@@ -114,12 +135,23 @@ export function useMailThreads(query: ThreadsQuery) {
             if (!forPage.length) return page;
 
             const threads = [...page.threads];
+            // Rows removed together share an anchor, so each one chains onto
+            // the previous restore to keep a contiguous batch in order.
+            let previousAfterId: string | null | undefined;
+            let previousRestoredId: string | null = null;
+
             for (const entry of forPage) {
+              const anchorId =
+                entry.afterId === previousAfterId && previousRestoredId
+                  ? previousRestoredId
+                  : entry.afterId;
               threads.splice(
-                Math.min(entry.index, threads.length),
+                insertionPoint(threads, entry, anchorId),
                 0,
                 entry.thread,
               );
+              previousAfterId = entry.afterId;
+              previousRestoredId = entry.thread.id;
             }
             return { ...page, threads };
           }),
@@ -139,4 +171,19 @@ export function useMailThreads(query: ThreadsQuery) {
     removeThreads,
     restoreThreads,
   };
+}
+
+function insertionPoint(
+  threads: ListThread[],
+  entry: RemovedThread,
+  anchorId: string | null,
+): number {
+  if (anchorId === null) return 0;
+
+  const anchor = threads.findIndex((thread) => thread.id === anchorId);
+  if (anchor !== -1) return anchor + 1;
+
+  // The neighbour is gone too — another batch removed it — so fall back to
+  // where the row originally sat.
+  return Math.min(entry.index, threads.length);
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import useSWRInfinite from "swr/infinite";
+import type { ThreadsListResponse } from "@/app/api/threads/route";
+import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+import { createSearchParams } from "@/utils/url";
+
+/**
+ * One SWR key per split, so switching splits reads from cache instead of
+ * refetching, and each split asks the server for its own rows rather than
+ * filtering pages that happen to be loaded.
+ */
+export function useMailThreads(query: ThreadsQuery) {
+  const getKey = useCallback(
+    (pageIndex: number, previousPageData: ThreadsListResponse | null) => {
+      if (previousPageData && !previousPageData.nextPageToken) return null;
+
+      const params = createSearchParams({
+        ...query,
+        view: "list",
+        ...(pageIndex > 0 && previousPageData?.nextPageToken
+          ? { nextPageToken: previousPageData.nextPageToken }
+          : {}),
+      });
+
+      return `/api/threads?${params.toString()}`;
+    },
+    [query],
+  );
+
+  const { data, size, setSize, isLoading, error, mutate } =
+    useSWRInfinite<ThreadsListResponse>(getKey, {
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+      revalidateFirstPage: false,
+    });
+
+  const threads: ListThread[] = useMemo(
+    () => data?.flatMap((page) => page.threads) ?? [],
+    [data],
+  );
+
+  const removeThreads = useCallback(
+    (threadIds: string[]) => {
+      if (!threadIds.length) return;
+      const removed = new Set(threadIds);
+
+      // Optimistic: drop the rows now and don't revalidate, so triage keeps its
+      // rhythm instead of the list flickering back after every archive.
+      mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            threads: page.threads.filter((thread) => !removed.has(thread.id)),
+          })),
+        { revalidate: false, populateCache: true, rollbackOnError: true },
+      );
+    },
+    [mutate],
+  );
+
+  const restoreThreads = useCallback(() => mutate(), [mutate]);
+
+  return {
+    threads,
+    isLoading,
+    error,
+    hasMore: data ? Boolean(data.at(-1)?.nextPageToken) : false,
+    isLoadingMore:
+      isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),
+    loadMore: useCallback(() => setSize((current) => current + 1), [setSize]),
+    removeThreads,
+    restoreThreads,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -35,7 +35,7 @@ export function useThreadActions({
 }: {
   emailAccountId: string;
   removeThreads: (threadIds: string[]) => void;
-  restoreThreads: () => void;
+  restoreThreads: (threadIds: string[]) => void;
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
 
@@ -59,7 +59,7 @@ export function useThreadActions({
         notCancelled.map((threadId) => reverse(emailAccountId, { threadId })),
       );
 
-      restoreThreads();
+      restoreThreads(batch.threadIds);
 
       if (results.some((result) => result?.serverError))
         toast.error("Some conversations couldn't be restored");
@@ -89,7 +89,7 @@ export function useThreadActions({
         emailAccountId,
         onSuccess: () => {},
         onError: () => {
-          restoreThreads();
+          restoreThreads(threadIds);
           toast.error(
             type === "archive"
               ? "There was an error archiving"

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -15,7 +15,11 @@ import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 type UndoableAction = "archive" | "delete";
 
-type LastAction = { type: UndoableAction; threadIds: string[] };
+type UndoableBatch = {
+  type: UndoableAction;
+  threadIds: string[];
+  undone: boolean;
+};
 
 /**
  * Archive and delete with a real undo.
@@ -33,37 +37,50 @@ export function useThreadActions({
   removeThreads: (threadIds: string[]) => void;
   restoreThreads: () => void;
 }) {
-  const lastAction = useRef<LastAction | null>(null);
+  const lastAction = useRef<UndoableBatch | null>(null);
 
+  // Takes the batch to reverse rather than reading the latest one: each toast
+  // must undo the action it announced, even after another archive has happened.
+  const undoBatch = useCallback(
+    async (batch: UndoableBatch) => {
+      if (batch.undone) return;
+      batch.undone = true;
+      if (lastAction.current === batch) lastAction.current = null;
+
+      const { notCancelled } = cancelQueuedThreads({
+        threadIds: batch.threadIds,
+        actionType: batch.type,
+      });
+
+      const reverse =
+        batch.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
+
+      const results = await Promise.all(
+        notCancelled.map((threadId) => reverse(emailAccountId, { threadId })),
+      );
+
+      restoreThreads();
+
+      if (results.some((result) => result?.serverError))
+        toast.error("Some conversations couldn't be restored");
+      else toast.success(summarise("Restored", batch.threadIds.length));
+    },
+    [emailAccountId, restoreThreads],
+  );
+
+  // The keyboard shortcut has no toast to anchor to, so it undoes the latest.
   const undo = useCallback(async () => {
-    const action = lastAction.current;
-    if (!action) return;
-    lastAction.current = null;
-
-    const { notCancelled } = cancelQueuedThreads({
-      threadIds: action.threadIds,
-      actionType: action.type,
-    });
-
-    const reverse =
-      action.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
-
-    const results = await Promise.all(
-      notCancelled.map((threadId) => reverse(emailAccountId, { threadId })),
-    );
-
-    restoreThreads();
-
-    if (results.some((result) => result?.serverError))
-      toast.error("Some conversations couldn't be restored");
-    else toast.success(summarise("Restored", action.threadIds.length));
-  }, [emailAccountId, restoreThreads]);
+    const batch = lastAction.current;
+    if (!batch) return;
+    await undoBatch(batch);
+  }, [undoBatch]);
 
   const run = useCallback(
     (type: UndoableAction, threadIds: string[]) => {
       if (!threadIds.length) return;
 
-      lastAction.current = { type, threadIds };
+      const batch: UndoableBatch = { type, threadIds, undone: false };
+      lastAction.current = batch;
       removeThreads(threadIds);
 
       const queue = type === "archive" ? archiveEmails : deleteEmails;
@@ -90,13 +107,13 @@ export function useThreadActions({
           action: {
             label: `Undo · ${getShortcutHint("undo")}`,
             onClick: () => {
-              undo();
+              undoBatch(batch);
             },
           },
         },
       );
     },
-    [emailAccountId, removeThreads, restoreThreads, undo],
+    [emailAccountId, removeThreads, restoreThreads, undoBatch],
   );
 
   return {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -12,12 +12,14 @@ import {
   untrashThreadAction,
 } from "@/utils/actions/mail";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
+import type { ThreadRemoval } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 
 type UndoableAction = "archive" | "delete";
 
 type UndoableBatch = {
   type: UndoableAction;
   threadIds: string[];
+  removal: ThreadRemoval;
   undone: boolean;
 };
 
@@ -34,8 +36,8 @@ export function useThreadActions({
   restoreThreads,
 }: {
   emailAccountId: string;
-  removeThreads: (threadIds: string[]) => void;
-  restoreThreads: (threadIds: string[]) => void;
+  removeThreads: (threadIds: string[]) => ThreadRemoval;
+  restoreThreads: (removal: ThreadRemoval, threadIds: string[]) => void;
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
 
@@ -55,15 +57,27 @@ export function useThreadActions({
       const reverse =
         batch.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
 
-      const results = await Promise.all(
-        notCancelled.map((threadId) => reverse(emailAccountId, { threadId })),
+      const reversed = await Promise.all(
+        notCancelled.map(async (threadId) => {
+          const result = await reverse(emailAccountId, { threadId });
+          return { threadId, ok: !result?.serverError };
+        }),
       );
 
-      restoreThreads(batch.threadIds);
+      // A thread the provider refused to unarchive is still archived, so
+      // putting its row back would show a conversation that isn't there.
+      const failed = reversed.filter((r) => !r.ok).map((r) => r.threadId);
+      const restored = batch.threadIds.filter((id) => !failed.includes(id));
 
-      if (results.some((result) => result?.serverError))
-        toast.error("Some conversations couldn't be restored");
-      else toast.success(summarise("Restored", batch.threadIds.length));
+      restoreThreads(batch.removal, restored);
+
+      if (failed.length)
+        toast.error(
+          failed.length === batch.threadIds.length
+            ? "Couldn't restore"
+            : `Couldn't restore ${failed.length} of ${batch.threadIds.length}`,
+        );
+      else toast.success(summarise("Restored", restored.length));
     },
     [emailAccountId, restoreThreads],
   );
@@ -79,17 +93,19 @@ export function useThreadActions({
     (type: UndoableAction, threadIds: string[]) => {
       if (!threadIds.length) return;
 
-      const batch: UndoableBatch = { type, threadIds, undone: false };
+      const removal = removeThreads(threadIds);
+      const batch: UndoableBatch = { type, threadIds, removal, undone: false };
       lastAction.current = batch;
-      removeThreads(threadIds);
 
       const queue = type === "archive" ? archiveEmails : deleteEmails;
       queue({
         threadIds,
         emailAccountId,
         onSuccess: () => {},
-        onError: () => {
-          restoreThreads(threadIds);
+        // The queue reports the specific thread that failed; the rest of the
+        // batch archived fine and must stay gone.
+        onError: (threadId) => {
+          restoreThreads(removal, [threadId]);
           toast.error(
             type === "archive"
               ? "There was an error archiving"

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -120,7 +120,6 @@ export function useThreadActions({
     archive: useCallback((ids: string[]) => run("archive", ids), [run]),
     trash: useCallback((ids: string[]) => run("delete", ids), [run]),
     undo,
-    canUndo: () => lastAction.current !== null,
   };
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { toast } from "sonner";
+import {
+  archiveEmails,
+  cancelQueuedThreads,
+  deleteEmails,
+} from "@/store/archive-queue";
+import {
+  unarchiveThreadAction,
+  untrashThreadAction,
+} from "@/utils/actions/mail";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+
+type UndoableAction = "archive" | "delete";
+
+type LastAction = { type: UndoableAction; threadIds: string[] };
+
+/**
+ * Archive and delete with a real undo.
+ *
+ * Undo tries to cancel the queued job first: the queue usually drains in well
+ * under a second, but when it hasn't, cancelling avoids a pointless round trip
+ * to the provider and back. Anything already sent gets reversed properly.
+ */
+export function useThreadActions({
+  emailAccountId,
+  removeThreads,
+  restoreThreads,
+}: {
+  emailAccountId: string;
+  removeThreads: (threadIds: string[]) => void;
+  restoreThreads: () => void;
+}) {
+  const lastAction = useRef<LastAction | null>(null);
+
+  const undo = useCallback(async () => {
+    const action = lastAction.current;
+    if (!action) return;
+    lastAction.current = null;
+
+    const { notCancelled } = cancelQueuedThreads({
+      threadIds: action.threadIds,
+      actionType: action.type,
+    });
+
+    const reverse =
+      action.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
+
+    const results = await Promise.all(
+      notCancelled.map((threadId) => reverse(emailAccountId, { threadId })),
+    );
+
+    restoreThreads();
+
+    if (results.some((result) => result?.serverError))
+      toast.error("Some conversations couldn't be restored");
+    else toast.success(summarise("Restored", action.threadIds.length));
+  }, [emailAccountId, restoreThreads]);
+
+  const run = useCallback(
+    (type: UndoableAction, threadIds: string[]) => {
+      if (!threadIds.length) return;
+
+      lastAction.current = { type, threadIds };
+      removeThreads(threadIds);
+
+      const queue = type === "archive" ? archiveEmails : deleteEmails;
+      queue({
+        threadIds,
+        emailAccountId,
+        onSuccess: () => {},
+        onError: () => {
+          restoreThreads();
+          toast.error(
+            type === "archive"
+              ? "There was an error archiving"
+              : "There was an error deleting",
+          );
+        },
+      });
+
+      toast.success(
+        summarise(
+          type === "archive" ? "Archived" : "Deleted",
+          threadIds.length,
+        ),
+        {
+          action: {
+            label: `Undo · ${getShortcutHint("undo")}`,
+            onClick: () => {
+              undo();
+            },
+          },
+        },
+      );
+    },
+    [emailAccountId, removeThreads, restoreThreads, undo],
+  );
+
+  return {
+    archive: useCallback((ids: string[]) => run("archive", ids), [run]),
+    trash: useCallback((ids: string[]) => run("delete", ids), [run]),
+    undo,
+    canUndo: () => lastAction.current !== null,
+  };
+}
+
+function summarise(verb: string, count: number) {
+  return count === 1 ? verb : `${verb} ${count} conversations`;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
+
+const IDS = ["a", "b", "c", "d", "e"];
+
+function setup(ids: string[] = IDS) {
+  return renderHook(() => useThreadSelection(ids));
+}
+
+describe("useThreadSelection", () => {
+  it("toggles a row on and back off", () => {
+    const { result } = setup();
+
+    act(() => result.current.toggle(1));
+    expect([...result.current.selectedIds]).toEqual(["b"]);
+
+    act(() => result.current.toggle(1));
+    expect(result.current.hasSelection).toBe(false);
+  });
+
+  it("shift-clicks a range from the last toggled row", () => {
+    const { result } = setup();
+
+    act(() => result.current.toggle(1));
+    act(() => result.current.selectRangeTo(3));
+
+    expect([...result.current.selectedIds].sort()).toEqual(["b", "c", "d"]);
+  });
+
+  it("shift-clicking with nothing toggled yet just selects that row", () => {
+    const { result } = setup();
+
+    act(() => result.current.selectRangeTo(2));
+
+    expect([...result.current.selectedIds]).toEqual(["c"]);
+  });
+
+  it("shrinks the extended range when reversing direction", () => {
+    const { result } = setup();
+
+    act(() => result.current.extendTo(1, 0));
+    act(() => result.current.extendTo(2, 1));
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "b", "c"]);
+
+    // Back towards the anchor: the range shrinks rather than staying grown
+    act(() => result.current.extendTo(1, 2));
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("keeps selections made before extension started", () => {
+    const { result } = setup();
+
+    act(() => result.current.toggle(4));
+    act(() => result.current.extendTo(1, 0));
+    act(() => result.current.extendTo(2, 1));
+
+    expect([...result.current.selectedIds].sort()).toEqual([
+      "a",
+      "b",
+      "c",
+      "e",
+    ]);
+
+    // ...and shrinking must not eat the pre-existing one
+    act(() => result.current.extendTo(0, 1));
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "e"]);
+  });
+
+  it("starts a fresh anchor after an explicit toggle", () => {
+    const { result } = setup();
+
+    act(() => result.current.extendTo(2, 0));
+    act(() => result.current.toggle(4));
+    act(() => result.current.extendTo(3, 4));
+
+    expect([...result.current.selectedIds].sort()).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+
+  it("clamps extension at the list bounds", () => {
+    const { result } = setup();
+
+    act(() => result.current.extendTo(-1, 0));
+    expect([...result.current.selectedIds]).toEqual(["a"]);
+
+    act(() => result.current.clear());
+    act(() => result.current.extendTo(99, 4));
+    expect([...result.current.selectedIds]).toEqual(["e"]);
+  });
+
+  it("targets the focused row only when nothing is selected", () => {
+    const { result } = setup();
+
+    expect(result.current.targetIds("c")).toEqual(["c"]);
+
+    act(() => result.current.toggle(0));
+    expect(result.current.targetIds("c")).toEqual(["a"]);
+  });
+
+  it("targets nothing when there is no selection and no focused row", () => {
+    const { result } = setup();
+    expect(result.current.targetIds(undefined)).toEqual([]);
+  });
+
+  it("ignores a toggle for an index outside the list", () => {
+    const { result } = setup();
+
+    act(() => result.current.toggle(99));
+    expect(result.current.hasSelection).toBe(false);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+/**
+ * Row selection for the mail list.
+ *
+ * Anchored range extension is the subtle part: `Shift+J/K` must grow and shrink a
+ * range from where the user started extending, without discarding selections they
+ * made before that. So the selection at the moment extension begins is kept as a
+ * base and the anchored range is layered on top of it each keystroke.
+ */
+export function useThreadSelection(orderedIds: string[]) {
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const anchorIndex = useRef<number | null>(null);
+  const baseSelection = useRef<ReadonlySet<string> | null>(null);
+  const lastToggledIndex = useRef<number | null>(null);
+
+  const resetAnchor = useCallback(() => {
+    anchorIndex.current = null;
+    baseSelection.current = null;
+  }, []);
+
+  const clear = useCallback(() => {
+    resetAnchor();
+    lastToggledIndex.current = null;
+    setSelectedIds((current) => (current.size ? new Set() : current));
+  }, [resetAnchor]);
+
+  const toggle = useCallback(
+    (index: number) => {
+      const id = orderedIds[index];
+      if (!id) return;
+      resetAnchor();
+      lastToggledIndex.current = index;
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        if (!next.delete(id)) next.add(id);
+        return next;
+      });
+    },
+    [orderedIds, resetAnchor],
+  );
+
+  // Shift+click: fill from the last individually toggled row to this one.
+  const selectRangeTo = useCallback(
+    (index: number) => {
+      const from = lastToggledIndex.current;
+      if (from === null) {
+        toggle(index);
+        return;
+      }
+      resetAnchor();
+      setSelectedIds((current) =>
+        addRange({ ids: orderedIds, base: current, from, to: index }),
+      );
+      lastToggledIndex.current = index;
+    },
+    [orderedIds, resetAnchor, toggle],
+  );
+
+  const extendTo = useCallback(
+    (index: number, fromIndex: number) => {
+      if (anchorIndex.current === null) {
+        anchorIndex.current = fromIndex;
+        baseSelection.current = selectedIds;
+      }
+      const anchor = anchorIndex.current;
+      const base = baseSelection.current ?? new Set<string>();
+      setSelectedIds(
+        addRange({ ids: orderedIds, base, from: anchor, to: index }),
+      );
+      lastToggledIndex.current = index;
+    },
+    [orderedIds, selectedIds],
+  );
+
+  // Acting on a selection consumes it; acting with none targets the focused row.
+  const targetIds = useCallback(
+    (focusedId: string | undefined) => {
+      if (selectedIds.size) return [...selectedIds];
+      return focusedId ? [focusedId] : [];
+    },
+    [selectedIds],
+  );
+
+  return useMemo(
+    () => ({
+      selectedIds,
+      selectedCount: selectedIds.size,
+      hasSelection: selectedIds.size > 0,
+      isSelected: (id: string) => selectedIds.has(id),
+      toggle,
+      selectRangeTo,
+      extendTo,
+      clear,
+      targetIds,
+    }),
+    [selectedIds, toggle, selectRangeTo, extendTo, clear, targetIds],
+  );
+}
+
+function addRange({
+  ids,
+  base,
+  from,
+  to,
+}: {
+  ids: string[];
+  base: ReadonlySet<string>;
+  from: number;
+  to: number;
+}): Set<string> {
+  const next = new Set(base);
+  const start = Math.max(0, Math.min(from, to));
+  const end = Math.min(ids.length - 1, Math.max(from, to));
+  for (let index = start; index <= end; index++) {
+    const id = ids[index];
+    if (id) next.add(id);
+  }
+  return next;
+}

--- a/apps/web/app/api/labels/counts/route.ts
+++ b/apps/web/app/api/labels/counts/route.ts
@@ -17,7 +17,7 @@ const CACHE_TTL_SECONDS = 60;
 const MAX_USER_LABELS = 100;
 const LABEL_LOOKUP_CONCURRENCY = 8;
 
-type LabelCount = {
+export type LabelCount = {
   id: string;
   name: string;
   kind: "system" | "category" | "label";

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Loader2Icon } from "lucide-react";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import {
   CommandDialog,
   CommandEmpty,
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/command";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
 import { refetchEmailListAtom } from "@/store/email";
+import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -61,7 +62,7 @@ export function CommandK() {
 }
 
 function CommandPalette() {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useAtom(commandPaletteOpenAtom);
   const [search, setSearch] = React.useState("");
 
   const { emailAccountId } = useAccount();
@@ -91,7 +92,7 @@ function CommandPalette() {
       // While the palette is open, Escape belongs to the dialog.
       close: open || !threadId ? undefined : () => showEmail(null),
     }),
-    [threadId, open, onArchive, onOpenComposeModal, showEmail],
+    [threadId, open, onArchive, onOpenComposeModal, showEmail, setOpen],
   );
 
   useShortcuts(shortcutHandlers);
@@ -134,17 +135,23 @@ function CommandPalette() {
   }, [filteredCommands]);
 
   // execute command
-  const executeCommand = React.useCallback((command: Command) => {
-    setOpen(false);
-    setSearch("");
-    command.action();
-  }, []);
+  const executeCommand = React.useCallback(
+    (command: Command) => {
+      setOpen(false);
+      setSearch("");
+      command.action();
+    },
+    [setOpen],
+  );
 
   // memoized handlers to avoid re-renders
-  const handleOpenChange = React.useCallback((isOpen: boolean) => {
-    setOpen(isOpen);
-    if (!isOpen) setSearch("");
-  }, []);
+  const handleOpenChange = React.useCallback(
+    (isOpen: boolean) => {
+      setOpen(isOpen);
+      if (!isOpen) setSearch("");
+    },
+    [setOpen],
+  );
 
   const commandProps = React.useMemo(
     () => ({

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Loader2Icon } from "lucide-react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import {
   CommandDialog,
   CommandEmpty,
@@ -14,7 +14,6 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
-import { refetchEmailListAtom } from "@/store/email";
 import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
@@ -26,8 +25,8 @@ import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import {
   buildShortcutPaletteCommands,
+  MAIL_SHORTCUT_SCOPES,
   type ShortcutHandlers,
-  type ShortcutScope,
 } from "@/lib/shortcuts/registry";
 
 const SECTION_ORDER: CommandSection[] = [
@@ -51,11 +50,9 @@ const SECTION_LABELS: Record<CommandSection, string> = {
 // route's own bindings: these handlers are only defined when the side panel has a
 // thread (`side-panel-thread-id`), which the mail list never sets — and the mail
 // screen in turn stands down while the side panel is open.
-const SHORTCUT_SCOPES: ShortcutScope[] = ["global", "mail"];
-
 export function CommandK() {
   return (
-    <ShortcutsProvider scopes={SHORTCUT_SCOPES}>
+    <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
       <CommandPalette />
     </ShortcutsProvider>
   );
@@ -67,22 +64,15 @@ function CommandPalette() {
 
   const { emailAccountId } = useAccount();
   const { threadId, showEmail } = useDisplayedEmail();
-  const refreshEmailList = useAtomValue(refetchEmailListAtom);
   const { onOpen: onOpenComposeModal } = useComposeModal();
   const { commands, isLoading } = useCommandPaletteCommands();
 
   const onArchive = React.useCallback(() => {
     if (threadId) {
-      const threadIds = [threadId];
-      archiveEmails({
-        threadIds,
-        onSuccess: () =>
-          refreshEmailList?.refetch({ removedThreadIds: threadIds }),
-        emailAccountId,
-      });
+      archiveEmails({ threadIds: [threadId], emailAccountId });
       showEmail(null);
     }
-  }, [refreshEmailList, threadId, showEmail, emailAccountId]);
+  }, [threadId, showEmail, emailAccountId]);
 
   const shortcutHandlers = React.useMemo<ShortcutHandlers>(
     () => ({

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -45,9 +45,11 @@ const SECTION_LABELS: Record<CommandSection, string> = {
   settings: "Settings",
 };
 
-// This component is mounted app-wide, and its archive/close bindings act on
-// whatever email is displayed, so the mail scope is enabled everywhere for now.
-// The mail redesign moves mail scope activation onto the mail route.
+// Mounted app-wide. It enables the mail scope everywhere so the side-panel email
+// viewer keeps its triage keys on any page. That doesn't collide with the mail
+// route's own bindings: these handlers are only defined when the side panel has a
+// thread (`side-panel-thread-id`), which the mail list never sets — and the mail
+// screen in turn stands down while the side panel is open.
 const SHORTCUT_SCOPES: ShortcutScope[] = ["global", "mail"];
 
 export function CommandK() {

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -247,7 +247,9 @@ const bottomMailLinks: NavItem[] = [
 export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const navigation = useNavigation();
   const path = usePathname();
-  const showMailNav = path.includes("/mail") || path.includes("/compose");
+  // The mail screen ships its own sidebar, so this one would be a second copy.
+  const isMailRoute = path.includes("/mail");
+  const showMailNav = isMailRoute || path.includes("/compose");
   const isMoreActive = navigation.moreItems.some(
     (item) => path === item.href || path.startsWith(`${item.href}/`),
   );
@@ -272,6 +274,8 @@ export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
   );
 
   const { state } = useSidebar();
+
+  if (isMailRoute) return null;
 
   return (
     <Sidebar collapsible="icon" {...props}>

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -247,9 +247,7 @@ const bottomMailLinks: NavItem[] = [
 export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const navigation = useNavigation();
   const path = usePathname();
-  // The mail screen ships its own sidebar, so this one would be a second copy.
-  const isMailRoute = path.includes("/mail");
-  const showMailNav = isMailRoute || path.includes("/compose");
+  const showMailNav = path.includes("/compose");
   const isMoreActive = navigation.moreItems.some(
     (item) => path === item.href || path.startsWith(`${item.href}/`),
   );
@@ -274,8 +272,6 @@ export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
   );
 
   const { state } = useSidebar();
-
-  if (isMailRoute) return null;
 
   return (
     <Sidebar collapsible="icon" {...props}>

--- a/apps/web/components/SideNavWithTopNav.tsx
+++ b/apps/web/components/SideNavWithTopNav.tsx
@@ -79,8 +79,15 @@ export function SideNavWithTopNav({
       defaultOpen={defaultOpen ? ["left-sidebar"] : []}
       sidebarNames={["left-sidebar", "chat-sidebar"]}
     >
-      <MobileHeader />
-      {!isMailRoute && <SideNav name="left-sidebar" />}
+      {/* Both are suppressed together: the trigger only opens SideNav, so
+          leaving it on the mail route would render a button that opens an
+          empty drawer. */}
+      {!isMailRoute && (
+        <>
+          <MobileHeader />
+          <SideNav name="left-sidebar" />
+        </>
+      )}
       <ContentWrapper>{children}</ContentWrapper>
       {!isAssistantRoute ? <SidebarRight name="chat-sidebar" /> : null}
     </SidebarProvider>

--- a/apps/web/components/SideNavWithTopNav.tsx
+++ b/apps/web/components/SideNavWithTopNav.tsx
@@ -62,6 +62,8 @@ export function SideNavWithTopNav({
   if (!pathname) return null;
 
   const isAssistantRoute = pathname.includes("/assistant");
+  // The mail screen ships its own sidebar, so this one would be a second copy.
+  const isMailRoute = pathname.includes("/mail");
 
   // Ugly code. May change the onboarding path later so we don't need to do this.
   // Only return children for the onboarding or onboarding-brief pages: /[emailAccountId]/onboarding or /[emailAccountId]/onboarding-brief
@@ -78,7 +80,7 @@ export function SideNavWithTopNav({
       sidebarNames={["left-sidebar", "chat-sidebar"]}
     >
       <MobileHeader />
-      <SideNav name="left-sidebar" />
+      {!isMailRoute && <SideNav name="left-sidebar" />}
       <ContentWrapper>{children}</ContentWrapper>
       {!isAssistantRoute ? <SidebarRight name="chat-sidebar" /> : null}
     </SidebarProvider>

--- a/apps/web/components/email-list/EmailDate.tsx
+++ b/apps/web/components/email-list/EmailDate.tsx
@@ -1,9 +1,21 @@
+import { cn } from "@/utils";
 import { formatShortDate } from "@/utils/date";
 
-export function EmailDate(props: { date: Date }) {
+export function EmailDate({
+  date,
+  className,
+}: {
+  date: Date;
+  className?: string;
+}) {
   return (
-    <div className="flex-shrink-0 text-sm font-medium leading-5 text-muted-foreground">
-      {formatShortDate(props.date)}
+    <div
+      className={cn(
+        "flex-shrink-0 text-sm font-medium leading-5 text-muted-foreground",
+        className,
+      )}
+    >
+      {formatShortDate(date)}
     </div>
   );
 }

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,8 +1,10 @@
 import useSWR from "swr";
-import type { ThreadQuery, ThreadResponse } from "@/app/api/threads/[id]/route";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 
+// `id` accepts null so "no thread open" is expressible in the type rather than
+// as a magic empty string that would silently resolve to the thread list route.
 export function useThread(
-  { id }: ThreadQuery,
+  { id }: { id: string | null },
   options?: { includeDrafts?: boolean },
 ) {
   const searchParams = new URLSearchParams();

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -7,6 +7,8 @@ export function useThread(
 ) {
   const searchParams = new URLSearchParams();
   if (options?.includeDrafts) searchParams.set("includeDrafts", "true");
-  const url = `/api/threads/${id}?${searchParams.toString()}`;
+  // An empty id would resolve to the thread *list* route and quietly fetch every
+  // thread with full message bodies, so skip the request instead.
+  const url = id ? `/api/threads/${id}?${searchParams.toString()}` : null;
   return useSWR<ThreadResponse>(url);
 }

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -11,6 +11,12 @@ const logger = createClientLogger("shortcuts");
  */
 export type ShortcutScope = "global" | "mail";
 
+/** Every surface that binds mail keys also needs the global ones. */
+export const MAIL_SHORTCUT_SCOPES: readonly ShortcutScope[] = [
+  "global",
+  "mail",
+];
+
 /** Display order of the `?` help dialog sections. */
 export const SHORTCUT_GROUPS = [
   "Navigate",

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -127,7 +127,7 @@ export const archiveEmails = async ({
 }: {
   threadIds: string[];
   labelId?: string;
-  onSuccess: (threadId: string) => void;
+  onSuccess?: (threadId: string) => void;
   onError?: (threadId: string) => void;
   emailAccountId: string;
 }) => {

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+/**
+ * Open state for the command palette. It lives outside CommandK so surfaces
+ * elsewhere — the mail toolbar's search field, for one — can open it without
+ * faking a ⌘K keystroke.
+ */
+export const commandPaletteOpenAtom = atom(false);

--- a/apps/web/store/email.ts
+++ b/apps/web/store/email.ts
@@ -1,5 +1,0 @@
-import { atom } from "jotai";
-
-export const refetchEmailListAtom = atom<
-  { refetch: (options?: { removedThreadIds?: string[] }) => void } | undefined
->(undefined);


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260811-193919_pr-3205_711c002b89ce/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The redesigned Mail screen, stacked on #3204. **Base that PR first** — this one is diffed against `mail-redesign-foundation`.

Mail is still URL-only (no `SideNav` entry), so nothing here is user-visible yet.

## What it looks like

Three columns — sidebar, list, reader — plus a dismissible hint bar advertising the shortcuts. `V` toggles list/split and the choice persists; `F` is focus mode and is deliberately ephemeral (nobody wants to land in focus mode after a refresh).

## The parts worth reviewing

**Splits** are tabs over the inbox. Each is its own server query. The existing "Planned" tab filters a paginated list client-side, so it only ever searches the pages already loaded — the new splits deliberately don't inherit that.

**Selection** is revealed on demand: the checkbox appears on hover, or once anything is selected. `X` toggles, `Shift`+arrows extend an anchored range. The anchoring is the subtle bit — extending has to grow *and* shrink from where extension began, without discarding selections made before that. `use-thread-selection.test.ts` pins that behaviour.

**Archive/delete** act on the selection, or on the focused row when there is none, and are undoable.

**The reader** reuses `EmailThread` rather than rebuilding a composer, so the AI draft still auto-opens exactly as before. Label chips navigate to that label's view; the rule explanation lives once per rule in the overflow menu and reuses the existing `FixWithChat`.

## Two changes outside the mail route

- **`SideNav` returns null on `/mail`.** It would otherwise render its own mail nav beside the new sidebar — two navs on one screen.
- **`useThread` no longer fetches without an id.** An empty id built `/api/threads/?…`, which resolves to the thread *list* route and pulled every thread with full message bodies on each mail page load — the exact fat payload the slim view exists to avoid.

## Verified in a browser

Against emulated Gmail (`dev-setup --auth emulate`, 17 seeded threads):

- `J`/`K` move the cursor, `Enter` opens, `U` returns
- `X` selects; `Shift+↓` grows the range to 3 and `Shift+↑` shrinks it back to 2, keeping the earlier selection
- `E` archives (17 → 16) with an "Archived · Undo · Z" toast; `Z` restores (16 → 17)
- `V` switches to split view, `F` drops all chrome, `?` opens the shortcuts dialog
- The shortcuts dialog and other portalled surfaces pick up the Mail palette, confirming the `data-theme`-on-`<html>` approach — a wrapper-scoped theme would have left them on the old palette

One layout bug found and fixed this way: the list column lacked `min-w-0`, so long snippets widened it ~230px past the viewport instead of truncating.

## Not covered

No rule had fired on the seeded threads, so the per-rule attribution menu renders empty-by-design and could not be exercised end to end. Worth a look on an account with rule history.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->