### PR TITLE
mail: Add Outlook navigation parity

### DIFF
--- a/apps/web/__tests__/integration/helpers.ts
+++ b/apps/web/__tests__/integration/helpers.ts
@@ -55,6 +55,7 @@ type OutlookSeedMessage = {
   parent_folder_id: string;
   is_read: boolean;
   is_draft?: boolean;
+  categories?: string[];
   received_date_time: string;
   sent_date_time?: string;
 };
@@ -179,11 +180,17 @@ export async function createOutlookTestHarness({
   email,
   messages,
   categories,
+  folders,
 }: {
   port?: number;
   email: string;
   messages: OutlookSeedMessage[];
   categories?: Array<{ display_name: string; color?: string }>;
+  folders?: Array<{
+    id: string;
+    display_name: string;
+    parent_folder_id?: string;
+  }>;
 }): Promise<OutlookTestHarness> {
   const emulatorPort = port ?? (await getAvailablePort());
   const emulator = await createEmulator({
@@ -200,6 +207,7 @@ export async function createOutlookTestHarness({
           },
         ],
         categories: categories || [],
+        folders: folders || [],
         messages,
       },
     },

--- a/apps/web/__tests__/integration/outlook-mail-view-parity.test.ts
+++ b/apps/web/__tests__/integration/outlook-mail-view-parity.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createOutlookTestHarness, type OutlookTestHarness } from "./helpers";
+
+vi.mock("server-only", () => ({}));
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const EMAIL = "mail-view@example.com";
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "Outlook mail view parity",
+  { timeout: 30_000 },
+  () => {
+    let harness: OutlookTestHarness;
+
+    beforeAll(async () => {
+      harness = await createOutlookTestHarness({
+        email: EMAIL,
+        folders: [{ id: "projects-folder", display_name: "Projects" }],
+        messages: [
+          {
+            microsoft_id: "project-message",
+            conversation_id: "project-thread",
+            user_email: EMAIL,
+            from: { address: "sender@example.com" },
+            to_recipients: [{ address: EMAIL }],
+            subject: "Project update",
+            body_content: "Update",
+            parent_folder_id: "projects-folder",
+            is_read: false,
+            received_date_time: "2026-08-11T12:00:00Z",
+          },
+          {
+            microsoft_id: "inbox-message",
+            conversation_id: "inbox-thread",
+            user_email: EMAIL,
+            from: { address: "sender@example.com" },
+            to_recipients: [{ address: EMAIL }],
+            subject: "Inbox update",
+            body_content: "Update",
+            parent_folder_id: "inbox",
+            is_read: false,
+            received_date_time: "2026-08-11T13:00:00Z",
+          },
+        ],
+      });
+    });
+
+    afterAll(async () => {
+      harness?.restoreFetch();
+      await harness?.emulator.close();
+    });
+
+    it("returns well-known and custom folders for the sidebar", async () => {
+      const counts = await harness.provider.getFolderCounts();
+
+      expect(counts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ systemType: "INBOX", name: "Inbox" }),
+          expect.objectContaining({ id: "projects-folder", name: "Projects" }),
+        ]),
+      );
+    });
+
+    it("loads only threads from the selected custom folder", async () => {
+      const result = await harness.provider.getThreadsWithQuery({
+        query: { folderId: "projects-folder" },
+      });
+
+      expect(result.threads.map((thread) => thread.id)).toEqual([
+        "project-thread",
+      ]);
+    });
+  },
+);

--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -102,6 +102,7 @@ export function createMockEmailProvider(
     getLabelById: vi.fn().mockResolvedValue(null),
     getLabelByName: vi.fn().mockResolvedValue(null),
     getFolders: vi.fn().mockResolvedValue([]),
+    getFolderCounts: vi.fn().mockResolvedValue([]),
     createLabel: vi
       .fn()
       .mockResolvedValue({ id: "label-123", name: "Test Label", type: "user" }),

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -7,8 +7,12 @@ import { ListToolbar } from "@/app/(app)/[emailAccountId]/mail/ListToolbar";
 import {
   MAIL_CATEGORIES,
   MailSidebar,
+  OUTLOOK_INBOX_SECTIONS,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
-import type { MailNavTarget } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
+import type {
+  MailCategory,
+  MailNavTarget,
+} from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { RuleAttributionMenu } from "@/app/(app)/[emailAccountId]/mail/RuleAttributionMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
@@ -31,12 +35,16 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useSetAtom } from "jotai";
 import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { isGoogleProvider } from "@/utils/email/provider-types";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
 import { useEmail } from "@/providers/EmailProvider";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useLabelCounts } from "@/hooks/useLabelCounts";
 import { useSplitLabels } from "@/hooks/useLabels";
+import { useFolders } from "@/hooks/useFolders";
 import { useMailSettings } from "@/hooks/useMailSettings";
 import { useThread } from "@/hooks/useThread";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
@@ -50,11 +58,15 @@ import {
   createLabelAction,
   removeThreadLabelAction,
 } from "@/utils/actions/mail";
-import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+import {
+  mailSplitToThreadsQuery,
+  mailTypeToThreadsQuery,
+} from "@/utils/mail/split-query";
 import { getActionErrorMessage } from "@/utils/error";
 import { prefixPath } from "@/utils/path";
 import { LoadingContent } from "@/components/LoadingContent";
 import type { ThreadsQuery } from "@/utils/threads/validation";
+import { getEmailTerminology } from "@/utils/terminology";
 
 // Always present, never deletable. Everything else is a saved split. They carry
 // a kind so built-ins and saved splits resolve through one mapping.
@@ -68,11 +80,13 @@ const NO_MESSAGES: ThreadMessage[] = [];
 
 export function MailShell() {
   const { emailAccountId, userEmail, provider } = useAccount();
-  // Gmail categories have no Outlook equivalent, so they're hidden rather than
-  // rendered as rows and split options that can never match anything.
-  const showCategories = isGoogleProvider(provider);
+  const isGoogle = isGoogleProvider(provider);
+  const isOutlook = isMicrosoftProvider(provider);
+  const categories = getMailCategories({ isGoogle, isOutlook });
+  const terminology = getEmailTerminology(provider);
   const { userLabels } = useEmail();
   const { visibleLabels, mutate: mutateLabels } = useSplitLabels();
+  const { folders } = useFolders(provider);
   const { countsById } = useLabelCounts();
   const { data: settings, mutate: mutateSettings } = useMailSettings();
   const { onOpen: openCompose } = useComposeModal();
@@ -89,6 +103,7 @@ export function MailShell() {
   });
   const [scopeType] = useQueryState("type");
   const [scopeLabelId] = useQueryState("labelId");
