### PR TITLE
fix: Prevent duplicate integration callback exchanges

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
@@ -15,7 +15,7 @@ import {
 import { useIntegrations } from "@/hooks/useIntegrations";
 import { IntegrationRow } from "@/app/(app)/[emailAccountId]/integrations/IntegrationRow";
 import { Card } from "@/components/ui/card";
-import { toastError, toastSuccess } from "@/components/Toast";
+import { toastError, toastInfo, toastSuccess } from "@/components/Toast";
 import { findIntegration } from "@/utils/mcp/integrations";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
@@ -68,8 +68,9 @@ function useIntegrationNotifications() {
 
   useEffect(() => {
     const connectedParam = searchParams.get("connected");
+    const pendingParam = searchParams.get("pending");
     const errorParam = searchParams.get("error");
-    if (!connectedParam && !errorParam) return;
+    if (!connectedParam && !pendingParam && !errorParam) return;
 
     if (connectedParam) {
       const displayName =
@@ -80,6 +81,16 @@ function useIntegrationNotifications() {
       });
       analytics.captureAction("integration_connected", {
         integration: connectedParam,
+      });
+    } else if (pendingParam) {
+      const displayName =
+        findIntegration(pendingParam)?.displayName || pendingParam;
+      toastInfo({
+        title: "Connection is still finishing",
+        description: `We're still connecting to ${displayName}. Refresh in a moment to see the latest status.`,
+      });
+      analytics.captureAction("integration_connection_pending", {
+        integration: pendingParam,
       });
     } else if (errorParam) {
       const errorMessages: Record<

--- a/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
@@ -101,6 +101,11 @@ function useIntegrationNotifications() {
           description:
             "We couldn't complete the connection. Please try again or contact support.",
         },
+        tool_sync_failed: {
+          title: "Connected, but tools unavailable",
+          description:
+            "We couldn't load this integration's tools. Reconnect to try again.",
+        },
         forbidden: {
           title: "Connection failed",
           description:

--- a/apps/web/app/api/mcp/[integration]/callback/route.test.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.test.ts
@@ -2,12 +2,23 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
-const { mockHandleOAuthCallback, mockSyncMcpTools, mockFindIntegration } =
-  vi.hoisted(() => ({
-    mockHandleOAuthCallback: vi.fn(),
-    mockSyncMcpTools: vi.fn(),
-    mockFindIntegration: vi.fn(() => ({ authType: "oauth" })),
-  }));
+const {
+  mockClaimOAuthCodeAndWait,
+  mockClearOAuthCode,
+  mockHandleOAuthCallback,
+  mockIsOAuthCodeStoreConfigured,
+  mockSetOAuthCodeResult,
+  mockSyncMcpTools,
+  mockFindIntegration,
+} = vi.hoisted(() => ({
+  mockClaimOAuthCodeAndWait: vi.fn(),
+  mockClearOAuthCode: vi.fn(),
+  mockHandleOAuthCallback: vi.fn(),
+  mockIsOAuthCodeStoreConfigured: vi.fn(),
+  mockSetOAuthCodeResult: vi.fn(),
+  mockSyncMcpTools: vi.fn(),
+  mockFindIntegration: vi.fn(() => ({ authType: "oauth" })),
+}));
 
 vi.mock("@/env", () => ({
   env: {
@@ -36,6 +47,13 @@ vi.mock("@/utils/mcp/oauth", () => ({
 
 vi.mock("@/utils/mcp/sync-tools", () => ({
   syncMcpTools: mockSyncMcpTools,
+}));
+
+vi.mock("@/utils/redis/oauth-code", () => ({
+  claimOAuthCodeAndWait: mockClaimOAuthCodeAndWait,
+  clearOAuthCode: mockClearOAuthCode,
+  isOAuthCodeStoreConfigured: mockIsOAuthCodeStoreConfigured,
+  setOAuthCodeResult: mockSetOAuthCodeResult,
 }));
 
 import {
@@ -76,7 +94,11 @@ describe("mcp callback route", () => {
       id: "email-account-123",
     } as Awaited<ReturnType<typeof prisma.emailAccount.findFirst>>);
     mockHandleOAuthCallback.mockResolvedValue(undefined);
+    mockIsOAuthCodeStoreConfigured.mockReturnValue(true);
     mockSyncMcpTools.mockResolvedValue({ toolsCount: 1 });
+    mockClaimOAuthCodeAndWait.mockResolvedValue({ status: "claimed" });
+    mockClearOAuthCode.mockResolvedValue(undefined);
+    mockSetOAuthCodeResult.mockResolvedValue(undefined);
   });
 
   it("rejects malformed unsigned state payloads", async () => {
@@ -161,5 +183,66 @@ describe("mcp callback route", () => {
       "email-account-123",
       expect.anything(),
     );
+    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith(
+      "valid-auth-code",
+      { connected: "notion" },
+      { ttlSeconds: 600 },
+    );
+  });
+
+  it("reports a tool sync failure without reporting the integration as connected", async () => {
+    const state = generateSignedOAuthState({
+      userId: "user-123",
+      emailAccountId: "email-account-123",
+      type: "notion-mcp",
+    });
+    mockSyncMcpTools.mockRejectedValue(new Error("Tool discovery failed"));
+
+    const response = await GET(
+      createRequest({
+        queryState: state,
+        cookieState: state,
+      }),
+      params,
+    );
+
+    const location = response.headers.get("location");
+    expect(location).toContain("/email-account-123/integrations");
+    expect(location).toContain("error=tool_sync_failed");
+    expect(location).not.toContain("connected=notion");
+    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith(
+      "valid-auth-code",
+      { error: "tool_sync_failed" },
+      { ttlSeconds: 600 },
+    );
+  });
+
+  it("waits for an in-flight duplicate callback instead of exchanging the code twice", async () => {
+    const state = generateSignedOAuthState({
+      userId: "user-123",
+      emailAccountId: "email-account-123",
+      type: "notion-mcp",
+    });
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: { connected: "notion" },
+        status: "success",
+      },
+      status: "success",
+      waited: true,
+    });
+
+    const responsePromise = GET(
+      createRequest({
+        queryState: state,
+        cookieState: state,
+      }),
+      params,
+    );
+    const response = await responsePromise;
+
+    expect(response.headers.get("location")).toContain("connected=notion");
+    expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    expect(mockSyncMcpTools).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/mcp/[integration]/callback/route.test.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.test.ts
@@ -223,25 +223,125 @@ describe("mcp callback route", () => {
       emailAccountId: "email-account-123",
       type: "notion-mcp",
     });
-    mockClaimOAuthCodeAndWait.mockResolvedValue({
-      result: {
-        params: { connected: "notion" },
-        status: "success",
-      },
-      status: "success",
-      waited: true,
+    let publishResult: (() => void) | undefined;
+    let completeExchange: (() => void) | undefined;
+    mockHandleOAuthCallback.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          completeExchange = resolve;
+        }),
+    );
+    mockClaimOAuthCodeAndWait
+      .mockResolvedValueOnce({ status: "claimed" })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            publishResult = () =>
+              resolve({
+                result: {
+                  params: { connected: "notion" },
+                  status: "success",
+                },
+                status: "success",
+                waited: true,
+              });
+          }),
+      );
+    mockSetOAuthCodeResult.mockImplementationOnce(async () => {
+      publishResult?.();
     });
 
-    const responsePromise = GET(
+    const firstResponsePromise = GET(
       createRequest({
         queryState: state,
         cookieState: state,
       }),
       params,
     );
-    const response = await responsePromise;
+    await vi.waitFor(() => expect(mockHandleOAuthCallback).toHaveBeenCalled());
+
+    const secondResponsePromise = GET(
+      createRequest({
+        queryState: state,
+        cookieState: state,
+      }),
+      params,
+    );
+    await vi.waitFor(() =>
+      expect(mockClaimOAuthCodeAndWait).toHaveBeenCalledTimes(2),
+    );
+    completeExchange?.();
+    const [firstResponse, secondResponse] = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(firstResponse.headers.get("location")).toContain("connected=notion");
+    expect(secondResponse.headers.get("location")).toContain(
+      "connected=notion",
+    );
+    expect(mockHandleOAuthCallback).toHaveBeenCalledOnce();
+    expect(mockSyncMcpTools).toHaveBeenCalledOnce();
+  });
+
+  it("continues the OAuth flow when the initial Redis claim fails", async () => {
+    const state = generateSignedOAuthState({
+      userId: "user-123",
+      emailAccountId: "email-account-123",
+      type: "notion-mcp",
+    });
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      error: new Error("Redis unavailable"),
+      stage: "claim",
+      status: "error",
+    });
+
+    const response = await GET(
+      createRequest({
+        queryState: state,
+        cookieState: state,
+      }),
+      params,
+    );
 
     expect(response.headers.get("location")).toContain("connected=notion");
+    expect(mockHandleOAuthCallback).toHaveBeenCalledOnce();
+    expect(mockSyncMcpTools).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "the duplicate callback wait fails",
+      outcome: {
+        error: new Error("Redis unavailable"),
+        stage: "wait",
+        status: "error",
+      },
+    },
+    {
+      name: "the duplicate callback wait times out",
+      outcome: { status: "timeout" },
+    },
+  ])("reports a pending connection when $name", async ({ outcome }) => {
+    const state = generateSignedOAuthState({
+      userId: "user-123",
+      emailAccountId: "email-account-123",
+      type: "notion-mcp",
+    });
+    mockClaimOAuthCodeAndWait.mockResolvedValue(outcome);
+
+    const response = await GET(
+      createRequest({
+        queryState: state,
+        cookieState: state,
+      }),
+      params,
+    );
+
+    expect(response.headers.get("location")).toContain("pending=notion");
+    expect(response.headers.get("location")).not.toContain(
+      "error=connection_failed",
+    );
     expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
     expect(mockSyncMcpTools).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/mcp/[integration]/callback/route.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.ts
@@ -155,13 +155,11 @@ export const GET = withError("mcp/callback", async (request, { params }) => {
 
   if (isOAuthCodeStoreConfigured()) {
     const claim = await claimOAuthCodeAndWait(code);
-    if (claim.status === "error") {
-      logger.error("MCP OAuth callback deduplication unavailable", {
+    if (claim.status === "error" && claim.stage === "claim") {
+      logger.warn("MCP OAuth callback deduplication unavailable", {
         error: claim.error,
         integration,
       });
-      redirectUrl.searchParams.set("error", "connection_failed");
-      return buildRedirectResponse(redirectUrl);
     }
 
     if (claim.status === "success") {
@@ -175,9 +173,15 @@ export const GET = withError("mcp/callback", async (request, { params }) => {
       return buildRedirectResponse(redirectUrl);
     }
 
-    if (claim.status === "timeout") {
-      logger.warn("MCP OAuth callback wait timed out", { integration });
-      redirectUrl.searchParams.set("error", "connection_failed");
+    if (
+      claim.status === "timeout" ||
+      (claim.status === "error" && claim.stage === "wait")
+    ) {
+      logger.warn("MCP OAuth callback result is still pending", {
+        error: claim.status === "error" ? claim.error : undefined,
+        integration,
+      });
+      redirectUrl.searchParams.set("pending", integration);
       return buildRedirectResponse(redirectUrl);
     }
   }
@@ -272,7 +276,7 @@ async function cacheCallbackResult({
       ttlSeconds: CALLBACK_RESULT_TTL_SECONDS,
     });
   } catch (error) {
-    logger.warn("Failed to cache MCP OAuth callback result", {
+    logger.warn("Failed to publish MCP OAuth callback result after retries", {
       error,
       integration,
     });

--- a/apps/web/app/api/mcp/[integration]/callback/route.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.ts
@@ -13,6 +13,16 @@ import { findIntegration } from "@/utils/mcp/integrations";
 import { syncMcpTools } from "@/utils/mcp/sync-tools";
 import { handleOAuthCallback } from "@/utils/mcp/oauth";
 import { env } from "@/env";
+import {
+  claimOAuthCodeAndWait,
+  clearOAuthCode,
+  isOAuthCodeStoreConfigured,
+  setOAuthCodeResult,
+  type OAuthCodeResult,
+} from "@/utils/redis/oauth-code";
+import type { Logger } from "@/utils/logger";
+
+const CALLBACK_RESULT_TTL_SECONDS = 600;
 
 export const GET = withError("mcp/callback", async (request, { params }) => {
   const logger = request.logger;
@@ -143,6 +153,35 @@ export const GET = withError("mcp/callback", async (request, { params }) => {
     return buildRedirectResponse(redirectUrl);
   }
 
+  if (isOAuthCodeStoreConfigured()) {
+    const claim = await claimOAuthCodeAndWait(code);
+    if (claim.status === "error") {
+      logger.error("MCP OAuth callback deduplication unavailable", {
+        error: claim.error,
+        integration,
+      });
+      redirectUrl.searchParams.set("error", "connection_failed");
+      return buildRedirectResponse(redirectUrl);
+    }
+
+    if (claim.status === "success") {
+      logger.info(
+        claim.waited
+          ? "Reusing in-flight MCP OAuth callback result"
+          : "Reusing completed MCP OAuth callback",
+        { integration },
+      );
+      applyCallbackResult(redirectUrl, claim.result);
+      return buildRedirectResponse(redirectUrl);
+    }
+
+    if (claim.status === "timeout") {
+      logger.warn("MCP OAuth callback wait timed out", { integration });
+      redirectUrl.searchParams.set("error", "connection_failed");
+      return buildRedirectResponse(redirectUrl);
+    }
+  }
+
   try {
     // Exchange authorization code for tokens and save to DB
     const redirectUri = `${env.NEXT_PUBLIC_BASE_URL}/api/mcp/${integration}/callback`;
@@ -178,11 +217,26 @@ export const GET = withError("mcp/callback", async (request, { params }) => {
         integration,
         emailAccountId,
       });
+      redirectUrl.searchParams.set("error", "tool_sync_failed");
+      await cacheCallbackResult({
+        code,
+        integration,
+        logger,
+        params: { error: "tool_sync_failed" },
+      });
+      return buildRedirectResponse(redirectUrl);
     }
 
     redirectUrl.searchParams.set("connected", integration);
+    await cacheCallbackResult({
+      code,
+      integration,
+      logger,
+      params: { connected: integration },
+    });
     return buildRedirectResponse(redirectUrl);
   } catch (error) {
+    if (isOAuthCodeStoreConfigured()) await clearOAuthCode(code);
     logger.error("Error during MCP token exchange", {
       error,
       integration,
@@ -193,3 +247,34 @@ export const GET = withError("mcp/callback", async (request, { params }) => {
     return buildRedirectResponse(redirectUrl);
   }
 });
+
+function applyCallbackResult(redirectUrl: URL, result: OAuthCodeResult) {
+  for (const [key, value] of Object.entries(result.params)) {
+    redirectUrl.searchParams.set(key, value);
+  }
+}
+
+async function cacheCallbackResult({
+  code,
+  integration,
+  logger,
+  params,
+}: {
+  code: string;
+  integration: string;
+  logger: Logger;
+  params: Record<string, string>;
+}) {
+  if (!isOAuthCodeStoreConfigured()) return;
+
+  try {
+    await setOAuthCodeResult(code, params, {
+      ttlSeconds: CALLBACK_RESULT_TTL_SECONDS,
+    });
+  } catch (error) {
+    logger.warn("Failed to cache MCP OAuth callback result", {
+      error,
+      integration,
+    });
+  }
+}

--- a/apps/web/utils/analytics/product.ts
+++ b/apps/web/utils/analytics/product.ts
@@ -71,6 +71,7 @@ export const PRODUCT_ANALYTICS_ACTIONS = {
   integrations: {
     connected: "integration_connected",
     connectFailed: "integration_connect_failed",
+    connectionPending: "integration_connection_pending",
     connectStarted: "integration_connect_started",
     disconnected: "integration_disconnected",
     disconnectStarted: "integration_disconnect_started",

--- a/apps/web/utils/oauth/auth-callback-deduplication.test.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
 
 const OAUTH_STATE_COOKIE =
@@ -9,23 +9,20 @@ const REQUEST_FINGERPRINT = createHash("sha256")
   .digest("hex");
 
 const {
-  mockClaimOAuthCode,
+  mockClaimOAuthCodeAndWait,
   mockClearOAuthCode,
-  mockGetOAuthCodeResult,
   mockIsOAuthCodeStoreConfigured,
   mockSetOAuthCodeResult,
 } = vi.hoisted(() => ({
-  mockClaimOAuthCode: vi.fn(),
+  mockClaimOAuthCodeAndWait: vi.fn(),
   mockClearOAuthCode: vi.fn(),
-  mockGetOAuthCodeResult: vi.fn(),
   mockIsOAuthCodeStoreConfigured: vi.fn(),
   mockSetOAuthCodeResult: vi.fn(),
 }));
 
 vi.mock("@/utils/redis/oauth-code", () => ({
-  claimOAuthCode: mockClaimOAuthCode,
+  claimOAuthCodeAndWait: mockClaimOAuthCodeAndWait,
   clearOAuthCode: mockClearOAuthCode,
-  getOAuthCodeResult: mockGetOAuthCodeResult,
   isOAuthCodeStoreConfigured: mockIsOAuthCodeStoreConfigured,
   setOAuthCodeResult: mockSetOAuthCodeResult,
 }));
@@ -38,14 +35,9 @@ describe("deduplicateOAuthCallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsOAuthCodeStoreConfigured.mockReturnValue(true);
-    mockClaimOAuthCode.mockResolvedValue(null);
-    mockGetOAuthCodeResult.mockResolvedValue(null);
+    mockClaimOAuthCodeAndWait.mockResolvedValue({ status: "claimed" });
     mockSetOAuthCodeResult.mockResolvedValue(undefined);
     mockClearOAuthCode.mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("passes non-callback requests directly to Better Auth", async () => {
@@ -64,7 +56,7 @@ describe("deduplicateOAuthCallback", () => {
     expect(response.status).toBe(200);
     expect(handleRequest).toHaveBeenCalledOnce();
     expect(mockIsOAuthCodeStoreConfigured).not.toHaveBeenCalled();
-    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+    expect(mockClaimOAuthCodeAndWait).not.toHaveBeenCalled();
   });
 
   it("does not use Redis when the callback store is not configured", async () => {
@@ -81,7 +73,7 @@ describe("deduplicateOAuthCallback", () => {
     ).resolves.toBe(response);
 
     expect(handleRequest).toHaveBeenCalledOnce();
-    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+    expect(mockClaimOAuthCodeAndWait).not.toHaveBeenCalled();
   });
 
   it("does not use Redis without Better Auth's OAuth state cookie", async () => {
@@ -99,7 +91,7 @@ describe("deduplicateOAuthCallback", () => {
     ).resolves.toBe(response);
 
     expect(handleRequest).toHaveBeenCalledOnce();
-    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+    expect(mockClaimOAuthCodeAndWait).not.toHaveBeenCalled();
   });
 
   it("caches the first successful callback redirect", async () => {
@@ -114,7 +106,7 @@ describe("deduplicateOAuthCallback", () => {
       }),
     ).resolves.toBe(response);
 
-    expect(mockClaimOAuthCode).toHaveBeenCalledWith(
+    expect(mockClaimOAuthCodeAndWait).toHaveBeenCalledWith(
       "oauth-code",
       REQUEST_FINGERPRINT,
     );
@@ -135,16 +127,20 @@ describe("deduplicateOAuthCallback", () => {
   });
 
   it("reuses a cached callback redirect without exchanging the code again", async () => {
-    mockClaimOAuthCode.mockResolvedValue({
-      params: {
-        redirect: "https://example.com/welcome-redirect",
-        setCookies: JSON.stringify([
-          "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
-        ]),
-        status: "302",
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: {
+          redirect: "https://example.com/welcome-redirect",
+          setCookies: JSON.stringify([
+            "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+          ]),
+          status: "302",
+        },
+        requestFingerprint: REQUEST_FINGERPRINT,
+        status: "success",
       },
-      requestFingerprint: REQUEST_FINGERPRINT,
       status: "success",
+      waited: false,
     });
     const handleRequest = vi.fn();
 
@@ -165,16 +161,20 @@ describe("deduplicateOAuthCallback", () => {
   });
 
   it("does not replay session cookies to a different OAuth state", async () => {
-    mockClaimOAuthCode.mockResolvedValue({
-      params: {
-        redirect: "https://example.com/welcome-redirect",
-        setCookies: JSON.stringify([
-          "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
-        ]),
-        status: "302",
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: {
+          redirect: "https://example.com/welcome-redirect",
+          setCookies: JSON.stringify([
+            "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+          ]),
+          status: "302",
+        },
+        requestFingerprint: "different-request",
+        status: "success",
       },
-      requestFingerprint: "different-request",
       status: "success",
+      waited: false,
     });
 
     const response = await deduplicateOAuthCallback({
@@ -187,18 +187,17 @@ describe("deduplicateOAuthCallback", () => {
   });
 
   it("waits for an in-flight callback and reuses its redirect", async () => {
-    vi.useFakeTimers();
-    mockGetOAuthCodeResult.mockResolvedValueOnce({
-      params: {
-        redirect: "https://example.com/welcome-redirect",
-        status: "302",
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: {
+          redirect: "https://example.com/welcome-redirect",
+          status: "302",
+        },
+        requestFingerprint: REQUEST_FINGERPRINT,
+        status: "success",
       },
-      requestFingerprint: REQUEST_FINGERPRINT,
       status: "success",
-    });
-    mockClaimOAuthCode.mockResolvedValue({
-      requestFingerprint: REQUEST_FINGERPRINT,
-      status: "processing",
+      waited: true,
     });
     const handleRequest = vi.fn();
 
@@ -207,7 +206,6 @@ describe("deduplicateOAuthCallback", () => {
       handleRequest,
       logger,
     });
-    await vi.advanceTimersByTimeAsync(250);
     const response = await responsePromise;
 
     expect(response.status).toBe(302);
@@ -218,7 +216,11 @@ describe("deduplicateOAuthCallback", () => {
   });
 
   it("falls back to Better Auth when the deduplication store is unavailable", async () => {
-    mockClaimOAuthCode.mockRejectedValue(new Error("Redis unavailable"));
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      error: new Error("Redis unavailable"),
+      stage: "claim",
+      status: "error",
+    });
     const response = createSuccessfulCallbackResponse();
     const handleRequest = vi.fn().mockResolvedValue(response);
 

--- a/apps/web/utils/oauth/auth-callback-deduplication.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.ts
@@ -1,9 +1,8 @@
 import { createHash } from "node:crypto";
 import type { Logger } from "@/utils/logger";
 import {
-  claimOAuthCode,
+  claimOAuthCodeAndWait,
   clearOAuthCode,
-  getOAuthCodeResult,
   isOAuthCodeStoreConfigured,
   type OAuthCodeResult,
   setOAuthCodeResult,
@@ -11,8 +10,6 @@ import {
 import { WELCOME_PATH } from "@/utils/config";
 
 const CALLBACK_PATH_REGEX = /\/api\/auth\/(?:oauth2\/)?callback\/([^/]+)\/?$/;
-const CALLBACK_RESULT_POLL_INTERVAL_MS = 250;
-const CALLBACK_RESULT_WAIT_MS = 15_000;
 const CALLBACK_RESULT_TTL_SECONDS = 600;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const OAUTH_STATE_COOKIE_NAMES = new Set([
@@ -36,40 +33,38 @@ export async function deduplicateOAuthCallback({
   const requestFingerprint = getOAuthStateFingerprint(request);
   if (!requestFingerprint) return handleRequest();
 
-  let claim: Awaited<ReturnType<typeof claimOAuthCode>>;
-
-  try {
-    claim = await claimOAuthCode(code, requestFingerprint);
-  } catch (error) {
+  const claim = await claimOAuthCodeAndWait(code, requestFingerprint);
+  if (claim.status === "error" && claim.stage === "claim") {
     logger.warn("OAuth callback deduplication unavailable", {
-      error,
+      error: claim.error,
       provider,
     });
     return handleRequest();
   }
 
-  if (claim?.status === "success") {
-    logger.info("Reusing completed OAuth callback", { provider });
-    return createCachedRedirect({ request, requestFingerprint, result: claim });
-  }
-
-  if (claim?.status === "processing") {
-    logger.info("Waiting for in-flight OAuth callback", { provider });
-    const inFlightResult = await waitForOAuthCodeResult({
-      code,
-      logger,
+  if (claim.status === "error") {
+    logger.warn("Failed while waiting for OAuth callback result", {
+      error: claim.error,
       provider,
     });
+    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+  }
 
-    if (inFlightResult) {
-      logger.info("Reusing in-flight OAuth callback result", { provider });
-      return createCachedRedirect({
-        request,
-        requestFingerprint,
-        result: inFlightResult,
-      });
-    }
+  if (claim.status === "success") {
+    logger.info(
+      claim.waited
+        ? "Reusing in-flight OAuth callback result"
+        : "Reusing completed OAuth callback",
+      { provider },
+    );
+    return createCachedRedirect({
+      request,
+      requestFingerprint,
+      result: claim.result,
+    });
+  }
 
+  if (claim.status === "timeout") {
     logger.warn("OAuth callback wait timed out", { provider });
     return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
   }
@@ -127,37 +122,6 @@ function getOAuthCallback(request: Request) {
   if (!code || !provider) return null;
 
   return { code, provider };
-}
-
-async function waitForOAuthCodeResult({
-  code,
-  logger,
-  provider,
-}: {
-  code: string;
-  logger: Logger;
-  provider: string;
-}) {
-  const attempts = CALLBACK_RESULT_WAIT_MS / CALLBACK_RESULT_POLL_INTERVAL_MS;
-
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    await new Promise((resolve) =>
-      setTimeout(resolve, CALLBACK_RESULT_POLL_INTERVAL_MS),
-    );
-
-    try {
-      const result = await getOAuthCodeResult(code);
-      if (result) return result;
-    } catch (error) {
-      logger.warn("Failed while waiting for OAuth callback result", {
-        error,
-        provider,
-      });
-      return null;
-    }
-  }
-
-  return null;
 }
 
 function createCachedRedirect({

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { redis } from "@/utils/redis";
-import { claimOAuthCode } from "@/utils/redis/oauth-code";
+import {
+  claimOAuthCode,
+  claimOAuthCodeAndWait,
+} from "@/utils/redis/oauth-code";
 
 vi.mock("@/env", () => ({
   env: {
@@ -11,6 +14,7 @@ vi.mock("@/env", () => ({
 
 vi.mock("@/utils/redis", () => ({
   redis: {
+    get: vi.fn(),
     set: vi.fn(),
   },
 }));
@@ -18,6 +22,10 @@ vi.mock("@/utils/redis", () => ({
 describe("claimOAuthCode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("atomically claims an unused code", async () => {
@@ -67,5 +75,57 @@ describe("claimOAuthCode", () => {
     vi.mocked(redis.set).mockResolvedValue(completed);
 
     await expect(claimOAuthCode("oauth-code")).resolves.toBe(completed);
+  });
+});
+
+describe("claimOAuthCodeAndWait", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("claims an unused code without polling", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+
+    await expect(claimOAuthCodeAndWait("oauth-code")).resolves.toEqual({
+      status: "claimed",
+    });
+
+    expect(redis.get).not.toHaveBeenCalled();
+  });
+
+  it("waits for an in-flight callback result", async () => {
+    vi.useFakeTimers();
+    vi.mocked(redis.set).mockResolvedValue({ status: "processing" });
+    vi.mocked(redis.get).mockResolvedValue({
+      params: { connected: "notion" },
+      status: "success",
+    });
+
+    const resultPromise = claimOAuthCodeAndWait("oauth-code");
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(resultPromise).resolves.toEqual({
+      result: {
+        params: { connected: "notion" },
+        status: "success",
+      },
+      status: "success",
+      waited: true,
+    });
+  });
+
+  it("reports which Redis stage failed", async () => {
+    const error = new Error("Redis unavailable");
+    vi.mocked(redis.set).mockRejectedValue(error);
+
+    await expect(claimOAuthCodeAndWait("oauth-code")).resolves.toEqual({
+      error,
+      stage: "claim",
+      status: "error",
+    });
   });
 });

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -130,20 +130,44 @@ describe("claimOAuthCodeAndWait", () => {
     });
   });
 
-  it("reports a Redis failure while waiting for another callback", async () => {
+  it("continues polling after a transient Redis wait failure", async () => {
+    vi.useFakeTimers();
+    vi.mocked(redis.set).mockResolvedValue({ status: "processing" });
+    vi.mocked(redis.get)
+      .mockRejectedValueOnce(new Error("Redis unavailable"))
+      .mockResolvedValueOnce({
+        params: { connected: "notion" },
+        status: "success",
+      });
+
+    const resultPromise = claimOAuthCodeAndWait("oauth-code");
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(resultPromise).resolves.toEqual({
+      result: {
+        params: { connected: "notion" },
+        status: "success",
+      },
+      status: "success",
+      waited: true,
+    });
+  });
+
+  it("reports a Redis failure after the full wait window", async () => {
     vi.useFakeTimers();
     const error = new Error("Redis unavailable");
     vi.mocked(redis.set).mockResolvedValue({ status: "processing" });
     vi.mocked(redis.get).mockRejectedValue(error);
 
     const resultPromise = claimOAuthCodeAndWait("oauth-code");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(15_000);
 
     await expect(resultPromise).resolves.toEqual({
       error,
       stage: "wait",
       status: "error",
     });
+    expect(redis.get).toHaveBeenCalledTimes(60);
   });
 
   it("times out when another callback does not publish a result", async () => {

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -3,6 +3,7 @@ import { redis } from "@/utils/redis";
 import {
   claimOAuthCode,
   claimOAuthCodeAndWait,
+  setOAuthCodeResult,
 } from "@/utils/redis/oauth-code";
 
 vi.mock("@/env", () => ({
@@ -127,5 +128,58 @@ describe("claimOAuthCodeAndWait", () => {
       stage: "claim",
       status: "error",
     });
+  });
+
+  it("reports a Redis failure while waiting for another callback", async () => {
+    vi.useFakeTimers();
+    const error = new Error("Redis unavailable");
+    vi.mocked(redis.set).mockResolvedValue({ status: "processing" });
+    vi.mocked(redis.get).mockRejectedValue(error);
+
+    const resultPromise = claimOAuthCodeAndWait("oauth-code");
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(resultPromise).resolves.toEqual({
+      error,
+      stage: "wait",
+      status: "error",
+    });
+  });
+
+  it("times out when another callback does not publish a result", async () => {
+    vi.useFakeTimers();
+    vi.mocked(redis.set).mockResolvedValue({ status: "processing" });
+    vi.mocked(redis.get).mockResolvedValue(null);
+
+    const resultPromise = claimOAuthCodeAndWait("oauth-code");
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await expect(resultPromise).resolves.toEqual({ status: "timeout" });
+    expect(redis.get).toHaveBeenCalledTimes(60);
+  });
+});
+
+describe("setOAuthCodeResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries transient result publication failures", async () => {
+    vi.useFakeTimers();
+    vi.mocked(redis.set)
+      .mockRejectedValueOnce(new Error("Redis unavailable"))
+      .mockResolvedValueOnce("OK");
+
+    const resultPromise = setOAuthCodeResult("oauth-code", {
+      connected: "notion",
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(resultPromise).resolves.toBeUndefined();
+    expect(redis.set).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -2,6 +2,9 @@ import { createHash } from "node:crypto";
 import { env } from "@/env";
 import { redis } from "@/utils/redis";
 
+const CALLBACK_RESULT_POLL_INTERVAL_MS = 250;
+const CALLBACK_RESULT_WAIT_MS = 15_000;
+
 // Not password hashing - creating a short cache key for OAuth authorization codes
 function createOAuthCodeCacheKey(code: string): string {
   return createHash("sha256").update(code).digest("hex").slice(0, 16);
@@ -24,6 +27,12 @@ interface OAuthCodeProcessing {
 
 type OAuthCodeClaim = OAuthCodeProcessing | OAuthCodeResult | null;
 
+type OAuthCodeClaimOutcome =
+  | { status: "claimed" }
+  | { error: unknown; stage: "claim" | "wait"; status: "error" }
+  | { result: OAuthCodeResult; status: "success"; waited: boolean }
+  | { status: "timeout" };
+
 export function isOAuthCodeStoreConfigured() {
   return Boolean(env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN);
 }
@@ -45,6 +54,38 @@ export async function claimOAuthCode(
   if (typeof existing === "string") return { status: "processing" };
 
   return existing as OAuthCodeClaim;
+}
+
+export async function claimOAuthCodeAndWait(
+  code: string,
+  requestFingerprint?: string,
+): Promise<OAuthCodeClaimOutcome> {
+  let claim: OAuthCodeClaim;
+  try {
+    claim = await claimOAuthCode(code, requestFingerprint);
+  } catch (error) {
+    return { error, stage: "claim", status: "error" };
+  }
+
+  if (!claim) return { status: "claimed" };
+  if (claim.status === "success") {
+    return { result: claim, status: "success", waited: false };
+  }
+
+  const attempts = CALLBACK_RESULT_WAIT_MS / CALLBACK_RESULT_POLL_INTERVAL_MS;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, CALLBACK_RESULT_POLL_INTERVAL_MS),
+    );
+    try {
+      const result = await getOAuthCodeResult(code);
+      if (result) return { result, status: "success", waited: true };
+    } catch (error) {
+      return { error, stage: "wait", status: "error" };
+    }
+  }
+
+  return { status: "timeout" };
 }
 
 export async function acquireOAuthCodeLock(code: string): Promise<boolean> {

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -1,9 +1,12 @@
 import { createHash } from "node:crypto";
 import { env } from "@/env";
 import { redis } from "@/utils/redis";
+import { sleep } from "@/utils/sleep";
 
 const CALLBACK_RESULT_POLL_INTERVAL_MS = 250;
 const CALLBACK_RESULT_WAIT_MS = 15_000;
+const CALLBACK_RESULT_WRITE_ATTEMPTS = 3;
+const CALLBACK_RESULT_WRITE_RETRY_MS = 250;
 
 // Not password hashing - creating a short cache key for OAuth authorization codes
 function createOAuthCodeCacheKey(code: string): string {
@@ -127,9 +130,17 @@ export async function setOAuthCodeResult(
     requestFingerprint: options?.requestFingerprint,
   };
 
-  await redis.set(getCodeKey(code), result, {
-    ex: options?.ttlSeconds ?? 60,
-  });
+  for (let attempt = 1; attempt <= CALLBACK_RESULT_WRITE_ATTEMPTS; attempt++) {
+    try {
+      await redis.set(getCodeKey(code), result, {
+        ex: options?.ttlSeconds ?? 60,
+      });
+      return;
+    } catch (error) {
+      if (attempt === CALLBACK_RESULT_WRITE_ATTEMPTS) throw error;
+      await sleep(CALLBACK_RESULT_WRITE_RETRY_MS);
+    }
+  }
 }
 
 /**

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -76,16 +76,22 @@ export async function claimOAuthCodeAndWait(
   }
 
   const attempts = CALLBACK_RESULT_WAIT_MS / CALLBACK_RESULT_POLL_INTERVAL_MS;
+  let lastWaitError: unknown;
   for (let attempt = 0; attempt < attempts; attempt++) {
     await new Promise((resolve) =>
       setTimeout(resolve, CALLBACK_RESULT_POLL_INTERVAL_MS),
     );
     try {
       const result = await getOAuthCodeResult(code);
+      lastWaitError = undefined;
       if (result) return { result, status: "success", waited: true };
     } catch (error) {
-      return { error, stage: "wait", status: "error" };
+      lastWaitError = error;
     }
+  }
+
+  if (lastWaitError) {
+    return { error: lastWaitError, stage: "wait", status: "error" };
   }
 
   return { status: "timeout" };


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-004407_pr-3217_8741da91a13d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents repeated integration OAuth callbacks from exchanging the same authorization code more than once. Centralizes callback claim-and-wait behavior and surfaces tool synchronization failures to users.

- Reuses cached callback outcomes for concurrent requests
- Adds regression coverage for callback deduplication and sync errors
- Validated with focused tests and repository lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->