### PR TITLE
chore: shorten pull request review interval

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -10,7 +10,7 @@ continue until the latest commit has clean reviews and checks.
 
 ## Defaults and boundaries
 
-- Wait 300 seconds before the first PR observation and after every push or
+- Wait 120 seconds before the first PR observation and after every push or
   review reply.
 - Keep going until reviews converge: as long as the latest review-bot run on
   the current PR HEAD produced new actionable comments, or a review bot is


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-003725_pr-3222_c68d75e37cdd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Reduces the default pause between automated review observations from five minutes to two minutes while preserving repeated polling and the existing monitoring backstop.\n\nValidation: `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->