### PR TITLE
Feedback: isolate layout environment access

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -22,7 +22,6 @@ import { AnnouncementDialog } from "@/components/feature-announcements/Announcem
 import { captureException } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { createScopedLogger } from "@/utils/logger";
-import { env } from "@/env";
 
 const logger = createScopedLogger("AppLayout");
 
@@ -64,6 +63,9 @@ export default async function AppLayout({
 
   const cookieStore = await cookies();
   const isClosed = cookieStore.get("left-sidebar:state")?.value === "false";
+  const bypassPremiumChecks =
+    Boolean(process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) &&
+    process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS?.toLowerCase() !== "false";
 
   after(async () => {
     const email = session.user.email;
@@ -85,8 +87,7 @@ export default async function AppLayout({
           <SideNavWithTopNav
             defaultOpen={!isClosed}
             feedbackEnabled={
-              !env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS ||
-              Boolean(env.FEEDBACK_WEBHOOK_URL)
+              !bypassPremiumChecks || Boolean(process.env.FEEDBACK_WEBHOOK_URL)
             }
           >
             <AiAutomationStatusBanner />

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -22,6 +22,7 @@ import { AnnouncementDialog } from "@/components/feature-announcements/Announcem
 import { captureException } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { createScopedLogger } from "@/utils/logger";
+import { booleanString } from "@/utils/zod";
 
 const logger = createScopedLogger("AppLayout");
 
@@ -64,8 +65,7 @@ export default async function AppLayout({
   const cookieStore = await cookies();
   const isClosed = cookieStore.get("left-sidebar:state")?.value === "false";
   const bypassPremiumChecks =
-    Boolean(process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) &&
-    process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS?.toLowerCase() !== "false";
+    booleanString.parse(process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) ?? false;
 
   after(async () => {
     const email = session.user.email;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-114202_pr-3238_cad64d7100b3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Avoids importing the shared server environment module from the global app layout while preserving feedback visibility behavior.

- Derives feedback enablement from server-side process environment values.
- Keeps the webhook URL server-only and passes only a boolean to client components.
- Validated with focused feedback tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->