### PR TITLE
fix: Harden recent integration and mail changes

### DIFF
--- a/apps/web/prisma/migrations/20260811160000_make_mail_split_order_unique/migration.sql
+++ b/apps/web/prisma/migrations/20260811160000_make_mail_split_order_unique/migration.sql
@@ -1,0 +1,26 @@
+-- Preserve the existing order while repairing any duplicates created by
+-- concurrent requests before the application-level lock was added.
+BEGIN;
+
+LOCK TABLE "MailSplit" IN ACCESS EXCLUSIVE MODE;
+
+WITH "rankedSplits" AS (
+  SELECT
+    "id",
+    (ROW_NUMBER() OVER (
+      PARTITION BY "emailAccountId"
+      ORDER BY "order", "createdAt", "id"
+    ) - 1)::integer AS "normalizedOrder"
+  FROM "MailSplit"
+)
+UPDATE "MailSplit"
+SET "order" = "rankedSplits"."normalizedOrder"
+FROM "rankedSplits"
+WHERE "MailSplit"."id" = "rankedSplits"."id";
+
+DROP INDEX "MailSplit_emailAccountId_order_idx";
+
+CREATE UNIQUE INDEX "MailSplit_emailAccountId_order_key"
+ON "MailSplit"("emailAccountId", "order");
+
+COMMIT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -247,7 +247,7 @@ model MailSplit {
   emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
 
   @@unique([emailAccountId, name])
-  @@index([emailAccountId, order])
+  @@unique([emailAccountId, order])
 }
 
 model Organization {

--- a/apps/web/utils/action-display.tsx
+++ b/apps/web/utils/action-display.tsx
@@ -19,7 +19,10 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import { truncate } from "@/utils/string";
-import { getIntegrationActionLabel } from "@/utils/mcp/tool-specs";
+import {
+  getIntegrationActionDisplayValue,
+  getIntegrationActionLabel,
+} from "@/utils/mcp/tool-specs";
 
 /**
  * Hide messaging-channel draft entries when an email draft already exists,
@@ -117,8 +120,8 @@ export function getActionDisplay(
       return "Notify Sender";
     case ActionType.INTEGRATION: {
       const label = getIntegrationActionLabel(action);
-      const taskContent = getIntegrationTaskContent(action.integrationArgs);
-      return taskContent ? `${label}: '${truncate(taskContent, 20)}'` : label;
+      const displayValue = getIntegrationActionDisplayValue(action);
+      return displayValue ? `${label}: '${truncate(displayValue, 20)}'` : label;
     }
     default: {
       const exhaustiveCheck: never = action.type;
@@ -189,17 +192,4 @@ export function getActionIcon(actionType: ActionType) {
       return exhaustiveCheck;
     }
   }
-}
-
-function getIntegrationTaskContent(integrationArgs: unknown): string | null {
-  if (
-    integrationArgs &&
-    typeof integrationArgs === "object" &&
-    !Array.isArray(integrationArgs) &&
-    "content" in integrationArgs &&
-    typeof integrationArgs.content === "string"
-  ) {
-    return integrationArgs.content;
-  }
-  return null;
 }

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  createMailSplitAction,
+  renameMailSplitAction,
+} from "@/utils/actions/mail-split";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+const EMAIL_ACCOUNT_ID = "email-account-1";
+
+describe("mail split actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: { userId: "user-1", provider: "google" },
+    } as never);
+  });
+
+  it("creates splits behind an account-scoped database lock", async () => {
+    const split = {
+      id: "split-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      name: "Unread",
+      kind: MailSplitKind.UNREAD,
+      value: null,
+      order: 0,
+      emailAccountId: EMAIL_ACCOUNT_ID,
+    };
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [split],
+      split,
+      1,
+    ] as never);
+
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
+      name: "Unread",
+      kind: MailSplitKind.UNREAD,
+      value: null,
+    });
+
+    expect(result?.data).toEqual({ split });
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining("pg_advisory_xact_lock"),
+      ]),
+      EMAIL_ACCOUNT_ID,
+    );
+  });
+
+  it("returns a user-safe error when the split limit is reached", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [],
+      null,
+      12,
+    ] as never);
+
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
+      name: "Later",
+      kind: MailSplitKind.UNREAD,
+      value: null,
+    });
+
+    expect(result?.serverError).toBe("You can only have 12 splits.");
+  });
+
+  it("returns a user-safe error when a split name already exists", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [],
+      { id: "existing-split" },
+      1,
+    ] as never);
+
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
+      name: "Unread",
+      kind: MailSplitKind.UNREAD,
+      value: null,
+    });
+
+    expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+
+  it("returns a user-safe error when a rename duplicates a split", async () => {
+    prisma.mailSplit.updateMany.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["emailAccountId", "name"] },
+      }),
+    );
+
+    const result = await renameMailSplitAction(EMAIL_ACCOUNT_ID, {
+      id: "split-1",
+      name: "Unread",
+    });
+
+    expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+});

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -38,9 +38,7 @@ describe("mail split actions", () => {
     };
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
-      [split],
-      split,
-      1,
+      [{ status: "created", ...split }],
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
@@ -61,9 +59,7 @@ describe("mail split actions", () => {
   it("returns a user-safe error when the split limit is reached", async () => {
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
-      [],
-      null,
-      12,
+      [{ status: "limit" }],
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
@@ -78,9 +74,7 @@ describe("mail split actions", () => {
   it("returns a user-safe error when a split name already exists", async () => {
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
-      [],
-      { id: "existing-split" },
-      1,
+      [{ status: "duplicate" }],
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
@@ -92,14 +86,20 @@ describe("mail split actions", () => {
     expect(result?.serverError).toBe('You already have a "Unread" split.');
   });
 
+  it("handles a duplicate-name constraint race with a safe error", async () => {
+    prisma.$transaction.mockRejectedValue(createDuplicateNameError());
+
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
+      name: "Unread",
+      kind: MailSplitKind.UNREAD,
+      value: null,
+    });
+
+    expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+
   it("returns a user-safe error when a rename duplicates a split", async () => {
-    prisma.mailSplit.updateMany.mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
-        code: "P2002",
-        clientVersion: "test",
-        meta: { target: ["emailAccountId", "name"] },
-      }),
-    );
+    prisma.$transaction.mockRejectedValue(createDuplicateNameError());
 
     const result = await renameMailSplitAction(EMAIL_ACCOUNT_ID, {
       id: "split-1",
@@ -109,3 +109,11 @@ describe("mail split actions", () => {
     expect(result?.serverError).toBe('You already have a "Unread" split.');
   });
 });
+
+function createDuplicateNameError() {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "test",
+    meta: { target: ["emailAccountId", "name"] },
+  });
+}

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -1,8 +1,11 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
+import type { MailSplit } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
 import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
+import { isDuplicateError } from "@/utils/prisma-helpers";
 import {
   createMailSplitBody,
   deleteMailSplitBody,
@@ -17,35 +20,68 @@ export const createMailSplitAction = actionClient
   .inputSchema(createMailSplitBody)
   .action(
     async ({ ctx: { emailAccountId }, parsedInput: { name, kind, value } }) => {
-      const existing = await prisma.mailSplit.count({
-        where: { emailAccountId },
-      });
-      if (existing >= MAX_SPLITS)
-        throw new SafeError(`You can only have ${MAX_SPLITS} splits.`);
+      const [, createdSplits, duplicate, splitCount] =
+        await prisma.$transaction([
+          prisma.$queryRaw`
+            SELECT true AS locked
+            FROM (
+              SELECT pg_advisory_xact_lock(742931, hashtext(${emailAccountId}))
+            ) lock
+          `,
+          prisma.$queryRaw<MailSplit[]>`
+            WITH split_state AS (
+              SELECT
+                COUNT(*)::integer AS count,
+                COALESCE(MAX("order"), -1)::integer + 1 AS next_order
+              FROM "MailSplit"
+              WHERE "emailAccountId" = ${emailAccountId}
+            )
+            INSERT INTO "MailSplit" (
+              "id",
+              "createdAt",
+              "updatedAt",
+              "name",
+              "kind",
+              "value",
+              "order",
+              "emailAccountId"
+            )
+            SELECT
+              ${randomUUID()},
+              CURRENT_TIMESTAMP,
+              CURRENT_TIMESTAMP,
+              ${name},
+              ${kind}::"MailSplitKind",
+              ${value ?? null},
+              split_state.next_order,
+              ${emailAccountId}
+            FROM split_state
+            WHERE split_state.count < ${MAX_SPLITS}
+              AND NOT EXISTS (
+                SELECT 1
+                FROM "MailSplit"
+                WHERE "emailAccountId" = ${emailAccountId}
+                  AND "name" = ${name}
+              )
+            RETURNING *
+          `,
+          prisma.mailSplit.findUnique({
+            where: { emailAccountId_name: { emailAccountId, name } },
+            select: { id: true },
+          }),
+          prisma.mailSplit.count({ where: { emailAccountId } }),
+        ]);
 
-      const duplicate = await prisma.mailSplit.findUnique({
-        where: { emailAccountId_name: { emailAccountId, name } },
-        select: { id: true },
-      });
-      if (duplicate) throw new SafeError(`You already have a "${name}" split.`);
-
-      // Derived from the highest order rather than the count: deleting a split
-      // from the middle would otherwise hand the next one a duplicate order.
-      const last = await prisma.mailSplit.findFirst({
-        where: { emailAccountId },
-        orderBy: { order: "desc" },
-        select: { order: true },
-      });
-
-      const split = await prisma.mailSplit.create({
-        data: {
-          emailAccountId,
-          name,
-          kind,
-          value: value ?? null,
-          order: (last?.order ?? -1) + 1,
-        },
-      });
+      const [split] = createdSplits;
+      if (!split) {
+        if (duplicate) {
+          throw new SafeError(`You already have a "${name}" split.`);
+        }
+        if (splitCount >= MAX_SPLITS) {
+          throw new SafeError(`You can only have ${MAX_SPLITS} splits.`);
+        }
+        throw new SafeError("Could not create split. Please try again.");
+      }
 
       return { split };
     },
@@ -55,11 +91,18 @@ export const renameMailSplitAction = actionClient
   .metadata({ name: "renameMailSplit" })
   .inputSchema(renameMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id, name } }) => {
-    const { count } = await prisma.mailSplit.updateMany({
-      where: { id, emailAccountId },
-      data: { name },
-    });
-    if (!count) throw new SafeError("Split not found");
+    try {
+      const { count } = await prisma.mailSplit.updateMany({
+        where: { id, emailAccountId },
+        data: { name },
+      });
+      if (!count) throw new SafeError("Split not found");
+    } catch (error) {
+      if (isDuplicateError(error, "name")) {
+        throw new SafeError(`You already have a "${name}" split.`);
+      }
+      throw error;
+    }
   });
 
 export const deleteMailSplitAction = actionClient

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -20,70 +20,32 @@ export const createMailSplitAction = actionClient
   .inputSchema(createMailSplitBody)
   .action(
     async ({ ctx: { emailAccountId }, parsedInput: { name, kind, value } }) => {
-      const [, createdSplits, duplicate, splitCount] =
-        await prisma.$transaction([
-          prisma.$queryRaw`
-            SELECT true AS locked
-            FROM (
-              SELECT pg_advisory_xact_lock(742931, hashtext(${emailAccountId}))
-            ) lock
-          `,
-          prisma.$queryRaw<MailSplit[]>`
-            WITH split_state AS (
-              SELECT
-                COUNT(*)::integer AS count,
-                COALESCE(MAX("order"), -1)::integer + 1 AS next_order
-              FROM "MailSplit"
-              WHERE "emailAccountId" = ${emailAccountId}
-            )
-            INSERT INTO "MailSplit" (
-              "id",
-              "createdAt",
-              "updatedAt",
-              "name",
-              "kind",
-              "value",
-              "order",
-              "emailAccountId"
-            )
-            SELECT
-              ${randomUUID()},
-              CURRENT_TIMESTAMP,
-              CURRENT_TIMESTAMP,
-              ${name},
-              ${kind}::"MailSplitKind",
-              ${value ?? null},
-              split_state.next_order,
-              ${emailAccountId}
-            FROM split_state
-            WHERE split_state.count < ${MAX_SPLITS}
-              AND NOT EXISTS (
-                SELECT 1
-                FROM "MailSplit"
-                WHERE "emailAccountId" = ${emailAccountId}
-                  AND "name" = ${name}
-              )
-            RETURNING *
-          `,
-          prisma.mailSplit.findUnique({
-            where: { emailAccountId_name: { emailAccountId, name } },
-            select: { id: true },
-          }),
-          prisma.mailSplit.count({ where: { emailAccountId } }),
-        ]);
+      try {
+        const result = await createMailSplit({
+          emailAccountId,
+          name,
+          kind,
+          value: value ?? null,
+        });
 
-      const [split] = createdSplits;
-      if (!split) {
-        if (duplicate) {
+        if (!result) {
+          throw new SafeError("Could not create split. Please try again.");
+        }
+        if (result.status === "duplicate") {
           throw new SafeError(`You already have a "${name}" split.`);
         }
-        if (splitCount >= MAX_SPLITS) {
+        if (result.status === "limit") {
           throw new SafeError(`You can only have ${MAX_SPLITS} splits.`);
         }
-        throw new SafeError("Could not create split. Please try again.");
-      }
 
-      return { split };
+        const { status: _, ...split } = result;
+        return { split };
+      } catch (error) {
+        if (isDuplicateError(error, "name")) {
+          throw new SafeError(`You already have a "${name}" split.`);
+        }
+        throw error;
+      }
     },
   );
 
@@ -92,10 +54,13 @@ export const renameMailSplitAction = actionClient
   .inputSchema(renameMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id, name } }) => {
     try {
-      const { count } = await prisma.mailSplit.updateMany({
-        where: { id, emailAccountId },
-        data: { name },
-      });
+      const [, { count }] = await prisma.$transaction([
+        lockMailSplits(emailAccountId),
+        prisma.mailSplit.updateMany({
+          where: { id, emailAccountId },
+          data: { name },
+        }),
+      ]);
       if (!count) throw new SafeError("Split not found");
     } catch (error) {
       if (isDuplicateError(error, "name")) {
@@ -132,3 +97,78 @@ export const updateMailPreferencesAction = actionClient
       });
     },
   );
+
+type CreateMailSplitResult =
+  | ({ status: "created" } & MailSplit)
+  | { status: "duplicate" | "limit" };
+
+async function createMailSplit({
+  emailAccountId,
+  name,
+  kind,
+  value,
+}: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">) {
+  const [, results] = await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$queryRaw<CreateMailSplitResult[]>`
+      WITH split_state AS (
+        SELECT
+          COUNT(*)::integer AS count,
+          COALESCE(MAX("order"), -1)::integer + 1 AS next_order,
+          EXISTS (
+            SELECT 1
+            FROM "MailSplit"
+            WHERE "emailAccountId" = ${emailAccountId}
+              AND "name" = ${name}
+          ) AS name_exists
+        FROM "MailSplit"
+        WHERE "emailAccountId" = ${emailAccountId}
+      ),
+      inserted AS (
+        INSERT INTO "MailSplit" (
+          "id",
+          "createdAt",
+          "updatedAt",
+          "name",
+          "kind",
+          "value",
+          "order",
+          "emailAccountId"
+        )
+        SELECT
+          ${randomUUID()},
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP,
+          ${name},
+          ${kind}::"MailSplitKind",
+          ${value},
+          split_state.next_order,
+          ${emailAccountId}
+        FROM split_state
+        WHERE split_state.count < ${MAX_SPLITS}
+          AND NOT split_state.name_exists
+        RETURNING *
+      )
+      SELECT
+        CASE
+          WHEN inserted."id" IS NOT NULL THEN 'created'
+          WHEN split_state.name_exists THEN 'duplicate'
+          ELSE 'limit'
+        END AS status,
+        inserted.*
+      FROM split_state
+      LEFT JOIN inserted ON TRUE
+    `,
+  ]);
+
+  return results[0];
+}
+
+function lockMailSplits(emailAccountId: string) {
+  return prisma.$queryRaw`
+    SELECT true AS locked
+    FROM (
+      SELECT pg_advisory_xact_lock(742931, hashtext(${emailAccountId}))
+    ) lock
+  `;
+}

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -90,18 +90,8 @@ const zodActionType = z.enum([
   ActionType.INTEGRATION,
 ]);
 
-// Arg keys are owned by the tool spec, so unknown keys are kept here and
-// rejected in the refinement rather than silently stripped.
-const zodIntegrationArgs = z
-  .object({
-    content: z.string().nullish(),
-    description: z.string().nullish(),
-    dueString: z.string().nullish(),
-    projectId: z.string().nullish(),
-    projectName: z.string().nullish(),
-  })
-  .catchall(z.string().nullish())
-  .nullish();
+// Arg keys are owned and validated by the selected tool spec below.
+const zodIntegrationArgs = z.record(z.string(), z.string().nullish()).nullish();
 export type IntegrationActionArgs = z.infer<typeof zodIntegrationArgs>;
 
 const zodConditionType = z.enum([ConditionType.AI, ConditionType.STATIC]);

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -11,14 +11,14 @@ import { deleteRuleTool } from "./tools/rules/delete-rule-tool";
 
 const {
   mockCreateRule,
-  mockOutboundActionsNeedChatRiskConfirmation,
+  mockActionsNeedChatRiskConfirmation,
   mockPartialUpdateRule,
   mockPrisma,
   mockSetRuleEnabled,
   mockUpdateRuleActions,
 } = vi.hoisted(() => ({
   mockCreateRule: vi.fn(),
-  mockOutboundActionsNeedChatRiskConfirmation: vi.fn(),
+  mockActionsNeedChatRiskConfirmation: vi.fn(),
   mockPartialUpdateRule: vi.fn(),
   mockSetRuleEnabled: vi.fn(),
   mockUpdateRuleActions: vi.fn(),
@@ -43,8 +43,7 @@ vi.mock("@/utils/rule/rule", async (importOriginal) => {
   return {
     ...actual,
     createRule: mockCreateRule,
-    outboundActionsNeedChatRiskConfirmation:
-      mockOutboundActionsNeedChatRiskConfirmation,
+    actionsNeedChatRiskConfirmation: mockActionsNeedChatRiskConfirmation,
     partialUpdateRule: mockPartialUpdateRule,
     setRuleEnabled: mockSetRuleEnabled,
     updateRuleActions: mockUpdateRuleActions,
@@ -64,7 +63,7 @@ const defaultActions = [
 describe("createRuleTool overlap guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockOutboundActionsNeedChatRiskConfirmation.mockReturnValue({
+    mockActionsNeedChatRiskConfirmation.mockReturnValue({
       needsConfirmation: false,
       riskMessages: [],
     });

--- a/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
@@ -1,10 +1,7 @@
 import { type InferUITool, tool } from "ai";
 import type { Logger } from "@/utils/logger";
 import { createRuleSchema } from "@/utils/ai/rule/create-rule-schema";
-import {
-  createRule,
-  outboundActionsNeedChatRiskConfirmation,
-} from "@/utils/rule/rule";
+import { actionsNeedChatRiskConfirmation, createRule } from "@/utils/rule/rule";
 import {
   findSenderOnlyOverlapConflict,
   formatSenderOnlyOverlapError,
@@ -63,7 +60,7 @@ export const createRuleTool = ({
         );
 
         const { needsConfirmation, riskMessages } =
-          outboundActionsNeedChatRiskConfirmation(resultPayload);
+          actionsNeedChatRiskConfirmation(resultPayload);
 
         if (needsConfirmation) {
           return {

--- a/apps/web/utils/ai/assistant/tools/rules/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/shared.ts
@@ -3,6 +3,7 @@ import type { Logger } from "@/utils/logger";
 import type {
   createRuleSchema,
   CreateOrUpdateRuleSchema,
+  RuleActionFields,
 } from "@/utils/ai/rule/create-rule-schema";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { RULE_MANAGED_BY_ORGANIZATION_ERROR } from "@/utils/organizations/rules";
@@ -20,18 +21,7 @@ const RULE_READ_FRESHNESS_WINDOW_MS = 2 * 60 * 1000;
 const RULE_NOT_FOUND_ERROR =
   "Rule not found. Try listing the rules again. The user may have made changes since you last checked.";
 
-type RuleActionFieldValues = {
-  content?: string | null;
-  to?: string | null;
-  subject?: string | null;
-  label?: string | null;
-  webhookUrl?: string | null;
-  cc?: string | null;
-  bcc?: string | null;
-  folderName?: string | null;
-  description?: string | null;
-  dueString?: string | null;
-};
+type RuleActionFieldValues = RuleActionFields;
 
 const providerRuleActionFieldBuilders: Record<
   string,
@@ -50,6 +40,7 @@ export function buildProviderRuleActionFields({
   fields: RuleActionFieldValues;
 }): RuleActionFieldValues {
   return {
+    ...fields,
     content: fields.content ?? null,
     to: fields.to ?? null,
     subject: fields.subject ?? null,
@@ -57,8 +48,6 @@ export function buildProviderRuleActionFields({
     webhookUrl: fields.webhookUrl ?? null,
     cc: fields.cc ?? null,
     bcc: fields.bcc ?? null,
-    description: fields.description ?? null,
-    dueString: fields.dueString ?? null,
     ...(providerRuleActionFieldBuilders[provider]?.(fields) ?? {}),
   };
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -158,9 +158,7 @@ export type RuleActionFields = {
   content?: string | null;
   webhookUrl?: string | null;
   folderName?: string | null;
-  description?: string | null;
-  dueString?: string | null;
-};
+} & Record<string, string | null | undefined>;
 
 export type RuleAction = {
   type: ActionType;

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -158,7 +158,7 @@ export type RuleActionFields = {
   content?: string | null;
   webhookUrl?: string | null;
   folderName?: string | null;
-} & Record<string, string | null | undefined>;
+};
 
 export type RuleAction = {
   type: ActionType;

--- a/apps/web/utils/mcp/call-tool.test.ts
+++ b/apps/web/utils/mcp/call-tool.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCallTool,
+  mockClientClose,
+  mockClientConnect,
+  mockGetAuthToken,
+  mockTransportClose,
+} = vi.hoisted(() => ({
+  mockCallTool: vi.fn(),
+  mockClientClose: vi.fn(),
+  mockClientConnect: vi.fn(),
+  mockGetAuthToken: vi.fn(),
+  mockTransportClose: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class {
+    connect = mockClientConnect;
+    callTool = mockCallTool;
+    close = mockClientClose;
+  },
+}));
+
+vi.mock("@/utils/mcp/oauth", () => ({
+  getAuthToken: mockGetAuthToken,
+}));
+
+vi.mock("@/utils/mcp/transport", () => ({
+  createMcpTransport: () => ({ close: mockTransportClose }),
+}));
+
+import { callMcpTool } from "@/utils/mcp/call-tool";
+
+describe("callMcpTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthToken.mockResolvedValue("token");
+  });
+
+  it("does not expose remote tool error content", async () => {
+    mockCallTool.mockResolvedValue({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Task title copied from a private email",
+        },
+      ],
+    });
+
+    const error = await callMcpTool({
+      emailAccountId: "email-account-1",
+      integration: "todoist",
+      toolName: "add-tasks",
+      args: { content: "private task" },
+    }).catch((caught) => caught);
+
+    expect(error).toEqual(new Error("Failed to call todoist tool add-tasks"));
+    expect(error.message).not.toContain("private email");
+    expect(mockClientClose).toHaveBeenCalledOnce();
+    expect(mockTransportClose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/utils/mcp/call-tool.ts
+++ b/apps/web/utils/mcp/call-tool.ts
@@ -50,33 +50,21 @@ export async function callMcpTool({
     const result = await client.callTool({ name: toolName, arguments: args });
 
     if (result.isError) {
-      throw new Error(
-        `Tool ${toolName} returned an error: ${stringifyToolContent(result.content)}`,
-      );
+      throw new Error("MCP tool returned an error");
     }
 
     logger.info("Called MCP tool", { integration, toolName });
 
     return result.content;
   } catch (error) {
-    logger.error("Failed to call MCP tool", { error, integration, toolName });
-    throw new Error(
-      `Failed to call ${integration} tool ${toolName}: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
+    logger.error("Failed to call MCP tool", {
+      integration,
+      toolName,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    throw new Error(`Failed to call ${integration} tool ${toolName}`);
   } finally {
     await client.close();
     await transport.close();
   }
-}
-
-function stringifyToolContent(content: unknown): string {
-  if (!Array.isArray(content)) return JSON.stringify(content);
-
-  return content
-    .map((item) =>
-      item && typeof item === "object" && "text" in item
-        ? String(item.text)
-        : JSON.stringify(item),
-    )
-    .join("\n");
 }

--- a/apps/web/utils/mcp/call-tool.ts
+++ b/apps/web/utils/mcp/call-tool.ts
@@ -62,6 +62,7 @@ export async function callMcpTool({
       toolName,
       errorType: error instanceof Error ? error.name : typeof error,
     });
+    logger.trace("MCP tool call failure details", () => ({ error }));
     throw new Error(`Failed to call ${integration} tool ${toolName}`);
   } finally {
     await client.close();

--- a/apps/web/utils/mcp/integrations.ts
+++ b/apps/web/utils/mcp/integrations.ts
@@ -4,7 +4,7 @@ type McpIntegrationConfig = {
   authType: "oauth" | "api-token";
   scopes: string[];
   skipResourceParam?: boolean; // Some OAuth servers don't support RFC 8707 resource parameter
-  filterWriteTools?: boolean; // Auto-filter write tools, only sync read-only tools (get, list, find, search)
+  filterWriteTools?: boolean; // Require read-only annotations and names; new tools start disabled
   ruleActionWriteTools?: string[];
 };
 
@@ -170,8 +170,8 @@ export const MCP_INTEGRATIONS: Record<
     authType: "oauth",
     scopes: ["mcp", "offline_access"],
     skipResourceParam: true, // Pipedream doesn't support RFC 8707 resource parameter
-    filterWriteTools: true, // Only sync read-only tools (get, list, find, search)
-    // No allowedTools - accept all tools Pipedream provides
+    filterWriteTools: true,
+    // No fixed allowlist because Pipedream's catalog is dynamic
     // OAuth endpoints auto-discovered via RFC 8414
   },
 };

--- a/apps/web/utils/mcp/sync-tools.test.ts
+++ b/apps/web/utils/mcp/sync-tools.test.ts
@@ -49,11 +49,12 @@ describe("syncMcpTools", () => {
     });
   });
 
-  it("filters write tools using readOnlyHint, falling back to the name heuristic", async () => {
+  it("only syncs Pipedream tools that both declare and look read-only", async () => {
     mockConnection([], "pipedream");
     mockListMcpTools.mockResolvedValue([
       { name: "slack_v2-list-channels" },
-      { name: "slack_v2-send-message" },
+      { name: "slack_v2-list-users", readOnlyHint: true },
+      { name: "slack_v2-send-message", readOnlyHint: true },
       { name: "custom_read_tool", readOnlyHint: true },
       { name: "app-list-archived-items", readOnlyHint: false },
     ]);
@@ -63,11 +64,28 @@ describe("syncMcpTools", () => {
     expect(prisma.mcpTool.createMany).toHaveBeenCalledWith({
       data: [
         expect.objectContaining({
-          name: "slack_v2-list-channels",
-          isEnabled: true,
+          name: "slack_v2-list-users",
+          isEnabled: false,
         }),
+      ],
+    });
+  });
+
+  it("preserves explicitly enabled Pipedream tools during resync", async () => {
+    mockConnection(
+      [{ name: "slack_v2-list-users", isEnabled: true }],
+      "pipedream",
+    );
+    mockListMcpTools.mockResolvedValue([
+      { name: "slack_v2-list-users", readOnlyHint: true },
+    ]);
+
+    await syncMcpTools("pipedream", "email-account-1", logger);
+
+    expect(prisma.mcpTool.createMany).toHaveBeenCalledWith({
+      data: [
         expect.objectContaining({
-          name: "custom_read_tool",
+          name: "slack_v2-list-users",
           isEnabled: true,
         }),
       ],

--- a/apps/web/utils/mcp/sync-tools.ts
+++ b/apps/web/utils/mcp/sync-tools.ts
@@ -51,11 +51,12 @@ export async function syncMcpTools(
       : allTools;
     readTools = readTools.filter((tool) => !writeToolNames.includes(tool.name));
 
-    // Filter out write tools if enabled (keeps only get, list, find, search, etc.)
+    // Pipedream exposes a changing tool catalog. Require both its annotation
+    // and the operation name to indicate a read before storing the tool.
     if (integrationConfig.filterWriteTools) {
       const beforeCount = readTools.length;
       readTools = readTools.filter(
-        (tool) => tool.readOnlyHint ?? isReadOnlyTool(tool.name),
+        (tool) => tool.readOnlyHint === true && isReadOnlyTool(tool.name),
       );
       logger.info("Filtered write tools", {
         before: beforeCount,
@@ -94,7 +95,9 @@ export async function syncMcpTools(
                 name: tool.name,
                 description: tool.description,
                 schema: tool.inputSchema as Prisma.InputJsonValue,
-                isEnabled: existingEnabledByName.get(tool.name) ?? true,
+                isEnabled:
+                  existingEnabledByName.get(tool.name) ??
+                  !integrationConfig.filterWriteTools,
                 isWrite: tool.isWrite,
               })),
             }),

--- a/apps/web/utils/mcp/tool-specs.test.ts
+++ b/apps/web/utils/mcp/tool-specs.test.ts
@@ -53,4 +53,21 @@ describe("getIntegrationActionDisplayValue", () => {
       }),
     ).toBeNull();
   });
+
+  it("trims the display value and hides whitespace-only content", () => {
+    expect(
+      getIntegrationActionDisplayValue({
+        integrationName: "todoist",
+        integrationToolName: "add-tasks",
+        integrationArgs: { content: "  Review the contract  " },
+      }),
+    ).toBe("Review the contract");
+    expect(
+      getIntegrationActionDisplayValue({
+        integrationName: "todoist",
+        integrationToolName: "add-tasks",
+        integrationArgs: { content: "   " },
+      }),
+    ).toBeNull();
+  });
 });

--- a/apps/web/utils/mcp/tool-specs.test.ts
+++ b/apps/web/utils/mcp/tool-specs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getIntegrationActionLabel } from "./tool-specs";
+import {
+  getIntegrationActionDisplayValue,
+  getIntegrationActionLabel,
+} from "./tool-specs";
 
 describe("getIntegrationActionLabel", () => {
   it("names the action after the tool it calls", () => {
@@ -27,5 +30,27 @@ describe("getIntegrationActionLabel", () => {
     });
 
     expect(label).not.toBe("Add Todoist task");
+  });
+});
+
+describe("getIntegrationActionDisplayValue", () => {
+  it("uses the display argument declared by the tool spec", () => {
+    expect(
+      getIntegrationActionDisplayValue({
+        integrationName: "todoist",
+        integrationToolName: "add-tasks",
+        integrationArgs: { content: "Review the contract" },
+      }),
+    ).toBe("Review the contract");
+  });
+
+  it("does not borrow display metadata for an unknown tool", () => {
+    expect(
+      getIntegrationActionDisplayValue({
+        integrationName: "todoist",
+        integrationToolName: "unknown-tool",
+        integrationArgs: { content: "Review the contract" },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/utils/mcp/tool-specs.ts
+++ b/apps/web/utils/mcp/tool-specs.ts
@@ -225,7 +225,7 @@ export function getIntegrationActionDisplayValue(action: {
   if (!args || typeof args !== "object" || Array.isArray(args)) return null;
 
   const value = (args as Record<string, unknown>)[spec.displayArgKey];
-  return typeof value === "string" ? value : null;
+  return typeof value === "string" ? value.trim() || null : null;
 }
 
 /** Read tools the app calls directly to populate a remote-select. */

--- a/apps/web/utils/mcp/tool-specs.ts
+++ b/apps/web/utils/mcp/tool-specs.ts
@@ -61,6 +61,7 @@ export type IntegrationToolSpec = {
   integration: IntegrationKey;
   tool: string;
   actionLabel: string;
+  displayArgKey?: string;
   llmDescription: string; // describes the action to the rule-writing LLM
   args: readonly IntegrationArgSpec[];
   buildPayload: (resolved: Record<string, string>) => Record<string, unknown>;
@@ -86,6 +87,7 @@ const todoistAddTasksSpec: IntegrationToolSpec = {
   integration: "todoist",
   tool: "add-tasks",
   actionLabel: "Add Todoist task",
+  displayArgKey: "content",
   llmDescription:
     "Add a task to the user's Todoist for the matching email. Only use this when the user explicitly asks to create Todoist tasks. Fails if Todoist isn't connected.",
   args: [
@@ -206,6 +208,24 @@ export function getIntegrationActionLabel(action?: {
     : getOnlyIntegrationToolSpec();
 
   return spec?.actionLabel ?? GENERIC_INTEGRATION_ACTION_LABEL;
+}
+
+export function getIntegrationActionDisplayValue(action: {
+  integrationName?: string | null;
+  integrationToolName?: string | null;
+  integrationArgs?: unknown;
+}): string | null {
+  const namesTool = !!action.integrationName || !!action.integrationToolName;
+  const spec = namesTool
+    ? getIntegrationToolSpec(action.integrationName, action.integrationToolName)
+    : getOnlyIntegrationToolSpec();
+  if (!spec?.displayArgKey) return null;
+
+  const args = action.integrationArgs;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return null;
+
+  const value = (args as Record<string, unknown>)[spec.displayArgKey];
+  return typeof value === "string" ? value : null;
 }
 
 /** Read tools the app calls directly to populate a remote-select. */

--- a/apps/web/utils/rule/chat-rule-risk.test.ts
+++ b/apps/web/utils/rule/chat-rule-risk.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { ActionType } from "@/generated/prisma/enums";
-import { outboundActionsNeedChatRiskConfirmation } from "@/utils/rule/rule";
+import { actionsNeedChatRiskConfirmation } from "@/utils/rule/rule";
 
-describe("outboundActionsNeedChatRiskConfirmation", () => {
+describe("actionsNeedChatRiskConfirmation", () => {
   it("returns needsConfirmation false when only label actions", () => {
-    const result = outboundActionsNeedChatRiskConfirmation({
+    const result = actionsNeedChatRiskConfirmation({
       name: "x",
       condition: {
         aiInstructions: null,
@@ -25,7 +25,7 @@ describe("outboundActionsNeedChatRiskConfirmation", () => {
   });
 
   it("returns needsConfirmation true for fully dynamic reply content and recipient", () => {
-    const result = outboundActionsNeedChatRiskConfirmation({
+    const result = actionsNeedChatRiskConfirmation({
       name: "x",
       condition: {
         aiInstructions: "when urgent",
@@ -45,7 +45,7 @@ describe("outboundActionsNeedChatRiskConfirmation", () => {
   });
 
   it("returns needsConfirmation false for static reply body and implicit recipient", () => {
-    const result = outboundActionsNeedChatRiskConfirmation({
+    const result = actionsNeedChatRiskConfirmation({
       name: "x",
       condition: {
         aiInstructions: null,
@@ -67,7 +67,7 @@ describe("outboundActionsNeedChatRiskConfirmation", () => {
   });
 
   it("returns needsConfirmation true for webhook actions", () => {
-    const result = outboundActionsNeedChatRiskConfirmation({
+    const result = actionsNeedChatRiskConfirmation({
       name: "x",
       condition: {
         aiInstructions: null,
@@ -89,5 +89,57 @@ describe("outboundActionsNeedChatRiskConfirmation", () => {
     expect(result.riskMessages).toEqual([
       expect.stringContaining("Webhook actions can send email data"),
     ]);
+  });
+
+  it("returns needsConfirmation true when an integration action uses AI-filled args", () => {
+    const result = actionsNeedChatRiskConfirmation({
+      name: "x",
+      condition: {
+        aiInstructions: null,
+        conditionalOperator: null,
+        static: { from: "@vendor.com", to: null, subject: null },
+      },
+      actions: [
+        {
+          type: ActionType.INTEGRATION,
+          fields: {
+            content: null,
+            description: null,
+            dueString: null,
+          },
+          delayInMinutes: null,
+        },
+      ],
+    });
+
+    expect(result.needsConfirmation).toBe(true);
+    expect(result.riskMessages).toEqual([
+      expect.stringContaining("creating unwanted or misleading tasks"),
+    ]);
+  });
+
+  it("returns needsConfirmation false for integration actions with static args", () => {
+    const result = actionsNeedChatRiskConfirmation({
+      name: "x",
+      condition: {
+        aiInstructions: null,
+        conditionalOperator: null,
+        static: { from: "@vendor.com", to: null, subject: null },
+      },
+      actions: [
+        {
+          type: ActionType.INTEGRATION,
+          fields: {
+            content: "Review the contract",
+            description: "Sent by the contracts team",
+            dueString: "today",
+          },
+          delayInMinutes: null,
+        },
+      ],
+    });
+
+    expect(result.needsConfirmation).toBe(false);
+    expect(result.riskMessages).toEqual([]);
   });
 });

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -80,7 +80,7 @@ function addNestedActionOwnershipToInput<T extends Record<string, unknown>>(
   };
 }
 
-export function outboundActionsNeedChatRiskConfirmation(
+export function actionsNeedChatRiskConfirmation(
   result: CreateOrUpdateRuleSchema,
 ): { needsConfirmation: boolean; riskMessages: string[] } {
   const ruleCtx = ruleConditionsForRisk(result);
@@ -95,17 +95,10 @@ export function outboundActionsNeedChatRiskConfirmation(
       continue;
     }
 
-    if (!OUTBOUND_ACTION_TYPES.includes(action.type)) continue;
-
-    const ra: RiskAction = {
-      type: action.type,
-      subject: action.fields?.subject ?? null,
-      content: action.fields?.content ?? null,
-      to: action.fields?.to?.trim() || null,
-      cc: action.fields?.cc ?? null,
-      bcc: action.fields?.bcc ?? null,
-    };
-    const { level, message } = getActionRiskLevel(ra, ruleCtx);
+    const { level, message } = getActionRiskLevel(
+      buildRiskAction(action),
+      ruleCtx,
+    );
     if (level !== "low" && !messages.includes(message)) {
       messages.push(message);
     }
@@ -692,22 +685,10 @@ function shouldEnable(
       return false;
     }
 
-    const hasOutbound = rule.actions.some((a) =>
-      OUTBOUND_ACTION_TYPES.includes(a.type),
-    );
-    if (!hasOutbound) {
-      return actions.every(
-        (action) => getActionRiskLevel(action, {}).level === "low",
-      );
-    }
     const ruleCtx = ruleConditionsForRisk(rule);
-    for (const action of actions) {
-      if (!OUTBOUND_ACTION_TYPES.includes(action.type)) continue;
-      if (getActionRiskLevel(action, ruleCtx).level !== "low") {
-        return false;
-      }
-    }
-    return true;
+    return actions.every(
+      (action) => getActionRiskLevel(action, ruleCtx).level === "low",
+    );
   }
 
   if (rule.actions.find((a) => OUTBOUND_ACTION_TYPES.includes(a.type)))
@@ -902,6 +883,25 @@ function getIntegrationCreateFields(action: MappableAction) {
         integrationToolName,
         fields: action.fields,
       })) as Prisma.InputJsonValue,
+  };
+}
+
+function buildRiskAction(action: MappableAction): RiskAction {
+  const integrationFields =
+    action.type === ActionType.INTEGRATION
+      ? getIntegrationCreateFields(action)
+      : null;
+
+  return {
+    type: action.type,
+    subject: action.fields?.subject ?? null,
+    content: action.fields?.content ?? null,
+    to: action.fields?.to?.trim() || null,
+    cc: action.fields?.cc ?? null,
+    bcc: action.fields?.bcc ?? null,
+    integrationName: integrationFields?.integrationName ?? null,
+    integrationToolName: integrationFields?.integrationToolName ?? null,
+    integrationArgs: integrationFields?.integrationArgs ?? null,
   };
 }
 

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -901,7 +901,9 @@ function buildRiskAction(action: MappableAction): RiskAction {
     bcc: action.fields?.bcc ?? null,
     integrationName: integrationFields?.integrationName ?? null,
     integrationToolName: integrationFields?.integrationToolName ?? null,
-    integrationArgs: integrationFields?.integrationArgs ?? null,
+    integrationArgs:
+      (integrationFields?.integrationArgs as Prisma.JsonValue | undefined) ??
+      null,
   };
 }
 

--- a/docs/changelog-entries/2026-08-07.mdx
+++ b/docs/changelog-entries/2026-08-07.mdx
@@ -8,4 +8,4 @@ Setting up Inbox Zero now starts with a real conversation. Tell the assistant wh
 - Your setup and cleanup cards appear inline in the conversation and stay editable as you go
 - Pick up where you left off — your chat, draft rules, and cleanup choices restore if you reload or come back later
 - A quick inbox scan surfaces newsletter suggestions you can unsubscribe from during setup
-- When you're done, jump straight into your inbox
+- When the conversation is done, continue through guided setup before opening your inbox

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -18,7 +18,7 @@ description: "Latest updates and improvements to Inbox Zero"
   - Your setup and cleanup cards appear inline in the conversation and stay editable as you go
   - Pick up where you left off — your chat, draft rules, and cleanup choices restore if you reload or come back later
   - A quick inbox scan surfaces newsletter suggestions you can unsubscribe from during setup
-  - When you're done, jump straight into your inbox
+  - When the conversation is done, continue through guided setup before opening your inbox
 </Update>
 
 <Update label="August 2, 2026" description="Inbox Health Reports">


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260811-171338_pr-3209_5a03003d1ca7/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Addresses security, correctness, and cleanup issues found while reviewing the PRs merged over the last few days.

- fail closed for dynamic Pipedream tool discovery and keep remote MCP error content out of logs and responses
- include integration actions in chat risk confirmation and centralize integration field/display metadata
- serialize mail-split creation, enforce unique ordering, and return safe duplicate errors
- correct the onboarding changelog to match the guided setup flow

Validation:
- 262 focused unit tests passed
- Ultracite checks passed for all changed TypeScript files
- Prisma schema validation passed

No model-facing prompts or tool parameters were changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->