### PR TITLE
security: Revoke cached access after account transfers

### DIFF
--- a/apps/web/utils/user/merge-account.test.ts
+++ b/apps/web/utils/user/merge-account.test.ts
@@ -2,15 +2,38 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mergeAccount } from "./merge-account";
 import prisma from "@/utils/__mocks__/prisma";
 import { getMockUserSelect, createTestLogger } from "@/__tests__/helpers";
+import { getEmailAccount } from "@/utils/redis/account-validation";
+import { redis } from "@/utils/redis";
+import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/user/merge-premium");
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
 
 const logger = createTestLogger();
+const validationCache = new Map<string, unknown>();
 
 describe("mergeAccount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    validationCache.clear();
+    vi.mocked(redis.get).mockImplementation(
+      async (key) => validationCache.get(String(key)) ?? null,
+    );
+    vi.mocked(redis.set).mockImplementation(async (key, value) => {
+      validationCache.set(String(key), value);
+      return "OK";
+    });
+    vi.mocked(redis.del).mockImplementation(async (key) =>
+      validationCache.delete(String(key)) ? 1 : 0,
+    );
   });
 
   describe("source user has multiple email accounts", () => {
@@ -121,6 +144,52 @@ describe("mergeAccount", () => {
       expect(prisma.user.update).not.toHaveBeenCalled();
       expect(prisma.user.delete).not.toHaveBeenCalled();
     });
+
+    it("revokes cached access for the source user after a partial reassignment", async () => {
+      const sourceUserId = "source-user-id";
+      const targetUserId = "target-user-id";
+      const accountId = "account-id";
+      const emailAccountId = "email-2";
+
+      prisma.emailAccount.findUnique
+        .mockResolvedValueOnce({ email: "secondary@test.com" } as any)
+        .mockResolvedValueOnce(null);
+      prisma.emailAccount.findMany.mockResolvedValue([
+        {
+          id: "email-1",
+          email: "primary@test.com",
+          accountId: "other-account",
+        },
+        {
+          id: emailAccountId,
+          email: "secondary@test.com",
+          accountId,
+        },
+      ] as any);
+      prisma.user.findUnique.mockResolvedValue(
+        getMockUserSelect({ email: "primary@test.com" }) as any,
+      );
+      prisma.account.update.mockResolvedValue({} as any);
+      prisma.emailAccount.update.mockResolvedValue({} as any);
+      prisma.$transaction.mockImplementation((ops) => Promise.resolve(ops));
+
+      await expect(
+        getEmailAccount({ userId: sourceUserId, emailAccountId }),
+      ).resolves.toBe("secondary@test.com");
+
+      await mergeAccount({
+        sourceAccountId: accountId,
+        sourceUserId,
+        targetUserId,
+        email: "secondary@test.com",
+        name: "Test User",
+        logger,
+      });
+
+      await expect(
+        getEmailAccount({ userId: sourceUserId, emailAccountId }),
+      ).resolves.toBeNull();
+    });
   });
 
   describe("source user has only one email account", () => {
@@ -146,9 +215,6 @@ describe("mergeAccount", () => {
       prisma.user.delete.mockResolvedValue({} as any);
       prisma.$transaction.mockImplementation((ops) => Promise.resolve(ops));
 
-      const { transferPremiumDuringMerge } = await import(
-        "@/utils/user/merge-premium"
-      );
       vi.mocked(transferPremiumDuringMerge).mockResolvedValue();
 
       const result = await mergeAccount({
@@ -181,6 +247,50 @@ describe("mergeAccount", () => {
       expect(prisma.user.delete).toHaveBeenCalledWith({
         where: { id: sourceUserId },
       });
+    });
+
+    it("revokes cached access for the source user after a full merge", async () => {
+      const sourceUserId = "source-user-id";
+      const targetUserId = "target-user-id";
+      const accountId = "account-id";
+      const emailAccountId = "email-1";
+
+      prisma.emailAccount.findUnique
+        .mockResolvedValueOnce({ email: "only@test.com" } as any)
+        .mockResolvedValueOnce(null);
+      prisma.emailAccount.findMany.mockResolvedValue([
+        {
+          id: emailAccountId,
+          email: "only@test.com",
+          accountId,
+        },
+      ] as any);
+      prisma.user.findUnique.mockResolvedValue(
+        getMockUserSelect({ email: "only@test.com" }) as any,
+      );
+      prisma.account.update.mockResolvedValue({} as any);
+      prisma.emailAccount.update.mockResolvedValue({} as any);
+      prisma.user.delete.mockResolvedValue({} as any);
+      prisma.$transaction.mockImplementation((ops) => Promise.resolve(ops));
+
+      vi.mocked(transferPremiumDuringMerge).mockResolvedValue();
+
+      await expect(
+        getEmailAccount({ userId: sourceUserId, emailAccountId }),
+      ).resolves.toBe("only@test.com");
+
+      await mergeAccount({
+        sourceAccountId: accountId,
+        sourceUserId,
+        targetUserId,
+        email: "only@test.com",
+        name: "Test User",
+        logger,
+      });
+
+      await expect(
+        getEmailAccount({ userId: sourceUserId, emailAccountId }),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/apps/web/utils/user/merge-account.ts
+++ b/apps/web/utils/user/merge-account.ts
@@ -1,6 +1,7 @@
 import prisma from "@/utils/prisma";
 import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
 import type { Logger } from "@/utils/logger";
+import { invalidateAccountValidation } from "@/utils/redis/account-validation";
 
 interface MergeAccountOptions {
   email: string;
@@ -29,6 +30,13 @@ export async function mergeAccount({
     where: { id: sourceUserId },
     select: { email: true },
   });
+  const accountBeingMoved = sourceUserEmailAccounts.find(
+    (account) => account.accountId === sourceAccountId,
+  );
+
+  if (!accountBeingMoved) {
+    throw new Error("Source email account not found");
+  }
 
   if (sourceUserEmailAccounts.length > 1) {
     logger.info(
@@ -39,10 +47,7 @@ export async function mergeAccount({
       },
     );
 
-    const accountBeingMoved = sourceUserEmailAccounts.find(
-      (acc) => acc.accountId === sourceAccountId,
-    );
-    const isPrimaryAccount = accountBeingMoved?.email === sourceUser?.email;
+    const isPrimaryAccount = accountBeingMoved.email === sourceUser?.email;
 
     const accountUpdate = prisma.account.update({
       where: { id: sourceAccountId },
@@ -60,7 +65,7 @@ export async function mergeAccount({
 
     if (isPrimaryAccount) {
       const newPrimaryAccount = sourceUserEmailAccounts.find(
-        (acc) => acc.id !== accountBeingMoved?.id,
+        (acc) => acc.id !== accountBeingMoved.id,
       );
       if (newPrimaryAccount) {
         const userUpdate = prisma.user.update({
@@ -78,6 +83,10 @@ export async function mergeAccount({
     } else {
       await prisma.$transaction([accountUpdate, emailAccountUpdate]);
     }
+    await invalidateAccountValidation({
+      userId: sourceUserId,
+      emailAccountId: accountBeingMoved.id,
+    });
     return "partial_reassign";
   }
 
@@ -104,6 +113,11 @@ export async function mergeAccount({
       where: { id: sourceUserId },
     }),
   ]);
+
+  await invalidateAccountValidation({
+    userId: sourceUserId,
+    emailAccountId: accountBeingMoved.id,
+  });
 
   return "full_merge";
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260813-221601_pr-3247_52624a98e4a7/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Clears former-owner authorization cache entries whenever an email account moves between users.

- fail closed when the requested source account is not owned by the source user
- invalidate cached access after both partial reassignment and full merge paths
- cover the former-owner denial behavior with focused Redis-backed tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->