### PR TITLE
fix(mail): improve rule attribution layout

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
@@ -122,14 +122,16 @@ function RuleAttribution({
               : "Action issues"}
           </div>
           <ul className="mt-0.5 list-disc space-y-0.5 pl-4">
-            {reasonDisplay.actionFailureMessages.map((failureMessage) => (
-              <li
-                className="break-words [overflow-wrap:anywhere]"
-                key={failureMessage}
-              >
-                {failureMessage}
-              </li>
-            ))}
+            {reasonDisplay.actionFailureMessages.map(
+              (failureMessage, failureIndex) => (
+                <li
+                  className="break-words [overflow-wrap:anywhere]"
+                  key={`${failureMessage}-${failureIndex}`}
+                >
+                  {failureMessage}
+                </li>
+              ),
+            )}
           </ul>
         </div>
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/RuleAttributionMenu.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { MoreHorizontalIcon } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
+import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
 import { Button } from "@/components/ui/button";
@@ -59,7 +60,10 @@ export function RuleAttributionMenu({
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end" className="w-80">
+      <DropdownMenuContent
+        align="end"
+        className="w-[min(24rem,calc(100vw-1rem))]"
+      >
         {plans.map((plan) => (
           <RuleAttribution
             key={plan.id}
@@ -89,20 +93,45 @@ function RuleAttribution({
   const otherActions = actions.filter(
     (action) => action.type !== ActionType.LABEL,
   );
+  const reasonDisplay = getRuleResultReasonDisplay(plan.reason ?? "");
 
   return (
-    <div className="border-border border-b px-2 py-2.5 last:border-b-0">
-      <div className="text-muted-foreground text-xs">
-        {plan.status === ExecutedRuleStatus.APPLIED ? "Applied by" : "Matched"}{" "}
-        <span className="font-medium text-foreground">
+    <div className="min-w-0 border-border border-b px-3 py-3 last:border-b-0">
+      <div className="min-w-0 text-xs">
+        <span className="text-muted-foreground">
+          {plan.status === ExecutedRuleStatus.APPLIED
+            ? "Applied rule:"
+            : "Matched rule:"}{" "}
+        </span>
+        <span className="font-medium text-foreground break-words [overflow-wrap:anywhere]">
           {plan.rule?.name ?? "a deleted rule"}
         </span>
       </div>
 
-      {plan.reason ? (
-        <p className="mt-1.5 text-foreground text-xs leading-relaxed">
-          {plan.reason}
+      {reasonDisplay.reason ? (
+        <p className="mt-1.5 whitespace-pre-wrap text-foreground text-xs leading-relaxed break-words [overflow-wrap:anywhere]">
+          {reasonDisplay.reason}
         </p>
+      ) : null}
+
+      {reasonDisplay.actionFailureMessages.length > 0 ? (
+        <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-destructive text-xs">
+          <div className="font-medium">
+            {reasonDisplay.actionFailureMessages.length === 1
+              ? "Action issue"
+              : "Action issues"}
+          </div>
+          <ul className="mt-0.5 list-disc space-y-0.5 pl-4">
+            {reasonDisplay.actionFailureMessages.map((failureMessage) => (
+              <li
+                className="break-words [overflow-wrap:anywhere]"
+                key={failureMessage}
+              >
+                {failureMessage}
+              </li>
+            ))}
+          </ul>
+        </div>
       ) : null}
 
       {labels.length > 0 || otherActions.length > 0 ? (


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260812-004728_pr-3221_68f519aef506/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves the rule attribution popover for clearer, responsive presentation.

- Formats action failures as readable issue messages instead of internal codes.
- Wraps long content and clarifies heading capitalization.
- Validation: focused unit tests and formatting check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->