### PR TITLE
mail: Keep layout changes after switching views

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -113,7 +113,10 @@ export function MailShell() {
         // the UI showing a preference the server never accepted.
         if (result?.serverError || result?.validationErrors)
           throw new Error(getActionErrorMessage(result));
-        return current;
+        return {
+          layout: next,
+          splits: current?.splits ?? [],
+        };
       },
       {
         optimisticData: (current) => ({

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Prisma } from "@/generated/prisma/client";
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   createMailSplitAction,
   renameMailSplitAction,
+  updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 
 vi.mock("@/utils/prisma");
@@ -107,6 +108,17 @@ describe("mail split actions", () => {
     });
 
     expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+
+  it("persists the selected mail layout", async () => {
+    await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
+      layout: MailLayout.SPLIT,
+    });
+
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: EMAIL_ACCOUNT_ID },
+      data: { mailLayout: MailLayout.SPLIT },
+    });
   });
 });
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260811-231448_pr-3213_ba5d52297f1a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix the mail layout preference update so the selected view remains active after the save completes.

- retain the saved layout in the client settings cache
- verify the layout preference is persisted for subsequent loads

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->