### PR TITLE
security: Restrict onboarding chat to text messages

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboarding.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboarding.tsx
@@ -23,6 +23,7 @@ import {
   applySetupUpdate,
   buildInitialSetup,
   deriveOnboardingFlow,
+  serializeOnboardingChatMessages,
   STAGE_CHIPS,
   STAGE_QUESTIONS,
   STAGE_STEP,
@@ -110,7 +111,9 @@ export function ChatOnboarding() {
       prepareSendMessagesRequest({ messages }) {
         return {
           body: {
-            messages,
+            // Tool parts drive the local UI; the current setup and scan below
+            // carry their durable state to the model.
+            messages: serializeOnboardingChatMessages(messages),
             setup: setupRef.current,
             scan: scanRef.current,
             isPremium: isPremiumRef.current,

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  serializeOnboardingChatMessages,
+  type OnboardingChatMessage,
+} from "@/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig";
+
+describe("serializeOnboardingChatMessages", () => {
+  it("keeps conversation text while excluding UI tool parts", () => {
+    const messages: OnboardingChatMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-advanceStage",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { stage: "discovery" },
+            output: { stage: "discovery" },
+          },
+          { type: "text", text: "What is hardest about your inbox?" },
+        ],
+      },
+      {
+        id: "user-1",
+        role: "user",
+        metadata: { hidden: true },
+        parts: [{ type: "text", text: "[panel] Keep newsletters labeled" }],
+      },
+    ];
+
+    expect(serializeOnboardingChatMessages(messages)).toEqual([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "What is hardest about your inbox?" }],
+      },
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "[panel] Keep newsletters labeled" }],
+      },
+    ]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/chatOnboardingConfig.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/utils/ai/onboarding/chat";
 import {
   MAX_SETUP_RULES,
+  type OnboardingChatInput,
   type OnboardingRuleAction,
   type OnboardingSetup,
 } from "@/app/api/chat/onboarding/validation";
@@ -193,4 +194,20 @@ export function buildInitialSetup(provider: string): OnboardingSetup {
     })),
     status: "draft",
   };
+}
+
+export function serializeOnboardingChatMessages(
+  messages: OnboardingChatMessage[],
+): OnboardingChatInput["messages"] {
+  return messages.flatMap((message) => {
+    if (message.role === "system") return [];
+
+    const parts = message.parts.flatMap((part) =>
+      part.type === "text" ? [{ type: "text" as const, text: part.text }] : [],
+    );
+
+    return parts.length > 0
+      ? [{ id: message.id, role: message.role, parts }]
+      : [];
+  });
 }

