### PR TITLE
fix: persist one sender categorization result

### DIFF
--- a/apps/web/utils/categorize/senders/categorize.test.ts
+++ b/apps/web/utils/categorize/senders/categorize.test.ts
@@ -83,6 +83,10 @@ describe("categorizeWithAi", () => {
       ["newsletter@substack.com", []],
       ["other@example.com", []],
     ]);
+    vi.mocked(aiCategorizeSenders).mockResolvedValue([
+      { sender: "newsletter@substack.com", category: "Marketing" },
+      { sender: "other@example.com", category: "Marketing" },
+    ]);
 
     const result = await categorizeWithAi({
       emailAccount,
@@ -99,8 +103,8 @@ describe("categorizeWithAi", () => {
       }),
     );
     expect(result).toEqual([
-      { sender: "newsletter@substack.com", category: undefined },
-      { sender: "other@example.com", category: undefined },
+      { sender: "newsletter@substack.com", category: "Marketing" },
+      { sender: "other@example.com", category: "Marketing" },
     ]);
   });
 

--- a/apps/web/utils/categorize/senders/categorize.ts
+++ b/apps/web/utils/categorize/senders/categorize.ts
@@ -206,5 +206,12 @@ export async function categorizeWithAi({
     categories,
   });
 
-  return [...categorizedSenders, ...aiResults];
+  const aiResultsBySender = new Map(
+    aiResults.map((result) => [result.sender, result]),
+  );
+
+  return categorizedSenders.map((result) => {
+    if (result.category) return result;
+    return aiResultsBySender.get(result.sender) ?? result;
+  });
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260813-102425_pr-3253_86c4f48e95d9/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensure batch sender categorization returns one final outcome per sender, preventing placeholder results from being persisted before AI results.

- Merge AI outcomes into pre-categorized entries while preserving input order
- Keep the existing fallback when AI omits a sender
- Add regression coverage for customized category configurations

Validation:
- Focused sender categorization tests pass
- Changed files pass formatting checks
- Full unit suite reached 5,198 passing tests; two unrelated import timeouts passed on immediate isolated rerun

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->