### PR TITLE
security: Encode Gmail batch message IDs

### DIFF
--- a/apps/web/utils/gmail/batch.test.ts
+++ b/apps/web/utils/gmail/batch.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getBatch } from "./batch";
+
+vi.mock("@/utils/google/oauth", () => ({
+  getGoogleGmailBatchUrl: () => "https://example.com/batch/gmail/v1",
+}));
+
+describe("getBatch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("prevents message IDs from injecting multipart subrequests", async () => {
+    const validId = "18f4c6b280d6f124";
+    const injectedId =
+      "message-id\r\n\r\n--batch_boundary\r\nContent-Type: application/http\r\n\r\nGET /gmail/v1/users/me/messages/injected";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        '--response_boundary\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"id":"18f4c6b280d6f124"}\r\n--response_boundary--',
+        {
+          headers: {
+            "Content-Type": "multipart/mixed; boundary=response_boundary",
+          },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getBatch(
+      [validId, injectedId],
+      "/gmail/v1/users/me/messages",
+      "access-token",
+    );
+
+    const requestBody = fetchMock.mock.calls[0]?.[1]?.body as string;
+
+    expect(requestBody).toContain(
+      `GET /gmail/v1/users/me/messages/${validId}\n\n`,
+    );
+    expect(requestBody.match(/^GET /gm)).toHaveLength(2);
+    expect(requestBody).not.toContain(
+      "\r\nGET /gmail/v1/users/me/messages/injected",
+    );
+  });
+});

--- a/apps/web/utils/gmail/batch.test.ts
+++ b/apps/web/utils/gmail/batch.test.ts
@@ -37,6 +37,9 @@ describe("getBatch", () => {
     expect(requestBody).toContain(
       `GET /gmail/v1/users/me/messages/${validId}\n\n`,
     );
+    expect(requestBody).toContain(
+      `GET /gmail/v1/users/me/messages/${encodeURIComponent(injectedId)}\n\n`,
+    );
     expect(requestBody.match(/^GET /gm)).toHaveLength(2);
     expect(requestBody).not.toContain(
       "\r\nGET /gmail/v1/users/me/messages/injected",

--- a/apps/web/utils/gmail/batch.ts
+++ b/apps/web/utils/gmail/batch.ts
@@ -24,7 +24,7 @@ export async function getBatch(
   let batchRequestBody = "";
   const query = queryString ? `?${queryString}` : "";
   for (const id of ids) {
-    batchRequestBody += `--batch_boundary\nContent-Type: application/http\n\nGET ${endpoint}/${id}${query}\n\n`;
+    batchRequestBody += `--batch_boundary\nContent-Type: application/http\n\nGET ${endpoint}/${encodeURIComponent(id)}${query}\n\n`;
   }
   batchRequestBody += "--batch_boundary--";
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-120328_pr-3237_93b346c17925/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents user-controlled Gmail message IDs from injecting additional multipart batch subrequests.

- encode each opaque message ID before interpolating it into a Gmail request path
- add a regression test covering CRLF and multipart-boundary injection
- preserve existing behavior for normal Gmail message IDs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->