--- a/apps/web/app/api/chat/onboarding/route.test.ts
+++ b/apps/web/app/api/chat/onboarding/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount } from "@/__tests__/helpers";
+import { getOnboardingChatInput } from "@/app/api/chat/onboarding/test-utils";
 
 const { aiProcessOnboardingChatMock, convertToModelMessagesMock } = vi.hoisted(
   () => ({
@@ -44,7 +45,7 @@ describe("onboarding chat route", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(
-          getInput([
+          getOnboardingChatInput([
             {
               type: "file",
               url: "https://example.com/image.png",
@@ -61,27 +62,3 @@ describe("onboarding chat route", () => {
     expect(aiProcessOnboardingChatMock).not.toHaveBeenCalled();
   });
 });
-
-function getInput(parts: unknown[]) {
-  return {
-    messages: [
-      {
-        id: "message-1",
-        role: "user",
-        parts,
-      },
-    ],
-    setup: {
-      rules: [],
-      status: "draft",
-    },
-    scan: {
-      status: "pending",
-      emailsPerDay: null,
-      emailsLastMonth: null,
-      cleanupSuggestions: [],
-      totalCleanupSuggestions: 0,
-    },
-    isPremium: false,
-  };
-}

--- a/apps/web/app/api/chat/onboarding/route.test.ts
+++ b/apps/web/app/api/chat/onboarding/route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEmailAccount } from "@/__tests__/helpers";
+
+const { aiProcessOnboardingChatMock, convertToModelMessagesMock } = vi.hoisted(
+  () => ({
+    aiProcessOnboardingChatMock: vi.fn(),
+    convertToModelMessagesMock: vi.fn(),
+  }),
+);
+
+vi.mock("ai", () => ({
+  convertToModelMessages: convertToModelMessagesMock,
+  createUIMessageStream: vi.fn(),
+  createUIMessageStreamResponse: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
+
+vi.mock("@/utils/user/get", () => ({
+  getEmailAccountWithAi: vi.fn().mockResolvedValue(getEmailAccount()),
+}));
+
+vi.mock("@/utils/ai/onboarding/chat", () => ({
+  aiProcessOnboardingChat: aiProcessOnboardingChatMock,
+}));
+
+import { POST } from "./route";
+
+describe("onboarding chat route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects file parts before converting messages for the model", async () => {
+    const response = await POST(
+      new NextRequest("https://www.getinboxzero.com/api/chat/onboarding", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          getInput([
+            {
+              type: "file",
+              url: "https://example.com/image.png",
+              mediaType: "image/png",
+            },
+          ]),
+        ),
+      }),
+      {} as never,
+    );
+
+    expect(response.status).toBe(400);
+    expect(convertToModelMessagesMock).not.toHaveBeenCalled();
+    expect(aiProcessOnboardingChatMock).not.toHaveBeenCalled();
+  });
+});
+
+function getInput(parts: unknown[]) {
+  return {
+    messages: [
+      {
+        id: "message-1",
+        role: "user",
+        parts,
+      },
+    ],
+    setup: {
+      rules: [],
+      status: "draft",
+    },
+    scan: {
+      status: "pending",
+      emailsPerDay: null,
+      emailsLastMonth: null,
+      cleanupSuggestions: [],
+      totalCleanupSuggestions: 0,
+    },
+    isPremium: false,
+  };
+}

--- a/apps/web/app/api/chat/onboarding/route.ts
+++ b/apps/web/app/api/chat/onboarding/route.ts
@@ -3,7 +3,6 @@ import {
   convertToModelMessages,
   createUIMessageStream,
   createUIMessageStreamResponse,
-  type UIMessage,
 } from "ai";
 import { withEmailAccount } from "@/utils/middleware";
 import { getEmailAccountWithAi } from "@/utils/user/get";
@@ -36,7 +35,7 @@ export const POST = withEmailAccount("onboarding-chat", async (request) => {
 
   let modelMessages: Awaited<ReturnType<typeof convertToModelMessages>>;
   try {
-    modelMessages = await convertToModelMessages(data.messages as UIMessage[], {
+    modelMessages = await convertToModelMessages(data.messages, {
       ignoreIncompleteToolCalls: true,
     });
   } catch (error) {

--- a/apps/web/app/api/chat/onboarding/test-utils.ts
+++ b/apps/web/app/api/chat/onboarding/test-utils.ts
@@ -1,0 +1,23 @@
+export function getOnboardingChatInput(parts: unknown[]) {
+  return {
+    messages: [
+      {
+        id: "message-1",
+        role: "user",
+        parts,
+      },
+    ],
+    setup: {
+      rules: [],
+      status: "draft",
+    },
+    scan: {
+      status: "pending",
+      emailsPerDay: null,
+      emailsLastMonth: null,
+      cleanupSuggestions: [],
+      totalCleanupSuggestions: 0,
+    },
+    isPremium: false,
+  };
+}

--- a/apps/web/app/api/chat/onboarding/validation.test.ts
+++ b/apps/web/app/api/chat/onboarding/validation.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { onboardingChatInputSchema } from "@/app/api/chat/onboarding/validation";
+import { getOnboardingChatInput } from "@/app/api/chat/onboarding/test-utils";
 
 describe("onboardingChatInputSchema", () => {
   it("accepts text-only messages", () => {
     const result = onboardingChatInputSchema.safeParse(
-      getInput([{ type: "text", text: "Help me organize my inbox" }]),
+      getOnboardingChatInput([
+        { type: "text", text: "Help me organize my inbox" },
+      ]),
     );
 
     expect(result.success).toBe(true);
@@ -12,7 +15,7 @@ describe("onboardingChatInputSchema", () => {
 
   it("rejects non-text message parts", () => {
     const result = onboardingChatInputSchema.safeParse(
-      getInput([
+      getOnboardingChatInput([
         {
           type: "file",
           url: "https://example.com/image.png",
@@ -24,27 +27,3 @@ describe("onboardingChatInputSchema", () => {
     expect(result.success).toBe(false);
   });
 });
-
-function getInput(parts: unknown[]) {
-  return {
-    messages: [
-      {
-        id: "message-1",
-        role: "user",
-        parts,
-      },
-    ],
-    setup: {
-      rules: [],
-      status: "draft",
-    },
-    scan: {
-      status: "pending",
-      emailsPerDay: null,
-      emailsLastMonth: null,
-      cleanupSuggestions: [],
-      totalCleanupSuggestions: 0,
-    },
-    isPremium: false,
-  };
-}

--- a/apps/web/app/api/chat/onboarding/validation.test.ts
+++ b/apps/web/app/api/chat/onboarding/validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { onboardingChatInputSchema } from "@/app/api/chat/onboarding/validation";
+
+describe("onboardingChatInputSchema", () => {
+  it("accepts text-only messages", () => {
+    const result = onboardingChatInputSchema.safeParse(
+      getInput([{ type: "text", text: "Help me organize my inbox" }]),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-text message parts", () => {
+    const result = onboardingChatInputSchema.safeParse(
+      getInput([
+        {
+          type: "file",
+          url: "https://example.com/image.png",
+          mediaType: "image/png",
+        },
+      ]),
+    );
+
+    expect(result.success).toBe(false);
+  });
+});
+
+function getInput(parts: unknown[]) {
+  return {
+    messages: [
+      {
+        id: "message-1",
+        role: "user",
+        parts,
+      },
+    ],
+    setup: {
+      rules: [],
+      status: "draft",
+    },
+    scan: {
+      status: "pending",
+      emailsPerDay: null,
+      emailsLastMonth: null,
+      cleanupSuggestions: [],
+      totalCleanupSuggestions: 0,
+    },
+    isPremium: false,
+  };
+}

--- a/apps/web/app/api/chat/onboarding/validation.ts
+++ b/apps/web/app/api/chat/onboarding/validation.ts
@@ -48,15 +48,10 @@ export const onboardingScanSchema = z.object({
 });
 export type OnboardingScan = z.infer<typeof onboardingScanSchema>;
 
-const messagePartSchema = z
-  .looseObject({ type: z.string() })
-  .refine(
-    (part) =>
-      part.type !== "text" ||
-      (typeof part.text === "string" &&
-        part.text.length <= ONBOARDING_CHAT_MAX_TEXT_LENGTH),
-    { message: "Message text too long" },
-  );
+const messagePartSchema = z.object({
+  type: z.literal("text"),
+  text: z.string().max(ONBOARDING_CHAT_MAX_TEXT_LENGTH),
+});
 
 export const ONBOARDING_CHAT_MAX_TOTAL_TEXT_LENGTH = 40_000;
 
@@ -79,11 +74,7 @@ export const onboardingChatInputSchema = z.object({
         messages.reduce(
           (total, message) =>
             total +
-            message.parts.reduce(
-              (sum, part) =>
-                sum + (typeof part.text === "string" ? part.text.length : 0),
-              0,
-            ),
+            message.parts.reduce((sum, part) => sum + part.text.length, 0),
           0,
         ) <= ONBOARDING_CHAT_MAX_TOTAL_TEXT_LENGTH,
       { message: "Conversation too long" },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260812-110925_pr-3233_4429d0167f98/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Hardens the unreleased onboarding chat input boundary so client-controlled file URLs cannot reach model message conversion.

- serialize replayed onboarding history to text while retaining tool-driven UI state locally
- accept only text message parts at the API boundary
- remove the broad UIMessage cast and rely on the validated input type
- cover client serialization, schema rejection, and route-level rejection before model conversion