### PR TITLE
rules: Show messaging provider in notification labels

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/AvailableActionsPanel.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/AvailableActionsPanel.tsx
@@ -116,7 +116,7 @@ function getNotifyActionName(
   );
 
   return providerNames.length > 0
-    ? `Notify via ${formatProviderList(providerNames)}`
+    ? `Notify on ${formatProviderList(providerNames)}`
     : "Notify";
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -39,7 +39,7 @@ import { getActionColor } from "@/components/PlanBadge";
 import { toastError } from "@/components/Toast";
 import { useRules } from "@/hooks/useRules";
 import { LogicalOperator } from "@/generated/prisma/enums";
-import type { ActionType } from "@/generated/prisma/client";
+import type { ActionType, MessagingProvider } from "@/generated/prisma/client";
 import { useAction } from "next-safe-action/hooks";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
@@ -151,6 +151,7 @@ export function Rules({
         actions: getDefaultActions(systemType, provider).map((action) => ({
           ...action,
           emailAccountId,
+          messagingChannel: null,
           messagingChannelEmailAccountId: null,
         })),
         group: null,
@@ -441,6 +442,7 @@ export function ActionBadges({
     folderName?: string | null;
     content?: string | null;
     to?: string | null;
+    messagingChannel?: { provider: MessagingProvider } | null;
   }[];
   provider: string;
   labels: Array<{ id: string; name: string }>;

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DraftReplies.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DraftReplies.tsx
@@ -92,6 +92,7 @@ export function useDraftReplies() {
                       folderId: null,
                       messagingChannelId: null,
                       messagingChannelEmailAccountId: null,
+                      messagingChannel: null,
                       staticAttachments: null,
                       integrationName: null,
                       integrationToolName: null,

--- a/apps/web/app/api/user/rules/route.ts
+++ b/apps/web/app/api/user/rules/route.ts
@@ -9,7 +9,13 @@ async function getRules({ emailAccountId }: { emailAccountId: string }) {
   const rules = await prisma.rule.findMany({
     where: { emailAccountId },
     include: {
-      actions: true,
+      actions: {
+        include: {
+          messagingChannel: {
+            select: { provider: true },
+          },
+        },
+      },
       group: { select: { name: true } },
       organizationRule: {
         select: {

--- a/apps/web/components/PlanBadge.tsx
+++ b/apps/web/components/PlanBadge.tsx
@@ -120,7 +120,7 @@ function getActionLabel(
       return "Star";
     case ActionType.NOTIFY_MESSAGING_CHANNEL:
       return action?.messagingChannel?.provider
-        ? `Notify via ${getMessagingProviderName(action.messagingChannel.provider)}`
+        ? `Notify on ${getMessagingProviderName(action.messagingChannel.provider)}`
         : "Notify";
     case ActionType.NOTIFY_SENDER:
       return "Notify Sender";

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -399,8 +399,8 @@ describe("AssistantInlineEmailResponse", () => {
     );
 
     expect(screen.getByText("Label as 'Support'")).toBeTruthy();
-    expect(screen.getByText("Notify via Slack")).toBeTruthy();
-    expect(screen.queryByText("Notify via chat app")).toBeNull();
+    expect(screen.getByText("Notify on Slack")).toBeTruthy();
+    expect(screen.queryByText("Notify on chat app")).toBeNull();
   });
 
   it("renders structured draft and mark-read actions in rule suggestions", () => {

--- a/apps/web/utils/action-display.test.ts
+++ b/apps/web/utils/action-display.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { ActionType, MessagingProvider } from "@/generated/prisma/enums";
+import { getActionDisplay } from "@/utils/action-display";
+
+describe("getActionDisplay", () => {
+  it.each([
+    [MessagingProvider.SLACK, "Notify on Slack"],
+    [MessagingProvider.TEAMS, "Notify on Teams"],
+    [MessagingProvider.TELEGRAM, "Notify on Telegram"],
+  ])("shows the notification provider for %s", (provider, expected) => {
+    expect(
+      getActionDisplay(
+        {
+          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+          messagingChannel: { provider },
+        },
+        "gmail",
+        [],
+      ),
+    ).toBe(expected);
+  });
+
+  it("keeps a generic fallback when the messaging channel is missing", () => {
+    expect(
+      getActionDisplay(
+        { type: ActionType.NOTIFY_MESSAGING_CHANNEL },
+        "gmail",
+        [],
+      ),
+    ).toBe("Notify");
+  });
+});

--- a/apps/web/utils/action-display.tsx
+++ b/apps/web/utils/action-display.tsx
@@ -1,4 +1,4 @@
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, type MessagingProvider } from "@/generated/prisma/enums";
 import { getEmailTerminology } from "@/utils/terminology";
 import { sortActionsByPriority } from "@/utils/action-sort";
 import {
@@ -23,6 +23,7 @@ import {
   getIntegrationActionDisplayValue,
   getIntegrationActionLabel,
 } from "@/utils/mcp/tool-specs";
+import { getMessagingProviderName } from "@/utils/messaging/platforms";
 
 /**
  * Hide messaging-channel draft entries when an email draft already exists,
@@ -51,6 +52,7 @@ export function getActionDisplay(
     content?: string | null;
     to?: string | null;
     notificationDestination?: string | null;
+    messagingChannel?: { provider: MessagingProvider } | null;
     integrationName?: string | null;
     integrationToolName?: string | null;
     integrationArgs?: unknown;
@@ -113,8 +115,11 @@ export function getActionDisplay(
     case ActionType.CALL_WEBHOOK:
       return "Call Webhook";
     case ActionType.NOTIFY_MESSAGING_CHANNEL:
+      if (action.messagingChannel?.provider) {
+        return `Notify on ${getMessagingProviderName(action.messagingChannel.provider)}`;
+      }
       return action.notificationDestination
-        ? `Notify via ${truncate(action.notificationDestination, 18)}`
+        ? `Notify on ${truncate(action.notificationDestination, 18)}`
         : "Notify";
     case ActionType.NOTIFY_SENDER:
       return "Notify Sender";


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-111739_pr-3234_306f437c1f4b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improve notification action labels by including their messaging provider.

- load the provider associated with rule notification actions
- use consistent provider-aware wording with a safe fallback
- add focused regression coverage for supported messaging providers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->