### PR TITLE
fix(mail): preserve provider label colors

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHIP_COLORS,
   chipColorForLabel,
+  contrastingTextColor,
 } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 
 describe("chipColorForLabel", () => {
@@ -45,5 +46,16 @@ describe("chipColorForLabel", () => {
     expect(chipColorForLabel("Newsletters")).not.toBe(
       chipColorForLabel("Newsletter"),
     );
+  });
+});
+
+describe("contrastingTextColor", () => {
+  it("chooses readable text for light and dark provider backgrounds", () => {
+    expect(contrastingTextColor("#fce8b3")).toBe("#000000");
+    expect(contrastingTextColor("#3c4043")).toBe("#ffffff");
+  });
+
+  it("leaves unsupported color formats to the chip palette", () => {
+    expect(contrastingTextColor("var(--label-color)")).toBeUndefined();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.test.ts
@@ -9,7 +9,7 @@ describe("chipColorForLabel", () => {
     expect(chipColorForLabel("To Reply")).toBe("blue");
     expect(chipColorForLabel("to reply")).toBe("blue");
     expect(chipColorForLabel("  Cold Email  ")).toBe("red");
-    expect(chipColorForLabel("Newsletter")).toBe("gray");
+    expect(chipColorForLabel("Newsletter")).toBe("purple");
     expect(chipColorForLabel("Awaiting Reply")).toBe("cyan");
   });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
@@ -129,6 +129,27 @@ function providerColorStyle(
   return {
     backgroundColor: color.backgroundColor,
     borderColor: color.backgroundColor,
-    color: color.textColor || undefined,
+    color: color.textColor || contrastingTextColor(color.backgroundColor),
   };
+}
+
+export function contrastingTextColor(backgroundColor: string) {
+  const hex = backgroundColor.trim();
+  if (!/^#[\da-f]{6}$/i.test(hex)) return;
+
+  const red = linearColorChannel(hex.slice(1, 3));
+  const green = linearColorChannel(hex.slice(3, 5));
+  const blue = linearColorChannel(hex.slice(5, 7));
+  const luminance = red * 0.2126 + green * 0.7152 + blue * 0.0722;
+  const blackContrast = (luminance + 0.05) / 0.05;
+  const whiteContrast = 1.05 / (luminance + 0.05);
+
+  return blackContrast >= whiteContrast ? "#000000" : "#ffffff";
+}
+
+function linearColorChannel(hex: string) {
+  const channel = Number.parseInt(hex, 16) / 255;
+  return channel <= 0.040_45
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailLabelChip.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import Link from "next/link";
+import type { CSSProperties } from "react";
 import { XIcon } from "lucide-react";
+import type { EmailLabel } from "@/providers/email-label-types";
 import { cn } from "@/utils";
 
 export type MailLabelChipProps = {
   name: string;
+  /** The color assigned by Gmail or Outlook. */
+  color?: EmailLabel["color"];
   /** Interactive: the chip navigates to that label's view. */
   href?: string;
   /** Interactive: reveals a `×` on hover that removes the label. */
@@ -14,12 +18,14 @@ export type MailLabelChipProps = {
 };
 
 /**
- * A label pill. Its colour comes from the name, so a label reads the same
- * everywhere. Without `href` or `onRemove` the chip is inert; each adds its own
- * affordance — a link on the name, and a `×` revealed on hover.
+ * A label pill. Provider colors take precedence; otherwise its color comes from
+ * the name, so a label reads the same everywhere. Without `href` or `onRemove`
+ * the chip is inert; each adds its own affordance — a link on the name, and a
+ * `×` revealed on hover.
  */
 export function MailLabelChip({
   name,
+  color,
   href,
   onRemove,
   className,
@@ -31,6 +37,7 @@ export function MailLabelChip({
         CHIP_CLASSES[chipColorForLabel(name)],
         className,
       )}
+      style={providerColorStyle(color)}
     >
       {href ? (
         <Link className="min-w-0 truncate hover:underline" href={href}>
@@ -86,7 +93,7 @@ const NAMED_CHIP_COLORS: Record<string, ChipColor> = {
   notification: "green",
   receipt: "orange",
   "cold email": "red",
-  newsletter: "gray",
+  newsletter: "purple",
   actioned: "orange",
   "awaiting reply": "cyan",
   calendar: "yellow",
@@ -112,4 +119,16 @@ export function chipColorForLabel(name: string): ChipColor {
   }
 
   return CHIP_COLORS[hash % CHIP_COLORS.length];
+}
+
+function providerColorStyle(
+  color: EmailLabel["color"],
+): CSSProperties | undefined {
+  if (!color?.backgroundColor) return;
+
+  return {
+    backgroundColor: color.backgroundColor,
+    borderColor: color.backgroundColor,
+    color: color.textColor || undefined,
+  };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -12,6 +12,7 @@ import {
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { Kbd } from "@/components/Kbd";
+import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 
@@ -20,7 +21,7 @@ export type ReaderToolbarProps = {
   /** Display name of the other party. Falls back to the address when absent. */
   senderName: string;
   senderEmail: string;
-  labels: { id: string; name: string }[];
+  labels: EmailMessageCellLabel[];
   /**
    * Chips navigate to a label's view and nothing else: a label carries no
    * reason, because several rules — or none at all — can put one on a thread.
@@ -99,6 +100,7 @@ export function ReaderToolbar({
             ) : null}
             {labels.map((label) => (
               <MailLabelChip
+                color={label.color}
                 href={labelHref(label.id)}
                 key={label.id}
                 name={label.name}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -158,7 +158,11 @@ export const ThreadRow = memo(function ThreadRow({
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2.5">
             {chips.map((label) => (
-              <MailLabelChip key={label.id} name={label.name} />
+              <MailLabelChip
+                color={label.color}
+                key={label.id}
+                name={label.name}
+              />
             ))}
             <span
               className={cn(
@@ -206,7 +210,11 @@ export const ThreadRow = memo(function ThreadRow({
           {chips.length ? (
             <div className="flex flex-wrap gap-1 pt-1">
               {chips.map((label) => (
-                <MailLabelChip key={label.id} name={label.name} />
+                <MailLabelChip
+                  color={label.color}
+                  key={label.id}
+                  name={label.name}
+                />
               ))}
             </div>
           ) : null}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-083126_pr-3229_33120890e6bc/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Preserve provider-assigned colors when rendering mail labels and use a colored fallback for labels without provider metadata.

- Pass provider label color data through list and reader chips.
- Use a purple fallback for the newsletter label and update the focused test.
- Validated with the focused Vitest suite and Biome checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->