### PR TITLE
fix: isolate browser queue storage

### DIFF
--- a/apps/web/store/archive-queue.test.ts
+++ b/apps/web/store/archive-queue.test.ts
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockArchiveThreadAction = vi.fn();
 const mockTrashThreadAction = vi.fn();
 const mockMarkReadThreadAction = vi.fn();
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage",
+);
 
 vi.mock("@/utils/actions/mail", () => ({
   archiveThreadAction: (...args: Parameters<typeof mockArchiveThreadAction>) =>
@@ -54,6 +58,18 @@ describe("cancelQueuedThreads", () => {
     window.localStorage.clear();
     mockArchiveThreadAction.mockResolvedValue(undefined);
     mockTrashThreadAction.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(
+        window,
+        "localStorage",
+        originalLocalStorageDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(window, "localStorage");
+    }
   });
 
   it("stops a queued thread from ever reaching the provider", async () => {

--- a/apps/web/store/archive-queue.test.ts
+++ b/apps/web/store/archive-queue.test.ts
@@ -39,13 +39,19 @@ const archivedThreadIds = () =>
 
 // The queue state is persisted, and ArchiveProgress reads it to draw the bar.
 const persistedTotalThreads = () =>
-  JSON.parse(localStorage.getItem("gmailActionQueue") ?? "{}").totalThreads;
+  JSON.parse(window.localStorage.getItem("gmailActionQueue") ?? "{}")
+    .totalThreads;
 
 describe("cancelQueuedThreads", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    localStorage.clear();
+    // Keep these browser-storage tests isolated from Node's ambient storage.
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: window.sessionStorage,
+    });
+    window.localStorage.clear();
     mockArchiveThreadAction.mockResolvedValue(undefined);
     mockTrashThreadAction.mockResolvedValue(undefined);
   });
@@ -268,7 +274,9 @@ describe("cancelQueuedThreads", () => {
 // The queue atom isn't exported; it persists to localStorage on every write,
 // which is the same state the progress UI reads through `useQueueState`.
 function readPersistedQueueState() {
-  return JSON.parse(localStorage.getItem("gmailActionQueue") ?? "{}") as {
+  return JSON.parse(
+    window.localStorage.getItem("gmailActionQueue") ?? "{}",
+  ) as {
     activeThreads: Record<string, unknown>;
     totalThreads: number;
   };

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -41,7 +41,7 @@ const queuedJobs = new Map<QueueKey, QueuedJob>();
 // some users were somehow getting null for activeThreads, this should fix it
 const createStorage = () => {
   if (typeof window === "undefined") return;
-  const storage = createJSONStorage<QueueState>(() => localStorage);
+  const storage = createJSONStorage<QueueState>(() => window.localStorage);
   return {
     ...storage,
     getItem: (key: string, initialValue: QueueState) => {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260811-151114_pr-3207_06db4894cf2f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensure queue persistence uses the browser-owned storage boundary and keep its unit tests isolated from runtime-provided globals.

- scope queue persistence to browser storage
- make storage-backed queue tests runtime-independent
- validate the complete unit suite and repository checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->