### PR TITLE
fix: apply static sender categorization only when category exists

### DIFF
--- a/apps/web/utils/categorize/senders/categorize.test.ts
+++ b/apps/web/utils/categorize/senders/categorize.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount } from "@/__tests__/helpers";
 import { defaultCategory } from "@/utils/categories";
-import { categorizeSender } from "@/utils/categorize/senders/categorize";
+import {
+  categorizeSender,
+  categorizeWithAi,
+} from "@/utils/categorize/senders/categorize";
 import { aiCategorizeSender } from "@/utils/ai/categorize-sender/ai-categorize-single-sender";
+import { aiCategorizeSenders } from "@/utils/ai/categorize-sender/ai-categorize-senders";
 import { upsertSenderRecord } from "@/utils/senders/record";
 
 vi.mock("@/utils/ai/categorize-sender/ai-categorize-single-sender", () => ({
   aiCategorizeSender: vi.fn(),
+}));
+
+vi.mock("@/utils/ai/categorize-sender/ai-categorize-senders", () => ({
+  aiCategorizeSenders: vi.fn(),
 }));
 
 vi.mock("@/utils/senders/record", () => ({
@@ -59,5 +67,68 @@ describe("categorizeSender", () => {
       },
     });
     expect(result).toEqual({ categoryId: "cat-other" });
+  });
+});
+
+describe("categorizeWithAi", () => {
+  const emailAccount = getEmailAccount();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(aiCategorizeSenders).mockResolvedValue([]);
+  });
+
+  it("does not apply static rules for categories the user does not have", async () => {
+    const sendersWithEmails = new Map([
+      ["newsletter@substack.com", []],
+      ["other@example.com", []],
+    ]);
+
+    const result = await categorizeWithAi({
+      emailAccount,
+      sendersWithEmails,
+      categories: [{ name: "Marketing", description: "Promotions" }],
+    });
+
+    expect(vi.mocked(aiCategorizeSenders)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senders: [
+          { emailAddress: "newsletter@substack.com", emails: [] },
+          { emailAddress: "other@example.com", emails: [] },
+        ],
+      }),
+    );
+    expect(result).toEqual([
+      { sender: "newsletter@substack.com", category: undefined },
+      { sender: "other@example.com", category: undefined },
+    ]);
+  });
+
+  it("applies static rules and skips AI for senders when the matching category exists", async () => {
+    const sendersWithEmails = new Map([
+      ["newsletter@substack.com", []],
+      ["receipt@example.com", []],
+      ["other@example.com", []],
+    ]);
+
+    const result = await categorizeWithAi({
+      emailAccount,
+      sendersWithEmails,
+      categories: [
+        { name: "Newsletter", description: "Editorial" },
+        { name: "Receipt", description: "Purchase confirmations" },
+      ],
+    });
+
+    expect(vi.mocked(aiCategorizeSenders)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senders: [{ emailAddress: "other@example.com", emails: [] }],
+      }),
+    );
+    expect(result).toEqual([
+      { sender: "newsletter@substack.com", category: "Newsletter" },
+      { sender: "receipt@example.com", category: "Receipt" },
+      { sender: "other@example.com", category: undefined },
+    ]);
   });
 });

--- a/apps/web/utils/categorize/senders/categorize.ts
+++ b/apps/web/utils/categorize/senders/categorize.ts
@@ -138,16 +138,26 @@ export async function updateCategoryForSender({
   });
 }
 
-// TODO: what if user doesn't have all these categories set up?
-// Use static rules to categorize senders if we can, before sending to LLM
+// Use static rules to categorize senders if we can, before sending to LLM.
+// Only apply a rule if the user has the matching category, so we don't invent
+// categories the user deleted or renamed.
 function preCategorizeSendersWithStaticRules(
   senders: string[],
+  categories: Pick<Category, "name">[],
 ): { sender: string; category: SenderCategory | undefined }[] {
+  const categoryNames = new Set(categories.map((c) => c.name));
+
   return senders.map((sender) => {
-    if (isNewsletterSender(sender))
+    if (
+      categoryNames.has(defaultCategory.NEWSLETTER.name) &&
+      isNewsletterSender(sender)
+    )
       return { sender, category: defaultCategory.NEWSLETTER.name };
 
-    if (isReceiptSender(sender))
+    if (
+      categoryNames.has(defaultCategory.RECEIPT.name) &&
+      isReceiptSender(sender)
+    )
       return { sender, category: defaultCategory.RECEIPT.name };
 
     return { sender, category: undefined };
@@ -175,6 +185,7 @@ export async function categorizeWithAi({
 }) {
   const categorizedSenders = preCategorizeSendersWithStaticRules(
     Array.from(sendersWithEmails.keys()),
+    categories,
   );
 
   const sendersToCategorizeWithAi = categorizedSenders


### PR DESCRIPTION
## What
`preCategorizeSendersWithStaticRules` now checks the user's categories before assigning Newsletter/Receipt static rules. Senders whose default category was deleted or renamed fall through to AI categorization instead of having a stale category name forced on them.

## Why
Closes the TODO at categorize.ts:141 — static rules assumed all defaults existed, which mislabeled senders for customized category setups.

## Tests
Added 2 tests: static rule skipped when category missing, applied (AI skipped) when present.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

