### PR TITLE
security: Keep request secrets out of logs

### DIFF
--- a/apps/web/app/api/slack/callback/route.test.ts
+++ b/apps/web/app/api/slack/callback/route.test.ts
@@ -193,6 +193,9 @@ describe("slack callback route", () => {
   it("rejects a signed callback state that does not match the browser state cookie", async () => {
     const attackerState = createSignedState("attacker-account");
     const victimState = createSignedState("victim-account");
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
 
     const response = await GET(
       createRequest(
@@ -210,6 +213,11 @@ describe("slack callback route", () => {
     expect(mockAcquireOAuthCodeLock).not.toHaveBeenCalled();
     expect(prisma.messagingChannel.upsert).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
+    const warning = consoleWarnSpy.mock.calls.flat().join(" ");
+    expect(warning).toContain('"hasReceivedState": true');
+    expect(warning).not.toContain(attackerState);
+    expect(warning).not.toContain(victimState);
+    consoleWarnSpy.mockRestore();
   });
 
   it("redirects Slack OAuth failures back to the account channels page", async () => {

--- a/apps/web/app/api/slack/callback/route.test.ts
+++ b/apps/web/app/api/slack/callback/route.test.ts
@@ -196,28 +196,32 @@ describe("slack callback route", () => {
     const consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => {});
+    try {
+      const response = await GET(
+        createRequest(
+          `http://localhost:3000/api/slack/callback?code=valid-auth-code&state=${encodeURIComponent(attackerState)}`,
+          victimState,
+        ),
+      );
 
-    const response = await GET(
-      createRequest(
-        `http://localhost:3000/api/slack/callback?code=valid-auth-code&state=${encodeURIComponent(attackerState)}`,
-        victimState,
-      ),
-    );
+      const location = new URL(response.headers.get("location")!);
 
-    const location = new URL(response.headers.get("location")!);
-
-    expect(location.pathname).toBe("/channels");
-    expect(location.searchParams.get("error")).toBe("connection_failed");
-    expect(location.searchParams.get("error_reason")).toBe("invalid_state");
-    expect(mockGetOAuthCodeResult).not.toHaveBeenCalled();
-    expect(mockAcquireOAuthCodeLock).not.toHaveBeenCalled();
-    expect(prisma.messagingChannel.upsert).not.toHaveBeenCalled();
-    expect(global.fetch).not.toHaveBeenCalled();
-    const warning = consoleWarnSpy.mock.calls.flat().join(" ");
-    expect(warning).toContain('"hasReceivedState": true');
-    expect(warning).not.toContain(attackerState);
-    expect(warning).not.toContain(victimState);
-    consoleWarnSpy.mockRestore();
+      expect(location.pathname).toBe("/channels");
+      expect(location.searchParams.get("error")).toBe("connection_failed");
+      expect(location.searchParams.get("error_reason")).toBe("invalid_state");
+      expect(mockGetOAuthCodeResult).not.toHaveBeenCalled();
+      expect(mockAcquireOAuthCodeLock).not.toHaveBeenCalled();
+      expect(prisma.messagingChannel.upsert).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+      const warning = consoleWarnSpy.mock.calls.flat().join(" ");
+      expect(warning).toMatch(
+        /"receivedStateFingerprint": "sha256:[a-f0-9]{12}"/,
+      );
+      expect(warning).not.toContain(attackerState);
+      expect(warning).not.toContain(victimState);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("redirects Slack OAuth failures back to the account channels page", async () => {

--- a/apps/web/utils/logger.test.ts
+++ b/apps/web/utils/logger.test.ts
@@ -331,6 +331,17 @@ describe("Logger", () => {
     expect(loggedMessage).toContain("/api/endpoint");
   });
 
+  it("always redacts received OAuth state values", () => {
+    const logger = createScopedLogger("test");
+    const receivedState = "signed-oauth-state-secret";
+
+    logger.error("Invalid OAuth state", { receivedState });
+
+    const loggedMessage = consoleErrorSpy.mock.calls[0][0];
+    expect(loggedMessage).toContain('"receivedState": true');
+    expect(loggedMessage).not.toContain(receivedState);
+  });
+
   it("should handle complex nested error objects without [object Object]", () => {
     const logger = createScopedLogger("test");
 

--- a/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
+++ b/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
@@ -249,7 +249,7 @@ function validateOAuthCallback(
   });
   if (!stateValidation.success) {
     logger.warn("Invalid state during Slack callback", {
-      receivedState,
+      hasReceivedState: !!receivedState,
       hasStoredState: !!storedState,
       error: stateValidation.error,
     });

--- a/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
+++ b/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type NextRequest, NextResponse } from "next/server";
+import { createHash } from "node:crypto";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
 import {
@@ -249,7 +250,7 @@ function validateOAuthCallback(
   });
   if (!stateValidation.success) {
     logger.warn("Invalid state during Slack callback", {
-      hasReceivedState: !!receivedState,
+      receivedStateFingerprint: getOAuthStateFingerprint(receivedState),
       hasStoredState: !!storedState,
       error: stateValidation.error,
     });
@@ -296,6 +297,10 @@ function extractEmailAccountIdFromState(state: string): string | null {
   } catch {
     return null;
   }
+}
+
+function getOAuthStateFingerprint(state: string) {
+  return `sha256:${createHash("sha256").update(state).digest("hex").slice(0, 12)}`;
 }
 
 function buildChannelsRedirectUrl(emailAccountId: string): URL {

--- a/apps/web/utils/middleware.test.ts
+++ b/apps/web/utils/middleware.test.ts
@@ -148,17 +148,20 @@ describe("Middleware", () => {
       const consoleLogSpy = vi
         .spyOn(console, "log")
         .mockImplementation(() => {});
-      const wrappedHandler = withError("google/webhook", async (request) => {
-        request.logger.info("Processing webhook");
-        return NextResponse.json({ ok: true });
-      });
+      try {
+        const wrappedHandler = withError("google/webhook", async (request) => {
+          request.logger.info("Processing webhook");
+          return NextResponse.json({ ok: true });
+        });
 
-      await wrappedHandler(mockReq, mockContext);
+        await wrappedHandler(mockReq, mockContext);
 
-      const loggedMessage = consoleLogSpy.mock.calls.flat().join(" ");
-      expect(loggedMessage).toContain('"url": "/api/google/webhook"');
-      expect(loggedMessage).not.toContain(verificationToken);
-      consoleLogSpy.mockRestore();
+        const loggedMessage = consoleLogSpy.mock.calls.flat().join(" ");
+        expect(loggedMessage).toContain('"url": "/api/google/webhook"');
+        expect(loggedMessage).not.toContain(verificationToken);
+      } finally {
+        consoleLogSpy.mockRestore();
+      }
     });
 
     it("should return 400 for ZodError", async () => {

--- a/apps/web/utils/middleware.test.ts
+++ b/apps/web/utils/middleware.test.ts
@@ -139,6 +139,28 @@ describe("Middleware", () => {
       expect(responseBody).toEqual({ success: true });
     });
 
+    it("logs the request path without query parameters", async () => {
+      const verificationToken = "google-webhook-secret";
+      mockReq = createMockRequest(
+        "POST",
+        `http://localhost/api/google/webhook?token=${verificationToken}`,
+      );
+      const consoleLogSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => {});
+      const wrappedHandler = withError("google/webhook", async (request) => {
+        request.logger.info("Processing webhook");
+        return NextResponse.json({ ok: true });
+      });
+
+      await wrappedHandler(mockReq, mockContext);
+
+      const loggedMessage = consoleLogSpy.mock.calls.flat().join(" ");
+      expect(loggedMessage).toContain('"url": "/api/google/webhook"');
+      expect(loggedMessage).not.toContain(verificationToken);
+      consoleLogSpy.mockRestore();
+    });
+
     it("should return 400 for ZodError", async () => {
       const zodError = new ZodError([
         { path: ["field"], message: "Required" },
@@ -204,13 +226,22 @@ describe("Middleware", () => {
     it("should handle common errors using checkCommonErrors", async () => {
       const commonError = { message: "API Error", code: 409, type: "Conflict" };
       mockCheckCommonErrors.mockReturnValue(commonError);
-      const handler = vi.fn().mockRejectedValue(new Error("Some API error"));
+      const apiError = new Error("Some API error");
+      mockReq = createMockRequest(
+        "GET",
+        "http://localhost/api/google/webhook?token=webhook-secret",
+      );
+      const handler = vi.fn().mockRejectedValue(apiError);
       const wrappedHandler = withError(handler);
 
       const response = await wrappedHandler(mockReq, mockContext);
       const responseBody = await response.json();
 
-      expect(checkCommonErrors).toHaveBeenCalled();
+      expect(checkCommonErrors).toHaveBeenCalledWith(
+        apiError,
+        "/api/google/webhook",
+        expect.anything(),
+      );
       expect(response.status).toBe(commonError.code);
       expect(responseBody).toEqual({
         error: commonError.message,
@@ -252,6 +283,10 @@ describe("Middleware", () => {
     it("should return 500 and capture unhandled errors", async () => {
       const unexpectedError = new Error("Something went very wrong");
       mockCheckCommonErrors.mockReturnValue(null);
+      mockReq = createMockRequest(
+        "GET",
+        "http://localhost/api/slack/callback?code=oauth-code&state=oauth-state",
+      );
       const handler = vi.fn().mockRejectedValue(unexpectedError);
       const wrappedHandler = withError(handler);
 
@@ -260,7 +295,7 @@ describe("Middleware", () => {
 
       expect(checkCommonErrors).toHaveBeenCalled();
       expect(mockCaptureException).toHaveBeenCalledWith(unexpectedError, {
-        extra: { url: mockReq.url },
+        extra: { url: "/api/slack/callback" },
       });
       expect(response.status).toBe(500);
       expect(responseBody).toEqual({ error: "An unexpected error occurred" });
@@ -339,7 +374,7 @@ describe("Middleware", () => {
       expect(auth).toHaveBeenCalledTimes(1);
       expect(handler).not.toHaveBeenCalled();
       expect(mockCaptureException).toHaveBeenCalledWith(authError, {
-        extra: { url: mockReq.url },
+        extra: { url: "/test" },
       });
       expect(response.status).toBe(500);
       expect(responseBody).toEqual({
@@ -613,7 +648,7 @@ describe("Middleware", () => {
       expect(handler).not.toHaveBeenCalled();
       expect(checkCommonErrors).toHaveBeenCalledWith(
         rateLimitError,
-        mockReq.url,
+        "/api/labels",
         expect.anything(),
       );
       expect(mockRecordRateLimitFromApiError).toHaveBeenCalledWith(

--- a/apps/web/utils/middleware.ts
+++ b/apps/web/utils/middleware.ts
@@ -81,7 +81,7 @@ function withMiddleware<T extends NextRequest>(
     const requestId = getRequestId(req.headers.get("x-request-id"));
     const baseLogger = createScopedLogger(scope || "api").with({
       requestId,
-      url: req.url,
+      url: getRequestPath(req),
     });
     const requestTimer =
       options?.requestTiming !== undefined
@@ -173,7 +173,7 @@ function withMiddleware<T extends NextRequest>(
 
           const apiError = checkCommonErrors(
             error,
-            requestForError.url,
+            getRequestPath(requestForError),
             reqLogger,
           );
           if (apiError) {
@@ -187,7 +187,7 @@ function withMiddleware<T extends NextRequest>(
 
             await logErrorToPosthog(
               "api",
-              requestForError.url,
+              getRequestPath(requestForError),
               apiError.type,
               "unknown",
               reqLogger,
@@ -226,7 +226,9 @@ function withMiddleware<T extends NextRequest>(
                 : undefined,
             stack: error instanceof Error ? error.stack : undefined,
           });
-          captureException(error, { extra: { url: requestForError.url } });
+          captureException(error, {
+            extra: { url: getRequestPath(requestForError) },
+          });
 
           return NextResponse.json(
             { error: "An unexpected error occurred" },
@@ -689,12 +691,16 @@ function getRequestId(rawRequestId: string | null) {
   return randomUUID();
 }
 
+function getRequestPath(req: NextRequest) {
+  return req.nextUrl.pathname;
+}
+
 function flushLogger(req: NextRequest) {
   const reqWithLogger = req as RequestWithLogger;
   if (reqWithLogger.logger) {
     const loggerToFlush = reqWithLogger.logger;
     after(async () => {
-      await flushLoggerSafely(loggerToFlush, { url: req.url });
+      await flushLoggerSafely(loggerToFlush, { url: getRequestPath(req) });
     });
   }
 }

--- a/apps/web/utils/redact-fields.ts
+++ b/apps/web/utils/redact-fields.ts
@@ -22,6 +22,7 @@ export const REDACTED_FIELD_NAMES = new Set([
   "set-cookie",
   "authorization",
   "requestBodyValues",
+  "receivedState",
   "systemInstruction",
   "contents",
 ]);


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-174654_pr-3245_1cf17f6ff92b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents query-parameter credentials and OAuth state from reaching request logs and error telemetry.

- retain path-only request correlation across logs, PostHog, Sentry, and logger flushes
- replace Slack raw state logging with presence metadata
- centrally redact remaining `receivedState` fields
- cover Google webhook token and Slack OAuth state regressions with focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->