### PR TITLE
mail: add actions to the reader's ⋯ menu

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -13,7 +13,7 @@ import type {
   MailCategory,
   MailNavTarget,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
-import { RuleAttributionMenu } from "@/app/(app)/[emailAccountId]/mail/RuleAttributionMenu";
+import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
@@ -29,6 +29,7 @@ import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threa
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
+import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -196,14 +197,16 @@ export function MailShell() {
     loadMore,
     removeThreads,
     restoreThreads,
+    updateThreads,
   } = useMailThreads({ emailAccountId, query });
 
   const orderedIds = useMemo(() => threads.map((t) => t.id), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, undo } = useThreadActions({
+  const { archive, trash, markRead, undo } = useThreadActions({
     emailAccountId,
     removeThreads,
     restoreThreads,
+    updateThreads,
   });
 
   const clampIndex = useCallback(
@@ -233,6 +236,13 @@ export function MailShell() {
     readerThreadId === openThreadId
       ? (openThreadData?.thread.messages ?? NO_MESSAGES)
       : NO_MESSAGES;
+
+  // The row, not the fetched thread: marking read patches the row optimistically,
+  // so it is the copy that stays in step. The fetch only stands in for a link
+  // straight into a conversation, where there is no row yet.
+  const isOpenThreadUnread = isThreadUnread(
+    openThread?.messages ?? openMessages,
+  );
 
   const hrefFor = useCallback(
     (target: MailNavTarget) =>
@@ -534,10 +544,14 @@ export function MailShell() {
             refetch={refetchOpenThread}
             autoOpenReplyForMessageId={replyToMessageId}
             menu={
-              <RuleAttributionMenu
+              <ThreadActionsMenu
                 plans={openThread?.plans ?? []}
                 message={openMessages?.at(-1) ?? null}
                 setChatInput={setChatInput}
+                isUnread={isOpenThreadUnread}
+                onToggleRead={() => {
+                  if (openThreadId) markRead(openThreadId, isOpenThreadUnread);
+                }}
                 open={isMenuOpen}
                 onOpenChange={setIsMenuOpen}
               />

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -37,7 +37,7 @@ export type ReaderToolbarProps = {
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
-  /** The ⋯ dropdown, i.e. `RuleAttributionMenu`, composed by the shell. */
+  /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { MoreHorizontalIcon } from "lucide-react";
+import {
+  MailXIcon,
+  MailIcon,
+  MailOpenIcon,
+  MoreHorizontalIcon,
+} from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
+import { useUnsubscribeSender } from "@/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
@@ -19,61 +27,90 @@ import type { ParsedMessage } from "@/utils/types";
 
 type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
 
-export type RuleAttributionMenuProps = {
+export type ThreadActionsMenuProps = {
   /**
    * Every rule that fired on the thread, newest first. Attribution is
    * rule-scoped, not label-scoped: one entry per rule, each with its own reason,
    * the actions it applied, and its own way to correct it.
    */
   plans: ThreadPlan[];
-  /** The message the fix flow reasons about — the thread's latest message. */
+  /**
+   * The thread's latest message: what the fix flow reasons about, and the
+   * sender the unsubscribe entry acts on.
+   */
   message: ParsedMessage | null;
   /** `setInput` from `useChat()`: the fix flow seeds the assistant with it. */
   setChatInput: (input: string) => void;
+  isUnread: boolean;
+  onToggleRead: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 };
 
-/** The reader's ⋯ menu: why the thread looks the way it does. */
-export function RuleAttributionMenu({
+/**
+ * The reader's ⋯ menu: why the thread looks the way it does, and everything you
+ * can do to it that isn't worth a button of its own.
+ */
+export function ThreadActionsMenu({
   plans,
   message,
   setChatInput,
+  isUnread,
+  onToggleRead,
   open,
   onOpenChange,
-}: RuleAttributionMenuProps) {
-  if (!plans.length) return null;
-
+}: ThreadActionsMenuProps) {
   const hint = getShortcutHint("moreActions");
+  const { canUnsubscribe, onUnsubscribe, PremiumModal } =
+    useUnsubscribeSender(message);
+  const ReadIcon = isUnread ? MailOpenIcon : MailIcon;
 
   return (
-    <DropdownMenu onOpenChange={onOpenChange} open={open}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          aria-label={`More actions (${hint})`}
-          className="h-7 w-7"
-          size="icon"
-          title={`More actions (${hint})`}
-          variant="outline"
-        >
-          <MoreHorizontalIcon className="size-3.5" />
-        </Button>
-      </DropdownMenuTrigger>
+    <>
+      <DropdownMenu onOpenChange={onOpenChange} open={open}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label={`More actions (${hint})`}
+            className="h-7 w-7"
+            size="icon"
+            title={`More actions (${hint})`}
+            variant="outline"
+          >
+            <MoreHorizontalIcon className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        align="end"
-        className="w-[min(24rem,calc(100vw-1rem))]"
-      >
-        {plans.map((plan) => (
-          <RuleAttribution
-            key={plan.id}
-            message={message}
-            plan={plan}
-            setChatInput={setChatInput}
-          />
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+        <DropdownMenuContent
+          align="end"
+          className="w-[min(24rem,calc(100vw-1rem))]"
+        >
+          {plans.map((plan) => (
+            <RuleAttribution
+              key={plan.id}
+              message={message}
+              plan={plan}
+              setChatInput={setChatInput}
+            />
+          ))}
+
+          {plans.length > 0 ? <DropdownMenuSeparator /> : null}
+
+          <DropdownMenuItem onSelect={onToggleRead}>
+            <ReadIcon className="mr-2 size-4" />
+            {isUnread ? "Mark as read" : "Mark as unread"}
+          </DropdownMenuItem>
+
+          {canUnsubscribe ? (
+            <DropdownMenuItem onSelect={onUnsubscribe}>
+              <MailXIcon className="mr-2 size-4" />
+              Unsubscribe
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <PremiumModal />
+    </>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -45,7 +45,7 @@ export type ThreadReaderProps = {
    * a message that already has an AI draft.
    */
   autoOpenReplyForMessageId?: string;
-  /** The ⋯ dropdown, i.e. `RuleAttributionMenu`, composed by the shell. */
+  /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useMemo } from "react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import type {
   ListThread,
   MailLayoutMode,
@@ -61,8 +62,8 @@ export const ThreadRow = memo(function ThreadRow({
 
   if (!message) return null;
 
-  // Both providers normalise to these ids, so this is not a provider branch.
-  const isUnread = message.labelIds?.includes(GmailLabel.UNREAD) ?? false;
+  const isUnread = isThreadUnread(thread.messages);
+  // Both providers normalise to this id, so this is not a provider branch.
   const isDraft = message.labelIds?.includes(GmailLabel.DRAFT) ?? false;
   const isWide = layout === "list";
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
@@ -1,0 +1,35 @@
+import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import { GmailLabel } from "@/utils/gmail/label";
+
+/**
+ * A thread is unread when its latest message is. The row's styling, the reader's
+ * ⋯ menu and the update below all have to agree on that, so they read it here.
+ * Both providers normalise to these ids, so this is not a provider branch.
+ */
+export function isThreadUnread(
+  messages: readonly { labelIds?: string[] | null }[],
+) {
+  return messages.at(-1)?.labelIds?.includes(GmailLabel.UNREAD) ?? false;
+}
+
+/** Read state lives on every message, so marking a thread rewrites all of them. */
+export function withThreadReadState(
+  thread: ListThread,
+  read: boolean,
+): ListThread {
+  return {
+    ...thread,
+    messages: thread.messages.map((message) => {
+      const labelIds = message.labelIds ?? [];
+      const isRead = !labelIds.includes(GmailLabel.UNREAD);
+      if (isRead === read) return message;
+
+      return {
+        ...message,
+        labelIds: read
+          ? labelIds.filter((labelId) => labelId !== GmailLabel.UNREAD)
+          : [...labelIds, GmailLabel.UNREAD],
+      };
+    }),
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -309,6 +309,36 @@ export function useMailThreads({
     [emailAccountId, mutate, viewIdentity, viewKey],
   );
 
+  // Rows the user changed rather than removed, e.g. read state. Written into
+  // the SWR pages so the list reflects it without a refetch; the cache write
+  // effect picks the new pages up on its own.
+  const updateThreads = useCallback(
+    (threadIds: string[], update: (thread: ListThread) => ListThread) => {
+      if (!threadIds.length) return;
+
+      const targets = new Set(threadIds);
+      const applyUpdate = (rows: ListThread[]) =>
+        rows.map((thread) =>
+          targets.has(thread.id) ? update(thread) : thread,
+        );
+
+      setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? { ...current, threads: applyUpdate(current.threads) }
+          : current,
+      );
+      mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            threads: applyUpdate(page.threads),
+          })),
+        { revalidate: false, populateCache: true },
+      ).catch(() => {});
+    },
+    [mutate, viewIdentity],
+  );
+
   const hasMore = data
     ? Boolean(data.at(-1)?.nextPageToken)
     : persistent?.identity === viewIdentity && persistent.hasMore;
@@ -331,6 +361,7 @@ export function useMailThreads({
     }, [data, setSize, viewIdentity]),
     removeThreads,
     restoreThreads,
+    updateThreads,
   };
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -335,8 +335,28 @@ export function useMailThreads({
           })),
         { revalidate: false, populateCache: true },
       ).catch(() => {});
+
+      // A view still running off the cache has no SWR pages, so the effect that
+      // mirrors them into the cache never fires and the change would be lost on
+      // reopen. Persist it here instead, the way removal does.
+      if (!data && persistentThreads) {
+        writeCachedThreadList({
+          emailAccountId,
+          viewKey,
+          threads: applyUpdate(persistentThreads),
+          hasMore: Boolean(persistent?.hasMore),
+        }).catch(() => {});
+      }
     },
-    [mutate, viewIdentity],
+    [
+      data,
+      emailAccountId,
+      mutate,
+      persistent?.hasMore,
+      persistentThreads,
+      viewIdentity,
+      viewKey,
+    ],
   );
 
   const hasMore = data

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -338,15 +338,14 @@ export function useMailThreads({
       ).catch(() => {});
 
       // The effect that mirrors the cache only watches SWR pages, so a view
-      // still running off the cache would lose this on reopen. Only the changed
-      // rows are written: an update leaves every view's membership and order
-      // alone, so nothing else has to be rewritten from a captured snapshot.
-      const changed = (remoteThreads ?? persistentThreads ?? [])
-        .filter((thread) => targets.has(thread.id))
-        .map(update);
-      updateCachedThreads({ emailAccountId, threads: changed }).catch(() => {});
+      // still running off the cache would lose this on reopen. Applied straight
+      // to the cached rows, which also covers a thread the current view does
+      // not list, and leaves every view's membership and order alone.
+      updateCachedThreads({ emailAccountId, threadIds, update }).catch(
+        () => {},
+      );
     },
-    [emailAccountId, mutate, persistentThreads, remoteThreads, viewIdentity],
+    [emailAccountId, mutate, viewIdentity],
   );
 
   const hasMore = data

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -16,6 +16,7 @@ import {
   readCachedThreadList,
   removeCachedThreadsFromView,
   restoreCachedThreadsToView,
+  updateCachedThreads,
   writeCachedThreadList,
 } from "@/utils/email-cache/thread-lists";
 import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
@@ -336,27 +337,16 @@ export function useMailThreads({
         { revalidate: false, populateCache: true },
       ).catch(() => {});
 
-      // A view still running off the cache has no SWR pages, so the effect that
-      // mirrors them into the cache never fires and the change would be lost on
-      // reopen. Persist it here instead, the way removal does.
-      if (!data && persistentThreads) {
-        writeCachedThreadList({
-          emailAccountId,
-          viewKey,
-          threads: applyUpdate(persistentThreads),
-          hasMore: Boolean(persistent?.hasMore),
-        }).catch(() => {});
-      }
+      // The effect that mirrors the cache only watches SWR pages, so a view
+      // still running off the cache would lose this on reopen. Only the changed
+      // rows are written: an update leaves every view's membership and order
+      // alone, so nothing else has to be rewritten from a captured snapshot.
+      const changed = (remoteThreads ?? persistentThreads ?? [])
+        .filter((thread) => targets.has(thread.id))
+        .map(update);
+      updateCachedThreads({ emailAccountId, threads: changed }).catch(() => {});
     },
-    [
-      data,
-      emailAccountId,
-      mutate,
-      persistent?.hasMore,
-      persistentThreads,
-      viewIdentity,
-      viewKey,
-    ],
+    [emailAccountId, mutate, persistentThreads, remoteThreads, viewIdentity],
   );
 
   const hasMore = data

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
+
+const markReadThreadAction = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/actions/mail", () => ({
+  markReadThreadAction,
+  unarchiveThreadAction: vi.fn(),
+  untrashThreadAction: vi.fn(),
+}));
+
+vi.mock("@/store/archive-queue", () => ({
+  archiveEmails: vi.fn(),
+  cancelQueuedThreads: vi.fn(() => ({ notCancelled: [] })),
+  deleteEmails: vi.fn(),
+}));
+
+describe("useThreadActions markRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    markReadThreadAction.mockResolvedValue({});
+  });
+
+  it("drops the unread label from every message in the thread", async () => {
+    const { result, labelsOf } = setup([["INBOX", "UNREAD"], ["UNREAD"]]);
+
+    await act(() => result.current.markRead("thread", true));
+
+    expect(labelsOf()).toEqual([["INBOX"], []]);
+    expect(markReadThreadAction).toHaveBeenCalledWith("account", {
+      threadId: "thread",
+      read: true,
+    });
+  });
+
+  it("puts the unread label back when the provider refuses", async () => {
+    markReadThreadAction.mockResolvedValue({ serverError: "nope" });
+    const { result, labelsOf } = setup([["INBOX", "UNREAD"]]);
+
+    await act(() => result.current.markRead("thread", true));
+
+    expect(labelsOf()).toEqual([["INBOX", "UNREAD"]]);
+  });
+
+  it("marks unread without duplicating the label on messages that already have it", async () => {
+    const { result, labelsOf } = setup([["INBOX", "UNREAD"], ["INBOX"]]);
+
+    await act(() => result.current.markRead("thread", false));
+
+    expect(labelsOf()).toEqual([
+      ["INBOX", "UNREAD"],
+      ["INBOX", "UNREAD"],
+    ]);
+  });
+});
+
+function setup(messageLabels: string[][]) {
+  const thread = {
+    id: "thread",
+    messages: messageLabels.map((labelIds, index) => ({
+      id: `message-${index}`,
+      labelIds,
+    })),
+  } as unknown as ListThread;
+
+  const rows = new Map<string, ListThread>([[thread.id, thread]]);
+
+  const { result } = renderHook(() =>
+    useThreadActions({
+      emailAccountId: "account",
+      removeThreads: vi.fn(),
+      restoreThreads: vi.fn(),
+      updateThreads: (threadIds, update) => {
+        for (const threadId of threadIds) {
+          const row = rows.get(threadId);
+          if (row) rows.set(threadId, update(row));
+        }
+      },
+    }),
+  );
+
+  return {
+    result,
+    labelsOf: () =>
+      rows.get("thread")?.messages.map((message) => message.labelIds),
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -46,6 +46,15 @@ describe("useThreadActions markRead", () => {
     expect(labelsOf()).toEqual([["INBOX", "UNREAD"]]);
   });
 
+  it("puts the unread label back when the request never reaches the provider", async () => {
+    markReadThreadAction.mockRejectedValue(new Error("offline"));
+    const { result, labelsOf } = setup([["INBOX", "UNREAD"]]);
+
+    await act(() => result.current.markRead("thread", true));
+
+    expect(labelsOf()).toEqual([["INBOX", "UNREAD"]]);
+  });
+
   it("marks unread without duplicating the label on messages that already have it", async () => {
     const { result, labelsOf } = setup([["INBOX", "UNREAD"], ["INBOX"]]);
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -8,10 +8,13 @@ import {
   deleteEmails,
 } from "@/store/archive-queue";
 import {
+  markReadThreadAction,
   unarchiveThreadAction,
   untrashThreadAction,
 } from "@/utils/actions/mail";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { withThreadReadState } from "@/app/(app)/[emailAccountId]/mail/read-state";
+import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadRemoval } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 
 type UndoableAction = "archive" | "delete";
@@ -24,7 +27,7 @@ type UndoableBatch = {
 };
 
 /**
- * Archive and delete with a real undo.
+ * Archive and delete with a real undo, plus read state.
  *
  * Undo tries to cancel the queued job first: the queue usually drains in well
  * under a second, but when it hasn't, cancelling avoids a pointless round trip
@@ -34,10 +37,15 @@ export function useThreadActions({
   emailAccountId,
   removeThreads,
   restoreThreads,
+  updateThreads,
 }: {
   emailAccountId: string;
   removeThreads: (threadIds: string[]) => ThreadRemoval;
   restoreThreads: (removal: ThreadRemoval, threadIds: string[]) => void;
+  updateThreads: (
+    threadIds: string[],
+    update: (thread: ListThread) => ListThread,
+  ) => void;
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
 
@@ -132,9 +140,37 @@ export function useThreadActions({
     [emailAccountId, removeThreads, restoreThreads, undoBatch],
   );
 
+  // Applied to the list first: in list layout the reader covers the rows, so
+  // waiting on the provider would leave the click with no visible effect.
+  const markRead = useCallback(
+    async (threadId: string, read: boolean) => {
+      const update = (isRead: boolean) =>
+        updateThreads([threadId], (thread) =>
+          withThreadReadState(thread, isRead),
+        );
+
+      update(read);
+
+      const result = await markReadThreadAction(emailAccountId, {
+        threadId,
+        read,
+      });
+
+      if (result?.serverError) {
+        update(!read);
+        toast.error(read ? "Couldn't mark as read" : "Couldn't mark as unread");
+        return;
+      }
+
+      toast.success(read ? "Marked as read" : "Marked as unread");
+    },
+    [emailAccountId, updateThreads],
+  );
+
   return {
     archive: useCallback((ids: string[]) => run("archive", ids), [run]),
     trash: useCallback((ids: string[]) => run("delete", ids), [run]),
+    markRead,
     undo,
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -151,12 +151,15 @@ export function useThreadActions({
 
       update(read);
 
-      const result = await markReadThreadAction(emailAccountId, {
-        threadId,
-        read,
-      });
-
-      if (result?.serverError) {
+      // A rejected request has to roll back too, or the row keeps showing a
+      // state the provider never took: nothing else reverts it.
+      try {
+        const result = await markReadThreadAction(emailAccountId, {
+          threadId,
+          read,
+        });
+        if (result?.serverError) throw new Error(result.serverError);
+      } catch {
         update(!read);
         toast.error(read ? "Couldn't mark as read" : "Couldn't mark as unread");
         return;

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
+import { usePremium } from "@/hooks/usePremium";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { decrementUnsubscribeCreditAction } from "@/utils/actions/premium";
+import { unsubscribeSenderAction } from "@/utils/actions/unsubscriber";
+import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
+import {
+  getHttpUnsubscribeLink,
+  getUserFacingUnsubscribeLink,
+} from "@/utils/parse/unsubscribe";
+import type { ParsedMessage } from "@/utils/types";
+
+/**
+ * Unsubscribing from a single message, for the reader.
+ *
+ * Only the sender's own `List-Unsubscribe` header is trusted here: the bulk
+ * page can fall back to a link scraped out of the body, but that scrape happens
+ * server-side while indexing senders and isn't available on an open thread.
+ *
+ * A one-click header is unsubscribed server-side and the sender is marked; when
+ * that fails, or when the sender only offers a mailto, the user gets the link.
+ */
+export function useUnsubscribeSender(message: ParsedMessage | null) {
+  const { emailAccountId } = useAccount();
+  const { hasUnsubscribeAccess, mutate: refetchPremium } = usePremium();
+  const { PremiumModal, openModal } = usePremiumModal();
+
+  const listUnsubscribeHeader = message?.headers["list-unsubscribe"] ?? null;
+  // Only ever asked whether it exists: the request itself is made server-side
+  // from the header, so the URL never has to reach the browser.
+  const hasOneClickLink = Boolean(
+    getHttpUnsubscribeLink({ listUnsubscribeHeader }),
+  );
+  const userFacingLink = getUserFacingUnsubscribeLink({
+    listUnsubscribeHeader,
+  });
+  const from = message?.headers.from ?? "";
+  const senderEmail = extractEmailAddress(from);
+  const senderName = extractNameFromEmail(from);
+  const canUnsubscribe = Boolean(senderEmail && userFacingLink);
+
+  const onUnsubscribe = useCallback(() => {
+    if (!(canUnsubscribe && userFacingLink)) return;
+
+    if (!hasUnsubscribeAccess) {
+      openModal();
+      return;
+    }
+
+    if (!hasOneClickLink) {
+      openUnsubscribePage(userFacingLink);
+      return;
+    }
+
+    const toastId = toast.loading(`Unsubscribing from ${senderName}`);
+
+    unsubscribeSenderAction(emailAccountId, {
+      senderEmail,
+      listUnsubscribeHeader,
+    })
+      .then(async (result) => {
+        if (!result?.data?.unsubscribe.success) {
+          toast.error(`Couldn't unsubscribe from ${senderName}`, {
+            id: toastId,
+            action: {
+              label: "Open page",
+              onClick: () => openUnsubscribePage(userFacingLink),
+            },
+          });
+          return;
+        }
+
+        await decrementUnsubscribeCreditAction();
+        toast.success(`Unsubscribed from ${senderName}`, { id: toastId });
+        // A stale credit count is cosmetic: never let refreshing it turn an
+        // unsubscribe that already succeeded into an error.
+        refetchPremium().catch(() => {});
+      })
+      .catch(() => {
+        toast.error(`Couldn't unsubscribe from ${senderName}`, { id: toastId });
+      });
+  }, [
+    canUnsubscribe,
+    emailAccountId,
+    hasOneClickLink,
+    hasUnsubscribeAccess,
+    listUnsubscribeHeader,
+    openModal,
+    refetchPremium,
+    senderEmail,
+    senderName,
+    userFacingLink,
+  ]);
+
+  return { canUnsubscribe, onUnsubscribe, PremiumModal };
+}
+
+function openUnsubscribePage(link: string) {
+  window.open(link, "_blank", "noopener,noreferrer");
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
@@ -30,11 +30,7 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
   const { PremiumModal, openModal } = usePremiumModal();
 
   const listUnsubscribeHeader = message?.headers["list-unsubscribe"] ?? null;
-  // Only ever asked whether it exists: the request itself is made server-side
-  // from the header, so the URL never has to reach the browser.
-  const hasOneClickLink = Boolean(
-    getHttpUnsubscribeLink({ listUnsubscribeHeader }),
-  );
+  const httpLink = getHttpUnsubscribeLink({ listUnsubscribeHeader });
   const userFacingLink = getUserFacingUnsubscribeLink({
     listUnsubscribeHeader,
   });
@@ -43,7 +39,7 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
   const senderName = extractNameFromEmail(from);
   const canUnsubscribe = Boolean(senderEmail && userFacingLink);
 
-  const onUnsubscribe = useCallback(() => {
+  const onUnsubscribe = useCallback(async () => {
     if (!(canUnsubscribe && userFacingLink)) return;
 
     if (!hasUnsubscribeAccess) {
@@ -51,43 +47,51 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
       return;
     }
 
-    if (!hasOneClickLink) {
+    // Sending the user to a mailto they have to compose is the last resort: an
+    // http link opens a page that finishes the job, so it wins when both exist.
+    const manualLink = httpLink ?? userFacingLink;
+
+    if (!httpLink) {
       openUnsubscribePage(userFacingLink);
       return;
     }
 
     const toastId = toast.loading(`Unsubscribing from ${senderName}`);
-
-    unsubscribeSenderAction(emailAccountId, {
-      senderEmail,
-      listUnsubscribeHeader,
-    })
-      .then(async (result) => {
-        if (!result?.data?.unsubscribe.success) {
-          toast.error(`Couldn't unsubscribe from ${senderName}`, {
-            id: toastId,
-            action: {
-              label: "Open page",
-              onClick: () => openUnsubscribePage(userFacingLink),
-            },
-          });
-          return;
-        }
-
-        await decrementUnsubscribeCreditAction();
-        toast.success(`Unsubscribed from ${senderName}`, { id: toastId });
-        // A stale credit count is cosmetic: never let refreshing it turn an
-        // unsubscribe that already succeeded into an error.
-        refetchPremium().catch(() => {});
-      })
-      .catch(() => {
-        toast.error(`Couldn't unsubscribe from ${senderName}`, { id: toastId });
+    const failed = () =>
+      toast.error(`Couldn't unsubscribe from ${senderName}`, {
+        id: toastId,
+        action: {
+          label: "Open page",
+          onClick: () => openUnsubscribePage(manualLink),
+        },
       });
+
+    try {
+      const result = await unsubscribeSenderAction(emailAccountId, {
+        senderEmail,
+        listUnsubscribeHeader,
+      });
+      if (!result?.data?.unsubscribe.success) {
+        failed();
+        return;
+      }
+    } catch {
+      failed();
+      return;
+    }
+
+    toast.success(`Unsubscribed from ${senderName}`, { id: toastId });
+
+    // Metering happens after the fact, and neither half changes what the user
+    // just saw: a failure here must not read as a failed unsubscribe.
+    decrementUnsubscribeCreditAction()
+      .then(() => refetchPremium())
+      .catch(() => {});
   }, [
     canUnsubscribe,
     emailAccountId,
-    hasOneClickLink,
     hasUnsubscribeAccess,
+    httpLink,
     listUnsubscribeHeader,
     openModal,
     refetchPremium,

--- a/apps/web/utils/email-cache/thread-lists.ts
+++ b/apps/web/utils/email-cache/thread-lists.ts
@@ -145,15 +145,21 @@ export async function removeCachedThreadsFromView({
  * Rewrites rows in place, for a change to a thread itself rather than to a
  * view's membership: rows are keyed by thread, so every view holding one picks
  * the change up and no view's order has to be touched.
+ *
+ * The updater runs against the cached row rather than one the caller supplies,
+ * so a thread that is cached but missing from the list on screen — an opened
+ * conversation the current view does not contain — is still kept in step.
  */
 export async function updateCachedThreads<T extends ThreadRow>({
   emailAccountId,
-  threads,
+  threadIds,
+  update,
 }: {
   emailAccountId: string;
-  threads: T[];
+  threadIds: string[];
+  update: (thread: T) => T;
 }) {
-  if (!threads.length) return;
+  if (!threadIds.length) return;
   const epoch = captureEmailCacheEpoch(emailAccountId);
 
   try {
@@ -164,17 +170,23 @@ export async function updateCachedThreads<T extends ThreadRow>({
     const now = Date.now();
 
     await Promise.all(
-      threads.map(async (thread) => {
-        // Absent means the row was evicted, and writing it back would resurrect
-        // a row no view lists any more.
-        const existing = await store.get([emailAccountId, thread.id]);
+      threadIds.map(async (threadId) => {
+        // Absent means the row was never cached or has been evicted, and
+        // writing one would resurrect a row no view lists any more.
+        const existing = await store.get([emailAccountId, threadId]);
         if (!existing) return;
-        return store.put({ ...existing, data: thread, lastAccessedAt: now });
+        return store.put({
+          ...existing,
+          data: update(existing.data as T),
+          lastAccessedAt: now,
+        });
       }),
     );
     await transaction.done;
   } catch {
-    // Optimistic UI state remains authoritative if persistence is unavailable.
+    // A failed write can be a full quota, which every later write would hit
+    // too, so make room rather than leaving the row stale for good.
+    scheduleEmailCacheCleanup({ force: true });
   }
 }
 

--- a/apps/web/utils/email-cache/thread-lists.ts
+++ b/apps/web/utils/email-cache/thread-lists.ts
@@ -141,6 +141,43 @@ export async function removeCachedThreadsFromView({
   }
 }
 
+/**
+ * Rewrites rows in place, for a change to a thread itself rather than to a
+ * view's membership: rows are keyed by thread, so every view holding one picks
+ * the change up and no view's order has to be touched.
+ */
+export async function updateCachedThreads<T extends ThreadRow>({
+  emailAccountId,
+  threads,
+}: {
+  emailAccountId: string;
+  threads: T[];
+}) {
+  if (!threads.length) return;
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+
+  try {
+    const database = await getEmailCacheDatabase();
+    if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+    const transaction = database.transaction("threadRows", "readwrite");
+    const store = transaction.objectStore("threadRows");
+    const now = Date.now();
+
+    await Promise.all(
+      threads.map(async (thread) => {
+        // Absent means the row was evicted, and writing it back would resurrect
+        // a row no view lists any more.
+        const existing = await store.get([emailAccountId, thread.id]);
+        if (!existing) return;
+        return store.put({ ...existing, data: thread, lastAccessedAt: now });
+      }),
+    );
+    await transaction.done;
+  } catch {
+    // Optimistic UI state remains authoritative if persistence is unavailable.
+  }
+}
+
 export async function restoreCachedThreadsToView<T extends ThreadRow>({
   emailAccountId,
   viewKey,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-092541_pr-3232_3eb98a8fe1a1/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The dropdown in the mail reader only ever showed rule attribution, and rendered nothing at all when no rule had fired on the thread. It is now a real actions menu.

- **Mark as read / mark as unread** — patches the list row optimistically and reverts it if the provider refuses, because in list view the reader covers the rows and waiting on the round trip would leave the click with no visible effect
- **Unsubscribe** — shown only for senders that carry a `List-Unsubscribe` header. A one-click header is unsubscribed server-side through the existing action and the sender is marked; when that fails, or the sender only offers a `mailto:`, the user gets a link to the sender's own page. Same premium gate and credit accounting as the bulk unsubscribe page
- Renamed `RuleAttributionMenu` to `ThreadActionsMenu` now that it holds both attribution and actions
- Centralised "a thread is unread when its latest message is" in `read-state.ts` — the row's styling, the reader's menu and the update itself had each re-derived it, and they have to agree

Mute is deliberately absent; it isn't a concept in this product. Reply, reply all and forward are also left out: reply is already a toolbar button, forward is already a button on each message row, and reply here keeps the original CC, so reply-all isn't a distinct action.

## Validation

- New unit tests cover the optimistic patch, the revert on server error, and marking unread without duplicating the label
- Full mail test suite passes (36 tests); lint clean; no type errors in the touched files
- Not exercised against a live provider — the unsubscribe path spends a real credit, so it is worth a manual pass

## Performance

No new work on the render hot path. The read-state update reuses the list hook's existing optimistic-patch shape, so it costs one re-render per action and no refetch. Two notes for follow-up, neither introduced by the menu logic itself: the menu now mounts for every opened thread, so `usePremium()` adds a `/api/user/me` revalidation per reader open, and `usePremiumModal` statically pulls the pricing UI into the mail route chunk. The fix for the latter belongs in `PremiumModal.tsx` (lazy-load `Pricing`, as `PricingLazy.tsx` already does), which would benefit every caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->