+  const [scopeFolderId] = useQueryState("folderId");
 
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [isFocusMode, setIsFocusMode] = useState(false);
@@ -135,9 +150,11 @@ export function MailShell() {
   // Resolved once so the tab bar and the fetched rows can't disagree.
   const scopeQuery: ThreadsQuery | null = useMemo(() => {
     if (scopeLabelId) return { labelId: scopeLabelId };
-    if (scopeType && scopeType !== "inbox") return { type: scopeType };
+    if (scopeFolderId) return { folderId: scopeFolderId };
+    if (scopeType && scopeType !== "inbox")
+      return mailTypeToThreadsQuery(scopeType);
     return null;
-  }, [scopeLabelId, scopeType]);
+  }, [scopeFolderId, scopeLabelId, scopeType]);
   const isScoped = scopeQuery !== null;
 
   const splits: MailSplitTab[] = useMemo(
@@ -216,12 +233,7 @@ export function MailShell() {
 
   const hrefFor = useCallback(
     (target: MailNavTarget) =>
-      prefixPath(
-        emailAccountId,
-        target.kind === "label"
-          ? `/mail?type=label&labelId=${encodeURIComponent(target.labelId)}`
-          : `/mail?type=${encodeURIComponent(target.type)}`,
-      ),
+      prefixPath(emailAccountId, getMailNavPath(target)),
     [emailAccountId],
   );
 
@@ -320,6 +332,7 @@ export function MailShell() {
 
   useShortcuts(handlers);
 
+  const categoryGroup = isOutlook ? "inbox" : "category";
   const newSplitOptions: NewSplitOption[] = useMemo(
     () => [
       {
@@ -329,12 +342,12 @@ export function MailShell() {
         value: null,
         group: "state",
       },
-      ...(showCategories ? MAIL_CATEGORIES : []).map((category) => ({
+      ...categories.map((category) => ({
         id: `category:${category.type}`,
         name: category.name,
         kind: MailSplitKind.CATEGORY,
         value: category.type,
-        group: "category" as const,
+        group: categoryGroup,
       })),
       ...visibleLabels.map((label) => ({
         id: `label:${label.id}`,
@@ -344,7 +357,7 @@ export function MailShell() {
         group: "label" as const,
       })),
     ],
-    [visibleLabels, showCategories],
+    [categories, categoryGroup, visibleLabels],
   );
 
   const onCreateSplit = useCallback(
@@ -384,9 +397,11 @@ export function MailShell() {
       // Without this the label the user just typed doesn't appear until an
       // unrelated revalidation happens to run.
       await mutateLabels();
-      toast.success(`Label "${name}" created`);
+      toast.success(
+        `${terminology.label.singularCapitalized} "${name}" created`,
+      );
     },
-    [emailAccountId, mutateLabels],
+    [emailAccountId, mutateLabels, terminology.label.singularCapitalized],
   );
 
   const onRemoveLabel = useCallback(
@@ -414,12 +429,19 @@ export function MailShell() {
         {!isFocusMode && (
           <MailSidebar
             className="hidden lg:flex"
-            activeType={scopeLabelId ? null : (scopeType ?? "inbox")}
+            activeType={
+              scopeLabelId || scopeFolderId ? null : (scopeType ?? "inbox")
+            }
             activeLabelId={scopeLabelId}
+            activeFolderId={scopeFolderId}
             hrefFor={hrefFor}
             labels={visibleLabels}
+            folders={isOutlook ? folders : []}
             countsById={countsById}
-            showCategories={showCategories}
+            categories={categories}
+            categoryHeading={isOutlook ? "Inbox" : "Categories"}
+            labelsHeading={terminology.label.pluralCapitalized}
+            labelSingular={terminology.label.singular}
             backToAppHref={prefixPath(emailAccountId, "/automation")}
             onCompose={openCompose}
             onCreateLabel={onCreateLabel}
@@ -522,4 +544,27 @@ export function MailShell() {
       <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
     </div>
   );
+}
+
+function getMailCategories({
+  isGoogle,
+  isOutlook,
+}: {
+  isGoogle: boolean;
+  isOutlook: boolean;
+}): MailCategory[] {
+  if (isGoogle) return MAIL_CATEGORIES;
+  if (isOutlook) return OUTLOOK_INBOX_SECTIONS;
+  return [];
+}
+
+function getMailNavPath(target: MailNavTarget): string {
+  switch (target.kind) {
+    case "label":
+      return `/mail?type=label&labelId=${encodeURIComponent(target.labelId)}`;
+    case "folder":
+      return `/mail?type=folder&folderId=${encodeURIComponent(target.folderId)}`;
+    case "type":
+      return `/mail?type=${encodeURIComponent(target.type)}`;
+  }
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -7,7 +7,7 @@ import { ListToolbar } from "@/app/(app)/[emailAccountId]/mail/ListToolbar";
 import {
   MAIL_CATEGORIES,
   MailSidebar,
-  OUTLOOK_INBOX_SECTIONS,
+  OUTLOOK_INBOX_CATEGORIES,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import type {
   MailCategory,
@@ -556,7 +556,7 @@ function getMailCategories({
   isOutlook: boolean;
 }): MailCategory[] {
   if (isGoogle) return MAIL_CATEGORIES;
-  if (isOutlook) return OUTLOOK_INBOX_SECTIONS;
+  if (isOutlook) return OUTLOOK_INBOX_CATEGORIES;
   return [];
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -332,7 +332,9 @@ export function MailShell() {
 
   useShortcuts(handlers);
 
-  const categoryGroup = isOutlook ? "inbox" : "category";
+  const categoryGroup: NewSplitOption["group"] = isOutlook
+    ? "inbox"
+    : "category";
   const newSplitOptions: NewSplitOption[] = useMemo(
     () => [
       {
@@ -558,7 +560,7 @@ function getMailCategories({
   return [];
 }
 
-function getMailNavPath(target: MailNavTarget): string {
+function getMailNavPath(target: MailNavTarget): `/${string}` {
   switch (target.kind) {
     case "label":
       return `/mail?type=label&labelId=${encodeURIComponent(target.labelId)}`;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeftIcon,
   BellIcon,
   FileIcon,
+  FolderIcon,
   InboxIcon,
   KeyboardIcon,
   type LucideIcon,
@@ -15,6 +16,7 @@ import {
   PenLineIcon,
   PlusIcon,
   SendIcon,
+  SparklesIcon,
   UserIcon,
   Users2Icon,
 } from "lucide-react";
@@ -26,24 +28,32 @@ import { getShortcutHint } from "@/lib/shortcuts/registry";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { GmailLabel } from "@/utils/gmail/label";
 import { cn } from "@/utils";
+import type { OutlookFolder } from "@/utils/outlook/folders";
+import { getMailSidebarFolders } from "./outlook-folder-list";
 
 /** Where a sidebar row navigates. Mirrors the mail page's `?type=` query shape. */
 export type MailNavTarget =
   | { kind: "type"; type: string }
-  | { kind: "label"; labelId: string };
+  | { kind: "label"; labelId: string }
+  | { kind: "folder"; folderId: string };
 
 export type MailSidebarProps = {
   /** `?type=` of the current view — `inbox` when nothing is selected. */
   activeType: string | null;
   /** `?labelId=` of the current view, when a user label is open. */
   activeLabelId: string | null;
+  /** `?folderId=` of the current view, when an Outlook folder is open. */
+  activeFolderId: string | null;
   /** Builds the href for a row so the sidebar never owns routing. */
   hrefFor: (target: MailNavTarget) => string;
   labels: EmailLabel[];
-  /** Keyed by provider label id. Arrives after first paint; may be empty. */
+  folders: OutlookFolder[];
+  /** Keyed by provider label/folder id. Arrives after first paint; may be empty. */
   countsById: Map<string, LabelCount>;
-  /** Gmail-only concept, so Outlook accounts hide the section entirely. */
-  showCategories: boolean;
+  categories: MailCategory[];
+  categoryHeading: string;
+  labelsHeading: string;
+  labelSingular: string;
   backToAppHref: string;
   onCompose: () => void;
   onCreateLabel: (name: string) => void;
@@ -55,14 +65,16 @@ const SYSTEM_ITEMS = [
   { name: "Inbox", type: "inbox", countId: "INBOX", Icon: InboxIcon },
   { name: "Drafts", type: "draft", countId: "DRAFT", Icon: FileIcon },
   { name: "Sent", type: "sent", countId: "SENT", Icon: SendIcon },
-  { name: "Archived", type: "archive", countId: null, Icon: ArchiveIcon },
+  { name: "Archived", type: "archive", countId: "ARCHIVE", Icon: ArchiveIcon },
 ] as const;
 
-export const MAIL_CATEGORIES: {
+export type MailCategory = {
   name: string;
   type: string;
   Icon: LucideIcon;
-}[] = [
+};
+
+export const MAIL_CATEGORIES: MailCategory[] = [
   { name: "Personal", type: GmailLabel.PERSONAL, Icon: UserIcon },
   { name: "Social", type: GmailLabel.SOCIAL, Icon: Users2Icon },
   { name: "Updates", type: GmailLabel.UPDATES, Icon: BellIcon },
@@ -70,13 +82,23 @@ export const MAIL_CATEGORIES: {
   { name: "Promotions", type: GmailLabel.PROMOTIONS, Icon: MegaphoneIcon },
 ];
 
+export const OUTLOOK_INBOX_SECTIONS: MailCategory[] = [
+  { name: "Focused", type: "focused", Icon: SparklesIcon },
+  { name: "Other", type: "other", Icon: InboxIcon },
+];
+
 export function MailSidebar({
   activeType,
   activeLabelId,
+  activeFolderId,
   hrefFor,
   labels,
+  folders,
   countsById,
-  showCategories,
+  categories,
+  categoryHeading,
+  labelsHeading,
+  labelSingular,
   backToAppHref,
   onCompose,
   onCreateLabel,
@@ -129,7 +151,7 @@ export function MailSidebar({
             <NavRow
               key={type}
               href={hrefFor({ kind: "type", type })}
-              active={!activeLabelId && activeType === type}
+              active={!activeLabelId && !activeFolderId && activeType === type}
               icon={<Icon className="size-4 shrink-0" />}
               name={name}
               count={countId ? displayCount(countsById.get(countId)) : null}
@@ -138,18 +160,43 @@ export function MailSidebar({
           ))}
         </nav>
 
-        {showCategories && (
+        {categories.length > 0 && (
           <>
-            <GroupHeading>Categories</GroupHeading>
+            <GroupHeading>{categoryHeading}</GroupHeading>
             <nav className="flex flex-col gap-px">
-              {MAIL_CATEGORIES.map(({ name, type, Icon }) => (
+              {categories.map(({ name, type, Icon }) => (
                 <NavRow
                   key={type}
                   href={hrefFor({ kind: "type", type })}
-                  active={!activeLabelId && activeType === type}
+                  active={
+                    !activeLabelId && !activeFolderId && activeType === type
+                  }
                   icon={<Icon className="size-3.5 shrink-0" />}
                   name={name}
                   count={displayCount(countsById.get(type))}
+                />
+              ))}
+            </nav>
+          </>
+        )}
+
+        {folders.length > 0 && (
+          <>
+            <GroupHeading>Folders</GroupHeading>
+            <nav className="flex flex-col gap-px">
+              {getMailSidebarFolders(folders).map((folder) => (
+                <NavRow
+                  key={folder.id}
+                  href={hrefFor({ kind: "folder", folderId: folder.id })}
+                  active={activeFolderId === folder.id}
+                  icon={
+                    <FolderIcon
+                      className="size-3.5 shrink-0"
+                      style={{ marginLeft: folder.depth * 12 }}
+                    />
+                  }
+                  name={folder.displayName}
+                  count={displayCount(countsById.get(folder.id))}
                 />
               ))}
             </nav>
@@ -162,14 +209,14 @@ export function MailSidebar({
               type="button"
               onClick={() => setIsAddingLabel((open) => !open)}
               aria-expanded={isAddingLabel}
-              aria-label="Create label"
+              aria-label={`Create ${labelSingular}`}
               className="rounded-md p-0.5 text-muted-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <PlusIcon className="size-3.5" />
             </button>
           }
         >
-          Labels
+          {labelsHeading}
         </GroupHeading>
         <nav className="flex flex-col gap-px">
           {labels.map((label) => (
@@ -201,8 +248,8 @@ export function MailSidebar({
               onKeyDown={(event) => {
                 if (event.key === "Escape") setIsAddingLabel(false);
               }}
-              placeholder="Label name"
-              aria-label="New label name"
+              placeholder={`${labelSingular} name`}
+              aria-label={`New ${labelSingular} name`}
               autoFocus
               className="h-7 min-w-0 flex-1 px-2 text-xs"
             />

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -29,6 +29,7 @@ import type { EmailLabel } from "@/providers/email-label-types";
 import { GmailLabel } from "@/utils/gmail/label";
 import { cn } from "@/utils";
 import type { OutlookFolder } from "@/utils/outlook/folders";
+import { OUTLOOK_INBOX_SECTIONS } from "@/utils/mail/outlook-inbox";
 import { getMailSidebarFolders } from "./outlook-folder-list";
 
 /** Where a sidebar row navigates. Mirrors the mail page's `?type=` query shape. */
@@ -72,20 +73,48 @@ export type MailCategory = {
   name: string;
   type: string;
   Icon: LucideIcon;
+  showCount: boolean;
 };
 
 export const MAIL_CATEGORIES: MailCategory[] = [
-  { name: "Personal", type: GmailLabel.PERSONAL, Icon: UserIcon },
-  { name: "Social", type: GmailLabel.SOCIAL, Icon: Users2Icon },
-  { name: "Updates", type: GmailLabel.UPDATES, Icon: BellIcon },
-  { name: "Forums", type: GmailLabel.FORUMS, Icon: MessagesSquareIcon },
-  { name: "Promotions", type: GmailLabel.PROMOTIONS, Icon: MegaphoneIcon },
+  {
+    name: "Personal",
+    type: GmailLabel.PERSONAL,
+    Icon: UserIcon,
+    showCount: true,
+  },
+  {
+    name: "Social",
+    type: GmailLabel.SOCIAL,
+    Icon: Users2Icon,
+    showCount: true,
+  },
+  {
+    name: "Updates",
+    type: GmailLabel.UPDATES,
+    Icon: BellIcon,
+    showCount: true,
+  },
+  {
+    name: "Forums",
+    type: GmailLabel.FORUMS,
+    Icon: MessagesSquareIcon,
+    showCount: true,
+  },
+  {
+    name: "Promotions",
+    type: GmailLabel.PROMOTIONS,
+    Icon: MegaphoneIcon,
+    showCount: true,
+  },
 ];
 
-export const OUTLOOK_INBOX_SECTIONS: MailCategory[] = [
-  { name: "Focused", type: "focused", Icon: SparklesIcon },
-  { name: "Other", type: "other", Icon: InboxIcon },
-];
+export const OUTLOOK_INBOX_CATEGORIES: MailCategory[] =
+  OUTLOOK_INBOX_SECTIONS.map((section) => ({
+    ...section,
+    Icon: section.type === "focused" ? SparklesIcon : InboxIcon,
+    showCount: false,
+  }));
 
 export function MailSidebar({
   activeType,
@@ -107,6 +136,7 @@ export function MailSidebar({
 }: MailSidebarProps) {
   const [isAddingLabel, setIsAddingLabel] = useState(false);
   const [newLabelName, setNewLabelName] = useState("");
+  const sidebarFolders = getMailSidebarFolders(folders);
 
   const submitNewLabel = (event: FormEvent) => {
     event.preventDefault();
@@ -164,7 +194,7 @@ export function MailSidebar({
           <>
             <GroupHeading>{categoryHeading}</GroupHeading>
             <nav className="flex flex-col gap-px">
-              {categories.map(({ name, type, Icon }) => (
+              {categories.map(({ name, type, Icon, showCount }) => (
                 <NavRow
                   key={type}
                   href={hrefFor({ kind: "type", type })}
@@ -173,18 +203,18 @@ export function MailSidebar({
                   }
                   icon={<Icon className="size-3.5 shrink-0" />}
                   name={name}
-                  count={displayCount(countsById.get(type))}
+                  count={showCount ? displayCount(countsById.get(type)) : null}
                 />
               ))}
             </nav>
           </>
         )}
 
-        {folders.length > 0 && (
+        {sidebarFolders.length > 0 && (
           <>
             <GroupHeading>Folders</GroupHeading>
             <nav className="flex flex-col gap-px">
-              {getMailSidebarFolders(folders).map((folder) => (
+              {sidebarFolders.map((folder) => (
                 <NavRow
                   key={folder.id}
                   href={hrefFor({ kind: "folder", folderId: folder.id })}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -11,9 +11,10 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/utils";
+import { isOutlookInboxSection } from "@/utils/mail/split-query";
 
 /** Display grouping only — "To reply" is a LABEL split that belongs under State. */
-export type NewSplitOptionGroup = "state" | "category" | "label";
+export type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
 
 export type NewSplitOption = {
   /** Unique across every group; identifies the choice, not the split. */
@@ -38,6 +39,7 @@ export type NewSplitPopoverProps = {
 
 const GROUP_TITLES: { group: NewSplitOptionGroup; title: string }[] = [
   { group: "state", title: "State" },
+  { group: "inbox", title: "Inbox" },
   { group: "category", title: "Category" },
   { group: "label", title: "Label" },
 ];
@@ -164,6 +166,9 @@ function summarize(option: NewSplitOption | undefined): string {
     case MailSplitKind.UNREAD:
       return "Shows unread mail";
     case MailSplitKind.CATEGORY:
+      if (option.value && isOutlookInboxSection(option.value)) {
+        return `Shows ${option.name} inbox mail`;
+      }
       return `Shows mail in the ${option.name} category`;
     default:
       return `Shows mail labelled ${option.name}`;

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -11,7 +11,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/utils";
-import { isOutlookInboxSection } from "@/utils/mail/split-query";
+import { isOutlookInboxSection } from "@/utils/mail/outlook-inbox";
 
 /** Display grouping only — "To reply" is a LABEL split that belongs under State. */
 export type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";

--- a/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
@@ -35,4 +35,13 @@ describe("getMailSidebarFolders", () => {
       { id: "root-folder", depth: 0 },
     ]);
   });
+
+  it("returns no rows when Outlook only provides system folders", () => {
+    expect(
+      getMailSidebarFolders([
+        folder("inbox-id", [], "INBOX"),
+        folder("sent-id", [], "SENT"),
+      ]),
+    ).toEqual([]);
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { OutlookFolder } from "@/utils/outlook/folders";
+import { getMailSidebarFolders } from "./outlook-folder-list";
+
+function folder(
+  id: string,
+  childFolders: OutlookFolder[] = [],
+  systemType?: OutlookFolder["systemType"],
+): OutlookFolder {
+  return {
+    id,
+    displayName: id,
+    childFolders,
+    childFolderCount: childFolders.length,
+    totalItemCount: 0,
+    unreadItemCount: 0,
+    systemType,
+  };
+}
+
+describe("getMailSidebarFolders", () => {
+  it("omits duplicate system rows but keeps folders nested below them", () => {
+    const result = getMailSidebarFolders([
+      folder(
+        "inbox-id",
+        [folder("inbox-child", [folder("inbox-grandchild")])],
+        "INBOX",
+      ),
+      folder("root-folder"),
+    ]);
+
+    expect(result.map(({ id, depth }) => ({ id, depth }))).toEqual([
+      { id: "inbox-child", depth: 0 },
+      { id: "inbox-grandchild", depth: 1 },
+      { id: "root-folder", depth: 0 },
+    ]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.ts
@@ -1,0 +1,14 @@
+import type { OutlookFolder } from "@/utils/outlook/folders";
+
+export type MailSidebarFolder = OutlookFolder & { depth: number };
+
+export function getMailSidebarFolders(
+  folders: OutlookFolder[],
+  depth = 0,
+): MailSidebarFolder[] {
+  return folders.flatMap((folder) => {
+    const childDepth = folder.systemType ? depth : depth + 1;
+    const children = getMailSidebarFolders(folder.childFolders, childDepth);
+    return folder.systemType ? children : [{ ...folder, depth }, ...children];
+  });
+}

--- a/apps/web/app/api/labels/counts/route.test.ts
+++ b/apps/web/app/api/labels/counts/route.test.ts
@@ -5,6 +5,7 @@ const {
   mockGetLabels,
   mockGetLabelById,
   mockGetInboxStats,
+  mockGetFolderCounts,
   mockRedisGet,
   mockRedisSet,
   providerName,
@@ -12,6 +13,7 @@ const {
   mockGetLabels: vi.fn(),
   mockGetLabelById: vi.fn(),
   mockGetInboxStats: vi.fn(),
+  mockGetFolderCounts: vi.fn(),
   mockRedisGet: vi.fn(),
   mockRedisSet: vi.fn(),
   providerName: { current: "google" as "google" | "microsoft" },
@@ -49,6 +51,7 @@ vi.mock("@/utils/middleware", async () => {
               getLabels: mockGetLabels,
               getLabelById: mockGetLabelById,
               getInboxStats: mockGetInboxStats,
+              getFolderCounts: mockGetFolderCounts,
             },
           }),
         ),
@@ -167,9 +170,23 @@ describe("GET /api/labels/counts", () => {
     expect(counts(body)).toContain("INBOX");
   });
 
-  it("returns inbox-only counts for Outlook", async () => {
+  it("returns system and custom folder counts for Outlook", async () => {
     providerName.current = "microsoft";
-    mockGetInboxStats.mockResolvedValue({ total: 7, unread: 2 });
+    mockGetFolderCounts.mockResolvedValue([
+      {
+        id: "outlook-inbox-id",
+        name: "Inbox",
+        systemType: "INBOX",
+        total: 7,
+        unread: 2,
+      },
+      {
+        id: "folder-projects",
+        name: "Projects",
+        total: 4,
+        unread: 1,
+      },
+    ]);
 
     const response = await GET(request());
     const body = await response.json();
@@ -177,9 +194,17 @@ describe("GET /api/labels/counts", () => {
     expect(body).toEqual({
       counts: [
         { id: "INBOX", name: "Inbox", kind: "system", total: 7, unread: 2 },
+        {
+          id: "folder-projects",
+          name: "Projects",
+          kind: "folder",
+          total: 4,
+          unread: 1,
+        },
       ],
-      partial: true,
+      partial: false,
     });
     expect(mockGetLabelById).not.toHaveBeenCalled();
+    expect(mockGetInboxStats).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/labels/counts/route.ts
+++ b/apps/web/app/api/labels/counts/route.ts
@@ -20,8 +20,8 @@ const LABEL_LOOKUP_CONCURRENCY = 8;
 export type LabelCount = {
   id: string;
   name: string;
-  kind: "system" | "category" | "label";
-  /** Threads in the label, unread ones included */
+  kind: "system" | "category" | "label" | "folder";
+  /** Conversations or folder items in this scope, unread ones included. */
   total: number;
   unread: number;
 };
@@ -92,12 +92,16 @@ async function getCounts({
       return await getGmailCounts({ emailProvider, logger });
     }
 
-    // Outlook has no per-category counts and its categories carry none either,
-    // so only the inbox is reported.
-    const { total, unread } = await emailProvider.getInboxStats();
+    const folderCounts = await emailProvider.getFolderCounts();
     return {
-      counts: [{ id: "INBOX", name: "Inbox", kind: "system", total, unread }],
-      partial: true,
+      counts: folderCounts.map((folder) => ({
+        id: folder.systemType ?? folder.id,
+        name: folder.name,
+        kind: folder.systemType ? "system" : "folder",
+        total: folder.total,
+        unread: folder.unread,
+      })),
+      partial: false,
       anyFailed: false,
     };
   } catch (error) {

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -112,6 +112,25 @@ describe("GET /api/threads", () => {
     });
   });
 
+  it("passes an Outlook inbox section to the email provider", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads?type=inbox&inboxSection=focused",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetThreadsWithQuery).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        type: "inbox",
+        inboxSection: "focused",
+      }),
+      maxResults: 50,
+      pageToken: undefined,
+      messageFormat: "full",
+    });
+  });
+
   describe("list view", () => {
     beforeEach(() => {
       mockGetThreadsWithQuery.mockResolvedValue({

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -22,6 +22,8 @@ export const GET = withEmailProvider(
     const limit = searchParams.get("limit");
     const fromEmail = searchParams.get("fromEmail");
     const type = searchParams.get("type");
+    const folderId = searchParams.get("folderId");
+    const inboxSection = searchParams.get("inboxSection");
     const nextPageToken = searchParams.get("nextPageToken");
     const q = searchParams.get("q");
     const labelId = searchParams.get("labelId");
@@ -39,6 +41,8 @@ export const GET = withEmailProvider(
       limit,
       fromEmail,
       type,
+      folderId,
+      inboxSection,
       nextPageToken,
       q,
       labelId,

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -398,13 +398,15 @@ function MailNav({ path }: { path: string }) {
           activeHref={path}
         />
       </SidebarGroup>
-      <SidebarGroup>
-        <SidebarGroupLabel>Categories</SidebarGroupLabel>
-        <SideNavMenu
-          items={markActiveType(bottomMailLinks, activeType)}
-          activeHref={path}
-        />
-      </SidebarGroup>
+      {isGoogleProvider(provider) && (
+        <SidebarGroup>
+          <SidebarGroupLabel>Categories</SidebarGroupLabel>
+          <SideNavMenu
+            items={markActiveType(bottomMailLinks, activeType)}
+            activeHref={path}
+          />
+        </SidebarGroup>
+      )}
 
       <SidebarGroup>
         <SidebarGroupLabel>

--- a/apps/web/hooks/useLabelCounts.ts
+++ b/apps/web/hooks/useLabelCounts.ts
@@ -3,7 +3,7 @@ import useSWR from "swr";
 import type { LabelCountsResponse } from "@/app/api/labels/counts/route";
 
 /**
- * Unread/total counts per label and Gmail category for the mail sidebar.
+ * Unread/total counts per label, Gmail category, or Outlook folder.
  * Deliberately not blocking: the sidebar renders without counts and fills in.
  */
 export function useLabelCounts() {

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -48,6 +48,7 @@ export const createMockEmailProvider = (
   getLabelByName: vi.fn().mockResolvedValue(null),
   getMessageByRfc822MessageId: vi.fn().mockResolvedValue(null),
   getFolders: vi.fn().mockResolvedValue([]),
+  getFolderCounts: vi.fn().mockResolvedValue([]),
   getSignatures: vi.fn().mockResolvedValue([]),
   getInboxStats: vi.fn().mockResolvedValue({ total: 0, unread: 0 }),
   getMessage: vi.fn().mockResolvedValue({

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1656,6 +1656,10 @@ export class GmailProvider implements EmailProvider {
     return [];
   }
 
+  async getFolderCounts() {
+    return [];
+  }
+
   async moveThreadToFolder(
     _threadId: string,
     _ownerEmail: string,

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -156,7 +156,7 @@ describe("OutlookProvider.getSentMessageIds", () => {
     });
 
     expect(client.getRequestLog()).toContainEqual({
-      apiPath: "/me/mailFolders('sentitems')/messages",
+      apiPath: "/me/mailFolders/sentitems/messages",
       filter:
         "sentDateTime ge 2026-03-31T12:00:00.000Z and sentDateTime le 2026-04-30T17:00:00.000Z",
     });
@@ -178,6 +178,25 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
 
     expect(client.getSelectLog()[0]).toContain("bodyPreview");
     expect(client.getSelectLog()[0]?.split(",")).not.toContain("body");
+  });
+
+  it.each([
+    "focused",
+    "other",
+  ] as const)("queries the Outlook inbox's %s section", async (inboxSection) => {
+    const client = createMockOutlookClient([
+      createMessage({ id: `${inboxSection}-message` }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    await provider.getThreadsWithQuery({
+      query: { type: "inbox", inboxSection },
+    });
+
+    expect(client.getRequestLog()[0]).toEqual({
+      apiPath: "/me/mailFolders/inbox/messages",
+      filter: `inferenceClassification eq '${inboxSection}'`,
+    });
   });
 
   it("filters returned threads by explicit labelIds", async () => {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -199,6 +199,22 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     });
   });
 
+  it("does not apply an inbox section filter to a custom folder", async () => {
+    const client = createMockOutlookClient([
+      createMessage({ id: "folder-message" }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    await provider.getThreadsWithQuery({
+      query: { folderId: "custom-folder", inboxSection: "focused" },
+    });
+
+    expect(client.getRequestLog()[0]).toEqual({
+      apiPath: "/me/mailFolders/custom-folder/messages",
+      filter: undefined,
+    });
+  });
+
   it("filters returned threads by explicit labelIds", async () => {
     getFolderIdsMock.mockResolvedValue({
       inbox: "folder-inbox",

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -66,6 +66,7 @@ import type {
   EmailLabel,
   EmailFilter,
   EmailSignature,
+  EmailFolderCount,
   SentMessagePage,
   BulkArchiveThread,
   BulkArchiveResult,
@@ -80,6 +81,7 @@ import {
 import {
   getOrCreateOutlookFolderIdByName,
   getOutlookFolderTree,
+  addOutlookSystemFolderTypes,
 } from "@/utils/outlook/folders";
 import { extractSignatureFromHtml } from "@/utils/email/signature-extraction";
 import {
@@ -279,7 +281,7 @@ export class OutlookProvider implements EmailProvider {
       () =>
         this.client
           .getClient()
-          .api("/me/mailFolders('sentitems')/messages")
+          .api("/me/mailFolders/sentitems/messages")
           .select(MESSAGE_SELECT_FIELDS)
           .top(maxResults)
           .orderby("sentDateTime desc")
@@ -301,7 +303,7 @@ export class OutlookProvider implements EmailProvider {
       () =>
         this.client
           .getClient()
-          .api("/me/mailFolders('inbox')/messages")
+          .api("/me/mailFolders/inbox/messages")
           .select(MESSAGE_SELECT_FIELDS)
           .top(maxResults)
           .orderby("receivedDateTime desc")
@@ -335,7 +337,7 @@ export class OutlookProvider implements EmailProvider {
 
       let request = this.client
         .getClient()
-        .api("/me/mailFolders('sentitems')/messages")
+        .api("/me/mailFolders/sentitems/messages")
         .select("id,conversationId")
         .top(maxResults)
         .orderby("sentDateTime desc");
@@ -395,7 +397,7 @@ export class OutlookProvider implements EmailProvider {
 
     // Get messages from Microsoft Graph API (well-known Sent Items folder)
     let request = client
-      .api("/me/mailFolders('sentitems')/messages")
+      .api("/me/mailFolders/sentitems/messages")
       .select(MESSAGE_SELECT_FIELDS)
       .top(maxResults)
       .orderby("sentDateTime desc");
@@ -1536,6 +1538,8 @@ export class OutlookProvider implements EmailProvider {
       before,
       isUnread,
       type,
+      folderId,
+      inboxSection,
       labelId,
       labelIds,
       excludeLabelNames,
@@ -1598,8 +1602,12 @@ export class OutlookProvider implements EmailProvider {
 
       // Route to appropriate endpoint based on type
       // parentFolderId on messages is a GUID, not a well-known name — always resolve
-      if (type === "sent" && !hasExplicitLabelFilters) {
-        endpoint = "/me/mailFolders('sentitems')/messages";
+      if (folderId) {
+        endpoint = `/me/mailFolders/${encodeURIComponent(folderId)}/messages`;
+      } else if (inboxSection && !hasExplicitLabelFilters) {
+        endpoint = "/me/mailFolders/inbox/messages";
+      } else if (type === "sent" && !hasExplicitLabelFilters) {
+        endpoint = "/me/mailFolders/sentitems/messages";
       } else {
         if (labelId && !labelIds?.length) {
           const labelFilter = await resolveOutlookThreadQueryFilter({
@@ -1633,6 +1641,10 @@ export class OutlookProvider implements EmailProvider {
 
       if (isUnread) {
         filters.push("isRead eq false");
+      }
+
+      if (inboxSection) {
+        filters.push(`inferenceClassification eq '${inboxSection}'`);
       }
 
       const filter = filters.length > 0 ? filters.join(" and ") : undefined;
@@ -1993,7 +2005,22 @@ export class OutlookProvider implements EmailProvider {
   }
 
   async getFolders() {
-    return await getOutlookFolderTree(this.client, undefined, this.logger);
+    const [folders, folderIds] = await Promise.all([
+      getOutlookFolderTree(this.client, undefined, this.logger),
+      getFolderIds(this.client, this.logger),
+    ]);
+    return addOutlookSystemFolderTypes(folders, folderIds);
+  }
+
+  async getFolderCounts(): Promise<EmailFolderCount[]> {
+    const folders = await this.getFolders();
+    return flattenOutlookFolders(folders).map((folder) => ({
+      id: folder.id,
+      name: folder.displayName,
+      total: folder.totalItemCount ?? 0,
+      unread: folder.unreadItemCount ?? 0,
+      systemType: folder.systemType,
+    }));
   }
 
   async getSignatures(): Promise<EmailSignature[]> {
@@ -2036,7 +2063,7 @@ export class OutlookProvider implements EmailProvider {
       () =>
         this.client
           .getClient()
-          .api("/me/mailFolders('inbox')")
+          .api("/me/mailFolders/inbox")
           .select("totalItemCount,unreadItemCount")
           .get(),
       this.logger,
@@ -2064,6 +2091,15 @@ function resolveOutlookFolderId(
 ): string | undefined {
   const folderKey = LABEL_TO_FOLDER_KEY[labelId.toUpperCase()];
   return folderKey ? folderIds[folderKey] : undefined;
+}
+
+function flattenOutlookFolders(
+  folders: Awaited<ReturnType<OutlookProvider["getFolders"]>>,
+): Awaited<ReturnType<OutlookProvider["getFolders"]>> {
+  return folders.flatMap((folder) => [
+    folder,
+    ...flattenOutlookFolders(folder.childFolders),
+  ]);
 }
 
 function filterMessagesForParticipant(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1643,7 +1643,7 @@ export class OutlookProvider implements EmailProvider {
         filters.push("isRead eq false");
       }
 
-      if (inboxSection) {
+      if (inboxSection && !folderId) {
         filters.push(`inferenceClassification eq '${inboxSection}'`);
       }
 

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -1,7 +1,10 @@
 import type { ParsedMessage } from "@/utils/types";
 import type { InboxZeroLabel } from "@/utils/label";
 import type { ThreadsQuery } from "@/utils/threads/validation";
-import type { OutlookFolder } from "@/utils/outlook/folders";
+import type {
+  OutlookFolder,
+  OutlookSystemFolder,
+} from "@/utils/outlook/folders";
 import type { Attachment as MailAttachment } from "nodemailer/lib/mailer";
 
 export interface EmailThread {
@@ -33,6 +36,14 @@ export interface EmailLabel {
   threadsUnread?: number;
   type: string;
 }
+
+export type EmailFolderCount = {
+  id: string;
+  name: string;
+  total: number;
+  unread: number;
+  systemType?: OutlookSystemFolder;
+};
 
 export interface EmailFilter {
   action?: {
@@ -146,6 +157,7 @@ export interface EmailProvider {
   getDraft(draftId: string): Promise<ParsedMessage | null>;
   getDrafts(options?: { maxResults?: number }): Promise<ParsedMessage[]>;
   getFiltersList(): Promise<EmailFilter[]>;
+  getFolderCounts(): Promise<EmailFolderCount[]>;
   getFolders(): Promise<OutlookFolder[]>;
   getInboxMessages(maxResults?: number): Promise<ParsedMessage[]>;
   getInboxStats(): Promise<{ total: number; unread: number }>;

--- a/apps/web/utils/mail/outlook-inbox.ts
+++ b/apps/web/utils/mail/outlook-inbox.ts
@@ -1,0 +1,13 @@
+export const OUTLOOK_INBOX_SECTIONS = [
+  { name: "Focused", type: "focused" },
+  { name: "Other", type: "other" },
+] as const;
+
+export type OutlookInboxSection =
+  (typeof OUTLOOK_INBOX_SECTIONS)[number]["type"];
+
+export function isOutlookInboxSection(
+  value: string,
+): value is OutlookInboxSection {
+  return OUTLOOK_INBOX_SECTIONS.some((section) => section.type === value);
+}

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -38,6 +38,15 @@ describe("mailSplitToThreadsQuery", () => {
   });
 
   it.each([
+    "focused",
+    "other",
+  ] as const)("queries Outlook's %s section inside the inbox", (inboxSection) => {
+    expect(
+      mailSplitToThreadsQuery(split(MailSplitKind.CATEGORY, inboxSection)),
+    ).toEqual({ type: "inbox", inboxSection });
+  });
+
+  it.each([
     MailSplitKind.LABEL,
     MailSplitKind.CATEGORY,
   ])("throws rather than silently querying the whole inbox when %s has no value", (kind) => {

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -1,5 +1,6 @@
 import { MailSplitKind } from "@/generated/prisma/enums";
 import type { ThreadsQuery } from "@/utils/threads/validation";
+import { isOutlookInboxSection } from "@/utils/mail/outlook-inbox";
 
 export type MailSplit = {
   id: string;
@@ -7,10 +8,6 @@ export type MailSplit = {
   kind: MailSplitKind;
   value: string | null;
 };
-
-export const OUTLOOK_INBOX_SECTIONS = ["focused", "other"] as const;
-
-export type OutlookInboxSection = (typeof OUTLOOK_INBOX_SECTIONS)[number];
 
 /**
  * Every split is its own server query. Filtering a paginated list client-side would
@@ -37,10 +34,4 @@ export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
     return { type: "inbox", inboxSection: type };
   }
   return { type };
-}
-
-export function isOutlookInboxSection(
-  value: string,
-): value is OutlookInboxSection {
-  return OUTLOOK_INBOX_SECTIONS.some((section) => section === value);
 }

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -8,6 +8,10 @@ export type MailSplit = {
   value: string | null;
 };
 
+export const OUTLOOK_INBOX_SECTIONS = ["focused", "other"] as const;
+
+export type OutlookInboxSection = (typeof OUTLOOK_INBOX_SECTIONS)[number];
+
 /**
  * Every split is its own server query. Filtering a paginated list client-side would
  * only ever search the pages already loaded, which silently under-reports.
@@ -24,6 +28,19 @@ export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
     case MailSplitKind.CATEGORY:
       if (!split.value)
         throw new Error(`Split "${split.name}" has no category`);
-      return { type: split.value };
+      return mailTypeToThreadsQuery(split.value);
   }
+}
+
+export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
+  if (isOutlookInboxSection(type)) {
+    return { type: "inbox", inboxSection: type };
+  }
+  return { type };
+}
+
+export function isOutlookInboxSection(
+  value: string,
+): value is OutlookInboxSection {
+  return OUTLOOK_INBOX_SECTIONS.some((section) => section === value);
 }

--- a/apps/web/utils/outlook/client.test.ts
+++ b/apps/web/utils/outlook/client.test.ts
@@ -16,6 +16,13 @@ import {
 vi.mock("@microsoft/microsoft-graph-client", () => ({
   Client: {
     init: vi.fn(),
+    initWithMiddleware: vi.fn(),
+  },
+  MiddlewareFactory: {
+    getDefaultMiddlewareChain: vi.fn(() => [
+      { execute: vi.fn(), setNext: vi.fn() },
+      { execute: vi.fn(), setNext: vi.fn() },
+    ]),
   },
 }));
 
@@ -60,24 +67,22 @@ describe("outlook client emulator configuration", () => {
     vi.clearAllMocks();
   });
 
-  it("passes emulator-aware Graph options into the client", () => {
+  it("uses a request-rewriting middleware for the HTTP emulator", () => {
     createOutlookClient("emulator-token", createTestLogger());
 
     expect(getMicrosoftGraphClientOptions).toHaveBeenCalledWith(
       "emulator-token",
     );
-    expect(Client.init).toHaveBeenCalledWith({
-      authProvider: expect.any(Function),
-      baseUrl: "http://localhost:4003/",
-      customHosts: new Set(["localhost"]),
+    expect(Client.initWithMiddleware).toHaveBeenCalledWith({
       defaultVersion: "v1.0",
       fetchOptions: {
         headers: {
-          Authorization: "Bearer emulator-token",
           Prefer: 'IdType="ImmutableId"',
         },
       },
+      middleware: expect.any(Array),
     });
+    expect(Client.init).not.toHaveBeenCalled();
   });
 
   it("uses the emulator authorize URL for linking", () => {

--- a/apps/web/utils/outlook/client.test.ts
+++ b/apps/web/utils/outlook/client.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Client } from "@microsoft/microsoft-graph-client";
+import {
+  Client,
+  type Context,
+  type Middleware,
+} from "@microsoft/microsoft-graph-client";
 import { saveTokens } from "@/utils/auth/save-tokens";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
@@ -67,7 +71,7 @@ describe("outlook client emulator configuration", () => {
     vi.clearAllMocks();
   });
 
-  it("uses a request-rewriting middleware for the HTTP emulator", () => {
+  it("uses a request-rewriting middleware for the HTTP emulator", async () => {
     createOutlookClient("emulator-token", createTestLogger());
 
     expect(getMicrosoftGraphClientOptions).toHaveBeenCalledWith(
@@ -83,6 +87,22 @@ describe("outlook client emulator configuration", () => {
       middleware: expect.any(Array),
     });
     expect(Client.init).not.toHaveBeenCalled();
+
+    const clientOptions = vi.mocked(Client.initWithMiddleware).mock
+      .calls[0]?.[0];
+    const rewriteMiddleware = clientOptions?.middleware?.[1];
+    const executeNext = vi.fn();
+    const nextMiddleware: Middleware = { execute: executeNext };
+    const context: Context = {
+      request: "https://graph.microsoft.com/v1.0/me/messages",
+    };
+
+    expect(clientOptions?.middleware).toHaveLength(3);
+    rewriteMiddleware?.setNext?.(nextMiddleware);
+    await rewriteMiddleware?.execute(context);
+
+    expect(context.request).toBe("http://localhost:4003/v1.0/me/messages");
+    expect(executeNext).toHaveBeenCalledWith(context);
   });
 
   it("uses the emulator authorize URL for linking", () => {

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -1,4 +1,9 @@
-import { Client } from "@microsoft/microsoft-graph-client";
+import {
+  Client,
+  MiddlewareFactory,
+  type Context,
+  type Middleware,
+} from "@microsoft/microsoft-graph-client";
 import type { User } from "@microsoft/microsoft-graph-types";
 import { saveTokens } from "@/utils/auth/save-tokens";
 import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
@@ -27,20 +32,38 @@ export class OutlookClient {
     this.accessToken = accessToken;
     this.logger = logger;
     const graphClientOptions = getMicrosoftGraphClientOptions(accessToken);
+    const fetchOptions = {
+      headers: {
+        Prefer: 'IdType="ImmutableId"',
+      },
+    };
+
+    if (graphClientOptions.baseUrl?.startsWith("http://")) {
+      const authProvider = {
+        getAccessToken: async () => this.accessToken,
+      };
+      const middleware =
+        MiddlewareFactory.getDefaultMiddlewareChain(authProvider);
+      middleware.splice(
+        1,
+        0,
+        new OutlookEmulatorUrlMiddleware(graphClientOptions.baseUrl),
+      );
+      this.client = Client.initWithMiddleware({
+        defaultVersion: "v1.0",
+        fetchOptions,
+        middleware,
+      });
+      return;
+    }
+
     this.client = Client.init({
       authProvider: (done) => {
         done(null, this.accessToken);
       },
       defaultVersion: "v1.0",
       ...graphClientOptions,
-      // Use immutable IDs to ensure message IDs remain stable
-      // https://learn.microsoft.com/en-us/graph/outlook-immutable-id
-      fetchOptions: {
-        headers: {
-          ...(graphClientOptions.fetchOptions?.headers ?? {}),
-          Prefer: 'IdType="ImmutableId"',
-        },
-      },
+      fetchOptions,
     });
   }
 
@@ -94,6 +117,38 @@ export class OutlookClient {
       this.logger.warn("Error getting user photo");
       return null;
     }
+  }
+}
+
+class OutlookEmulatorUrlMiddleware implements Middleware {
+  private next?: Middleware;
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  setNext(next: Middleware) {
+    this.next = next;
+  }
+
+  async execute(context: Context) {
+    const requestUrl =
+      typeof context.request === "string"
+        ? context.request
+        : context.request.url;
+    const rewrittenUrl = requestUrl.replace(
+      "https://graph.microsoft.com",
+      this.baseUrl,
+    );
+    context.request =
+      typeof context.request === "string"
+        ? rewrittenUrl
+        : new Request(rewrittenUrl, context.request);
+
+    if (!this.next)
+      throw new Error("Outlook emulator middleware is incomplete");
+    await this.next.execute(context);
   }
 }
 

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -50,7 +50,7 @@ export class OutlookClient {
         new OutlookEmulatorUrlMiddleware(graphClientOptions.baseUrl),
       );
       this.client = Client.initWithMiddleware({
-        defaultVersion: "v1.0",
+        defaultVersion: graphClientOptions.defaultVersion,
         fetchOptions,
         middleware,
       });

--- a/apps/web/utils/outlook/folders.test.ts
+++ b/apps/web/utils/outlook/folders.test.ts
@@ -3,6 +3,7 @@ import {
   getOutlookFolderTree,
   getOutlookRootFolders,
   getOutlookChildFolders,
+  addOutlookSystemFolderTypes,
 } from "./folders";
 import type { OutlookClient } from "./client";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -382,11 +383,15 @@ describe("getOutlookRootFolders", () => {
             id: "folder-id",
             displayName: "TestFolder",
             childFolderCount: 1,
+            totalItemCount: 8,
+            unreadItemCount: 3,
             childFolders: [
               {
                 id: "child-id",
                 displayName: "ChildFolder",
                 childFolderCount: 0,
+                totalItemCount: 2,
+                unreadItemCount: 1,
                 childFolders: [],
               },
             ],
@@ -402,11 +407,15 @@ describe("getOutlookRootFolders", () => {
         id: "folder-id",
         displayName: "TestFolder",
         childFolderCount: 1,
+        totalItemCount: 8,
+        unreadItemCount: 3,
         childFolders: [
           {
             id: "child-id",
             displayName: "ChildFolder",
             childFolderCount: 0,
+            totalItemCount: 2,
+            unreadItemCount: 1,
             childFolders: [],
           },
         ],
@@ -436,8 +445,29 @@ describe("getOutlookRootFolders", () => {
         displayName: "",
         childFolderCount: 0,
         childFolders: [],
+        totalItemCount: 0,
+        unreadItemCount: 0,
       },
     ]);
+  });
+});
+
+describe("addOutlookSystemFolderTypes", () => {
+  it("marks well-known folders by id without relying on localized names", () => {
+    const [inbox, custom] = addOutlookSystemFolderTypes(
+      [
+        {
+          id: "inbox-id",
+          displayName: "Boîte de réception",
+          childFolders: [],
+        },
+        { id: "custom-id", displayName: "Projects", childFolders: [] },
+      ],
+      { inbox: "inbox-id" },
+    );
+
+    expect(inbox?.systemType).toBe("INBOX");
+    expect(custom?.systemType).toBeUndefined();
   });
 });
 

--- a/apps/web/utils/outlook/folders.ts
+++ b/apps/web/utils/outlook/folders.ts
@@ -3,6 +3,17 @@ import type { OutlookClient } from "./client-types";
 import type { Logger } from "@/utils/logger";
 import { withOutlookRetry } from "@/utils/outlook/retry";
 
+export type OutlookSystemFolder =
+  | "INBOX"
+  | "DRAFT"
+  | "SENT"
+  | "ARCHIVE"
+  | "TRASH"
+  | "SPAM";
+
+const OUTLOOK_FOLDER_FIELDS =
+  "id,displayName,childFolderCount,totalItemCount,unreadItemCount";
+
 // Should not use a common separator like "/|\>" as it may be used in the folder name.
 // Using U+2999 as it is unlikely to appear in normal text
 export const FOLDER_SEPARATOR = " ⦙ ";
@@ -12,6 +23,9 @@ export type OutlookFolder = {
   displayName: NonNullable<MailFolder["displayName"]>;
   childFolders: OutlookFolder[];
   childFolderCount?: number;
+  totalItemCount?: number;
+  unreadItemCount?: number;
+  systemType?: OutlookSystemFolder;
 };
 
 function convertMailFolderToOutlookFolder(folder: MailFolder): OutlookFolder {
@@ -21,6 +35,8 @@ function convertMailFolderToOutlookFolder(folder: MailFolder): OutlookFolder {
     childFolders:
       folder.childFolders?.map(convertMailFolderToOutlookFolder) ?? [],
     childFolderCount: folder.childFolderCount ?? 0,
+    totalItemCount: folder.totalItemCount ?? 0,
+    unreadItemCount: folder.unreadItemCount ?? 0,
   };
 }
 
@@ -28,16 +44,15 @@ export async function getOutlookRootFolders(
   client: OutlookClient,
   logger: Logger,
 ): Promise<OutlookFolder[]> {
-  const fields = "id,displayName,childFolderCount";
   const response: { value: MailFolder[] } = await withOutlookRetry(
     () =>
       client
         .getClient()
         .api("/me/mailFolders")
-        .select(fields)
+        .select(OUTLOOK_FOLDER_FIELDS)
         .top(999)
         .expand(
-          `childFolders($select=${fields};$top=999;$expand=childFolders($select=${fields};$top=999))`,
+          `childFolders($select=${OUTLOOK_FOLDER_FIELDS};$top=999;$expand=childFolders($select=${OUTLOOK_FOLDER_FIELDS};$top=999))`,
         )
         .get(),
     logger,
@@ -51,16 +66,15 @@ export async function getOutlookChildFolders(
   folderId: string,
   logger: Logger,
 ): Promise<OutlookFolder[]> {
-  const fields = "id,displayName,childFolderCount";
   const response: { value: MailFolder[] } = await withOutlookRetry(
     () =>
       client
         .getClient()
         .api(`/me/mailFolders/${folderId}/childFolders`)
-        .select(fields)
+        .select(OUTLOOK_FOLDER_FIELDS)
         .top(999)
         .expand(
-          `childFolders($select=${fields};$top=999;$expand=childFolders($select=${fields};$top=999))`,
+          `childFolders($select=${OUTLOOK_FOLDER_FIELDS};$top=999;$expand=childFolders($select=${OUTLOOK_FOLDER_FIELDS};$top=999))`,
         )
         .get(),
     logger,
@@ -163,6 +177,26 @@ export async function getOutlookFolderTree(
   await Promise.all(expandPromises);
 
   return folders;
+}
+
+export function addOutlookSystemFolderTypes(
+  folders: OutlookFolder[],
+  folderIds: Record<string, string>,
+): OutlookFolder[] {
+  const systemTypeById = new Map<string, OutlookSystemFolder>([
+    [folderIds.inbox, "INBOX"],
+    [folderIds.drafts, "DRAFT"],
+    [folderIds.sentitems, "SENT"],
+    [folderIds.archive, "ARCHIVE"],
+    [folderIds.deleteditems, "TRASH"],
+    [folderIds.junkemail, "SPAM"],
+  ]);
+
+  return folders.map((folder) => ({
+    ...folder,
+    systemType: systemTypeById.get(folder.id),
+    childFolders: addOutlookSystemFolderTypes(folder.childFolders, folderIds),
+  }));
 }
 
 export async function getOrCreateOutlookFolderIdByName(

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -5,6 +5,8 @@ export const threadsQuery = z.object({
   fromEmail: z.string().nullish(),
   limit: z.coerce.number().max(100).nullish(),
   type: z.string().nullish(),
+  folderId: z.string().nullish(), // For Outlook
+  inboxSection: z.enum(["focused", "other"]).nullish(),
   nextPageToken: microsoftGraphPageTokenSchema,
   labelId: z.string().nullish(), // For Google
   labelIds: z.array(z.string()).nullish(), // For Google


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260811-232157_pr-3214_27656f24c32e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Extends the mail view with provider-native navigation and count behavior for Microsoft accounts.

- add folder count and folder-scoped thread support
- add Focused and Other inbox sections with provider-specific terminology
- hide Gmail-only navigation for Microsoft accounts
- cover provider behavior with unit, integration, and emulator validation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->