### PR TITLE
marketing: Reduce GPU usage on animated pages

### DIFF
--- a/apps/web/components/layouts/BlogLayout.tsx
+++ b/apps/web/components/layouts/BlogLayout.tsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/new-landing/sections/Footer";
 export function BlogHeader() {
   return (
     <div className="sticky inset-x-0 top-0 z-30 w-full transition-all">
-      <div className="bg-white/75 shadow backdrop-blur-md">
+      <div className="bg-white shadow">
         <Header className="mx-auto w-full max-w-screen-xl px-6 lg:px-8" />
       </div>
     </div>

--- a/apps/web/components/new-landing/UnicornScene.tsx
+++ b/apps/web/components/new-landing/UnicornScene.tsx
@@ -101,10 +101,7 @@ function loadUnicornStudio() {
   if (!unicornStudioLoadPromise) {
     unicornStudioLoadPromise = new Promise<UnicornStudioApi>(
       (resolve, reject) => {
-        const existingScript = document.querySelector<HTMLScriptElement>(
-          `script[src="${UNICORN_STUDIO_SRC}"]`,
-        );
-        const script = existingScript ?? document.createElement("script");
+        const script = document.createElement("script");
 
         const onLoad = () => {
           if (window.UnicornStudio?.addScene) {
@@ -123,10 +120,8 @@ function loadUnicornStudio() {
         script.addEventListener("load", onLoad, { once: true });
         script.addEventListener("error", onError, { once: true });
 
-        if (!existingScript) {
-          script.src = UNICORN_STUDIO_SRC;
-          (document.head || document.body).appendChild(script);
-        }
+        script.src = UNICORN_STUDIO_SRC;
+        (document.head || document.body).appendChild(script);
       },
     ).catch((error: unknown) => {
       unicornStudioLoadPromise = undefined;

--- a/apps/web/components/new-landing/UnicornScene.tsx
+++ b/apps/web/components/new-landing/UnicornScene.tsx
@@ -1,63 +1,138 @@
 "use client";
 
 import { cn } from "@/utils";
-import { useEffect } from "react";
+import { useEffect, useId, useRef } from "react";
 import { scheduleAfterPageLoad } from "@/utils/schedule-after-page-load";
 
-type UnicornStudioInitFlag = {
-  isInitialized: boolean;
+const UNICORN_STUDIO_SRC =
+  "https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v1.4.34/dist/unicornStudio.umd.js";
+const UNICORN_STUDIO_PROJECT_ID = "7EOg9x6JDnLX6WDUJiAj";
+
+type UnicornStudioScene = {
+  destroy: () => void;
+};
+
+type UnicornStudioApi = {
+  addScene: (options: {
+    dpi: number;
+    elementId: string;
+    fps: number;
+    lazyLoad: boolean;
+    projectId: string;
+    scale: number;
+  }) => Promise<UnicornStudioScene>;
 };
 
 declare global {
   interface Window {
-    UnicornStudio?: UnicornStudioInitFlag;
+    UnicornStudio?: UnicornStudioApi;
   }
-  // eslint-disable-next-line no-var
-  var UnicornStudio:
-    | {
-        init: () => void;
-      }
-    | undefined;
 }
+
+let unicornStudioLoadPromise: Promise<UnicornStudioApi> | undefined;
 
 interface UnicornSceneProps {
   className?: string;
 }
 
 export function UnicornScene({ className }: UnicornSceneProps) {
-  useEffect(() => {
-    const loadUnicornStudio = () => {
-      if (window.UnicornStudio) return;
+  const elementRef = useRef<HTMLDivElement>(null);
+  const sceneId = `unicorn-scene-${useId()}`;
 
-      // @ts-expect-error - window.UnicornStudio is a flag object, not the global UnicornStudio
-      window.UnicornStudio = {
-        isInitialized: false,
-      };
-      const script = document.createElement("script");
-      script.src =
-        "https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v1.4.34/dist/unicornStudio.umd.js";
-      script.onload = () => {
-        if (!window.UnicornStudio?.isInitialized && UnicornStudio) {
-          UnicornStudio.init();
-          // @ts-expect-error - window.UnicornStudio is a flag object, not the global UnicornStudio
-          window.UnicornStudio = {
-            isInitialized: true,
-          };
-        }
-      };
-      (document.head || document.body).appendChild(script);
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    let disposed = false;
+    let scene: UnicornStudioScene | undefined;
+
+    const initializeScene = async () => {
+      const studio = await loadUnicornStudio();
+      if (disposed || !element.isConnected) return;
+
+      const initializedScene = await studio.addScene({
+        dpi: 1,
+        elementId: sceneId,
+        fps: 30,
+        lazyLoad: true,
+        projectId: UNICORN_STUDIO_PROJECT_ID,
+        scale: 1,
+      });
+
+      if (disposed || !element.isConnected) {
+        initializedScene.destroy();
+      } else {
+        scene = initializedScene;
+      }
     };
 
-    return scheduleAfterPageLoad(loadUnicornStudio, {
-      fallbackDelay: 1000,
-      idleTimeout: 4000,
-    });
-  }, []);
+    const cancelInitialization = scheduleAfterPageLoad(
+      () => {
+        initializeScene().catch(() => undefined);
+      },
+      {
+        fallbackDelay: 1000,
+        idleTimeout: 4000,
+      },
+    );
+
+    return () => {
+      disposed = true;
+      cancelInitialization();
+      scene?.destroy();
+    };
+  }, [sceneId]);
 
   return (
     <div
-      data-us-project="7EOg9x6JDnLX6WDUJiAj"
+      ref={elementRef}
+      id={sceneId}
+      aria-hidden="true"
       className={cn("w-full h-full absolute top-0 left-0 -z-10", className)}
     />
   );
+}
+
+function loadUnicornStudio() {
+  if (window.UnicornStudio?.addScene) {
+    return Promise.resolve(window.UnicornStudio);
+  }
+
+  if (!unicornStudioLoadPromise) {
+    unicornStudioLoadPromise = new Promise<UnicornStudioApi>(
+      (resolve, reject) => {
+        const existingScript = document.querySelector<HTMLScriptElement>(
+          `script[src="${UNICORN_STUDIO_SRC}"]`,
+        );
+        const script = existingScript ?? document.createElement("script");
+
+        const onLoad = () => {
+          if (window.UnicornStudio?.addScene) {
+            resolve(window.UnicornStudio);
+          } else {
+            script.remove();
+            reject(new Error("Unicorn Studio failed to initialize"));
+          }
+        };
+
+        const onError = () => {
+          script.remove();
+          reject(new Error("Unicorn Studio failed to load"));
+        };
+
+        script.addEventListener("load", onLoad, { once: true });
+        script.addEventListener("error", onError, { once: true });
+
+        if (!existingScript) {
+          script.src = UNICORN_STUDIO_SRC;
+          (document.head || document.body).appendChild(script);
+        }
+      },
+    ).catch((error: unknown) => {
+      unicornStudioLoadPromise = undefined;
+      throw error;
+    });
+  }
+
+  return unicornStudioLoadPromise;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-113518_pr-3236_aede0e7506b2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Reduce GPU load on marketing pages and stop decorative WebGL work from surviving client-side navigation.

- create and destroy each Unicorn Studio scene with its component lifecycle
- lazy-load scenes and cap rendering at 30 FPS and 1x DPI
- replace the sticky blog and case-study header backdrop blur with a solid background

Validation:
- `pnpm exec ultracite check apps/web/components/new-landing/UnicornScene.tsx apps/web/components/layouts/BlogLayout.tsx`
- `git diff --check`
- `pnpm lint` remains blocked by two unrelated pre-existing formatting errors in the marketing blog submodule

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->