### PR TITLE
security: Validate API key account ownership

### DIFF
--- a/apps/web/utils/api-auth.test.ts
+++ b/apps/web/utils/api-auth.test.ts
@@ -37,6 +37,30 @@ describe("api-auth", () => {
       ).rejects.toThrow("Invalid API key");
     });
 
+    it("rejects inactive keys", async () => {
+      mockApiKeyLookup(null);
+
+      await expect(
+        validateApiKey(getRequest("inactive-api-key")),
+      ).rejects.toThrow("Invalid API key");
+      expect(prisma.apiKey.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { hashedKey: "hashed-key", isActive: true },
+        }),
+      );
+    });
+
+    it("rejects expired keys", async () => {
+      mockApiKeyLookup(
+        buildApiKeyRecord({ expiresAt: new Date("2020-01-01T00:00:00Z") }),
+      );
+
+      await expect(
+        validateApiKey(getRequest("expired-api-key")),
+      ).rejects.toThrow("Invalid API key");
+      expect(prisma.apiKey.update).not.toHaveBeenCalled();
+    });
+
     it("returns the scoped api key and records last use", async () => {
       mockApiKeyLookup(buildApiKeyRecord());
 
@@ -68,7 +92,6 @@ describe("api-auth", () => {
       mockApiKeyLookup(
         buildApiKeyRecord({
           scopes: ["RULES_READ", "RULES_WRITE"],
-          emailAccount: null,
         }),
       );
 
@@ -77,6 +100,12 @@ describe("api-auth", () => {
         emailAccountId: "email-account-id",
         scopes: ["RULES_READ", "RULES_WRITE"],
       });
+    });
+
+    it("returns null when the scoped inbox relation is missing", async () => {
+      mockApiKeyLookup(buildApiKeyRecord({ emailAccount: null }));
+
+      await expect(getUserFromApiKey("orphaned-key")).resolves.toBeNull();
     });
 
     it("returns null for keys without an inbox scope", async () => {
@@ -118,6 +147,49 @@ describe("api-auth", () => {
         accountId: "account-id",
         scopes: ["RULES_READ", "RULES_WRITE"],
       });
+    });
+
+    it("rejects a key whose user no longer owns the email account", async () => {
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          emailAccount: buildEmailAccountRecord({
+            userId: "new-owner-id",
+          }),
+        }),
+      );
+
+      await expect(
+        validateAccountApiKey(getRequest("stale-key"), ["RULES_READ"]),
+      ).rejects.toThrow("Invalid API key");
+      expect(prisma.apiKey.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects a key whose user no longer owns the provider account", async () => {
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          emailAccount: buildEmailAccountRecord({
+            accountUserId: "new-owner-id",
+          }),
+        }),
+      );
+
+      await expect(
+        validateAccountApiKey(getRequest("stale-key"), ["RULES_READ"]),
+      ).rejects.toThrow("Invalid API key");
+      expect(prisma.apiKey.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects keys without an account scope", async () => {
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          emailAccountId: null,
+          emailAccount: null,
+        }),
+      );
+
+      await expect(
+        validateAccountApiKey(getRequest("legacy-key"), ["RULES_READ"]),
+      ).rejects.toThrow("Account-scoped API key required");
     });
   });
 
@@ -181,14 +253,26 @@ function buildApiKeyRecord(overrides: Record<string, unknown> = {}) {
     emailAccountId: "email-account-id",
     expiresAt: null,
     scopes: ["RULES_READ"],
-    emailAccount: {
-      id: "email-account-id",
-      email: "user@example.com",
-      account: {
-        id: "account-id",
-        provider: "google",
-      },
-    },
+    emailAccount: buildEmailAccountRecord(),
     ...overrides,
+  };
+}
+
+function buildEmailAccountRecord({
+  userId = "user-id",
+  accountUserId = "user-id",
+}: {
+  userId?: string;
+  accountUserId?: string;
+} = {}) {
+  return {
+    id: "email-account-id",
+    userId,
+    email: "user@example.com",
+    account: {
+      id: "account-id",
+      userId: accountUserId,
+      provider: "google",
+    },
   };
 }

--- a/apps/web/utils/api-auth.ts
+++ b/apps/web/utils/api-auth.ts
@@ -133,7 +133,7 @@ export async function validateApiKeyAndGetEmailProvider(
 async function getStoredApiKey(secretKey: string) {
   const hashedKey = hashApiKey(secretKey);
 
-  return prisma.apiKey.findUnique({
+  const storedApiKey = await prisma.apiKey.findUnique({
     where: { hashedKey, isActive: true },
     select: {
       id: true,
@@ -144,10 +144,12 @@ async function getStoredApiKey(secretKey: string) {
       emailAccount: {
         select: {
           id: true,
+          userId: true,
           email: true,
           account: {
             select: {
               id: true,
+              userId: true,
               provider: true,
             },
           },
@@ -155,6 +157,17 @@ async function getStoredApiKey(secretKey: string) {
       },
     },
   });
+
+  if (
+    storedApiKey?.emailAccountId &&
+    (!storedApiKey.emailAccount ||
+      storedApiKey.userId !== storedApiKey.emailAccount.userId ||
+      storedApiKey.userId !== storedApiKey.emailAccount.account.userId)
+  ) {
+    return null;
+  }
+
+  return storedApiKey;
 }
 
 function isExpired(expiresAt: Date | null): boolean {

--- a/apps/web/utils/api-auth.ts
+++ b/apps/web/utils/api-auth.ts
@@ -89,17 +89,19 @@ export async function validateAccountApiKey(
 ): Promise<AccountApiKeyPrincipal> {
   const { apiKey } = await validateApiKey(request, { requiredScopes });
 
-  if (!apiKey.emailAccountId || !apiKey.emailAccount) {
+  if (!apiKey.emailAccountId) {
     throw new SafeError("Account-scoped API key required", 403);
   }
+
+  const emailAccount = apiKey.emailAccount!;
 
   return {
     apiKeyId: apiKey.id,
     userId: apiKey.userId,
-    emailAccountId: apiKey.emailAccount.id,
-    email: apiKey.emailAccount.email,
-    provider: apiKey.emailAccount.account.provider,
-    accountId: apiKey.emailAccount.account.id,
+    emailAccountId: emailAccount.id,
+    email: emailAccount.email,
+    provider: emailAccount.account.provider,
+    accountId: emailAccount.account.id,
     scopes: apiKey.scopes,
   };
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260812-181046_pr-3249_a27617e5776c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Rejects account-scoped API keys when their recorded owner no longer owns the linked inbox or provider account.

- enforce both ownership relationships in the existing API-key lookup
- fail closed for orphaned account relationships
- cover active, expired, unscoped, and ownership-mismatch cases without adding queries

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->