### PR TITLE
fix(usage): rename openai* usage fields to provider-agnostic names

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/usage/usage.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/usage/usage.tsx
@@ -30,13 +30,13 @@ export function Usage(props: { usage: RedisUsage | null }) {
           },
           {
             name: "LLM API Calls",
-            value: formatStat(props.usage?.openaiCalls),
+            value: formatStat(props.usage?.calls),
             subvalue: "calls",
             icon: <BotIcon className="h-4 w-4" />,
           },
           {
             name: "LLM Tokens Used",
-            value: formatStat(props.usage?.openaiTokensUsed),
+            value: formatStat(props.usage?.tokensUsed),
             subvalue: "tokens",
             icon: <CpuIcon className="h-4 w-4" />,
           },

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -71,15 +71,54 @@ describe("redis usage tracking", () => {
     });
   });
 
-  it("reads usage by email account ID", async () => {
+  it("reads usage by email account ID, falling back to legacy openai field names", async () => {
     vi.mocked(redis.hgetall).mockResolvedValue({ openaiCalls: 3 });
 
     const usage = await getUsage({ emailAccountId: "email-account-1" });
 
-    expect(usage).toEqual({ openaiCalls: 3 });
+    expect(usage).toEqual({ calls: 3 });
     expect(redis.hgetall).toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
     );
+  });
+
+  it("sums legacy and renamed fields present in the same hash", async () => {
+    vi.mocked(redis.hgetall).mockResolvedValue({
+      openaiCalls: 5,
+      calls: 2,
+      openaiTokensUsed: 500,
+      tokensUsed: 100,
+    });
+
+    const usage = await getUsage({ emailAccountId: "email-account-1" });
+
+    expect(usage).toEqual({ calls: 7, tokensUsed: 600 });
+  });
+
+  it("round-trips saveUsage into a hash containing legacy and renamed fields", async () => {
+    const hash: Record<string, string> = {
+      openaiCalls: "5",
+      calls: "2",
+      openaiTokensUsed: "500",
+      tokensUsed: "100",
+    };
+    vi.mocked(redis.hincrby).mockImplementation(
+      async (_key: string, field: string, increment: number) => {
+        hash[field] = String(Number.parseFloat(hash[field] ?? "0") + increment);
+        return 1;
+      },
+    );
+    vi.mocked(redis.hgetall).mockImplementation(async () => hash);
+
+    await saveUsage({
+      emailAccountId: "email-account-1",
+      usage: { totalTokens: 10, inputTokens: 10 },
+      cost: 0,
+    });
+
+    const usage = await getUsage({ emailAccountId: "email-account-1" });
+
+    expect(usage).toEqual({ calls: 8, tokensUsed: 610, promptTokensUsed: 10 });
   });
 
   it("migrates legacy email usage into account and user usage before reading", async () => {
@@ -101,14 +140,10 @@ describe("redis usage tracking", () => {
     );
     expect(redis.hincrby).toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
-      "openaiCalls",
+      "calls",
       3,
     );
-    expect(redis.hincrby).toHaveBeenCalledWith(
-      "usage:user:user-1",
-      "openaiCalls",
-      3,
-    );
+    expect(redis.hincrby).toHaveBeenCalledWith("usage:user:user-1", "calls", 3);
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
       "cost",
@@ -118,7 +153,7 @@ describe("redis usage tracking", () => {
       "usage-migration:usage-email-account:email-account-1:done",
       expect.any(String),
     );
-    expect(usage).toEqual({ openaiCalls: 3 });
+    expect(usage).toEqual({ calls: 3 });
   });
 
   it("includes legacy email usage while another request owns the migration lock", async () => {
@@ -137,7 +172,7 @@ describe("redis usage tracking", () => {
       userId: "user-1",
     });
 
-    expect(usage).toEqual({ openaiCalls: 5, cost: 2 });
+    expect(usage).toEqual({ calls: 5, cost: 2 });
   });
 
   it("sums user usage cost across the last 7 days", async () => {
@@ -431,6 +466,26 @@ describe("redis usage tracking", () => {
       now: NOW,
     });
 
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "calls",
+      1,
+    );
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "tokensUsed",
+      300,
+    );
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "completionTokensUsed",
+      100,
+    );
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "promptTokensUsed",
+      200,
+    );
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
       "cost",
