### PR TITLE
fix: fail open on Gmail permission check network errors

### DIFF
--- a/apps/web/utils/gmail/permissions.test.ts
+++ b/apps/web/utils/gmail/permissions.test.ts
@@ -278,4 +278,54 @@ describe("handleGmailPermissionsCheck", () => {
       missingScopes: [],
     });
   });
+
+  it("fails open on 4xx responses with an unrecognized error body", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: vi.fn().mockResolvedValue({
+        error: {
+          code: 429,
+          message: "Quota exceeded",
+          status: "RESOURCE_EXHAUSTED",
+        },
+      }),
+    } as unknown as Response);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open on a 200 response with an unrecognized error body", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ error: "some_backend_error" }),
+    } as unknown as Response);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+  });
 });

--- a/apps/web/utils/gmail/permissions.test.ts
+++ b/apps/web/utils/gmail/permissions.test.ts
@@ -104,6 +104,7 @@ describe("handleGmailPermissionsCheck", () => {
     const oauth = await import("@/utils/google/oauth");
     vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
     vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue({ scope: SCOPES.join(" ") }),
     } as unknown as Response);
 
@@ -129,6 +130,7 @@ describe("handleGmailPermissionsCheck", () => {
 
     vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
     vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue({ error: "invalid_grant" }),
     } as unknown as Response);
     prisma.emailAccount.findUnique.mockResolvedValue({
@@ -149,6 +151,131 @@ describe("handleGmailPermissionsCheck", () => {
       hasAllPermissions: false,
       error: "Gmail access expired. Please reconnect your account.",
       missingScopes: SCOPES,
+    });
+  });
+
+  it("fails open when the token info request hits a network error", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockRejectedValue(new Error("network down"));
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/tokeninfo?access_token=access-token",
+    );
+  });
+
+  it("fails open when the token info request returns a non-OK response", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as unknown as Response);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+  });
+
+  it("fails closed on 4xx auth errors and refreshes the token", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    const gmailClient = await import("@/utils/gmail/client");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: vi.fn().mockResolvedValue({ error: "invalid_token" }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ scope: SCOPES.join(" ") }),
+      } as unknown as Response);
+    vi.mocked(gmailClient.getGmailClientWithRefresh).mockResolvedValue(
+      {} as never,
+    );
+    vi.mocked(gmailClient.getAccessTokenFromClient).mockReturnValue(
+      "refreshed-token",
+    );
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+    expect(gmailClient.getGmailClientWithRefresh).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/tokeninfo?access_token=refreshed-token",
+    );
+  });
+
+  it("fails closed on a 200 response with an error body", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ error: "invalid_token" }),
+    } as unknown as Response);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: null,
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: false,
+      missingScopes: SCOPES,
+      error: "invalid_token",
+    });
+  });
+
+  it("fails open on 4xx responses without a token error body", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(false);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({}),
+    } as unknown as Response);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: null,
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
     });
   });
 });

--- a/apps/web/utils/gmail/permissions.ts
+++ b/apps/web/utils/gmail/permissions.ts
@@ -12,7 +12,6 @@ import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("Gmail Permissions");
 
-// TODO: this can also error on network error
 async function checkGmailPermissions({
   accessToken,
   emailAccountId,
@@ -68,9 +67,17 @@ async function checkGmailPermissions({
   try {
     const response = await fetch(getGoogleTokenInfoUrl(accessToken));
 
+    if (!response.ok && response.status >= 500) {
+      throw new Error(
+        `Token info request failed with status ${response.status}`,
+      );
+    }
+
     const data = await response.json();
 
     if (data.error) {
+      // Auth failure (4xx body, or error body on 200 in emulation): fail
+      // closed so the refresh flow can run
       logger.error("Invalid token or Google API error", {
         emailAccountId,
         error: data.error,
@@ -80,6 +87,12 @@ async function checkGmailPermissions({
         missingScopes: SCOPES, // Assume all scopes are missing if we can't check
         error: data.error,
       };
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Token info request failed with status ${response.status}`,
+      );
     }
 
     const grantedScopes = data.scope?.split(" ") || [];
@@ -99,9 +112,8 @@ async function checkGmailPermissions({
   } catch (error) {
     logger.error("Error checking Gmail permissions", { emailAccountId, error });
     return {
-      hasAllPermissions: false,
-      missingScopes: SCOPES, // Assume all scopes are missing if we can't check
-      error: "Failed to check permissions",
+      hasAllPermissions: true,
+      missingScopes: [],
     };
   }
 }

--- a/apps/web/utils/gmail/permissions.ts
+++ b/apps/web/utils/gmail/permissions.ts
@@ -12,6 +12,13 @@ import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("Gmail Permissions");
 
+const AUTH_ERRORS = [
+  "invalid_token",
+  "invalid_grant",
+  "invalid_scope",
+  "access_denied",
+];
+
 async function checkGmailPermissions({
   accessToken,
   emailAccountId,
@@ -76,8 +83,16 @@ async function checkGmailPermissions({
     const data = await response.json();
 
     if (data.error) {
-      // Auth failure (4xx body, or error body on 200 in emulation): fail
-      // closed so the refresh flow can run
+      if (!AUTH_ERRORS.includes(data.error)) {
+        // Unrecognized error (rate-limit envelope, backend failure): not
+        // confirmable as an auth failure, fail open rather than prompting re-auth
+        throw new Error(
+          `Token info request failed with error ${JSON.stringify(data.error)}`,
+        );
+      }
+
+      // Recognized token error (4xx body, or error body on 200): fail closed
+      // so the refresh flow can run
       logger.error("Invalid token or Google API error", {
         emailAccountId,
         error: data.error,
@@ -137,12 +152,7 @@ export async function handleGmailPermissionsCheck({
 
   if (
     permissionsBeforeRefresh.error &&
-    [
-      "invalid_token",
-      "invalid_grant",
-      "invalid_scope",
-      "access_denied",
-    ].includes(permissionsBeforeRefresh.error)
+    AUTH_ERRORS.includes(permissionsBeforeRefresh.error)
   ) {
     // attempt to refresh the token one last time using only the refresh token
     if (refreshToken) {


### PR DESCRIPTION
## Problem

`checkGmailPermissions` treated any tokeninfo failure as "all scopes missing"
(`hasAllPermissions: false`, `missingScopes: SCOPES`). A network blip, 5xx,
rate-limit envelope, or unrecognized error body couldn't be distinguished
from a real auth failure, so users were falsely redirected to
`/permissions/consent` to re-auth and permission-gated features were disabled.
Transient non-2xx responses were also parsed as scope data, reporting zero
scopes granted.

## Fix

`apps/web/utils/gmail/permissions.ts`:

- **Network / 5xx / unparseable or unrecognized error bodies** → fail open:
  log the error, return `hasAllPermissions: true` with no `error`, so a blip
  never triggers re-auth. The check re-runs on the next page load, so a real
  revocation still gets caught.
- **Recognized token errors** (`invalid_token`, `invalid_grant`,
  `invalid_scope`, `access_denied`) → fail closed with the error so the
  existing refresh/cleanup flow still runs. Only confirmable auth failures
  fail closed; rate-limit/backend bodies fail open.
- Extracted the error list into a shared `AUTH_ERRORS` constant used by both
  the fail-closed branch and the refresh-trigger check (previously duplicated).

## Tests

`apps/web/utils/gmail/permissions.test.ts` — 5 new cases: 400 + `invalid_token`
fails closed and refreshes the token; 200 + error body fails closed; 4xx
without a token error, 429 `RESOURCE_EXHAUSTED` envelope, and unrecognized
error on 200 all fail open; network error fails open.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

