### PR TITLE
security: Restrict shared Stripe billing to plan admins

### DIFF
--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -102,6 +102,7 @@ describe("getBillingPortalUrlAction", () => {
   it("rejects a non-admin shared plan member", async () => {
     prisma.user.findUnique.mockResolvedValue({
       premium: {
+        id: "premium-1",
         stripeCustomerId: "cus_test",
         stripeSubscriptionId: "sub_test",
         stripeSubscriptionItemId: "si_test",
@@ -111,10 +112,53 @@ describe("getBillingPortalUrlAction", () => {
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
 
-    const result = await getBillingPortalUrlAction({});
+    const result = await getBillingPortalUrlAction({ tier: "BASIC_MONTHLY" });
 
     expect(result?.serverError).toBe("Not admin");
     expect(mocks.retrieveSubscription).not.toHaveBeenCalled();
+    expect(mocks.createBillingPortalSession).not.toHaveBeenCalled();
+  });
+
+  it("allows the original owner of a legacy premium record", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "user-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionItemId: "si_test",
+        stripeSubscriptionStatus: "active",
+        users: [{ _count: { emailAccounts: 1 } }],
+        admins: [],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+    mocks.createBillingPortalSession.mockResolvedValue({
+      url: "https://billing.stripe.test",
+    });
+
+    const result = await getBillingPortalUrlAction({});
+
+    expect(result?.data).toEqual({ url: "https://billing.stripe.test" });
+  });
+
+  it("rejects a member of a legacy shared plan without recorded admins", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "original-owner",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionItemId: "si_test",
+        stripeSubscriptionStatus: "active",
+        users: [
+          { _count: { emailAccounts: 1 } },
+          { _count: { emailAccounts: 1 } },
+        ],
+        admins: [],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await getBillingPortalUrlAction({});
+
+    expect(result?.serverError).toBe("Not admin");
     expect(mocks.createBillingPortalSession).not.toHaveBeenCalled();
   });
 });
@@ -127,6 +171,7 @@ describe("endStripeTrialAction", () => {
   it("rejects a non-admin shared plan member", async () => {
     prisma.user.findUnique.mockResolvedValue({
       premium: {
+        id: "premium-1",
         stripeSubscriptionId: "sub_test",
         stripeSubscriptionStatus: "trialing",
         admins: [{ id: "another-user" }],

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
+  endStripeTrialAction,
   generateCheckoutSessionAction,
+  getBillingPortalUrlAction,
   updateStripeInvoiceEmailsAction,
 } from "./premium";
 
 const mocks = vi.hoisted(() => ({
+  createBillingPortalSession: vi.fn(),
   createCheckoutSession: vi.fn(),
+  retrieveSubscription: vi.fn(),
+  updateSubscription: vi.fn(),
 }));
 
 vi.mock("@/utils/prisma");
@@ -17,7 +22,12 @@ vi.mock("@/utils/auth", () => ({
 }));
 vi.mock("@/ee/billing/stripe", () => ({
   getStripe: () => ({
+    billingPortal: { sessions: { create: mocks.createBillingPortalSession } },
     checkout: { sessions: { create: mocks.createCheckoutSession } },
+    subscriptions: {
+      retrieve: mocks.retrieveSubscription,
+      update: mocks.updateSubscription,
+    },
   }),
 }));
 vi.mock("next/headers", () => ({
@@ -84,9 +94,79 @@ describe("updateStripeInvoiceEmailsAction", () => {
   });
 });
 
+describe("getBillingPortalUrlAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a non-admin shared plan member", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionItemId: "si_test",
+        stripeSubscriptionStatus: "active",
+        users: [{ _count: { emailAccounts: 1 } }],
+        admins: [{ id: "another-user" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await getBillingPortalUrlAction({});
+
+    expect(result?.serverError).toBe("Not admin");
+    expect(mocks.retrieveSubscription).not.toHaveBeenCalled();
+    expect(mocks.createBillingPortalSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("endStripeTrialAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a non-admin shared plan member", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionStatus: "trialing",
+        admins: [{ id: "another-user" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await endStripeTrialAction();
+
+    expect(result?.serverError).toBe("Not admin");
+    expect(mocks.updateSubscription).not.toHaveBeenCalled();
+  });
+});
+
 describe("generateCheckoutSessionAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("rejects a non-admin shared plan member", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      utms: null,
+      _count: { emailAccounts: 1 },
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: null,
+        stripeSubscriptionStatus: null,
+        stripeEndedAt: null,
+        users: [{ _count: { emailAccounts: 1 } }],
+        admins: [{ id: "another-user" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await generateCheckoutSessionAction({
+      tier: "BASIC_MONTHLY",
+    });
+
+    expect(result?.serverError).toBe("Not admin");
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -107,6 +187,7 @@ describe("generateCheckoutSessionAction", () => {
         stripeSubscriptionStatus: status,
         stripeEndedAt: endedAt,
         users: [{ _count: { emailAccounts: 2 } }],
+        admins: [{ id: "user-1" }],
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
 
@@ -132,6 +213,7 @@ describe("generateCheckoutSessionAction", () => {
         stripeSubscriptionStatus: null,
         stripeEndedAt: null,
         users: [{ _count: { emailAccounts: 2 } }],
+        admins: [{ id: "user-1" }],
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createCheckoutSession.mockResolvedValue({
@@ -172,6 +254,7 @@ describe("generateCheckoutSessionAction", () => {
             stripeSubscriptionStatus: null,
             stripeEndedAt: null,
             users: [{ _count: { emailAccounts } }],
+            admins: [{ id: "user-1" }],
           },
         }) as Awaited<ReturnType<typeof prisma.user.findUnique>>,
     );
@@ -201,6 +284,7 @@ describe("generateCheckoutSessionAction", () => {
         stripeSubscriptionStatus: "canceled",
         stripeEndedAt: new Date(),
         users: [{ _count: { emailAccounts: 2 } }],
+        admins: [{ id: "user-1" }],
       },
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createCheckoutSession.mockResolvedValue({

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -405,13 +405,12 @@ export const getBillingPortalUrlAction = actionClientUser
   .action(async ({ ctx: { userId, logger }, parsedInput: { tier } }) => {
     const priceId = tier ? getStripePriceId({ tier }) : undefined;
 
-    const stripe = getStripe();
-
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
         premium: {
           select: {
+            admins: { select: { id: true } },
             stripeCustomerId: true,
             stripeSubscriptionId: true,
             stripeSubscriptionItemId: true,
@@ -424,10 +423,19 @@ export const getBillingPortalUrlAction = actionClientUser
       },
     });
 
-    if (!user?.premium?.stripeCustomerId) {
+    if (!user?.premium) {
       logger.error("Stripe customer id not found");
       throw new SafeError("Stripe customer id not found");
     }
+    if (!isAdminForPremium(user.premium.admins, userId)) {
+      throw new SafeError("Not admin");
+    }
+    if (!user.premium.stripeCustomerId) {
+      logger.error("Stripe customer id not found");
+      throw new SafeError("Stripe customer id not found");
+    }
+
+    const stripe = getStripe();
 
     const subscription =
       priceId &&
@@ -489,6 +497,7 @@ export const endStripeTrialAction = actionClientUser
       select: {
         premium: {
           select: {
+            admins: { select: { id: true } },
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
           },
@@ -497,7 +506,13 @@ export const endStripeTrialAction = actionClientUser
     });
 
     const premium = user?.premium;
-    if (!premium?.stripeSubscriptionId) {
+    if (!premium) {
+      throw new SafeError("Stripe subscription not found");
+    }
+    if (!isAdminForPremium(premium.admins, userId)) {
+      throw new SafeError("Not admin");
+    }
+    if (!premium.stripeSubscriptionId) {
       throw new SafeError("Stripe subscription not found");
     }
 
@@ -541,6 +556,7 @@ export const generateCheckoutSessionAction = actionClientUser
         _count: { select: { emailAccounts: true } },
         premium: {
           select: {
+            admins: { select: { id: true } },
             id: true,
             stripeCustomerId: true,
             stripeSubscriptionId: true,
@@ -556,6 +572,9 @@ export const generateCheckoutSessionAction = actionClientUser
     if (!user) {
       logger.error("User not found");
       throw new SafeError("User not found");
+    }
+    if (user.premium && !isAdminForPremium(user.premium.admins, userId)) {
+      throw new SafeError("Not admin");
     }
 
     if (

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -411,6 +411,7 @@ export const getBillingPortalUrlAction = actionClientUser
         premium: {
           select: {
             admins: { select: { id: true } },
+            id: true,
             stripeCustomerId: true,
             stripeSubscriptionId: true,
             stripeSubscriptionItemId: true,
@@ -423,11 +424,13 @@ export const getBillingPortalUrlAction = actionClientUser
       },
     });
 
-    if (!user?.premium) {
-      logger.error("Stripe customer id not found");
-      throw new SafeError("Stripe customer id not found");
+    if (!user) {
+      throw new SafeError("User not found");
     }
-    if (!isAdminForPremium(user.premium.admins, userId)) {
+    if (!user.premium) {
+      throw new SafeError("Premium subscription not found");
+    }
+    if (!isPremiumBillingAdmin(user.premium, userId)) {
       throw new SafeError("Not admin");
     }
     if (!user.premium.stripeCustomerId) {
@@ -498,6 +501,7 @@ export const endStripeTrialAction = actionClientUser
         premium: {
           select: {
             admins: { select: { id: true } },
+            id: true,
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
           },
@@ -509,7 +513,7 @@ export const endStripeTrialAction = actionClientUser
     if (!premium) {
       throw new SafeError("Stripe subscription not found");
     }
-    if (!isAdminForPremium(premium.admins, userId)) {
+    if (!isPremiumBillingAdmin(premium, userId)) {
       throw new SafeError("Not admin");
     }
     if (!premium.stripeSubscriptionId) {
@@ -573,7 +577,7 @@ export const generateCheckoutSessionAction = actionClientUser
       logger.error("User not found");
       throw new SafeError("User not found");
     }
-    if (user.premium && !isAdminForPremium(user.premium.admins, userId)) {
+    if (user.premium && !isPremiumBillingAdmin(user.premium, userId)) {
       throw new SafeError("Not admin");
     }
 
@@ -685,4 +689,16 @@ function getCheckoutPriceId({
   }
 
   return getStripePriceId({ tier });
+}
+
+function isPremiumBillingAdmin(
+  premium: { id: string; admins: { id: string }[] },
+  userId: string,
+) {
+  if (premium.admins.length) {
+    return isAdminForPremium(premium.admins, userId);
+  }
+
+  // The initial premium migration used the owner's user ID as the premium ID.
+  return premium.id === userId;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-174340_pr-3242_5f813fc1517b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Limits shared-plan Stripe management to the plan admins recorded on the premium account.

- authorize billing portal and plan-change sessions before contacting Stripe
- authorize trial ending and checkout creation for shared premium records
- add regression coverage proving non-admin members cannot reach Stripe operations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->