### PR TITLE
mail: tighten row layout and preserve thread labels

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -7,7 +7,7 @@ import type {
   MailLayoutMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import { EmailDate } from "@/components/email-list/EmailDate";
-import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
+import { getEmailThreadLabels } from "@/components/EmailMessageCellLabels";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { EmailLabels } from "@/providers/email-label-types";
@@ -52,11 +52,11 @@ export const ThreadRow = memo(function ThreadRow({
 
   const labels = useMemo(
     () =>
-      getEmailMessageCellLabels({
-        labelIds: message?.labelIds,
+      getEmailThreadLabels({
+        messages: thread.messages,
         userLabels,
-      }) ?? [],
-    [message?.labelIds, userLabels],
+      }),
+    [thread.messages, userLabels],
   );
 
   if (!message) return null;
@@ -70,40 +70,37 @@ export const ThreadRow = memo(function ThreadRow({
   const subject = message.headers.subject;
   const snippet = decodeSnippet(thread.snippet || message.snippet);
   const chips = labels.slice(0, isWide ? 3 : 2);
+  const showCheckbox = isSelected || hasAnySelection;
 
-  const checkbox = (
-    <Checkbox
-      aria-label={`Select conversation from ${sender}`}
-      checked={isSelected}
-      className={cn(
-        "size-3.5 shrink-0 rounded border-input transition-opacity [&_svg]:size-2.5",
-        isSelected || hasAnySelection
-          ? "opacity-100"
-          : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100",
-        isWide ? null : "mt-0.5",
-      )}
-      onClick={(event) => {
-        event.stopPropagation();
-        if (event.shiftKey) onSelectRangeTo(index);
-        else onToggleSelect(index);
-      }}
-      title={`Select (${SELECT_HINT})`}
-    />
-  );
-
-  const unreadDot = (
-    <span
-      className={cn(
-        "flex w-1.5 shrink-0 justify-center",
-        isWide ? "items-center" : "pt-1.5",
-      )}
-    >
-      <span
+  const selectionControl = (
+    <span className={cn("relative size-3.5 shrink-0", !isWide && "mt-0.5")}>
+      <Checkbox
+        aria-label={`Select conversation from ${sender}`}
+        checked={isSelected}
         className={cn(
-          "size-1.5 rounded-full",
-          isUnread ? "bg-primary" : "bg-transparent",
+          "absolute inset-0 size-3.5 rounded border-input transition-opacity [&_svg]:size-2.5",
+          showCheckbox
+            ? "opacity-100"
+            : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100",
         )}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (event.shiftKey) onSelectRangeTo(index);
+          else onToggleSelect(index);
+        }}
+        title={`Select (${SELECT_HINT})`}
       />
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity",
+          isUnread && !showCheckbox
+            ? "opacity-100 group-focus-within:opacity-0 group-hover:opacity-0"
+            : "opacity-0",
+        )}
+      >
+        <span className="size-1.5 rounded-full bg-primary" />
+      </span>
     </span>
   );
 
@@ -124,7 +121,7 @@ export const ThreadRow = memo(function ThreadRow({
       className={cn(
         "group relative flex cursor-pointer border-b border-border/60 outline-none",
         isWide
-          ? "items-center gap-3 py-2.5 pr-5 pl-3"
+          ? "items-center gap-2.5 py-2.5 pr-5 pl-3"
           : "items-start gap-2 px-3.5 py-2.5",
         rowBackground({ isSelected, isFocused }),
         isFocused &&
@@ -144,8 +141,7 @@ export const ThreadRow = memo(function ThreadRow({
       role="option"
       tabIndex={isFocused ? 0 : -1}
     >
-      {checkbox}
-      {unreadDot}
+      {selectionControl}
 
       {isWide ? (
         <>

--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getEmailMessageCellLabels } from "./EmailMessageCellLabels";
+import {
+  getEmailMessageCellLabels,
+  getEmailThreadLabels,
+} from "./EmailMessageCellLabels";
 
 describe("getEmailMessageCellLabels", () => {
   it("does not infer Outlook sent mail as archived just because it is outside the inbox", () => {
@@ -51,5 +54,24 @@ describe("getEmailMessageCellLabels", () => {
       { id: "ARCHIVE", name: "Archived" },
       { id: "label-newsletter", name: "Newsletter" },
     ]);
+  });
+});
+
+describe("getEmailThreadLabels", () => {
+  it("keeps a thread label when the newest message is a draft without it", () => {
+    const labels = getEmailThreadLabels({
+      messages: [
+        { labelIds: ["INBOX", "label-actioned"] },
+        { labelIds: ["DRAFT"] },
+      ],
+      userLabels: {
+        "label-actioned": {
+          id: "label-actioned",
+          name: "Actioned",
+        },
+      },
+    });
+
+    expect(labels).toEqual([{ id: "label-actioned", name: "Actioned" }]);
   });
 });

--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -74,4 +74,28 @@ describe("getEmailThreadLabels", () => {
 
     expect(labels).toEqual([{ id: "label-actioned", name: "Actioned" }]);
   });
+
+  it("prioritizes labels from newer messages", () => {
+    const labels = getEmailThreadLabels({
+      messages: [
+        { labelIds: ["label-older"] },
+        { labelIds: ["DRAFT", "label-newer"] },
+      ],
+      userLabels: {
+        "label-older": {
+          id: "label-older",
+          name: "Older",
+        },
+        "label-newer": {
+          id: "label-newer",
+          name: "Newer",
+        },
+      },
+    });
+
+    expect(labels).toEqual([
+      { id: "label-newer", name: "Newer" },
+      { id: "label-older", name: "Older" },
+    ]);
+  });
 });

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -62,6 +62,20 @@ export function getEmailMessageCellLabels({
   return labels;
 }
 
+export function getEmailThreadLabels({
+  messages,
+  userLabels,
+}: {
+  messages: { labelIds?: string[] }[];
+  userLabels: EmailLabels;
+}): EmailMessageCellLabel[] {
+  const labelIds = [
+    ...new Set(messages.flatMap((message) => message.labelIds ?? [])),
+  ];
+
+  return getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];
+}
+
 function shouldShowArchivedLabel({
   labelIds,
   provider,

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -70,7 +70,9 @@ export function getEmailThreadLabels({
   userLabels: EmailLabels;
 }): EmailMessageCellLabel[] {
   const labelIds = [
-    ...new Set(messages.flatMap((message) => message.labelIds ?? [])),
+    ...new Set(
+      [...messages].reverse().flatMap((message) => message.labelIds ?? []),
+    ),
   ];
 
   return getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-002713_pr-3218_bd40220d39a0/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves email list rows so controls use a compact slot and labels reflect the full conversation.

- Shares leading space between selection and unread state.
- Aggregates labels across thread messages with regression coverage.
- Validated with focused tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->