### PR TITLE
Mail: Emphasize unread subjects

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -168,8 +168,8 @@ export const ThreadRow = memo(function ThreadRow({
               className={cn(
                 "max-w-[46%] shrink-0 truncate whitespace-nowrap text-sm",
                 isUnread
-                  ? "font-medium text-foreground"
-                  : "text-muted-foreground",
+                  ? "font-semibold text-foreground"
+                  : "font-normal text-muted-foreground",
               )}
             >
               {subject}
@@ -198,8 +198,8 @@ export const ThreadRow = memo(function ThreadRow({
             className={cn(
               "truncate text-sm",
               isUnread
-                ? "font-medium text-foreground"
-                : "text-muted-foreground",
+                ? "font-semibold text-foreground"
+                : "font-normal text-muted-foreground",
             )}
           >
             {subject}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-001607_pr-3220_70be05e3be10/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates mail thread subject typography so unread messages are more distinct from read messages in both supported list layouts.

- Uses semibold weight for unread subjects and normal weight for read subjects.
- Validated with a file-scoped Ultracite check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->