### PR TITLE
integrations: explain what the page is for

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
@@ -5,6 +5,7 @@ import type { GetIntegrationsResponse } from "@/app/api/mcp/integrations/route";
 import type { GetMcpAuthUrlResponse } from "@/app/api/mcp/[integration]/auth-url/route";
 import { Toggle } from "@/components/Toggle";
 import { MutedText, TypographyP } from "@/components/Typography";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TableRow, TableCell } from "@/components/ui/table";
 import {
@@ -13,7 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ChevronDown, ChevronRight, MoreVertical } from "lucide-react";
+import { MoreVertical } from "lucide-react";
 import clsx from "clsx";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { DomainIcon } from "@/components/charts/DomainIcon";
@@ -220,13 +221,21 @@ export function IntegrationRow({
   return (
     <>
       <TableRow>
-        <TableCell>
+        <TableCell className="w-full">
           <div className="flex items-center gap-3">
             <DomainIcon domain={integration.url} size={32} />
-            <span>{integration.displayName}</span>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span>{integration.shortName || integration.displayName}</span>
+                {integration.comingSoon && (
+                  <Badge variant="secondary">Coming soon</Badge>
+                )}
+              </div>
+              <MutedText>{integration.description}</MutedText>
+            </div>
           </div>
         </TableCell>
-        <TableCell>
+        <TableCell className="whitespace-nowrap">
           {integration.comingSoon ? (
             <RequestAccessDialog integrationName={integration.displayName} />
           ) : integration.authType === "oauth" ||
@@ -259,35 +268,6 @@ export function IntegrationRow({
             </TypographyP>
           )}
         </TableCell>
-        <TableCell className="hidden sm:table-cell">
-          {integration.comingSoon ? (
-            <span className="text-gray-400 text-sm">Coming Soon</span>
-          ) : connected && tools.length > 0 ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="flex items-center gap-1"
-              onClick={() => {
-                analytics.captureAction("integration_tools_expanded", {
-                  integration: integration.name,
-                  expanded: !expandedTools,
-                  enabled_tool_count: toolsCount,
-                  total_tool_count: totalTools,
-                });
-                setExpandedTools(!expandedTools);
-              }}
-            >
-              {expandedTools ? (
-                <ChevronDown className="h-4 w-4" />
-              ) : (
-                <ChevronRight className="h-4 w-4" />
-              )}
-              {toolsCount}/{totalTools} tools
-            </Button>
-          ) : (
-            <span className="text-gray-400 text-sm">No tools</span>
-          )}
-        </TableCell>
         <TableCell>
           {connected && !integration.comingSoon && (
             <DropdownMenu>
@@ -313,9 +293,10 @@ export function IntegrationRow({
                       });
                       setExpandedTools(!expandedTools);
                     }}
-                    className="sm:hidden"
                   >
-                    {expandedTools ? "Hide tools" : "Manage tools"}
+                    {expandedTools
+                      ? "Hide tools"
+                      : `Manage tools (${toolsCount} of ${totalTools} on)`}
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem onClick={handleTogglePause}>
@@ -356,7 +337,7 @@ function ToolsList({ tools, onToggleTool }: ToolsListProps) {
 
   return (
     <TableRow>
-      <TableCell colSpan={4} className="bg-muted/50">
+      <TableCell colSpan={3} className="bg-muted/50">
         <div className="space-y-3">
           {sortedTools.map((tool) => (
             <div

--- a/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/Integrations.tsx
@@ -33,7 +33,6 @@ export function Integrations() {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Connection</TableHead>
-              <TableHead className="hidden sm:table-cell">Tools</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
@@ -48,7 +47,7 @@ export function Integrations() {
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={4}>
+                <TableCell colSpan={3}>
                   <TypographyP>No integrations found</TypographyP>
                 </TableCell>
               </TableRow>

--- a/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
@@ -1,17 +1,29 @@
 "use client";
 
 import Link from "next/link";
-import { ZapIcon } from "lucide-react";
+import { ListChecksIcon, PenLineIcon, ZapIcon } from "lucide-react";
 import { PageWrapper } from "@/components/PageWrapper";
 import { PageHeader } from "@/components/PageHeader";
 import { Integrations } from "@/app/(app)/[emailAccountId]/integrations/Integrations";
 import { Button } from "@/components/ui/button";
 import { ActionCard } from "@/components/ui/card";
+import {
+  Item,
+  ItemCard,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import { cn } from "@/utils";
 import { RequestAccessDialog } from "./RequestAccessDialog";
 import { usePremium } from "@/hooks/usePremium";
 import { hasTierAccess } from "@/utils/premium";
 import { IntegrationsPremiumAlert } from "./IntegrationsPremiumAlert";
-import { useIntegrationsEnabled } from "@/hooks/useFeatureFlags";
+import {
+  useIntegrationActionsEnabled,
+  useIntegrationsEnabled,
+} from "@/hooks/useFeatureFlags";
 
 export default function IntegrationsPage() {
   const integrationsEnabled = useIntegrationsEnabled();
@@ -31,7 +43,7 @@ export default function IntegrationsPage() {
         <div className="flex items-center justify-between gap-2">
           <PageHeader
             title="Integrations"
-            description="Connect to external services to help the AI assistant draft better replies by accessing relevant data from your tools."
+            description="Connect the tools you already use."
           />
         </div>
 
@@ -57,7 +69,7 @@ export default function IntegrationsPage() {
       <div className="flex items-center justify-between gap-2">
         <PageHeader
           title="Integrations"
-          description="Connect to external services to help the AI assistant draft better replies by accessing relevant data from your tools."
+          description="Connect the tools you already use."
         />
         {hasAccess && (
           <div className="shrink-0">
@@ -72,8 +84,42 @@ export default function IntegrationsPage() {
 
       <div className="mt-8 space-y-4">
         {!isPremiumLoading && !hasAccess && <IntegrationsPremiumAlert />}
+        <Capabilities />
         <Integrations />
       </div>
     </PageWrapper>
+  );
+}
+
+function Capabilities() {
+  const actionsEnabled = useIntegrationActionsEnabled();
+
+  return (
+    <ItemCard className={cn(actionsEnabled && "sm:grid sm:grid-cols-2")}>
+      <Item>
+        <ItemMedia>
+          <PenLineIcon className="size-4 text-blue-500" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Better drafts</ItemTitle>
+          <ItemDescription>
+            Replies arrive knowing the sender's plan, tickets, and history.
+          </ItemDescription>
+        </ItemContent>
+      </Item>
+      {actionsEnabled && (
+        <Item>
+          <ItemMedia>
+            <ListChecksIcon className="size-4 text-blue-500" />
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle>Rule actions</ItemTitle>
+            <ItemDescription>
+              Rules can write back, like adding a Todoist task.
+            </ItemDescription>
+          </ItemContent>
+        </Item>
+      )}
+    </ItemCard>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
@@ -5,6 +5,7 @@ import { ListChecksIcon, PenLineIcon, ZapIcon } from "lucide-react";
 import { PageWrapper } from "@/components/PageWrapper";
 import { PageHeader } from "@/components/PageHeader";
 import { Integrations } from "@/app/(app)/[emailAccountId]/integrations/Integrations";
+import { FeatureIcon } from "@/components/FeatureIcon";
 import { Button } from "@/components/ui/button";
 import { ActionCard } from "@/components/ui/card";
 import {
@@ -98,7 +99,9 @@ function Capabilities() {
     <ItemCard className={cn(actionsEnabled && "sm:grid sm:grid-cols-2")}>
       <Item>
         <ItemMedia>
-          <PenLineIcon className="size-4 text-blue-500" />
+          <FeatureIcon>
+            <PenLineIcon className="h-4 w-4" />
+          </FeatureIcon>
         </ItemMedia>
         <ItemContent>
           <ItemTitle>Better drafts</ItemTitle>
@@ -110,7 +113,9 @@ function Capabilities() {
       {actionsEnabled && (
         <Item>
           <ItemMedia>
-            <ListChecksIcon className="size-4 text-blue-500" />
+            <FeatureIcon>
+              <ListChecksIcon className="h-4 w-4" />
+            </FeatureIcon>
           </ItemMedia>
           <ItemContent>
             <ItemTitle>Rule actions</ItemTitle>

--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@/utils";
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -25,6 +24,7 @@ import {
 import { Card } from "@/components/ui/card";
 import { prefixPath } from "@/utils/path";
 import { useSetupProgress } from "@/hooks/useSetupProgress";
+import { FeatureIcon } from "@/components/FeatureIcon";
 import { LoadingContent } from "@/components/LoadingContent";
 import { EXTENSION_URL } from "@/utils/config";
 import { isGoogleProvider } from "@/utils/email/provider-types";
@@ -62,21 +62,9 @@ function FeatureCard({
     <Link href={prefixPath(emailAccountId, href)} className="block">
       <div className="h-full rounded-lg p-6 shadow transition-shadow hover:bg-muted/50 hover:shadow-md">
         <div className="mb-2 flex items-center gap-3">
-          <div
-            className={cn(
-              "inline-flex rounded-lg bg-gradient-to-b p-px shadow-sm",
-              "from-new-blue-150 to-new-blue-200",
-            )}
-          >
-            <div
-              className={cn(
-                "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[7px] bg-gradient-to-b shadow-sm transition-transform",
-                "from-new-blue-50 to-new-blue-100",
-              )}
-            >
-              <Icon className={cn("h-4 w-4", "text-new-blue-600")} />
-            </div>
-          </div>
+          <FeatureIcon>
+            <Icon className="h-4 w-4" />
+          </FeatureIcon>
           <h3 className="text-lg font-medium text-foreground">{title}</h3>
         </div>
         <MutedText>{description}</MutedText>
@@ -181,21 +169,7 @@ const StepItem = ({
           {...linkProps}
           className="flex max-w-lg min-w-0 flex-1 items-center rounded-md -m-2 p-2 transition-colors hover:bg-muted/40"
         >
-          <div
-            className={cn(
-              "p-px rounded-lg shadow-sm bg-gradient-to-b mr-3 flex flex-shrink-0 items-center justify-center",
-              "from-new-blue-150 to-new-blue-200",
-            )}
-          >
-            <div
-              className={cn(
-                "flex h-9 w-9 items-center justify-center rounded-[7px] bg-gradient-to-b shadow-sm",
-                "from-new-blue-50 to-new-blue-100",
-              )}
-            >
-              <div className="text-new-blue-600">{icon}</div>
-            </div>
-          </div>
+          <FeatureIcon className="mr-3 flex-shrink-0">{icon}</FeatureIcon>
           <div>
             <h3 className="font-medium text-foreground">{title}</h3>
             <p className="mt-0.5 text-xs text-muted-foreground/75">

--- a/apps/web/app/api/mcp/integrations/route.ts
+++ b/apps/web/app/api/mcp/integrations/route.ts
@@ -29,6 +29,7 @@ async function getData(emailAccountId: string) {
     name: integration.name,
     displayName: integration.displayName,
     shortName: integration.shortName,
+    description: integration.description,
     url: integration.url,
     comingSoon: integration.comingSoon,
     authType: integration.authType,

--- a/apps/web/components/FeatureIcon.tsx
+++ b/apps/web/components/FeatureIcon.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/utils";
+
+export function FeatureIcon({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "inline-flex rounded-lg bg-gradient-to-b from-new-blue-150 to-new-blue-200 p-px shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[7px] bg-gradient-to-b from-new-blue-50 to-new-blue-100 text-new-blue-600 shadow-sm">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/utils/mcp/integrations.ts
+++ b/apps/web/utils/mcp/integrations.ts
@@ -13,6 +13,7 @@ export const MCP_INTEGRATIONS: Record<
   McpIntegrationConfig & {
     displayName: string;
     shortName?: string; // Short name for display in compact contexts (e.g. "Connected to X")
+    description: string; // Plain-English summary of the data this integration exposes, shown on the integrations page
     url: string; // Domain URL for favicon display
     allowedTools?: string[];
     comingSoon?: boolean;
@@ -26,6 +27,7 @@ export const MCP_INTEGRATIONS: Record<
   notion: {
     name: "notion",
     displayName: "Notion",
+    description: "Docs, wikis, and project notes",
     url: "notion.com",
     serverUrl: "https://mcp.notion.com/mcp",
     authType: "oauth",
@@ -36,6 +38,7 @@ export const MCP_INTEGRATIONS: Record<
   stripe: {
     name: "stripe",
     displayName: "Stripe",
+    description: "Customers, subscriptions, invoices, and payments",
     url: "stripe.com",
     serverUrl: "https://mcp.stripe.com",
     authType: "oauth", // must request whitelisting of /api/mcp/stripe/callback from Stripe. localhost is whitelisted already.
@@ -55,6 +58,7 @@ export const MCP_INTEGRATIONS: Record<
   linear: {
     name: "linear",
     displayName: "Linear",
+    description: "Issues, projects, and status",
     url: "linear.app",
     // Dedicated read-only endpoint; the server only exposes read tools here
     serverUrl: "https://mcp.linear.app/mcp/readonly",
@@ -65,6 +69,7 @@ export const MCP_INTEGRATIONS: Record<
   attio: {
     name: "attio",
     displayName: "Attio",
+    description: "CRM records, contacts, notes, and meetings",
     url: "attio.com",
     serverUrl: "https://mcp.attio.com/mcp",
     authType: "oauth",
@@ -90,6 +95,7 @@ export const MCP_INTEGRATIONS: Record<
   intercom: {
     name: "intercom",
     displayName: "Intercom",
+    description: "Support conversations, contacts, and help articles",
     url: "intercom.com",
     // US-hosted workspaces only; EU workspaces use mcp.eu.intercom.com (not supported yet)
     serverUrl: "https://mcp.intercom.com/mcp",
@@ -114,6 +120,7 @@ export const MCP_INTEGRATIONS: Record<
   monday: {
     name: "monday",
     displayName: "Monday.com",
+    description: "Boards, items, and workspaces",
     url: "monday.com",
     serverUrl: "https://mcp.monday.com/mcp",
     authType: "oauth",
@@ -154,6 +161,7 @@ export const MCP_INTEGRATIONS: Record<
   todoist: {
     name: "todoist",
     displayName: "Todoist",
+    description: "Tasks and projects",
     url: "todoist.com",
     serverUrl: "https://ai.todoist.net/mcp",
     authType: "oauth",
@@ -165,6 +173,7 @@ export const MCP_INTEGRATIONS: Record<
     name: "pipedream",
     displayName: "HubSpot, Slack, Airtable, Todoist, and more (via Pipedream)",
     shortName: "Pipedream",
+    description: "HubSpot, Slack, Airtable, and hundreds more apps",
     url: "pipedream.com",
     serverUrl: "https://mcp.pipedream.net/v2",
     authType: "oauth",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-065031_pr-3223_3c23abd591bc/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Users did not understand what the Integrations page was for. The copy described the mechanism ("accessing relevant data from your tools") rather than the outcome, and every row read "No tools" — internal jargon that says nothing to someone who hasn't connected anything.

- Added a `description` to each entry in `MCP_INTEGRATIONS`, surfaced under the name in each row, so a row says what that integration actually provides ("Customers, subscriptions, invoices, and payments")
- Replaced the header copy with a short line plus two capability items covering both paths: richer reply drafts, and rule actions that write back. The second is gated on `useIntegrationActionsEnabled()`, and the card drops to a single column when it's hidden
- Dropped the Tools column. Tool management moved into the row's menu with the enabled count inline (`Manage tools (4 of 5 on)`), which removes eight "No tools" cells from the default view
- Pipedream now displays by its existing `shortName`, since the description carries the app list — the verbose `displayName` still drives toasts and the request dialog
- Column widths fixed so "✓ Connected" doesn't wrap at narrow viewports

Reuses the setup screen's `Item`/`ItemMedia` pattern with `size-4 text-blue-500` icons rather than introducing a new one.

Verified against a local emulated environment at 1440px and 390px, with the actions flag both on and off, plus a seeded connected integration to check the connected row, its menu, and the expanded tool toggles. `pnpm test utils/mcp/` passes (54 tests); Biome clean.

No runtime cost: `description` is a static config string already loaded with the rest of `MCP_INTEGRATIONS`, added to an existing response object. No new queries or network calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->