### PR TITLE
mail: redesign the thread view as a flat message list

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -69,7 +69,7 @@ export function ReaderToolbar({
   return (
     <div>
       {showBackBar ? (
-        <div className="-mx-1 sticky top-0 z-10 mb-4 flex items-center gap-3 bg-background px-1 py-2">
+        <div className="-mx-1 sticky top-0 z-10 mb-4 flex items-center gap-3 bg-card px-1 py-2">
           <Button onClick={onBack} size="xs-2" variant="outline">
             <ArrowLeftIcon className="mr-1.5 size-3.5" />
             Back

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -90,7 +90,9 @@ export function ThreadReader({
     }) ?? [];
 
   return (
-    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-background">
+    // White, unlike the list: the reader is its own surface, and it has to
+    // match `EmailThread` below or the toolbar reads as a separate band.
+    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-card">
       <div className={readerMeasure({ layout, isFocusMode })}>
         <ReaderToolbar
           isFocusMode={isFocusMode}
@@ -111,18 +113,13 @@ export function ThreadReader({
         />
 
         {messages.length > 0 ? (
-          // Workaround: `EmailThread` bakes in its own panel chrome, so the
-          // reader strips it from the outside to get a plain measure column.
-          // Fixing it properly means giving `EmailThread` a chrome-less mode.
-          <div className="[&>div]:bg-transparent [&>div]:p-0 [&>div>ul]:mt-0">
-            <EmailThread
-              autoOpenReplyForMessageId={autoOpenReplyForMessageId}
-              key={thread.id}
-              messages={messages}
-              refetch={refetch}
-              showReplyButton
-            />
-          </div>
+          <EmailThread
+            autoOpenReplyForMessageId={autoOpenReplyForMessageId}
+            key={thread.id}
+            messages={messages}
+            refetch={refetch}
+            showReplyButton
+          />
         ) : null}
       </div>
     </div>

--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
@@ -233,7 +233,7 @@ export function ReplyTrackerEmails({
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={65} minSize={0} className="bg-secondary">
-          <div className="h-full overflow-y-auto">
+          <div className="h-full overflow-y-auto p-4">
             <ThreadContent
               threadId={selectedEmail.threadId}
               showReplyButton={true}

--- a/apps/web/components/EmailViewer.tsx
+++ b/apps/web/components/EmailViewer.tsx
@@ -24,7 +24,7 @@ export function EmailViewer() {
       <SheetContent
         side="right"
         size="5xl"
-        className="overflow-y-auto bg-slate-100 p-0"
+        className="overflow-y-auto bg-background p-6"
         overlay="transparent"
       >
         {threadId && (

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -16,6 +16,12 @@ const IMAGE_PROXY_ORIGIN = IMAGE_PROXY_BASE_URL
 const IMAGE_PROXY_ENABLED = Boolean(IMAGE_PROXY_BASE_URL);
 const IMAGE_PROXY_RENDER_ROUTE = "/api/email/render-html";
 const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
+/**
+ * Reading size for a message body that brought no styling of its own. Shared by
+ * both paths: Tailwind classes can't reach inside the iframe, so plain text has
+ * to restate it or the two drift apart on screen.
+ */
+const BODY_TYPE = { fontSize: "14.5px", lineHeight: 1.65 } as const;
 
 export function HtmlEmail({ html }: { html: string }) {
   const sanitizedHtml = useMemo(() => sanitize(html), [html]);
@@ -99,7 +105,11 @@ export function HtmlEmail({ html }: { html: string }) {
 
 export function PlainEmail({ text }: { text: string }) {
   return (
-    <pre className="whitespace-pre-wrap text-foreground">
+    // `pre` keeps the sender's line breaks; the font stack keeps it readable.
+    <pre
+      className="whitespace-pre-wrap font-sans text-foreground"
+      style={BODY_TYPE}
+    >
       {decodeHtmlEntities(text)}
     </pre>
   );
@@ -192,6 +202,8 @@ function getIframeHtml(
       }
       body:not([style]):not([bgcolor]) {
         margin: 0;
+        font-size: ${BODY_TYPE.fontSize};
+        line-height: ${BODY_TYPE.lineHeight};
         color: hsl(var(--foreground));
         background-color: hsl(var(--background));
       }

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -160,6 +160,9 @@ function MessageHeader({
     "aria-expanded": expanded,
     onClick: onToggle,
     onKeyDown: (event: React.KeyboardEvent) => {
+      // Keydown bubbles, so without this the row would swallow Enter/Space
+      // aimed at the buttons nested inside it.
+      if (event.target !== event.currentTarget) return;
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
       onToggle();
@@ -417,7 +420,10 @@ function recipientSummary(to: string | undefined, userEmail: string) {
   const recipients = splitRecipientList(to ?? "");
   if (recipients.length === 0) return "";
 
-  const first = recipients[0];
+  // "me" leads whenever the account is in there at all, however it was addressed.
+  const first =
+    recipients.find((recipient) => isSameEmailAddress(recipient, userEmail)) ??
+    recipients[0];
   const firstLabel = isSameEmailAddress(first, userEmail)
     ? "me"
     : extractNameFromEmail(first) || extractEmailAddress(first);

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -6,24 +6,32 @@ import {
   ChevronsDownUpIcon,
 } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
-import { extractNameFromEmail } from "@/utils/email";
+import {
+  extractEmailAddress,
+  extractNameFromEmail,
+  isSameEmailAddress,
+  splitRecipientList,
+} from "@/utils/email";
 import { formatShortDate } from "@/utils/date";
 import { ComposeEmailFormLazy } from "@/app/(app)/[emailAccountId]/compose/ComposeEmailFormLazy";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
+import { Card } from "@/components/ui/card";
 import type { ParsedMessage } from "@/utils/types";
 import { forwardEmailHtml, forwardEmailSubject } from "@/utils/gmail/forward";
 import { extractEmailReply } from "@/utils/parse/extract-reply.client";
 import type { ReplyingToEmail } from "@/app/(app)/[emailAccountId]/compose/ComposeEmailForm";
 import { createReplyContent } from "@/utils/gmail/reply";
 import { cn } from "@/utils";
+import { decodeSnippet } from "@/utils/gmail/decode";
+import { GmailLabel } from "@/utils/gmail/label";
 import { generateNudgeReplyAction } from "@/utils/actions/generate-reply";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailDetails } from "@/components/email-list/EmailDetails";
 import { HtmlEmail, PlainEmail } from "@/components/email-list/EmailContents";
 import { EmailAttachments } from "@/components/email-list/EmailAttachments";
 import { Loading } from "@/components/Loading";
-import { MessageText, MutedText } from "@/components/Typography";
+import { MessageText } from "@/components/Typography";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { formatReplySubject } from "@/utils/email/subject";
 
@@ -34,7 +42,7 @@ export function EmailMessage({
   defaultShowReply,
   draftMessage,
   expanded,
-  onExpand,
+  onToggle,
   onSendSuccess,
   generateNudge,
 }: {
@@ -44,19 +52,24 @@ export function EmailMessage({
   showReplyButton: boolean;
   defaultShowReply?: boolean;
   expanded: boolean;
-  onExpand: () => void;
+  /** Absent when the thread has a single message, which never collapses. */
+  onToggle?: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
   generateNudge?: boolean;
 }) {
-  const [showReply, setShowReply] = useState(defaultShowReply || false);
-  const [showDetails, setShowDetails] = useState(false);
+  // `null` follows `defaultShowReply`, which the reader's Reply button flips
+  // long after this message mounted.
+  const [replyOverride, setReplyOverride] = useState<boolean | null>(null);
+  const showReply = replyOverride ?? Boolean(defaultShowReply);
 
-  const onReply = useCallback(() => setShowReply(true), []);
+  const [showDetails, setShowDetails] = useState(false);
   const [showForward, setShowForward] = useState(false);
+
+  const onReply = useCallback(() => setReplyOverride(true), []);
   const onForward = useCallback(() => setShowForward(true), []);
 
   const onCloseCompose = useCallback(() => {
-    setShowReply(false);
+    setReplyOverride(false);
     setShowForward(false);
   }, []);
 
@@ -66,26 +79,21 @@ export function EmailMessage({
   }, []);
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: ignore
-    <li
-      className={cn(
-        "bg-background p-4 shadow sm:rounded-lg",
-        !expanded && "cursor-pointer",
-      )}
-      onClick={onExpand}
-    >
-      <TopBar
-        message={message}
+    <li className="group/message border-border/60 border-t py-4 first:border-t-0 first:pt-0">
+      <MessageHeader
         expanded={expanded}
-        showDetails={showDetails}
-        toggleDetails={toggleDetails}
-        showReplyButton={showReplyButton}
-        onReply={onReply}
+        message={message}
         onForward={onForward}
+        onReply={onReply}
+        onToggle={onToggle}
+        showDetails={showDetails}
+        showReplyButton={showReplyButton}
+        toggleDetails={toggleDetails}
       />
 
       {expanded && (
-        <>
+        // Aligns the body with the sender's name rather than the avatar.
+        <div className="min-w-0 pt-3 pl-9">
           {showDetails && <EmailDetails message={message} />}
 
           {message.textHtml ? (
@@ -98,23 +106,28 @@ export function EmailMessage({
 
           {(showReply || showForward) && (
             <ReplyPanel
-              message={message}
-              refetch={refetch}
-              onSendSuccess={onSendSuccess}
-              onCloseCompose={onCloseCompose}
               defaultShowReply={defaultShowReply}
-              showReply={showReply}
               draftMessage={draftMessage}
               generateNudge={generateNudge}
+              message={message}
+              onCloseCompose={onCloseCompose}
+              onSendSuccess={onSendSuccess}
+              refetch={refetch}
+              showReply={showReply}
             />
           )}
-        </>
+        </div>
       )}
     </li>
   );
 }
 
-function TopBar({
+/**
+ * One row per message, and the whole thread's rhythm: an avatar, who sent it,
+ * and when. Collapsed it also carries the snippet, so a thread reads top to
+ * bottom without opening every message.
+ */
+function MessageHeader({
   message,
   expanded,
   showDetails,
@@ -122,6 +135,7 @@ function TopBar({
   showReplyButton,
   onReply,
   onForward,
+  onToggle,
 }: {
   message: ParsedMessage;
   expanded: boolean;
@@ -130,58 +144,135 @@ function TopBar({
   showReplyButton: boolean;
   onReply: () => void;
   onForward: () => void;
+  onToggle?: () => void;
 }) {
+  const { userEmail } = useAccount();
+
+  const isSent = message.labelIds?.includes(GmailLabel.SENT) ?? false;
+  const senderEmail = extractEmailAddress(message.headers.from);
+  const senderName = isSent
+    ? "Me"
+    : extractNameFromEmail(message.headers.from) || senderEmail;
+
+  // Collapsing is the thread's call, so a row is only interactive once it has
+  // been handed a toggle.
+  const toggleProps: React.ComponentProps<"div"> | undefined = onToggle && {
+    "aria-expanded": expanded,
+    onClick: onToggle,
+    onKeyDown: (event: React.KeyboardEvent) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      onToggle();
+    },
+    role: "button",
+    tabIndex: 0,
+  };
+
+  /**
+   * The composer renders inside the collapsed-away body, so replying to a
+   * collapsed message has to open it first.
+   */
+  const compose = (open: () => void) => (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (!expanded) onToggle?.();
+    open();
+  };
+
   return (
-    <div className="sm:flex sm:items-center sm:justify-between">
-      <div className="flex items-center gap-2">
-        <div className="flex items-center">
-          <h3 className="text-base font-medium">
-            <span className="text-foreground">
-              {message.labelIds?.includes("SENT")
-                ? "Me"
-                : extractNameFromEmail(message.headers.from)}
-            </span>{" "}
-            {expanded && <span className="text-muted-foreground">wrote</span>}
-          </h3>
-        </div>
-        {expanded && (
+    <div
+      {...toggleProps}
+      className={cn(
+        "flex min-w-0 items-center gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        onToggle && "cursor-pointer",
+      )}
+    >
+      <Avatar aria-hidden className="size-7">
+        <AvatarFallback
+          className={cn(
+            "font-semibold text-[10px] tracking-wide",
+            isSent
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {initialsFor(senderName)}
+        </AvatarFallback>
+      </Avatar>
+
+      <span
+        className={cn(
+          "shrink-0 truncate text-sm",
+          expanded
+            ? "font-semibold text-foreground"
+            : "font-medium text-secondary-foreground",
+        )}
+      >
+        {senderName}
+      </span>
+
+      {expanded ? (
+        <>
+          {senderEmail && senderEmail !== senderName ? (
+            <span className="truncate text-muted-foreground text-xs">
+              {senderEmail}
+            </span>
+          ) : null}
+          <span className="shrink-0 whitespace-nowrap text-muted-foreground/70 text-xs">
+            {recipientSummary(message.headers.to, userEmail)}
+          </span>
           <Button
-            variant="ghost"
-            size="sm"
-            className="size-6 p-0"
+            aria-label={showDetails ? "Hide details" : "Show details"}
+            className="size-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/message:opacity-100"
             onClick={toggleDetails}
+            size="sm"
+            variant="ghost"
           >
             {showDetails ? (
-              <ChevronsDownUpIcon className="size-4" />
+              <ChevronsDownUpIcon className="size-3.5" />
             ) : (
-              <ChevronsUpDownIcon className="size-4" />
+              <ChevronsUpDownIcon className="size-3.5" />
             )}
           </Button>
-        )}
-      </div>
-      <div className="flex items-center space-x-2">
-        <MutedText className="mt-1 whitespace-nowrap sm:ml-3 sm:mt-0">
-          <time dateTime={message.headers.date}>
-            {formatShortDate(new Date(message.headers.date))}
-          </time>
-        </MutedText>
-        {showReplyButton && (
-          <div className="relative flex items-center">
-            <Tooltip content="Reply">
-              <Button variant="ghost" size="icon" onClick={onReply}>
-                <ReplyIcon className="h-4 w-4" />
-                <span className="sr-only">Reply</span>
-              </Button>
-            </Tooltip>
-            <Tooltip content="Forward">
-              <Button variant="ghost" size="icon">
-                <ForwardIcon className="h-4 w-4" onClick={onForward} />
-                <span className="sr-only">Forward</span>
-              </Button>
-            </Tooltip>
-          </div>
-        )}
-      </div>
+        </>
+      ) : (
+        <span className="min-w-0 flex-1 truncate text-muted-foreground text-sm">
+          {decodeSnippet(message.snippet)}
+        </span>
+      )}
+
+      <time
+        className="ml-auto shrink-0 whitespace-nowrap pl-2.5 text-muted-foreground text-xs"
+        dateTime={message.headers.date}
+      >
+        {formatShortDate(new Date(message.headers.date))}
+      </time>
+
+      {showReplyButton && (
+        <span className="flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover/message:opacity-100">
+          <Tooltip content="Reply">
+            <Button
+              className="size-7 text-muted-foreground"
+              onClick={compose(onReply)}
+              size="icon"
+              variant="ghost"
+            >
+              <ReplyIcon className="size-3.5" />
+              <span className="sr-only">Reply</span>
+            </Button>
+          </Tooltip>
+          <Tooltip content="Forward">
+            <Button
+              className="size-7 text-muted-foreground"
+              onClick={compose(onForward)}
+              size="icon"
+              variant="ghost"
+            >
+              <ForwardIcon className="size-3.5" />
+              <span className="sr-only">Forward</span>
+            </Button>
+          </Tooltip>
+        </span>
+      )}
     </div>
   );
 }
@@ -282,39 +373,58 @@ function ReplyPanel({
   }, [showReply, message, draftMessage, reply]);
 
   return (
-    <>
-      <Separator className="my-4" />
-
-      <div ref={replyRef}>
-        {isGeneratingReply ? (
-          <div className="flex items-center justify-center">
-            <Loading />
-            <MessageText>Generating reply...</MessageText>
-            <Button
-              className="ml-4"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setIsGeneratingReply(false);
-              }}
-            >
-              Skip
-            </Button>
-          </div>
-        ) : (
-          <ComposeEmailFormLazy
-            replyingToEmail={replyingToEmail}
-            refetch={refetch}
-            onSuccess={(messageId: string, threadId: string) => {
-              onSendSuccess(messageId, threadId);
-              onCloseCompose();
+    <Card className="mt-6 rounded-xl p-3" ref={replyRef}>
+      {isGeneratingReply ? (
+        <div className="flex items-center justify-center">
+          <Loading />
+          <MessageText>Generating reply...</MessageText>
+          <Button
+            className="ml-4"
+            onClick={() => {
+              setIsGeneratingReply(false);
             }}
-            onDiscard={onCloseCompose}
-          />
-        )}
-      </div>
-    </>
+            size="sm"
+            variant="outline"
+          >
+            Skip
+          </Button>
+        </div>
+      ) : (
+        <ComposeEmailFormLazy
+          onDiscard={onCloseCompose}
+          onSuccess={(messageId: string, threadId: string) => {
+            onSendSuccess(messageId, threadId);
+            onCloseCompose();
+          }}
+          refetch={refetch}
+          replyingToEmail={replyingToEmail}
+        />
+      )}
+    </Card>
   );
+}
+
+/** Two letters at most: initials from a display name, or the address's first letters. */
+function initialsFor(name: string) {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[words.length - 1][0]}`.toUpperCase();
+}
+
+/** "to me", "to Dana", "to me and 3 others" — who a message went out to. */
+function recipientSummary(to: string | undefined, userEmail: string) {
+  const recipients = splitRecipientList(to ?? "");
+  if (recipients.length === 0) return "";
+
+  const first = recipients[0];
+  const firstLabel = isSameEmailAddress(first, userEmail)
+    ? "me"
+    : extractNameFromEmail(first) || extractEmailAddress(first);
+
+  const others = recipients.length - 1;
+  if (others === 0) return `to ${firstLabel}`;
+  return `to ${firstLabel} and ${others} ${others === 1 ? "other" : "others"}`;
 }
 
 const prepareReplyingToEmail = (

--- a/apps/web/components/email-list/EmailPanel.tsx
+++ b/apps/web/components/email-list/EmailPanel.tsx
@@ -65,7 +65,7 @@ export function EmailPanel({
           </Tooltip>
         </div>
       </div>
-      <div className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex min-w-0 flex-1 flex-col overflow-y-auto p-4">
         {plan?.rule && <PlanExplanation thread={row} provider={provider} />}
         <EmailThread
           key={row.id}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailMessage } from "@/components/email-list/EmailMessage";
+import { Button } from "@/components/ui/button";
 
 export function EmailThread({
   messages,
@@ -46,15 +47,23 @@ export function EmailThread({
 
   const lastMessageId = organizedMessages.at(-1)?.message.id;
 
-  const [expandedMessageIds, setExpandedMessageIds] = useState<Set<string>>(
-    new Set(lastMessageId ? [lastMessageId] : []),
+  /** Only the latest message is open: the state every thread starts in. */
+  const latestOnly = () => new Set(lastMessageId ? [lastMessageId] : []);
+
+  const [expandedMessageIds, setExpandedMessageIds] =
+    useState<Set<string>>(latestOnly);
+
+  const allExpanded = organizedMessages.every(({ message }) =>
+    expandedMessageIds.has(message.id),
   );
 
   return (
-    <div className="flex-1 overflow-auto bg-muted p-4">
+    // White regardless of the surface it is dropped on: an email body renders
+    // on white inside its iframe, so anything else leaves each message boxed.
+    <div className="min-w-0 bg-card">
       {withHeader && (
         <div className="flex items-center justify-between">
-          <div className="text-2xl font-semibold text-foreground">
+          <div className="font-semibold text-2xl text-foreground">
             {messages[0]?.headers.subject}
           </div>
           {topRightComponent && (
@@ -62,25 +71,41 @@ export function EmailThread({
           )}
         </div>
       )}
-      <ul className="mt-4 space-y-2 sm:space-y-4">
+
+      {organizedMessages.length > 1 && (
+        <div className="flex items-center gap-3 pt-4">
+          <span className="text-muted-foreground text-xs">
+            {organizedMessages.length} messages
+          </span>
+          <Button
+            className="ml-auto"
+            onClick={() =>
+              setExpandedMessageIds(
+                allExpanded
+                  ? latestOnly()
+                  : new Set(organizedMessages.map(({ message }) => message.id)),
+              )
+            }
+            size="xs-2"
+            variant="outline"
+          >
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </Button>
+        </div>
+      )}
+
+      <ul className="pt-2">
         {organizedMessages.map(({ message, draftMessage }) => {
           const defaultShowReply =
             autoOpenReplyForMessageId === message.id || Boolean(draftMessage);
           return (
             <EmailMessage
-              key={message.id}
-              message={message}
-              showReplyButton={showReplyButton}
-              refetch={refetch}
               defaultShowReply={defaultShowReply}
               draftMessage={draftMessage}
               expanded={expandedMessageIds.has(message.id)}
-              onExpand={() => {
-                setExpandedMessageIds((prev) => {
-                  if (prev.has(message.id)) return prev;
-                  return new Set(prev).add(message.id);
-                });
-              }}
+              generateNudge={defaultShowReply && !draftMessage?.textHtml}
+              key={message.id}
+              message={message}
               onSendSuccess={(messageId) => {
                 setExpandedMessageIds((prev) => {
                   if (prev.has(messageId)) return prev;
@@ -89,7 +114,20 @@ export function EmailThread({
 
                 onSendSuccess?.(messageId, message.threadId);
               }}
-              generateNudge={defaultShowReply && !draftMessage?.textHtml}
+              // A one-message thread has nothing to collapse back to.
+              onToggle={
+                organizedMessages.length === 1
+                  ? undefined
+                  : () => {
+                      setExpandedMessageIds((prev) => {
+                        const next = new Set(prev);
+                        if (!next.delete(message.id)) next.add(message.id);
+                        return next;
+                      });
+                    }
+              }
+              refetch={refetch}
+              showReplyButton={showReplyButton}
             />
           );
         })}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-063755_pr-3225_b19bde56b62c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Reshapes the open-thread view from a stack of shadowed cards into a flat message list, following the Claude Design mock for the mail screen.

## What changed

- Each message is a row — avatar, sender, snippet, time — with hairline separators instead of card chrome. Bodies indent under the sender name.
- Collapsed messages now show a snippet, so a thread reads top to bottom without opening every message. Previously they showed only a name and a date.
- Added a thread meta row with the message count and an expand/collapse all toggle.
- Expanded messages show the sender address and recipient summary inline; the old "Name wrote" label and its always-visible chevron toggle are gone. Reply/forward and the details toggle are revealed on row hover.
- Plain-text bodies render in the sans stack instead of monospace `pre`, at the same reading size as unstyled HTML bodies. Both now read one shared constant — they had drifted to different sizes and colors.
- `EmailThread` no longer bakes in panel chrome. Its three call sites own their spacing, which let a CSS hack that stripped that chrome from the outside be deleted. The component now paints its own white surface, since an email body always renders on white inside its iframe.

## Fixes found along the way

- The reader's **Reply** button did nothing. The composer read its prop only in the initial `useState`, so a flip after mount was ignored. Confirmed against unmodified `main` before fixing.
- Replying from a **collapsed** message opened the composer inside the collapsed body, so nothing appeared.

Known gap, not addressed here: the reply intent is a value rather than an event, so closing the composer and pressing Reply again on the same message sends no new value and won't reopen it. Fixing that means giving the request an identity where it originates, outside this diff.

## Validation

- 80 component tests pass; type check and Biome clean.
- Verified in a browser against emulated Gmail: list layout, split layout, single-message threads, multi-message threads, expand/collapse all, the reply composer, and the side-panel sheet.

## Performance

No new network or database calls. Per-row work is string formatting only (measured in the low microseconds). One thing worth knowing: **expand all mounts every message body at once**, so on a long thread it fires one `POST /api/email/render-html` per message when the image proxy is enabled, plus a sanitize pass and an iframe each. That is the feature behaving as designed, but it is a new one-click amplification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->