@@ -484,7 +539,7 @@ describe("redis usage tracking", () => {
       userId: "user-1",
     });
 
-    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+    expect(usage).toEqual({ calls: 3, cost: 1.5 });
   });
 
   it("does not persist post-migration legacy usage writes without the migration lock", async () => {
@@ -527,12 +582,12 @@ describe("redis usage tracking", () => {
     );
     expect(redis.hincrby).not.toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
-      "openaiCalls",
+      "calls",
       1,
     );
     expect(redis.hincrby).not.toHaveBeenCalledWith(
       "usage:user:user-1",
-      "openaiCalls",
+      "calls",
       1,
     );
     expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
@@ -545,7 +600,7 @@ describe("redis usage tracking", () => {
       "cost",
       0.5,
     );
-    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+    expect(usage).toEqual({ calls: 3, cost: 1.5 });
   });
 
   it("uses the latest usage migration marker after claiming the migration lock", async () => {
@@ -586,12 +641,12 @@ describe("redis usage tracking", () => {
     );
     expect(redis.hincrby).not.toHaveBeenCalledWith(
       "usage:email-account:email-account-1",
-      "openaiCalls",
+      "calls",
       1,
     );
     expect(redis.hincrby).not.toHaveBeenCalledWith(
       "usage:user:user-1",
-      "openaiCalls",
+      "calls",
       1,
     );
     expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
@@ -604,7 +659,7 @@ describe("redis usage tracking", () => {
       "cost",
       0.5,
     );
-    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+    expect(usage).toEqual({ calls: 3, cost: 1.5 });
   });
 
   it("stores account usage without weekly spend when user ID is missing", async () => {

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -121,7 +121,7 @@ describe("redis usage tracking", () => {
     expect(usage).toEqual({ calls: 8, tokensUsed: 610, promptTokensUsed: 10 });
   });
 
-  it("migrates legacy email usage into account and user usage before reading", async () => {
+  it("migrates legacy email usage and writes a checkpoint older servers can read", async () => {
     mockRedisHashes({
       "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
       "usage:email-account:email-account-1": { openaiCalls: 3 },
@@ -151,7 +151,7 @@ describe("redis usage tracking", () => {
     );
     expect(redis.set).toHaveBeenCalledWith(
       "usage-migration:usage-email-account:email-account-1:done",
-      expect.any(String),
+      JSON.stringify({ usage: { openaiCalls: 3, cost: 1.25 } }),
     );
     expect(usage).toEqual({ calls: 3 });
   });

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -10,24 +10,33 @@ const WEEKLY_USAGE_COST_KEY_PREFIX = "usage-weekly-cost";
 const USAGE_MIGRATION_LOCK_TTL_SECONDS = 5 * 60;
 
 export type RedisUsage = {
-  openaiCalls?: number;
-  openaiTokensUsed?: number;
-  openaiCompletionTokensUsed?: number;
-  openaiPromptTokensUsed?: number;
+  calls?: number;
+  tokensUsed?: number;
+  completionTokensUsed?: number;
+  promptTokensUsed?: number;
   cachedInputTokensUsed?: number;
   reasoningTokensUsed?: number;
   cost?: number;
 };
 
 const usageFields = [
-  "openaiCalls",
-  "openaiTokensUsed",
-  "openaiCompletionTokensUsed",
-  "openaiPromptTokensUsed",
+  "calls",
+  "tokensUsed",
+  "completionTokensUsed",
+  "promptTokensUsed",
   "cachedInputTokensUsed",
   "reasoningTokensUsed",
   "cost",
 ] as const satisfies Array<keyof RedisUsage>;
+
+// Fields were previously named openai* when OpenAI was the only LLM provider.
+// They've always aggregated usage across all providers, so we renamed them.
+const LEGACY_USAGE_FIELD_NAMES: Record<string, keyof RedisUsage> = {
+  openaiCalls: "calls",
+  openaiTokensUsed: "tokensUsed",
+  openaiCompletionTokensUsed: "completionTokensUsed",
+  openaiPromptTokensUsed: "promptTokensUsed",
+};
 
 export type WeeklyUsageCostBySubject =
   | { userId: string; cost: number }
@@ -55,7 +64,7 @@ export async function getUsage(options: {
     : null;
 
   if (!options.legacyEmail) {
-    return redis.hgetall<RedisUsage>(emailAccountUsageKey);
+    return getRedisUsage(emailAccountUsageKey);
   }
 
   const legacyUsageKey = getLegacyUsageKey(options.legacyEmail);
@@ -67,8 +76,8 @@ export async function getUsage(options: {
 
   if (migratedLegacyUsage) {
     const [currentUsage, legacyUsage] = await Promise.all([
-      redis.hgetall<RedisUsage>(emailAccountUsageKey),
-      redis.hgetall<RedisUsage>(legacyUsageKey),
+      getRedisUsage(emailAccountUsageKey),
+      getRedisUsage(legacyUsageKey),
     ]);
     const legacyDelta = getUsageDelta(legacyUsage, migratedLegacyUsage);
 
@@ -83,8 +92,8 @@ export async function getUsage(options: {
       try {
         const [latestCurrentUsage, latestLegacyUsage, latestRawMigrationState] =
           await Promise.all([
-            redis.hgetall<RedisUsage>(emailAccountUsageKey),
-            redis.hgetall<RedisUsage>(legacyUsageKey),
+            getRedisUsage(emailAccountUsageKey),
+            getRedisUsage(legacyUsageKey),
             redis.get(doneKey),
           ]);
         const latestMigratedLegacyUsage = parseLegacyUsageMigrationState(
@@ -139,8 +148,8 @@ export async function getUsage(options: {
 
   if (rawMigrationState) {
     const [currentUsage, legacyUsage] = await Promise.all([
-      redis.hgetall<RedisUsage>(emailAccountUsageKey),
-      redis.hgetall<RedisUsage>(legacyUsageKey),
+      getRedisUsage(emailAccountUsageKey),
+      getRedisUsage(legacyUsageKey),
     ]);
     return maxUsage(currentUsage, legacyUsage);
   }
@@ -150,8 +159,8 @@ export async function getUsage(options: {
     ex: USAGE_MIGRATION_LOCK_TTL_SECONDS,
   });
   const [currentUsage, legacyUsage] = await Promise.all([
-    redis.hgetall<RedisUsage>(emailAccountUsageKey),
-    redis.hgetall<RedisUsage>(legacyUsageKey),
+    getRedisUsage(emailAccountUsageKey),
+    getRedisUsage(legacyUsageKey),
   ]);
 
   if (!claimedLock) return mergeUsage(currentUsage, legacyUsage);
@@ -165,7 +174,7 @@ export async function getUsage(options: {
       redis.set(doneKey, JSON.stringify({ usage: legacyUsage ?? {} })),
     ]);
 
-    return redis.hgetall<RedisUsage>(emailAccountUsageKey);
+    return getRedisUsage(emailAccountUsageKey);
   } catch (error) {
     logger.error("Failed to migrate legacy usage", {
       migrationName,
@@ -449,16 +458,15 @@ function getUsageIncrementOperations(
   cost: number,
 ) {
   return [
-    // TODO: this isn't openai specific, it can be any llm
-    redis.hincrby(key, "openaiCalls", 1),
+    redis.hincrby(key, "calls", 1),
     usage.totalTokens
-      ? redis.hincrby(key, "openaiTokensUsed", usage.totalTokens)
+      ? redis.hincrby(key, "tokensUsed", usage.totalTokens)
       : null,
     usage.outputTokens
-      ? redis.hincrby(key, "openaiCompletionTokensUsed", usage.outputTokens)
+      ? redis.hincrby(key, "completionTokensUsed", usage.outputTokens)
       : null,
     usage.inputTokens
-      ? redis.hincrby(key, "openaiPromptTokensUsed", usage.inputTokens)
+      ? redis.hincrby(key, "promptTokensUsed", usage.inputTokens)
       : null,
     usage.cachedInputTokens
       ? redis.hincrby(key, "cachedInputTokensUsed", usage.cachedInputTokens)
@@ -682,11 +690,37 @@ function parseLegacyUsageMigrationState(rawState: unknown): RedisUsage | null {
   if (typeof rawState !== "string") return null;
 
   try {
-    const parsed = JSON.parse(rawState) as { usage?: RedisUsage };
-    return parsed.usage ?? null;
+    const parsed = JSON.parse(rawState) as { usage?: Record<string, unknown> };
+    return parsed.usage ? normalizeUsageFields(parsed.usage) : null;
   } catch {
     return null;
   }
+}
+
+async function getRedisUsage(key: string): Promise<RedisUsage> {
+  const raw = await redis.hgetall<Record<string, string>>(key);
+  return normalizeUsageFields(raw);
+}
+
+function normalizeUsageFields(
+  raw: Record<string, unknown> | null | undefined,
+): RedisUsage {
+  if (!raw) return {};
+
+  const usageFieldNames = new Set<string>(usageFields);
+  const usage: Record<string, number> = {};
+
+  for (const [field, value] of Object.entries(raw)) {
+    const normalizedField = LEGACY_USAGE_FIELD_NAMES[field] ?? field;
+    if (!usageFieldNames.has(normalizedField)) continue;
+
+    // During rolling deploys a hash may contain both the legacy openai* field
+    // and its renamed counterpart, so colliding fields accumulate.
+    usage[normalizedField] =
+      parseRedisNumber(usage[normalizedField]) + parseRedisNumber(value);
+  }
+
+  return usage as RedisUsage;
 }
 
 function parseWeeklyUsageMigrationState(

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -38,6 +38,12 @@ const LEGACY_USAGE_FIELD_NAMES: Record<string, keyof RedisUsage> = {
   openaiPromptTokensUsed: "promptTokensUsed",
 };
 
+const LEGACY_USAGE_FIELD_NAMES_BY_CURRENT = Object.fromEntries(
+  Object.entries(LEGACY_USAGE_FIELD_NAMES).map(
+    ([legacyField, currentField]) => [currentField, legacyField],
+  ),
+) as Partial<Record<keyof RedisUsage, string>>;
+
 export type WeeklyUsageCostBySubject =
   | { userId: string; cost: number }
   | { email: string; cost: number };
@@ -120,7 +126,7 @@ export async function getUsage(options: {
               : []),
             redis.set(
               doneKey,
-              JSON.stringify({ usage: latestLegacyUsage ?? {} }),
+              serializeLegacyUsageMigrationState(latestLegacyUsage),
             ),
           ]);
         }
@@ -171,7 +177,7 @@ export async function getUsage(options: {
       ...(userUsageKey
         ? getUsageDataIncrementOperations(userUsageKey, legacyUsage)
         : []),
-      redis.set(doneKey, JSON.stringify({ usage: legacyUsage ?? {} })),
+      redis.set(doneKey, serializeLegacyUsageMigrationState(legacyUsage)),
     ]);
 
     return getRedisUsage(emailAccountUsageKey);
@@ -695,6 +701,19 @@ function parseLegacyUsageMigrationState(rawState: unknown): RedisUsage | null {
   } catch {
     return null;
   }
+}
+
+function serializeLegacyUsageMigrationState(usage: RedisUsage) {
+  const legacyUsage = Object.fromEntries(
+    usageFields.flatMap((field) => {
+      const value = usage[field];
+      if (value === undefined) return [];
+
+      return [[LEGACY_USAGE_FIELD_NAMES_BY_CURRENT[field] ?? field, value]];
+    }),
+  );
+
+  return JSON.stringify({ usage: legacyUsage });
 }
 
 async function getRedisUsage(key: string): Promise<RedisUsage> {

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -600,7 +600,7 @@ function parseWeeklyUsageCostKey(key: string) {
   return { subject: `email:${email}`, email, day };
 }
 
-function parseRedisNumber(raw: string | number | undefined): number {
+function parseRedisNumber(raw: unknown): number {
   if (typeof raw === "number") return raw;
   if (typeof raw === "string") return Number.parseFloat(raw) || 0;
   return 0;


### PR DESCRIPTION
## What changed

Renamed the Redis usage hash fields from the legacy `openai*` names to
provider-agnostic ones (`calls`, `tokensUsed`, `completionTokensUsed`,
`promptTokensUsed`). The counters always aggregated usage across all LLM
providers, but the misleading names suggested OpenAI-only accounting.

- `utils/redis/usage.ts`: renamed fields in `RedisUsage`/`usageFields` and
  increment operations; new `getRedisUsage`/`normalizeUsageFields` readers
  fall back from legacy `openai*` fields, summing both when a hash contains
  both names (rolling-deploy state), and normalize old migration markers
- usage page: reads renamed fields (labels unchanged)
- tests: updated assertions, added mixed-hash sum + saveUsage↔getUsage
  round-trip coverage

## Why

No live data is lost: legacy fields remain readable via the fallback and
new writes use the new names.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

