### PR TITLE
Meetings: scope bot image file tracing

### DIFF
--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -307,23 +307,36 @@ function getMeetingBotCameraImage(): Promise<string> {
 }
 
 async function readMeetingBotCameraImage(): Promise<string> {
-  const relativePath = join(
-    "public",
-    "images",
-    "meetings",
-    "inbox-zero-notetaker.jpg",
-  );
-  const candidatePaths = [
-    join(process.cwd(), relativePath),
-    join(process.cwd(), "apps", "web", relativePath),
-  ];
+  try {
+    return await readFile(
+      join(
+        process.cwd(),
+        "public",
+        "images",
+        "meetings",
+        "inbox-zero-notetaker.jpg",
+      ),
+      "base64",
+    );
+  } catch (error) {
+    if (!isMissingFile(error)) throw error;
+  }
 
-  for (const path of candidatePaths) {
-    try {
-      return await readFile(path, "base64");
-    } catch (error) {
-      if (!isMissingFile(error)) throw error;
-    }
+  try {
+    return await readFile(
+      join(
+        process.cwd(),
+        "apps",
+        "web",
+        "public",
+        "images",
+        "meetings",
+        "inbox-zero-notetaker.jpg",
+      ),
+      "base64",
+    );
+  } catch (error) {
+    if (!isMissingFile(error)) throw error;
   }
 
   throw new Error("Recall meeting bot camera image is missing");


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-132104_pr-3241_5031ed5e459e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Scopes meeting bot camera asset reads so production bundling does not trace unrelated project files.

- Preserves app-root and monorepo-root asset lookup.
- Keeps graceful scheduling fallback when the image is unavailable.
- Validated with focused Recall provider tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->