### PR TITLE
fix(chat): make clearAiInstructions Gemini-compatible (#3047)

### DIFF
--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -552,9 +552,6 @@ function createPatchConditionSchema() {
         .describe(
           `${AI_INSTRUCTIONS_PROMPT_DESCRIPTION} Omit this field to preserve existing instructions.`,
         ),
-      // Use z.boolean() instead of z.literal(true): Gemini maps literal true to a
-      // boolean enum entry and rejects the tool schema (400 INVALID_ARGUMENT),
-      // which breaks all chat with the Google provider. Handlers only check truthiness.
       clearAiInstructions: z
         .boolean()
         .optional()

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -359,7 +359,8 @@ export type UpdateRuleOutput = {
 
 type PatchCondition = {
   aiInstructions?: string;
-  clearAiInstructions?: true;
+  // boolean (not literal true): Gemini rejects boolean constants in tool JSON Schema enums
+  clearAiInstructions?: boolean;
   static?: {
     from?: string | null;
     to?: string | null;
@@ -551,8 +552,11 @@ function createPatchConditionSchema() {
         .describe(
           `${AI_INSTRUCTIONS_PROMPT_DESCRIPTION} Omit this field to preserve existing instructions.`,
         ),
+      // Use z.boolean() instead of z.literal(true): Gemini maps literal true to a
+      // boolean enum entry and rejects the tool schema (400 INVALID_ARGUMENT),
+      // which breaks all chat with the Google provider. Handlers only check truthiness.
       clearAiInstructions: z
-        .literal(true)
+        .boolean()
         .optional()
         .describe(
           "Set to true only when the user explicitly asks to remove the semantic AI instructions from this rule.",


### PR DESCRIPTION
## Credit

This fix was **diagnosed, explained, and verified** by **@MQ1995** in https://github.com/elie222/inbox-zero/issues/3047.

- Root cause write-up and the exact two-line change: @MQ1995  
- Confirmed working with Gemini after a local Docker rebuild: @MQ1995 ([comment](https://github.com/elie222/inbox-zero/issues/3047#issuecomment-5074060122))  
- **@dandeannie** offered to open a PR for this as a contribution ([comment](https://github.com/elie222/inbox-zero/issues/3047#issuecomment-5127221582)); @MQ1995 invited them to take it. This PR only implements the same patch so the fix can land — **the discovery and validation credit belongs to @MQ1995**.

I am not claiming the investigation; this PR packages their fix for review/merge.

Fixes #3047

## Problem

With the Google Gemini (AI Studio) provider, **every assistant chat message fails** with:

```text
Error [AI_APICallError]: Invalid value at
'tools[0].function_declarations[13].parameters.properties[...].enum[0]' (TYPE_STRING), true
status: INVALID_ARGUMENT (400)
```

The UI shows no useful assistant response; logs may show empty assistant messages being skipped.

## Root cause (from @MQ1995)

In `apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts`, the update-rule tool schema used:

```ts
clearAiInstructions: z.literal(true).optional()
```

That serializes into the tool JSON Schema as a **boolean constant**. Anthropic/OpenAI accept it; **Gemini is stricter** and maps the constant into an `enum` entry in a way that fails validation. Because tool schemas are sent on every chat request, **all Gemini chat breaks**, not only “clear AI instructions” turns.

## Fix

Same change @MQ1995 proposed and verified:

1. Schema: `z.literal(true)` → `z.boolean()`
2. Type: `clearAiInstructions?: true` → `clearAiInstructions?: boolean`

Handlers already only use truthiness checks (`if (condition.clearAiInstructions)`), and the `.describe()` text still tells the model to set it only when the user explicitly asks to remove semantic instructions. Behavior for non-Gemini providers is unchanged.

## Test plan

- [ ] With Google Gemini provider: send any assistant chat message — should stream a normal reply (no `INVALID_ARGUMENT` on `function_declarations`)
- [ ] Ask to clear semantic AI instructions on a rule via chat — `clearAiInstructions: true` still works
- [ ] Spot-check OpenAI/Anthropic (or default provider) chat + rule update still works
- [x] Matches the two-line fix @MQ1995 verified on self-hosted Docker with `gemini-3-flash-preview` / `gemini-2.5-flash`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

