### PR TITLE
setup: Recover stalled completion actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -37,6 +37,10 @@ import { InviteMemberModal } from "@/components/InviteMemberModal";
 import { BRAND_NAME } from "@/utils/branding";
 import { dismissHintAction } from "@/utils/actions/hints";
 import { toastError } from "@/components/Toast";
+import { captureException } from "@/utils/error";
+import { withSetupActionTimeout } from "./setup-action-timeout";
+
+const SETUP_ACTION_TIMEOUT_MS = 15_000;
 
 type DismissibleSetupStep =
   | "aiAssistant"
@@ -283,8 +287,7 @@ function Checklist({
   } | null;
   onSetupProgressChanged: (stepKey: DismissibleSetupStep) => void;
 }) {
-  const { executeAsync: dismissSetupStep, isExecuting: isDismissingStep } =
-    useAction(dismissHintAction);
+  const { executeAsync: dismissSetupStep } = useAction(dismissHintAction);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [pendingStep, setPendingStep] = useState<DismissibleSetupStep | null>(
     null,
@@ -293,16 +296,19 @@ function Checklist({
 
   const handleMarkStepDone = useCallback(
     async (stepKey: DismissibleSetupStep) => {
-      if (isDismissingStep) {
+      if (pendingStep) {
         return;
       }
 
       setPendingStep(stepKey);
 
       try {
-        const result = await dismissSetupStep({
-          hintId: `setup:${stepKey}:${emailAccountId}`,
-        });
+        const result = await withSetupActionTimeout(
+          dismissSetupStep({
+            hintId: `setup:${stepKey}:${emailAccountId}`,
+          }),
+          SETUP_ACTION_TIMEOUT_MS,
+        );
 
         if (result?.serverError || result?.validationErrors) {
           toastError({ description: "Failed to skip this step" });
@@ -310,16 +316,18 @@ function Checklist({
         }
 
         onSetupProgressChanged(stepKey);
+      } catch (error) {
+        captureException(error, {
+          extra: { context: "setup/dismiss-step", stepKey },
+        });
+        toastError({
+          description: "Failed to skip this step. Please try again.",
+        });
       } finally {
         setPendingStep(null);
       }
     },
-    [
-      dismissSetupStep,
-      emailAccountId,
-      isDismissingStep,
-      onSetupProgressChanged,
-    ],
+    [dismissSetupStep, emailAccountId, onSetupProgressChanged, pendingStep],
   );
 
   const handleOpenInviteModal = () => {
@@ -354,7 +362,7 @@ function Checklist({
         actionText="Set up"
         onMarkDone={() => handleMarkStepDone("aiAssistant")}
         showMarkDone
-        markDoneDisabled={isDismissingStep}
+        markDoneDisabled={pendingStep !== null}
         markDonePending={pendingStep === "aiAssistant"}
       />
 
@@ -367,7 +375,7 @@ function Checklist({
         actionText="View"
         onMarkDone={() => handleMarkStepDone("bulkUnsubscribe")}
         showMarkDone
-        markDoneDisabled={isDismissingStep}
+        markDoneDisabled={pendingStep !== null}
         markDonePending={pendingStep === "bulkUnsubscribe"}
       />
 
@@ -381,7 +389,7 @@ function Checklist({
           actionText="Connect"
           onMarkDone={() => handleMarkStepDone("calendarConnected")}
           showMarkDone
-          markDoneDisabled={isDismissingStep}
+          markDoneDisabled={pendingStep !== null}
           markDonePending={pendingStep === "calendarConnected"}
         />
       )}
@@ -395,7 +403,7 @@ function Checklist({
           completed={teamInvite.completed}
           actionText="Invite"
           onMarkDone={() => handleMarkStepDone("teamInvite")}
-          markDoneDisabled={isDismissingStep}
+          markDoneDisabled={pendingStep !== null}
           markDonePending={pendingStep === "teamInvite"}
           showMarkDone
           markDoneText="Skip"
@@ -422,7 +430,7 @@ function Checklist({
           completed={isTabsExtensionCompleted}
           actionText="Install"
           onMarkDone={() => handleMarkStepDone("tabsExtension")}
-          markDoneDisabled={isDismissingStep}
+          markDoneDisabled={pendingStep !== null}
           markDonePending={pendingStep === "tabsExtension"}
           showMarkDone={true}
         />

--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -37,10 +37,11 @@ import { InviteMemberModal } from "@/components/InviteMemberModal";
 import { BRAND_NAME } from "@/utils/branding";
 import { dismissHintAction } from "@/utils/actions/hints";
 import { toastError } from "@/components/Toast";
-import { captureException } from "@/utils/error";
+import { createClientLogger } from "@/utils/logger-client";
 import { withSetupActionTimeout } from "./setup-action-timeout";
 
 const SETUP_ACTION_TIMEOUT_MS = 15_000;
+const logger = createClientLogger("setup");
 
 type DismissibleSetupStep =
   | "aiAssistant"
@@ -317,8 +318,9 @@ function Checklist({
 
         onSetupProgressChanged(stepKey);
       } catch (error) {
-        captureException(error, {
-          extra: { context: "setup/dismiss-step", stepKey },
+        logger.warn("Setup step dismissal failed", {
+          stepKey,
+          error: error instanceof Error ? error.message : "Unknown error",
         });
         toastError({
           description: "Failed to skip this step. Please try again.",

--- a/apps/web/app/(app)/[emailAccountId]/setup/setup-action-timeout.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/setup/setup-action-timeout.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withSetupActionTimeout } from "./setup-action-timeout";
+
+describe("withSetupActionTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns an action result that settles before the timeout", async () => {
+    await expect(
+      withSetupActionTimeout(Promise.resolve({ success: true }), 1000),
+    ).resolves.toEqual({ success: true });
+  });
+
+  it("preserves an action failure that occurs before the timeout", async () => {
+    const error = new Error("Network request failed");
+
+    await expect(
+      withSetupActionTimeout(Promise.reject(error), 1000),
+    ).rejects.toBe(error);
+  });
+
+  it("rejects when an action does not settle before the timeout", async () => {
+    vi.useFakeTimers();
+    const result = withSetupActionTimeout(
+      new Promise<never>(() => undefined),
+      1000,
+    );
+    const expectation = expect(result).rejects.toThrow(
+      "Setup action timed out",
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expectation;
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/setup/setup-action-timeout.ts
+++ b/apps/web/app/(app)/[emailAccountId]/setup/setup-action-timeout.ts
@@ -1,0 +1,20 @@
+export async function withSetupActionTimeout<T>(
+  action: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error("Setup action timed out")),
+      timeoutMs,
+    );
+  });
+
+  try {
+    return await Promise.race([action, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/web/utils/actions/hints.ts
+++ b/apps/web/utils/actions/hints.ts
@@ -9,8 +9,11 @@ export const dismissHintAction = actionClientUser
   .metadata({ name: "dismissHint" })
   .schema(dismissHintBody)
   .action(async ({ ctx: { userId }, parsedInput: { hintId } }) => {
-    await prisma.user.update({
-      where: { id: userId },
+    await prisma.user.updateMany({
+      where: {
+        id: userId,
+        NOT: { dismissedHints: { has: hintId } },
+      },
       data: {
         dismissedHints: { push: hintId },
       },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-064423_pr-3224_7cfd391a085e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevent setup completion controls from remaining pending when their server action fails or never settles.

- bound setup action wait time and restore retry state on failures
- report failures and show a retryable error message
- cover success, rejection, and timeout behavior with focused tests

Validation:
- focused unit tests
- targeted formatting and lint checks
- staged secret scan

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->