### PR TITLE
fix(meetings): keep bot scheduling resilient

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,6 +26,12 @@ const zodV4CorePath = path.join(
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
+  outputFileTracingIncludes: {
+    "/api/meeting-recorder/schedule": [
+      "./public/images/meetings/inbox-zero-notetaker.jpg",
+    ],
+    "/*/meetings": ["./public/images/meetings/inbox-zero-notetaker.jpg"],
+  },
   experimental:
     isDevelopment || isProductionBuild
       ? {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,12 +26,6 @@ const zodV4CorePath = path.join(
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
-  outputFileTracingIncludes: {
-    "/api/meeting-recorder/schedule": [
-      "./public/images/meetings/inbox-zero-notetaker.jpg",
-    ],
-    "/*/meetings": ["./public/images/meetings/inbox-zero-notetaker.jpg"],
-  },
   experimental:
     isDevelopment || isProductionBuild
       ? {

--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -16,11 +16,12 @@ describe("RecallBotProvider", () => {
     vi.resetModules();
     readFileMock.mockReset();
     readFileMock.mockResolvedValue("camera-image");
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ id: "bot-1" }), {
-        status: 201,
-        headers: { "Content-Type": "application/json" },
-      }),
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ id: "bot-1" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
     );
   });
 
@@ -48,7 +49,34 @@ describe("RecallBotProvider", () => {
     });
   });
 
-  it("retries loading the camera image after a transient failure", async () => {
+  it("schedules the bot without video when the camera image cannot be loaded", async () => {
+    const readError = Object.assign(new Error("Temporary read failure"), {
+      code: "EIO",
+    });
+    readFileMock.mockRejectedValue(readError);
+
+    const { RecallBotProvider } = await import("@/utils/recall/client");
+    const provider = new RecallBotProvider(createTestLogger());
+
+    await expect(
+      provider.scheduleBot({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        joinAt: new Date("2026-05-04T09:00:00.000Z"),
+      }),
+    ).resolves.toEqual({
+      externalBotId: "bot-1",
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(request?.body as string)).toEqual({
+      meeting_url: "https://meet.google.com/abc-defg-hij",
+      bot_name: "Inbox Zero Notetaker",
+      join_at: "2026-05-04T09:00:00.000Z",
+    });
+  });
+
+  it("retries loading the camera image for the next bot", async () => {
     const readError = Object.assign(new Error("Temporary read failure"), {
       code: "EIO",
     });
@@ -63,14 +91,23 @@ describe("RecallBotProvider", () => {
       joinAt: new Date("2026-05-04T09:00:00.000Z"),
     };
 
-    await expect(provider.scheduleBot(bot)).rejects.toThrow(
-      "Temporary read failure",
-    );
+    await expect(provider.scheduleBot(bot)).resolves.toEqual({
+      externalBotId: "bot-1",
+    });
     await expect(provider.scheduleBot(bot)).resolves.toEqual({
       externalBotId: "bot-1",
     });
 
     expect(readFileMock).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const secondRequest = vi.mocked(fetch).mock.calls[1]?.[1];
+    expect(JSON.parse(secondRequest?.body as string)).toMatchObject({
+      automatic_video_output: {
+        in_call_recording: {
+          kind: "jpeg",
+          b64_data: "camera-image",
+        },
+      },
+    });
   });
 });

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -67,7 +67,13 @@ export class RecallBotProvider implements MeetingBotProvider {
     meetingUrl: string;
     joinAt: Date;
   }): Promise<{ externalBotId: string }> {
-    const cameraImage = await getMeetingBotCameraImage();
+    const cameraImage = await getMeetingBotCameraImage().catch((error) => {
+      this.logger.warn(
+        "Meeting bot camera image is unavailable; scheduling without video",
+        { error },
+      );
+      return null;
+    });
 
     // No transcript config here on purpose: `recallai_async` is not a
     // bot-creation provider. Async transcription is requested per recording,
@@ -79,12 +85,14 @@ export class RecallBotProvider implements MeetingBotProvider {
         meeting_url: meetingUrl,
         bot_name: botName,
         join_at: joinAt.toISOString(),
-        automatic_video_output: {
-          in_call_recording: {
-            kind: "jpeg",
-            b64_data: cameraImage,
+        ...(cameraImage && {
+          automatic_video_output: {
+            in_call_recording: {
+              kind: "jpeg",
+              b64_data: cameraImage,
+            },
           },
-        },
+        }),
       },
     });
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-000022_pr-3215_726a5f483b26/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents an optional meeting bot camera asset from blocking scheduling.

- Falls back to scheduling without video and records a targeted warning when image loading fails.
- Adds regression coverage for fallback and retry behavior.
- Validated with `pnpm test utils/recall` and `pnpm check`.