### PR TITLE
security: Publish API package only from main

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: api-publish
+  cancel-in-progress: false
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -2,11 +2,13 @@ name: API Publish
 
 on:
   push:
-    tags: ["api-v*"]
-  workflow_dispatch:
+    branches: [main]
+    paths:
+      - "packages/api/**"
+      - ".github/workflows/api-release.yml"
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -27,13 +29,6 @@ jobs:
 
       - name: Upgrade npm
         run: npm install -g npm@latest
-
-      - name: Set version from tag
-        if: github.ref_type == 'tag'
-        run: |
-          VERSION="${GITHUB_REF_NAME#api-v}"
-          cd packages/api
-          npm version "$VERSION" --no-git-tag-version
 
       - name: Install dependencies
         run: cd packages/api && bun install


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-174514_pr-3243_b6ddb2be5995/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restricts API npm publishing to merged changes on protected `main`, so tags or manual runs from unreviewed refs cannot access publish credentials.

- publish when `packages/api` changes on `main`
- remove tag-derived version mutation and manual dispatch
- reduce the workflow contents permission to read
- validate the workflow with Actionlint 1.7.12 and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->