### PR TITLE
mail: Use Escape for back navigation

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -291,7 +291,10 @@ export function MailShell() {
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
   const archiveTargets = useCallback(() => runOn(archive), [runOn, archive]);
   const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
-  const isMailOverlayOpen = isHelpOpen || isMenuOpen || isPaletteOpen;
+  const isMailOverlayOpen =
+    isHelpOpen ||
+    isPaletteOpen ||
+    (isMenuOpen && Boolean(openThread?.plans.length));
 
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -32,7 +32,7 @@ import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { useSidebar } from "@/components/ui/sidebar";
-import { useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import { commandPaletteOpenAtom } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
@@ -92,7 +92,7 @@ export function MailShell() {
   const { onOpen: openCompose } = useComposeModal();
   const { setInput: setChatInput } = useChat();
   const { toggleSidebar } = useSidebar();
-  const setPaletteOpen = useSetAtom(commandPaletteOpenAtom);
+  const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
   const { threadId: sidePanelThreadId } = useDisplayedEmail();
@@ -291,6 +291,7 @@ export function MailShell() {
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
   const archiveTargets = useCallback(() => runOn(archive), [runOn, archive]);
   const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
+  const isMailOverlayOpen = isHelpOpen || isMenuOpen || isPaletteOpen;
 
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.
@@ -300,11 +301,13 @@ export function MailShell() {
       next: () => move(1),
       previous: () => move(-1),
       open: () => openAt(clampedIndex),
-      backToList: () => {
-        if (isFocusMode) setIsFocusMode(false);
-        else if (selection.hasSelection) selection.clear();
-        else if (layout === "list") setOpenThreadId(null);
-      },
+      backToList: isMailOverlayOpen
+        ? undefined
+        : () => {
+            if (isFocusMode) setIsFocusMode(false);
+            else if (selection.hasSelection) selection.clear();
+            else if (layout === "list") setOpenThreadId(null);
+          },
       nextSplit: () => {
         const index = splits.findIndex((s) => s.id === activeSplitId);
         const next = splits[(index + 1) % splits.length];

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -301,8 +301,9 @@ export function MailShell() {
       previous: () => move(-1),
       open: () => openAt(clampedIndex),
       backToList: () => {
-        setIsFocusMode(false);
-        setOpenThreadId(null);
+        if (isFocusMode) setIsFocusMode(false);
+        else if (selection.hasSelection) selection.clear();
+        else if (layout === "list") setOpenThreadId(null);
       },
       nextSplit: () => {
         const index = splits.findIndex((s) => s.id === activeSplitId);
@@ -324,11 +325,6 @@ export function MailShell() {
       undo: () => undo(),
       toggleLayout,
       focusMode: () => setIsFocusMode((on) => !on),
-      close: () => {
-        if (isFocusMode) setIsFocusMode(false);
-        else if (selection.hasSelection) selection.clear();
-        else if (layout === "list") setOpenThreadId(null);
-      },
       help: () => setIsHelpOpen(true),
     };
   })();

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -80,7 +80,7 @@ function CommandPalette() {
       compose: onOpenComposeModal,
       archive: threadId ? onArchive : undefined,
       // While the palette is open, Escape belongs to the dialog.
-      close: open || !threadId ? undefined : () => showEmail(null),
+      backToList: open || !threadId ? undefined : () => showEmail(null),
     }),
     [threadId, open, onArchive, onOpenComposeModal, showEmail, setOpen],
   );

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -89,10 +89,11 @@ const SHORTCUT_DEFINITIONS = [
   },
   {
     id: "backToList",
-    keys: ["u"],
+    keys: ["escape"],
     scope: "mail",
     group: "Navigate",
     label: "Back to the list",
+    allowWhileTyping: true,
   },
   {
     id: "nextSplit",
@@ -201,14 +202,6 @@ const SHORTCUT_DEFINITIONS = [
     scope: "mail",
     group: "View",
     label: "Focus mode (full screen)",
-  },
-  {
-    id: "close",
-    keys: ["escape"],
-    scope: "mail",
-    group: "View",
-    label: "Exit focus / close overlay",
-    allowWhileTyping: true,
   },
   {
     id: "help",

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -60,6 +60,19 @@ describe("useShortcuts", () => {
     expect(archive).not.toHaveBeenCalled();
   });
 
+  it("uses Escape rather than U for back navigation", () => {
+    const backToList = vi.fn();
+    renderShortcuts({ backToList });
+
+    press({ key: "Escape", code: "Escape" }, screen.getByRole("textbox"));
+
+    expect(backToList).toHaveBeenCalledOnce();
+
+    press({ key: "u", code: "KeyU" });
+
+    expect(backToList).toHaveBeenCalledOnce();
+  });
+
   it("treats G then A as back to the app rather than reply all", () => {
     const backToApp = vi.fn();
     const replyAll = vi.fn();


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260812-080001_pr-3227_04c51f18899d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates mail navigation to use Escape for the contextual back action.

- removes the previous letter-key binding and consolidates existing close behavior
- keeps the toolbar shortcut hint aligned with the registered shortcut
- adds focused keyboard behavior coverage

Validation: `pnpm test lib/shortcuts/useShortcuts.test.tsx lib/shortcuts/registry.test.ts`; `pnpm check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->