### PR TITLE
Landing: Fix mobile horizontal overflow

### DIFF
--- a/apps/web/components/new-landing/sections/ManageFromAnywhere.tsx
+++ b/apps/web/components/new-landing/sections/ManageFromAnywhere.tsx
@@ -52,7 +52,7 @@ export function ManageFromAnywhere() {
       </SectionSubtitle>
       <SectionContent className="flex justify-center">
         <BlurFade inView>
-          <div className="flex items-start gap-6 sm:gap-10">
+          <div className="flex flex-wrap items-start justify-center gap-6 sm:gap-10">
             {platforms.map((platform) => (
               <PlatformIcon key={platform.name} {...platform} />
             ))}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-082336_pr-3231_53e7ab8d0142/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The platform row on the landing page forced the document wider than mobile viewports.

- allow platform icons to wrap and remain centered on narrow screens
- verified document width at 320, 375, 393, 430, and 768px
- validated the changed file with Ultracite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->