### PR TITLE
security: Reject SVG image proxy responses

### DIFF
--- a/packages/image-proxy/src/proxy-service.test.ts
+++ b/packages/image-proxy/src/proxy-service.test.ts
@@ -156,6 +156,42 @@ describe("handleImageProxyRequest", () => {
     expect(upstreamFetch).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "GET",
+    "HEAD",
+  ] as const)("rejects cached SVG responses for %s requests", async (method) => {
+    const cachedResponse = new Response(
+      method === "GET" ? "cached-svg" : null,
+      {
+        status: 200,
+        headers: { "content-type": "image/svg+xml; charset=utf-8" },
+      },
+    );
+    const cache = {
+      match: vi.fn().mockResolvedValue(cachedResponse),
+      put: vi.fn(),
+    };
+    const upstreamFetch = vi.fn();
+
+    const response = await handleImageProxyRequest(
+      new Request(
+        "https://proxy.example.com/proxy?u=https%3A%2F%2Fcdn.example.com%2Fphoto.png",
+        { method },
+      ),
+      {},
+      {
+        cache,
+        fetchImpl: upstreamFetch as typeof fetch,
+      },
+    );
+
+    expect(response.status).toBe(415);
+    await expect(response.text()).resolves.toBe("Unsupported content type");
+    expect(cache.match).toHaveBeenCalledTimes(1);
+    expect(cache.put).not.toHaveBeenCalled();
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
   it("requires a valid signature when a signing secret is configured", async () => {
     const proxyUrl = await buildSignedAssetProxyUrl({
       assetUrl: "https://cdn.example.com/photo.png",
@@ -317,6 +353,60 @@ describe("handleImageProxyRequest", () => {
 
     expect(response.status).toBe(415);
     await expect(response.text()).resolves.toBe("Unsupported content type");
+  });
+
+  it.each([
+    "GET",
+    "HEAD",
+  ] as const)("rejects fresh parameterized SVG content for %s requests without caching it", async (method) => {
+    const cache = {
+      match: vi.fn().mockResolvedValue(undefined),
+      put: vi.fn(),
+    };
+    const upstreamFetch = vi.fn().mockResolvedValue(
+      new Response(method === "GET" ? "<svg></svg>" : null, {
+        status: 200,
+        headers: { "content-type": "Image/SvG+XmL; charset=UTF-8" },
+      }),
+    );
+
+    const response = await handleImageProxyRequest(
+      new Request(
+        "https://proxy.example.com/proxy?u=https%3A%2F%2Fcdn.example.com%2Fphoto.png",
+        { method },
+      ),
+      {},
+      {
+        cache,
+        fetchImpl: upstreamFetch as typeof fetch,
+      },
+    );
+
+    expect(response.status).toBe(415);
+    await expect(response.text()).resolves.toBe("Unsupported content type");
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it("continues to proxy passive font content", async () => {
+    const response = await handleImageProxyRequest(
+      new Request(
+        "https://proxy.example.com/proxy?u=https%3A%2F%2Fcdn.example.com%2Ffont.woff2",
+      ),
+      {},
+      {
+        fetchImpl: vi.fn().mockResolvedValue(
+          new Response("font-bytes", {
+            status: 200,
+            headers: { "content-type": "font/woff2" },
+          }),
+        ) as typeof fetch,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("font/woff2");
+    await expect(response.text()).resolves.toBe("font-bytes");
   });
 
   it("blocks redirects to local targets", async () => {

--- a/packages/image-proxy/src/proxy-service.ts
+++ b/packages/image-proxy/src/proxy-service.ts
@@ -118,7 +118,16 @@ export async function handleImageProxyRequest(
   const cacheKey = new Request(request.url, { method: "GET" });
   if (cache) {
     const cachedResponse = await cache.match(cacheKey);
-    if (cachedResponse) return cachedResponse;
+    if (cachedResponse) {
+      const cachedContentType =
+        cachedResponse.headers.get("content-type") || "";
+      if (isSvgContentType(cachedContentType)) {
+        cachedResponse.body?.cancel();
+        return new Response("Unsupported content type", { status: 415 });
+      }
+
+      return cachedResponse;
+    }
   }
 
   const fetchImpl = options?.fetchImpl || fetch;
@@ -137,7 +146,7 @@ export async function handleImageProxyRequest(
   }
 
   const contentType = upstreamResponse.headers.get("content-type") || "";
-  if (!isCacheableContentType(contentType)) {
+  if (isSvgContentType(contentType) || !isCacheableContentType(contentType)) {
     upstreamResponse.body?.cancel();
     return new Response("Unsupported content type", { status: 415 });
   }
@@ -312,6 +321,10 @@ function isCacheableContentType(contentType: string) {
   return CACHEABLE_CONTENT_TYPES.some((prefix) =>
     normalized.startsWith(prefix),
   );
+}
+
+function isSvgContentType(contentType: string) {
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() === "image/svg+xml";
 }
 
 function isRedirectResponse(status: number) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-120512_pr-3239_14c6e87b6de2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents the signed same-origin image proxy from serving active SVG documents.

- reject normalized image/svg+xml responses from upstream fetches and existing cache entries
- enforce the same boundary for GET and HEAD requests
- cover parameterized mixed-case SVG MIME types while retaining passive font support

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->