### PR TITLE
feat: onedrive resumable upload

### DIFF
--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/utils/microsoft/oauth", () => ({
   getMicrosoftGraphClientOptions: vi.fn(() => ({})),
 }));
 
+vi.mock("@/utils/sleep", () => ({
+  sleep: vi.fn(async () => undefined),
+}));
+
 describe("OneDriveProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -170,7 +174,7 @@ describe("OneDriveProvider", () => {
       "/me/drive/items/folder-1:/big-file.pdf:/createUploadSession",
     );
     expect(createUploadSessionPost).toHaveBeenCalledWith({
-      item: { "@microsoft.graph.conflictBehavior": "rename" },
+      item: { "@microsoft.graph.conflictBehavior": "replace" },
     });
 
     const putCalls = fetchMock.mock.calls.filter(
@@ -314,6 +318,129 @@ describe("OneDriveProvider", () => {
     expect(
       fetchMock.mock.calls.filter(([, init]) => init?.method === "PUT"),
     ).toHaveLength(3);
+  });
+
+  it("retries a timed-out chunk without advancing the upload", async () => {
+    const totalSize = ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const progressingFetch = createProgressingFetchMock(totalSize);
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("The operation timed out"), {
+          name: "TimeoutError",
+        }),
+      )
+      .mockImplementation(progressingFetch);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    const file = await provider.uploadFile({
+      filename: "big-file.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(file.id).toBe("file-1");
+    expect(getContentRangeHeader(fetchMock.mock.calls[0]?.[1])).toBe(
+      getContentRangeHeader(fetchMock.mock.calls[1]?.[1]),
+    );
+  });
+
+  it("recovers the uploaded item when the final chunk response is lost", async () => {
+    const totalSize = ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const recoveredItem = {
+      id: "file-1",
+      name: "big-file.pdf",
+      file: { mimeType: "application/pdf" },
+      size: totalSize,
+      parentReference: { id: "folder-1" },
+    };
+    const get = vi.fn(async () => recoveredItem);
+    let finalChunkAttempts = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return new Response("not found", { status: 404 });
+      }
+
+      const parsedRange = parseContentRange(getContentRangeHeader(init));
+      if (!parsedRange) {
+        throw new Error(
+          `Unexpected content range: ${getContentRangeHeader(init)}`,
+        );
+      }
+
+      if (parsedRange.endInclusive + 1 >= parsedRange.totalSize) {
+        finalChunkAttempts += 1;
+        if (finalChunkAttempts === 1) {
+          throw new TypeError("fetch failed");
+        }
+        return new Response("already received", { status: 416 });
+      }
+
+      return new Response(
+        JSON.stringify({
+          nextExpectedRanges: [
+            `${parsedRange.endInclusive + 1}-${parsedRange.totalSize - 1}`,
+          ],
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      if (path === "/me/drive/items/folder-1:/big-file.pdf:") {
+        return { get };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    const file = await provider.uploadFile({
+      filename: "big-file.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(file).toMatchObject({
+      id: "file-1",
+      name: "big-file.pdf",
+      size: totalSize,
+    });
+    expect(createUploadSessionPost).toHaveBeenCalledWith({
+      item: { "@microsoft.graph.conflictBehavior": "replace" },
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
+    ).toHaveLength(0);
   });
 
   it("does not re-upload the same chunk when a 202 response does not advance", async () => {

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@microsoft/microsoft-graph-client";
 import { createTestLogger } from "@/__tests__/helpers";
 import { OneDriveProvider } from "./microsoft";
@@ -17,6 +17,10 @@ vi.mock("@/utils/microsoft/oauth", () => ({
 describe("OneDriveProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("sanitizes invalid folder names before creating them", async () => {
@@ -101,4 +105,425 @@ describe("OneDriveProvider", () => {
     expect(header).toHaveBeenCalledWith("Content-Type", "application/pdf");
     expect(put).toHaveBeenCalledWith(content);
   });
+
+  it("uses simple upload for files up to 4MB without creating a session", async () => {
+    const content = Buffer.alloc(4 * 1024 * 1024);
+    const put = vi.fn(async () => ({
+      id: "file-1",
+      name: "exact-4mb.pdf",
+      file: { mimeType: "application/pdf" },
+      parentReference: { id: "folder-1" },
+    }));
+    const header = vi.fn(() => ({ put }));
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        throw new Error("Should not create an upload session for 4MB files");
+      }
+      return { header };
+    });
+
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    await provider.uploadFile({
+      filename: "exact-4mb.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      "/me/drive/items/folder-1:/exact-4mb.pdf:/content",
+    );
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put.mock.calls[0]?.[0]).toHaveLength(4 * 1024 * 1024);
+  });
+
+  it("uploads files larger than 4MB via an upload session in chunks", async () => {
+    const totalSize = 2 * ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const fetchMock = createProgressingFetchMock(totalSize);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    const file = await provider.uploadFile({
+      filename: "big-file.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      "/me/drive/items/folder-1:/big-file.pdf:/createUploadSession",
+    );
+    expect(createUploadSessionPost).toHaveBeenCalledWith({
+      item: { "@microsoft.graph.conflictBehavior": "rename" },
+    });
+
+    const putCalls = fetchMock.mock.calls.filter(
+      ([, init]) => init?.method === "PUT",
+    );
+    expect(putCalls).toHaveLength(3);
+    expect(getContentRangeHeader(putCalls[0]?.[1])).toBe(
+      `bytes 0-${ONEDRIVE_CHUNK_SIZE - 1}/${totalSize}`,
+    );
+    expect(getContentRangeHeader(putCalls[1]?.[1])).toBe(
+      `bytes ${ONEDRIVE_CHUNK_SIZE}-${ONEDRIVE_CHUNK_SIZE * 2 - 1}/${totalSize}`,
+    );
+    expect(getContentRangeHeader(putCalls[2]?.[1])).toBe(
+      `bytes ${ONEDRIVE_CHUNK_SIZE * 2}-${totalSize - 1}/${totalSize}`,
+    );
+
+    expect(file).toMatchObject({
+      id: "file-1",
+      name: "big-file.pdf",
+      mimeType: "application/pdf",
+      size: totalSize,
+      folderId: "folder-1",
+    });
+  });
+
+  it("resumes a session upload from nextExpectedRanges after a 416", async () => {
+    const totalSize = 2 * ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    let firstChunkAttempt = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return new Response(
+          JSON.stringify({
+            nextExpectedRanges: [`${ONEDRIVE_CHUNK_SIZE}-${totalSize - 1}`],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      const contentRange = getContentRangeHeader(init);
+      if (contentRange === `bytes 0-${ONEDRIVE_CHUNK_SIZE - 1}/${totalSize}`) {
+        if (firstChunkAttempt === 0) {
+          firstChunkAttempt += 1;
+          return new Response("already received", { status: 416 });
+        }
+      }
+
+      const parsedRange = parseContentRange(contentRange);
+      if (!parsedRange) {
+        throw new Error(`Unexpected content range: ${contentRange}`);
+      }
+
+      if (parsedRange.endInclusive + 1 >= parsedRange.totalSize) {
+        return createFinalItemResponse(totalSize);
+      }
+
+      return new Response(
+        JSON.stringify({
+          nextExpectedRanges: [
+            `${parsedRange.endInclusive + 1}-${parsedRange.totalSize - 1}`,
+          ],
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    const file = await provider.uploadFile({
+      filename: "big-file.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(file.id).toBe("file-1");
+
+    const statusCallIndex = fetchMock.mock.calls.findIndex(
+      ([, init]) => init?.method === "GET",
+    );
+    expect(statusCallIndex).toBeGreaterThan(-1);
+    const resumedPutCall = fetchMock.mock.calls
+      .slice(statusCallIndex + 1)
+      .find(([, init]) => init?.method === "PUT");
+    expect(getContentRangeHeader(resumedPutCall?.[1])).toBe(
+      `bytes ${ONEDRIVE_CHUNK_SIZE}-${ONEDRIVE_CHUNK_SIZE * 2 - 1}/${totalSize}`,
+    );
+  });
+
+  it("completes when the final upload chunk returns 200 with the item body", async () => {
+    const totalSize = 2 * ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const fetchMock = createProgressingFetchMock(totalSize, 200);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    const file = await provider.uploadFile({
+      filename: "big-file.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(file).toMatchObject({
+      id: "file-1",
+      name: "big-file.pdf",
+      mimeType: "application/pdf",
+      size: totalSize,
+      folderId: "folder-1",
+    });
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "PUT"),
+    ).toHaveLength(3);
+  });
+
+  it("does not re-upload the same chunk when a 202 response does not advance", async () => {
+    const totalSize = ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return new Response(
+          JSON.stringify({
+            nextExpectedRanges: [`0-${totalSize - 1}`],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          nextExpectedRanges: [`0-${totalSize - 1}`],
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    await expect(
+      provider.uploadFile({
+        filename: "big-file.pdf",
+        mimeType: "application/pdf",
+        content,
+        folderId: "folder-1",
+      }),
+    ).rejects.toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining("no usable resume range"),
+      }),
+    });
+
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "PUT"),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "GET"),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
+    ).toHaveLength(1);
+  });
+
+  it("cancels the upload session when a chunk upload fails", async () => {
+    const totalSize = ONEDRIVE_CHUNK_SIZE + 1;
+    const content = Buffer.alloc(totalSize);
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const fetchMock = vi.fn(async () => new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = vi.fn((path: string) => {
+      if (path.endsWith("/createUploadSession")) {
+        return { post: createUploadSessionPost };
+      }
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    await expect(
+      provider.uploadFile({
+        filename: "big-file.pdf",
+        mimeType: "application/pdf",
+        content,
+        folderId: "folder-1",
+      }),
+    ).rejects.toMatchObject({
+      error: expect.objectContaining({
+        message: expect.stringContaining(
+          "Failed to upload OneDrive file chunk: 500",
+        ),
+      }),
+    });
+
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
+    ).toHaveLength(1);
+  });
+
+  it("rejects files above the maximum upload size before creating a session", async () => {
+    const createUploadSessionPost = vi.fn();
+    const api = vi.fn(() => ({ post: createUploadSessionPost }));
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    await expect(
+      provider.uploadFile({
+        filename: "huge-file.pdf",
+        mimeType: "application/pdf",
+        content: {
+          length: MAX_ONEDRIVE_UPLOAD_SIZE_BYTES + 1,
+        } as unknown as Buffer,
+        folderId: "folder-1",
+      }),
+    ).rejects.toThrow("exceeds the maximum supported upload size");
+
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it("throws when the upload session has no upload URL", async () => {
+    const createUploadSessionPost = vi.fn(async () => ({}));
+    const api = vi.fn(() => ({ post: createUploadSessionPost }));
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+
+    await expect(
+      provider.uploadFile({
+        filename: "big-file.pdf",
+        mimeType: "application/pdf",
+        content: Buffer.alloc(4 * 1024 * 1024 + 1),
+        folderId: "folder-1",
+      }),
+    ).rejects.toThrow("Failed to create OneDrive upload session");
+  });
 });
+
+const ONEDRIVE_CHUNK_SIZE = 5 * 1024 * 1024;
+const MAX_ONEDRIVE_UPLOAD_SIZE_BYTES = 250 * 1024 * 1024 * 1024;
+
+function createProgressingFetchMock(
+  totalSize: number,
+  finalStatus: 200 | 201 = 201,
+) {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method === "GET") {
+      throw new Error("Unexpected GET in progressing fetch mock");
+    }
+
+    const parsedRange = parseContentRange(getContentRangeHeader(init));
+    if (!parsedRange) {
+      throw new Error(
+        `Unexpected content range: ${getContentRangeHeader(init)}`,
+      );
+    }
+
+    if (parsedRange.endInclusive + 1 >= parsedRange.totalSize) {
+      return createFinalItemResponse(totalSize, finalStatus);
+    }
+
+    return new Response(
+      JSON.stringify({
+        nextExpectedRanges: [
+          `${parsedRange.endInclusive + 1}-${parsedRange.totalSize - 1}`,
+        ],
+      }),
+      {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  });
+}
+
+function createFinalItemResponse(totalSize: number, status = 201) {
+  return new Response(
+    JSON.stringify({
+      id: "file-1",
+      name: "big-file.pdf",
+      file: { mimeType: "application/pdf" },
+      size: totalSize,
+      parentReference: { id: "folder-1" },
+    }),
+    {
+      status,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+function getContentRangeHeader(init?: RequestInit) {
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.["Content-Range"] || "";
+}
+
+function parseContentRange(contentRange: string) {
+  const match = /bytes (\d+)-(\d+)\/(\d+)/.exec(contentRange);
+  if (!match) return null;
+
+  return {
+    start: Number(match[1]),
+    endInclusive: Number(match[2]),
+    totalSize: Number(match[3]),
+  };
+}

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
 import { Client } from "@microsoft/microsoft-graph-client";
 import { createTestLogger } from "@/__tests__/helpers";
 import { OneDriveProvider } from "./microsoft";
@@ -153,11 +161,8 @@ describe("OneDriveProvider", () => {
     const fetchMock = createProgressingFetchMock(totalSize);
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
+    const { api, reserveItemPut, reserveItemQuery } = createLargeUploadApi({
+      createUploadSessionPost,
     });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
@@ -171,11 +176,13 @@ describe("OneDriveProvider", () => {
     });
 
     expect(api).toHaveBeenCalledWith(
-      "/me/drive/items/folder-1:/big-file.pdf:/createUploadSession",
+      "/me/drive/items/file-1/createUploadSession",
     );
-    expect(createUploadSessionPost).toHaveBeenCalledWith({
-      item: { "@microsoft.graph.conflictBehavior": "replace" },
+    expect(reserveItemQuery).toHaveBeenCalledWith({
+      "@microsoft.graph.conflictBehavior": "rename",
     });
+    expect(reserveItemPut).toHaveBeenCalledWith(Buffer.alloc(0));
+    expect(createUploadSessionPost).toHaveBeenCalledWith({});
 
     const putCalls = fetchMock.mock.calls.filter(
       ([, init]) => init?.method === "PUT",
@@ -251,12 +258,7 @@ describe("OneDriveProvider", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
-    });
+    const { api } = createLargeUploadApi({ createUploadSessionPost });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -291,12 +293,7 @@ describe("OneDriveProvider", () => {
     const fetchMock = createProgressingFetchMock(totalSize, 200);
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
-    });
+    const { api } = createLargeUploadApi({ createUploadSessionPost });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -337,12 +334,7 @@ describe("OneDriveProvider", () => {
       .mockImplementation(progressingFetch);
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
-    });
+    const { api } = createLargeUploadApi({ createUploadSessionPost });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -368,7 +360,7 @@ describe("OneDriveProvider", () => {
     }));
     const recoveredItem = {
       id: "file-1",
-      name: "big-file.pdf",
+      name: "big-file 1.pdf",
       file: { mimeType: "application/pdf" },
       size: totalSize,
       parentReference: { id: "folder-1" },
@@ -409,14 +401,16 @@ describe("OneDriveProvider", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      if (path === "/me/drive/items/folder-1:/big-file.pdf:") {
-        return { get };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
+    const { api, reserveItemPut, reserveItemQuery } = createLargeUploadApi({
+      createUploadSessionPost,
+      get,
+      reservedItem: {
+        id: "file-1",
+        name: "big-file 1.pdf",
+        file: { mimeType: "application/pdf" },
+        size: 0,
+        parentReference: { id: "folder-1" },
+      },
     });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
@@ -431,12 +425,14 @@ describe("OneDriveProvider", () => {
 
     expect(file).toMatchObject({
       id: "file-1",
-      name: "big-file.pdf",
+      name: "big-file 1.pdf",
       size: totalSize,
     });
-    expect(createUploadSessionPost).toHaveBeenCalledWith({
-      item: { "@microsoft.graph.conflictBehavior": "replace" },
+    expect(reserveItemQuery).toHaveBeenCalledWith({
+      "@microsoft.graph.conflictBehavior": "rename",
     });
+    expect(reserveItemPut).toHaveBeenCalledWith(Buffer.alloc(0));
+    expect(api).toHaveBeenCalledWith("/me/drive/items/file-1");
     expect(get).toHaveBeenCalledTimes(1);
     expect(
       fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
@@ -474,12 +470,7 @@ describe("OneDriveProvider", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
-    });
+    const { api } = createLargeUploadApi({ createUploadSessionPost });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -517,12 +508,7 @@ describe("OneDriveProvider", () => {
     const fetchMock = vi.fn(async () => new Response("boom", { status: 500 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const api = vi.fn((path: string) => {
-      if (path.endsWith("/createUploadSession")) {
-        return { post: createUploadSessionPost };
-      }
-      throw new Error(`Unexpected API path: ${path}`);
-    });
+    const { api } = createLargeUploadApi({ createUploadSessionPost });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -570,7 +556,9 @@ describe("OneDriveProvider", () => {
 
   it("throws when the upload session has no upload URL", async () => {
     const createUploadSessionPost = vi.fn(async () => ({}));
-    const api = vi.fn(() => ({ post: createUploadSessionPost }));
+    const { api, deleteItem } = createLargeUploadApi({
+      createUploadSessionPost,
+    });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -583,11 +571,55 @@ describe("OneDriveProvider", () => {
         folderId: "folder-1",
       }),
     ).rejects.toThrow("Failed to create OneDrive upload session");
+
+    expect(deleteItem).toHaveBeenCalledTimes(1);
   });
 });
 
 const ONEDRIVE_CHUNK_SIZE = 5 * 1024 * 1024;
 const MAX_ONEDRIVE_UPLOAD_SIZE_BYTES = 250 * 1024 * 1024 * 1024;
+
+function createLargeUploadApi({
+  createUploadSessionPost,
+  get,
+  reservedItem = {
+    id: "file-1",
+    name: "big-file.pdf",
+    file: { mimeType: "application/pdf" },
+    size: 0,
+    parentReference: { id: "folder-1" },
+  },
+}: {
+  createUploadSessionPost: Mock;
+  get?: Mock;
+  reservedItem?: {
+    id: string;
+    name: string;
+    file: { mimeType: string };
+    size: number;
+    parentReference: { id: string };
+  };
+}) {
+  const reserveItemPut = vi.fn(async () => reservedItem);
+  const reserveItemHeader = vi.fn(() => ({ put: reserveItemPut }));
+  const reserveItemQuery = vi.fn(() => ({ header: reserveItemHeader }));
+  const getItem = get ?? vi.fn(async () => reservedItem);
+  const deleteItem = vi.fn(async () => undefined);
+  const api = vi.fn((path: string) => {
+    if (path === "/me/drive/items/folder-1:/big-file.pdf:/content") {
+      return { query: reserveItemQuery };
+    }
+    if (path === `/me/drive/items/${reservedItem.id}/createUploadSession`) {
+      return { post: createUploadSessionPost };
+    }
+    if (path === `/me/drive/items/${reservedItem.id}`) {
+      return { delete: deleteItem, get: getItem };
+    }
+    throw new Error(`Unexpected API path: ${path}`);
+  });
+
+  return { api, deleteItem, reserveItemPut, reserveItemQuery };
+}
 
 function createProgressingFetchMock(
   totalSize: number,

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -470,7 +470,9 @@ describe("OneDriveProvider", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const { api } = createLargeUploadApi({ createUploadSessionPost });
+    const { api, deleteItem } = createLargeUploadApi({
+      createUploadSessionPost,
+    });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -497,6 +499,7 @@ describe("OneDriveProvider", () => {
     expect(
       fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
     ).toHaveLength(1);
+    expect(deleteItem).toHaveBeenCalledTimes(1);
   });
 
   it("cancels the upload session when a chunk upload fails", async () => {
@@ -508,7 +511,9 @@ describe("OneDriveProvider", () => {
     const fetchMock = vi.fn(async () => new Response("boom", { status: 500 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const { api } = createLargeUploadApi({ createUploadSessionPost });
+    const { api, deleteItem } = createLargeUploadApi({
+      createUploadSessionPost,
+    });
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
     const provider = new OneDriveProvider("token", createTestLogger());
@@ -531,6 +536,7 @@ describe("OneDriveProvider", () => {
     expect(
       fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
     ).toHaveLength(1);
+    expect(deleteItem).toHaveBeenCalledTimes(1);
   });
 
   it("rejects files above the maximum upload size before creating a session", async () => {

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -7,6 +7,7 @@ import {
   getMicrosoftGraphClientOptions,
 } from "@/utils/microsoft/oauth";
 import { isNotFoundError } from "@/utils/outlook/errors";
+import { uploadResumableChunks } from "@/utils/microsoft/upload-session";
 import type {
   DriveProvider,
   DriveFolder,
@@ -136,6 +137,10 @@ export class OneDriveProvider implements DriveProvider {
 
   async uploadFile(params: UploadFileParams): Promise<DriveFile> {
     const { filename, mimeType, content, folderId } = params;
+    // Graph upload sessions support up to 250 GB
+    const MAX_ONEDRIVE_UPLOAD_SIZE_BYTES = 250 * 1024 * 1024 * 1024; // 250 GB
+    const MAX_SIMPLE_UPLOAD_SIZE = 4 * 1024 * 1024; // 4MB
+
     this.logger.info("Uploading file", {
       filename,
       mimeType,
@@ -144,20 +149,13 @@ export class OneDriveProvider implements DriveProvider {
     });
 
     try {
-      // For files up to 4MB, use simple upload
-      // For larger files, would need to use upload session (not implemented yet)
-      const MAX_SIMPLE_UPLOAD_SIZE = 4 * 1024 * 1024; // 4MB
-
       if (content.length > MAX_SIMPLE_UPLOAD_SIZE) {
-        // TODO: Implement resumable upload for large files
-        this.logger.warn("File exceeds simple upload limit", {
-          filename,
-          size: content.length,
-          limit: MAX_SIMPLE_UPLOAD_SIZE,
-        });
-        throw new Error(
-          `File size ${content.length} exceeds 4MB limit. Large file upload not yet implemented.`,
-        );
+        if (content.length > MAX_ONEDRIVE_UPLOAD_SIZE_BYTES) {
+          throw new Error(
+            `File size ${content.length} exceeds the maximum supported upload size of ${MAX_ONEDRIVE_UPLOAD_SIZE_BYTES} bytes.`,
+          );
+        }
+        return await this.uploadFileViaUploadSession(params);
       }
 
       // Use the PUT endpoint for simple upload
@@ -175,6 +173,40 @@ export class OneDriveProvider implements DriveProvider {
       this.logger.error("Error uploading file", { error, filename, folderId });
       throw error;
     }
+  }
+
+  private async uploadFileViaUploadSession(
+    params: UploadFileParams,
+  ): Promise<DriveFile> {
+    const { filename, content, folderId } = params;
+    const ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024;
+
+    const uploadSession: DriveItem & { uploadUrl?: string } = await this.client
+      .api(
+        `/me/drive/items/${folderId}:/${encodeURIComponent(normalizeOneDriveItemName(filename))}:/createUploadSession`,
+      )
+      .post({
+        item: {
+          "@microsoft.graph.conflictBehavior": "rename",
+        },
+      });
+
+    const uploadUrl = uploadSession.uploadUrl;
+    if (!uploadUrl) {
+      throw new Error("Failed to create OneDrive upload session");
+    }
+
+    const finalResponse = await uploadResumableChunks({
+      uploadUrl,
+      content,
+      chunkSizeBytes: ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES,
+      logger: this.logger,
+      action: "upload OneDrive file chunk",
+      statusAction: "fetch OneDrive upload session status",
+    });
+
+    const item = (await finalResponse.json()) as DriveItem;
+    return this.convertToFile(item);
   }
 
   async getFile(fileId: string): Promise<DriveFile | null> {

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -182,20 +182,33 @@ export class OneDriveProvider implements DriveProvider {
   private async uploadFileViaUploadSession(
     params: UploadFileParams,
   ): Promise<DriveFile> {
-    const { filename, content, folderId } = params;
+    const { filename, mimeType, content, folderId } = params;
     const normalizedFilename = normalizeOneDriveItemName(filename);
-    const itemPath = `/me/drive/items/${folderId}:/${encodeURIComponent(normalizedFilename)}:`;
+    const newItemPath = `/me/drive/items/${folderId}:/${encodeURIComponent(normalizedFilename)}:/content`;
+    // Reserve the conflict-safe name so recovery can use a stable item ID even
+    // when Graph renamed the file and the final chunk response was lost.
+    const reservedItem: DriveItem = await this.client
+      .api(newItemPath)
+      .query({ "@microsoft.graph.conflictBehavior": "rename" })
+      .header("Content-Type", mimeType)
+      .put(Buffer.alloc(0));
+
+    if (!reservedItem.id) {
+      throw new Error("Failed to reserve a OneDrive file for upload");
+    }
+
+    const itemPath = `/me/drive/items/${reservedItem.id}`;
 
     const uploadSession: UploadSession = await this.client
       .api(`${itemPath}/createUploadSession`)
-      .post({
-        item: {
-          "@microsoft.graph.conflictBehavior": "replace",
-        },
-      });
+      .post({});
 
     const uploadUrl = uploadSession.uploadUrl;
     if (!uploadUrl) {
+      await this.client
+        .api(itemPath)
+        .delete()
+        .catch(() => undefined);
       throw new Error("Failed to create OneDrive upload session");
     }
 

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -1,5 +1,8 @@
 import { Client } from "@microsoft/microsoft-graph-client";
-import type { DriveItem } from "@microsoft/microsoft-graph-types";
+import type {
+  DriveItem,
+  UploadSession,
+} from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { createScopedLogger } from "@/utils/logger";
 import {
@@ -14,6 +17,10 @@ import type {
   DriveFile,
   UploadFileParams,
 } from "@/utils/drive/types";
+
+const MAX_ONEDRIVE_UPLOAD_SIZE_BYTES = 250 * 1024 * 1024 * 1024;
+const MAX_SIMPLE_UPLOAD_SIZE_BYTES = 4 * 1024 * 1024;
+const ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024;
 
 export class OneDriveProvider implements DriveProvider {
   readonly name = "microsoft" as const;
@@ -137,9 +144,6 @@ export class OneDriveProvider implements DriveProvider {
 
   async uploadFile(params: UploadFileParams): Promise<DriveFile> {
     const { filename, mimeType, content, folderId } = params;
-    // Graph upload sessions support up to 250 GB
-    const MAX_ONEDRIVE_UPLOAD_SIZE_BYTES = 250 * 1024 * 1024 * 1024; // 250 GB
-    const MAX_SIMPLE_UPLOAD_SIZE = 4 * 1024 * 1024; // 4MB
 
     this.logger.info("Uploading file", {
       filename,
@@ -149,7 +153,7 @@ export class OneDriveProvider implements DriveProvider {
     });
 
     try {
-      if (content.length > MAX_SIMPLE_UPLOAD_SIZE) {
+      if (content.length > MAX_SIMPLE_UPLOAD_SIZE_BYTES) {
         if (content.length > MAX_ONEDRIVE_UPLOAD_SIZE_BYTES) {
           throw new Error(
             `File size ${content.length} exceeds the maximum supported upload size of ${MAX_ONEDRIVE_UPLOAD_SIZE_BYTES} bytes.`,
@@ -179,15 +183,14 @@ export class OneDriveProvider implements DriveProvider {
     params: UploadFileParams,
   ): Promise<DriveFile> {
     const { filename, content, folderId } = params;
-    const ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024;
+    const normalizedFilename = normalizeOneDriveItemName(filename);
+    const itemPath = `/me/drive/items/${folderId}:/${encodeURIComponent(normalizedFilename)}:`;
 
-    const uploadSession: DriveItem & { uploadUrl?: string } = await this.client
-      .api(
-        `/me/drive/items/${folderId}:/${encodeURIComponent(normalizeOneDriveItemName(filename))}:/createUploadSession`,
-      )
+    const uploadSession: UploadSession = await this.client
+      .api(`${itemPath}/createUploadSession`)
       .post({
         item: {
-          "@microsoft.graph.conflictBehavior": "rename",
+          "@microsoft.graph.conflictBehavior": "replace",
         },
       });
 
@@ -196,7 +199,7 @@ export class OneDriveProvider implements DriveProvider {
       throw new Error("Failed to create OneDrive upload session");
     }
 
-    const finalResponse = await uploadResumableChunks({
+    const result = await uploadResumableChunks({
       uploadUrl,
       content,
       chunkSizeBytes: ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES,
@@ -205,7 +208,17 @@ export class OneDriveProvider implements DriveProvider {
       statusAction: "fetch OneDrive upload session status",
     });
 
-    const item = (await finalResponse.json()) as DriveItem;
+    const item: DriveItem =
+      result.kind === "complete"
+        ? await result.response.json()
+        : await this.client.api(itemPath).get();
+
+    if (result.kind === "committed" && item.size !== content.length) {
+      throw new Error(
+        "OneDrive upload completed without a response, but the uploaded item could not be verified",
+      );
+    }
+
     return this.convertToFile(item);
   }
 

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -198,41 +198,56 @@ export class OneDriveProvider implements DriveProvider {
     }
 
     const itemPath = `/me/drive/items/${reservedItem.id}`;
+    try {
+      const uploadSession: UploadSession = await this.client
+        .api(`${itemPath}/createUploadSession`)
+        .post({});
 
-    const uploadSession: UploadSession = await this.client
-      .api(`${itemPath}/createUploadSession`)
-      .post({});
+      const uploadUrl = uploadSession.uploadUrl;
+      if (!uploadUrl) {
+        throw new Error("Failed to create OneDrive upload session");
+      }
 
-    const uploadUrl = uploadSession.uploadUrl;
-    if (!uploadUrl) {
-      await this.client
+      const result = await uploadResumableChunks({
+        uploadUrl,
+        content,
+        chunkSizeBytes: ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES,
+        logger: this.logger,
+        action: "upload OneDrive file chunk",
+        statusAction: "fetch OneDrive upload session status",
+      });
+
+      const item: DriveItem =
+        result.kind === "complete"
+          ? await result.response.json()
+          : await this.client.api(itemPath).get();
+
+      if (result.kind === "committed" && item.size !== content.length) {
+        throw new Error(
+          "OneDrive upload completed without a response, but the uploaded item could not be verified",
+        );
+      }
+
+      return this.convertToFile(item);
+    } catch (error) {
+      const item = await this.client
         .api(itemPath)
-        .delete()
-        .catch(() => undefined);
-      throw new Error("Failed to create OneDrive upload session");
+        .get()
+        .catch(() => null);
+
+      if (item?.size === content.length) {
+        return this.convertToFile(item);
+      }
+
+      if (item?.size === 0) {
+        await this.client
+          .api(itemPath)
+          .delete()
+          .catch(() => undefined);
+      }
+
+      throw error;
     }
-
-    const result = await uploadResumableChunks({
-      uploadUrl,
-      content,
-      chunkSizeBytes: ONEDRIVE_UPLOAD_CHUNK_SIZE_BYTES,
-      logger: this.logger,
-      action: "upload OneDrive file chunk",
-      statusAction: "fetch OneDrive upload session status",
-    });
-
-    const item: DriveItem =
-      result.kind === "complete"
-        ? await result.response.json()
-        : await this.client.api(itemPath).get();
-
-    if (result.kind === "committed" && item.size !== content.length) {
-      throw new Error(
-        "OneDrive upload completed without a response, but the uploaded item could not be verified",
-      );
-    }
-
-    return this.convertToFile(item);
   }
 
   async getFile(fileId: string): Promise<DriveFile | null> {

--- a/apps/web/utils/microsoft/upload-session.ts
+++ b/apps/web/utils/microsoft/upload-session.ts
@@ -1,3 +1,4 @@
+import type { UploadSession } from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { withOutlookRetry } from "@/utils/outlook/retry";
 
@@ -11,13 +12,12 @@ const UPLOAD_SESSION_REQUEST_TIMEOUT_MS = 60_000;
  * Shared by Outlook attachment uploads and OneDrive file uploads. Both use
  * the same protocol (PUT chunks with Content-Range, resume from
  * `nextExpectedRanges`), but each resource has its own chunk-size constraint:
- * - Outlook attachment sessions: chunks must be exactly 320 KiB
+ * - Outlook attachment sessions: this caller uses 320 KiB chunks
  * - Drive upload sessions: chunks must be multiples of 320 KiB
  *
- * Returns the final response, whose body is the created resource. Microsoft
- * documents the final range as answered with 201 Created or 200 OK; a 200
- * response whose body lacks `nextExpectedRanges` is the created resource, not
- * a progress update. Callers must therefore inspect the returned body.
+ * Returns the final response when it is available. If a retry proves that the
+ * final chunk was already accepted after its response was lost, returns a
+ * committed result so the caller can recover the created resource.
  *
  * If any chunk fails, the session is cancelled with a DELETE so Microsoft does
  * not keep it alive for up to 48 hours or surface partial items on retry.
@@ -36,7 +36,7 @@ export async function uploadResumableChunks({
   logger: Logger;
   action: string;
   statusAction: string;
-}): Promise<Response> {
+}): Promise<UploadResult> {
   let start = 0;
   try {
     while (start < content.length) {
@@ -58,7 +58,11 @@ export async function uploadResumableChunks({
       );
 
       if (result.kind === "complete") {
-        return result.response;
+        return result;
+      }
+
+      if (result.nextStart === content.length) {
+        return { kind: "committed" };
       }
 
       start = result.nextStart;
@@ -77,6 +81,10 @@ export async function uploadResumableChunks({
 type ChunkUploadResult =
   | { kind: "complete"; response: Response }
   | { kind: "progress"; nextStart: number };
+
+type UploadResult =
+  | { kind: "complete"; response: Response }
+  | { kind: "committed" };
 
 async function uploadChunk({
   uploadUrl,
@@ -97,14 +105,14 @@ async function uploadChunk({
   action: string;
   statusAction: string;
 }): Promise<ChunkUploadResult> {
-  const response = await fetch(uploadUrl, {
+  const response = await fetchUploadSession(uploadUrl, {
     method: "PUT",
     headers: {
       "Content-Type": "application/octet-stream",
       "Content-Length": String(chunk.length),
       "Content-Range": `bytes ${start}-${end - 1}/${totalSize}`,
     },
-    body: new Uint8Array(chunk),
+    body: new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
     signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
   });
 
@@ -131,9 +139,14 @@ async function uploadChunk({
           uploadUrl,
           statusAction,
           start,
-          end,
         }),
       };
+    }
+
+    if (typeof uploadStatus.id !== "string" || !uploadStatus.id) {
+      throw new Error(
+        "Upload session returned 200 without nextExpectedRanges or a created item",
+      );
     }
 
     return { kind: "complete", response };
@@ -157,7 +170,6 @@ async function uploadChunk({
         uploadUrl,
         statusAction,
         start,
-        end,
       }),
     };
   }
@@ -171,7 +183,7 @@ async function uploadChunk({
         uploadUrl,
         statusAction,
         start,
-        end,
+        unavailableNextStart: end,
       }),
     };
   }
@@ -191,7 +203,6 @@ async function ensureMonotonicProgress({
   uploadUrl,
   statusAction,
   start,
-  end,
 }: {
   nextStart: number;
   chunkSizeBytes: number;
@@ -199,7 +210,6 @@ async function ensureMonotonicProgress({
   uploadUrl: string;
   statusAction: string;
   start: number;
-  end: number;
 }): Promise<number> {
   if (isTrustedProgress(nextStart, start, chunkSizeBytes, totalSize)) {
     return nextStart;
@@ -211,7 +221,6 @@ async function ensureMonotonicProgress({
     uploadUrl,
     statusAction,
     start,
-    end,
   });
 }
 
@@ -221,19 +230,21 @@ async function resolveResumeRange({
   uploadUrl,
   statusAction,
   start,
-  end,
+  unavailableNextStart,
 }: {
   chunkSizeBytes: number;
   totalSize: number;
   uploadUrl: string;
   statusAction: string;
   start: number;
-  end: number;
+  unavailableNextStart?: number;
 }): Promise<number> {
   const uploadStatus = await getUploadSessionStatus(uploadUrl, statusAction);
   if (!uploadStatus) {
-    // Session unavailable (expired or unknown); assume the chunk was received
-    return end;
+    if (typeof unavailableNextStart === "number") {
+      return unavailableNextStart;
+    }
+    throw new Error("Upload session status is unavailable");
   }
 
   const nextStart = getNextExpectedRangeStart(uploadStatus.nextExpectedRanges);
@@ -260,19 +271,20 @@ function isTrustedProgress(
 ): boolean {
   return (
     nextStart > start &&
-    (nextStart >= totalSize || nextStart % chunkSizeBytes === 0)
+    (nextStart === totalSize || nextStart % chunkSizeBytes === 0)
   );
 }
 
-interface UploadSessionStatus {
-  nextExpectedRanges?: string[];
+interface UploadSessionStatus
+  extends Pick<UploadSession, "nextExpectedRanges"> {
+  id?: unknown;
 }
 
 async function getUploadSessionStatus(
   uploadUrl: string,
   statusAction: string,
 ): Promise<UploadSessionStatus | null> {
-  const response = await fetch(uploadUrl, {
+  const response = await fetchUploadSession(uploadUrl, {
     method: "GET",
     signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
   });
@@ -289,21 +301,37 @@ async function getUploadSessionStatus(
 }
 
 async function cancelUploadSession(uploadUrl: string): Promise<void> {
-  await fetch(uploadUrl, {
+  await fetchUploadSession(uploadUrl, {
     method: "DELETE",
     signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
   });
 }
 
-function getNextExpectedRangeStart(nextExpectedRanges?: string[]) {
+async function fetchUploadSession(
+  uploadUrl: string,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetch(uploadUrl, init);
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new TypeError("fetch failed", { cause: error });
+    }
+    throw error;
+  }
+}
+
+function getNextExpectedRangeStart(nextExpectedRanges?: string[] | null) {
   const nextRange = nextExpectedRanges?.[0];
   if (!nextRange) return null;
 
   const [rangeStart] = nextRange.split("-");
   if (!rangeStart) return null;
 
-  const parsedRangeStart = Number.parseInt(rangeStart, 10);
-  return Number.isNaN(parsedRangeStart) ? null : parsedRangeStart;
+  const parsedRangeStart = Number(rangeStart);
+  return Number.isSafeInteger(parsedRangeStart) && parsedRangeStart >= 0
+    ? parsedRangeStart
+    : null;
 }
 
 async function throwUploadSessionResponseError(

--- a/apps/web/utils/microsoft/upload-session.ts
+++ b/apps/web/utils/microsoft/upload-session.ts
@@ -57,12 +57,8 @@ export async function uploadResumableChunks({
         logger,
       );
 
-      if (result.kind === "complete") {
+      if (result.kind !== "progress") {
         return result;
-      }
-
-      if (result.nextStart === content.length) {
-        return { kind: "committed" };
       }
 
       start = result.nextStart;
@@ -80,7 +76,8 @@ export async function uploadResumableChunks({
 
 type ChunkUploadResult =
   | { kind: "complete"; response: Response }
-  | { kind: "progress"; nextStart: number };
+  | { kind: "progress"; nextStart: number }
+  | { kind: "committed" };
 
 type UploadResult =
   | { kind: "complete"; response: Response }
@@ -175,16 +172,22 @@ async function uploadChunk({
   }
 
   if (response.status === 416) {
+    const nextStart = await resolveResumeRange({
+      chunkSizeBytes,
+      totalSize,
+      uploadUrl,
+      statusAction,
+      start,
+      unavailableNextStart: end,
+    });
+
+    if (nextStart === totalSize) {
+      return { kind: "committed" };
+    }
+
     return {
       kind: "progress",
-      nextStart: await resolveResumeRange({
-        chunkSizeBytes,
-        totalSize,
-        uploadUrl,
-        statusAction,
-        start,
-        unavailableNextStart: end,
-      }),
+      nextStart,
     };
   }
 

--- a/apps/web/utils/microsoft/upload-session.ts
+++ b/apps/web/utils/microsoft/upload-session.ts
@@ -112,7 +112,7 @@ async function uploadChunk({
       "Content-Length": String(chunk.length),
       "Content-Range": `bytes ${start}-${end - 1}/${totalSize}`,
     },
-    body: new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+    body: new Uint8Array(chunk),
     signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
   });
 

--- a/apps/web/utils/microsoft/upload-session.ts
+++ b/apps/web/utils/microsoft/upload-session.ts
@@ -1,0 +1,323 @@
+import type { Logger } from "@/utils/logger";
+import { withOutlookRetry } from "@/utils/outlook/retry";
+
+// Per-request bound so a hung connection stalls the upload for at most this
+// long. Chunk uploads already retry transient failures via `withOutlookRetry`.
+const UPLOAD_SESSION_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Uploads a Buffer to a Microsoft Graph upload session in chunks.
+ *
+ * Shared by Outlook attachment uploads and OneDrive file uploads. Both use
+ * the same protocol (PUT chunks with Content-Range, resume from
+ * `nextExpectedRanges`), but each resource has its own chunk-size constraint:
+ * - Outlook attachment sessions: chunks must be exactly 320 KiB
+ * - Drive upload sessions: chunks must be multiples of 320 KiB
+ *
+ * Returns the final response, whose body is the created resource. Microsoft
+ * documents the final range as answered with 201 Created or 200 OK; a 200
+ * response whose body lacks `nextExpectedRanges` is the created resource, not
+ * a progress update. Callers must therefore inspect the returned body.
+ *
+ * If any chunk fails, the session is cancelled with a DELETE so Microsoft does
+ * not keep it alive for up to 48 hours or surface partial items on retry.
+ */
+export async function uploadResumableChunks({
+  uploadUrl,
+  content,
+  chunkSizeBytes,
+  logger,
+  action,
+  statusAction,
+}: {
+  uploadUrl: string;
+  content: Buffer;
+  chunkSizeBytes: number;
+  logger: Logger;
+  action: string;
+  statusAction: string;
+}): Promise<Response> {
+  let start = 0;
+  try {
+    while (start < content.length) {
+      const end = Math.min(start + chunkSizeBytes, content.length);
+      const chunk = content.subarray(start, end);
+      const result = await withOutlookRetry(
+        () =>
+          uploadChunk({
+            uploadUrl,
+            chunk,
+            start,
+            end,
+            totalSize: content.length,
+            chunkSizeBytes,
+            action,
+            statusAction,
+          }),
+        logger,
+      );
+
+      if (result.kind === "complete") {
+        return result.response;
+      }
+
+      start = result.nextStart;
+    }
+
+    throw new Error(
+      `Failed to ${action}: upload session ended without returning the created item`,
+    );
+  } catch (error) {
+    // Best-effort cleanup: deleting the session is a documented cancellation.
+    await cancelUploadSession(uploadUrl).catch(() => undefined);
+    throw error;
+  }
+}
+
+type ChunkUploadResult =
+  | { kind: "complete"; response: Response }
+  | { kind: "progress"; nextStart: number };
+
+async function uploadChunk({
+  uploadUrl,
+  chunk,
+  start,
+  end,
+  totalSize,
+  chunkSizeBytes,
+  action,
+  statusAction,
+}: {
+  uploadUrl: string;
+  chunk: Buffer;
+  start: number;
+  end: number;
+  totalSize: number;
+  chunkSizeBytes: number;
+  action: string;
+  statusAction: string;
+}): Promise<ChunkUploadResult> {
+  const response = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(chunk.length),
+      "Content-Range": `bytes ${start}-${end - 1}/${totalSize}`,
+    },
+    body: new Uint8Array(chunk),
+    signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (response.status === 201) {
+    return { kind: "complete", response };
+  }
+
+  if (response.status === 200) {
+    // A 200 is a progress response when it carries nextExpectedRanges, but for
+    // the final range it is answered with the created resource in the body
+    // instead (Microsoft documents the last range as 201 Created or 200 OK).
+    // The body is peeked via a clone so the caller can still read it.
+    const uploadStatus = (await response.clone().json()) as UploadSessionStatus;
+    const nextStart = getNextExpectedRangeStart(
+      uploadStatus.nextExpectedRanges,
+    );
+    if (typeof nextStart === "number") {
+      return {
+        kind: "progress",
+        nextStart: await ensureMonotonicProgress({
+          nextStart,
+          chunkSizeBytes,
+          totalSize,
+          uploadUrl,
+          statusAction,
+          start,
+          end,
+        }),
+      };
+    }
+
+    return { kind: "complete", response };
+  }
+
+  if (response.status === 202) {
+    const uploadStatus = (await response.json()) as UploadSessionStatus;
+    const nextStart = getNextExpectedRangeStart(
+      uploadStatus.nextExpectedRanges,
+    );
+    if (typeof nextStart !== "number") {
+      throw new Error("Upload session returned 202 without nextExpectedRanges");
+    }
+
+    return {
+      kind: "progress",
+      nextStart: await ensureMonotonicProgress({
+        nextStart,
+        chunkSizeBytes,
+        totalSize,
+        uploadUrl,
+        statusAction,
+        start,
+        end,
+      }),
+    };
+  }
+
+  if (response.status === 416) {
+    return {
+      kind: "progress",
+      nextStart: await resolveResumeRange({
+        chunkSizeBytes,
+        totalSize,
+        uploadUrl,
+        statusAction,
+        start,
+        end,
+      }),
+    };
+  }
+
+  return await throwUploadSessionResponseError(response, action);
+}
+
+// The server reports where to continue via `nextExpectedRanges`, which the
+// docs warn is not guaranteed to list every range. A response that fails to
+// advance, or advances by a partial chunk (one byte at a time would otherwise
+// mean O(n) requests), is not trusted: recover from the session status like a
+// 416 and throw when the server offers no usable range.
+async function ensureMonotonicProgress({
+  nextStart,
+  chunkSizeBytes,
+  totalSize,
+  uploadUrl,
+  statusAction,
+  start,
+  end,
+}: {
+  nextStart: number;
+  chunkSizeBytes: number;
+  totalSize: number;
+  uploadUrl: string;
+  statusAction: string;
+  start: number;
+  end: number;
+}): Promise<number> {
+  if (isTrustedProgress(nextStart, start, chunkSizeBytes, totalSize)) {
+    return nextStart;
+  }
+
+  return await resolveResumeRange({
+    chunkSizeBytes,
+    totalSize,
+    uploadUrl,
+    statusAction,
+    start,
+    end,
+  });
+}
+
+async function resolveResumeRange({
+  chunkSizeBytes,
+  totalSize,
+  uploadUrl,
+  statusAction,
+  start,
+  end,
+}: {
+  chunkSizeBytes: number;
+  totalSize: number;
+  uploadUrl: string;
+  statusAction: string;
+  start: number;
+  end: number;
+}): Promise<number> {
+  const uploadStatus = await getUploadSessionStatus(uploadUrl, statusAction);
+  if (!uploadStatus) {
+    // Session unavailable (expired or unknown); assume the chunk was received
+    return end;
+  }
+
+  const nextStart = getNextExpectedRangeStart(uploadStatus.nextExpectedRanges);
+  if (
+    typeof nextStart === "number" &&
+    isTrustedProgress(nextStart, start, chunkSizeBytes, totalSize)
+  ) {
+    return nextStart;
+  }
+
+  throw new Error(
+    "Upload session did not make progress (no usable resume range)",
+  );
+}
+
+// Only chunk-aligned ranges are trusted: the upload always sends full chunks
+// from chunk-aligned offsets, and documented servers resume from a chunk
+// boundary (or from the end of the file).
+function isTrustedProgress(
+  nextStart: number,
+  start: number,
+  chunkSizeBytes: number,
+  totalSize: number,
+): boolean {
+  return (
+    nextStart > start &&
+    (nextStart >= totalSize || nextStart % chunkSizeBytes === 0)
+  );
+}
+
+interface UploadSessionStatus {
+  nextExpectedRanges?: string[];
+}
+
+async function getUploadSessionStatus(
+  uploadUrl: string,
+  statusAction: string,
+): Promise<UploadSessionStatus | null> {
+  const response = await fetch(uploadUrl, {
+    method: "GET",
+    signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (response.status === 404 || response.status === 405) {
+    return null;
+  }
+
+  if (!response.ok) {
+    return await throwUploadSessionResponseError(response, statusAction);
+  }
+
+  return (await response.json()) as UploadSessionStatus;
+}
+
+async function cancelUploadSession(uploadUrl: string): Promise<void> {
+  await fetch(uploadUrl, {
+    method: "DELETE",
+    signal: AbortSignal.timeout(UPLOAD_SESSION_REQUEST_TIMEOUT_MS),
+  });
+}
+
+function getNextExpectedRangeStart(nextExpectedRanges?: string[]) {
+  const nextRange = nextExpectedRanges?.[0];
+  if (!nextRange) return null;
+
+  const [rangeStart] = nextRange.split("-");
+  if (!rangeStart) return null;
+
+  const parsedRangeStart = Number.parseInt(rangeStart, 10);
+  return Number.isNaN(parsedRangeStart) ? null : parsedRangeStart;
+}
+
+async function throwUploadSessionResponseError(
+  response: Response,
+  action: string,
+): Promise<never> {
+  const errorText = await response.text();
+  const error = new Error(
+    `Failed to ${action}: ${response.status} ${errorText || response.statusText}`,
+  );
+  Object.assign(error, {
+    status: response.status,
+    body: errorText,
+    response: { headers: response.headers, status: response.status },
+  });
+  throw error;
+}

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -431,6 +431,80 @@ describe("sendEmailWithHtml", () => {
     expect(sendPost).not.toHaveBeenCalled();
   });
 
+  it("does not send when a 202 response reports the full size without finalizing", async () => {
+    const draftPost = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+        }) as Message,
+    );
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const sendPost = vi.fn(async () => ({}));
+    const totalSize = 3 * 1024 * 1024 + 1;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+
+      const parsedRange = parseContentRange(getContentRangeHeader(init));
+      if (!parsedRange) {
+        throw new Error(
+          `Unexpected content range: ${getContentRangeHeader(init)}`,
+        );
+      }
+
+      const nextStart = parsedRange.endInclusive + 1;
+      return new Response(
+        JSON.stringify({
+          nextExpectedRanges: [`${nextStart}-${parsedRange.totalSize - 1}`],
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages") return { post: draftPost };
+      if (path === "/me/messages/draft-1/attachments/createUploadSession") {
+        return { post: createUploadSessionPost };
+      }
+      if (path === "/me/messages/draft-1/send") return { post: sendPost };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await expect(
+      sendEmailWithHtml(
+        client,
+        {
+          to: "recipient@example.com",
+          subject: "Subject",
+          messageHtml: "<p>Hello</p>",
+          attachments: [
+            {
+              filename: "large.pdf",
+              content: Buffer.alloc(totalSize),
+              contentType: "application/pdf",
+            },
+          ],
+        },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow(
+      "upload session ended without returning the created item",
+    );
+
+    expect(sendPost).not.toHaveBeenCalled();
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),
+    ).toHaveLength(1);
+  });
+
   it("resumes upload-session progress after a retried chunk returns 416", async () => {
     const draftPost = vi.fn(
       async () =>

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -299,6 +299,135 @@ describe("sendEmailWithHtml", () => {
     expect(sendPost).toHaveBeenCalledTimes(1);
   });
 
+  it("accepts a final 200 chunk whose body is the created attachment", async () => {
+    const draftPost = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+        }) as Message,
+    );
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const sendPost = vi.fn(async () => ({}));
+    const totalSize = 3 * 1024 * 1024 + 1;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const parsedRange = parseContentRange(getContentRangeHeader(init));
+      if (!parsedRange) {
+        throw new Error(
+          `Unexpected content range: ${getContentRangeHeader(init)}`,
+        );
+      }
+
+      if (parsedRange.endInclusive + 1 >= parsedRange.totalSize) {
+        return new Response(
+          JSON.stringify({ id: "attachment-1", name: "large.pdf" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return createUploadChunkProgressResponse(init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages") return { post: draftPost };
+      if (path === "/me/messages/draft-1/attachments/createUploadSession") {
+        return { post: createUploadSessionPost };
+      }
+      if (path === "/me/messages/draft-1/send") return { post: sendPost };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await sendEmailWithHtml(
+      client,
+      {
+        to: "recipient@example.com",
+        subject: "Subject",
+        messageHtml: "<p>Hello</p>",
+        attachments: [
+          {
+            filename: "large.pdf",
+            content: Buffer.alloc(totalSize),
+            contentType: "application/pdf",
+          },
+        ],
+      },
+      createTestLogger(),
+    );
+
+    expect(sendPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when a final 200 chunk does not return the created attachment", async () => {
+    const draftPost = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+        }) as Message,
+    );
+    const createUploadSessionPost = vi.fn(async () => ({
+      uploadUrl: "https://upload.example.test/session",
+    }));
+    const sendPost = vi.fn(async () => ({}));
+    const totalSize = 3 * 1024 * 1024 + 1;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const parsedRange = parseContentRange(getContentRangeHeader(init));
+      if (!parsedRange) {
+        throw new Error(
+          `Unexpected content range: ${getContentRangeHeader(init)}`,
+        );
+      }
+
+      if (parsedRange.endInclusive + 1 >= parsedRange.totalSize) {
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return createUploadChunkProgressResponse(init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages") return { post: draftPost };
+      if (path === "/me/messages/draft-1/attachments/createUploadSession") {
+        return { post: createUploadSessionPost };
+      }
+      if (path === "/me/messages/draft-1/send") return { post: sendPost };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await expect(
+      sendEmailWithHtml(
+        client,
+        {
+          to: "recipient@example.com",
+          subject: "Subject",
+          messageHtml: "<p>Hello</p>",
+          attachments: [
+            {
+              filename: "large.pdf",
+              content: Buffer.alloc(totalSize),
+              contentType: "application/pdf",
+            },
+          ],
+        },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow(
+      "Upload session completed without returning the created attachment",
+    );
+
+    expect(sendPost).not.toHaveBeenCalled();
+  });
+
   it("resumes upload-session progress after a retried chunk returns 416", async () => {
     const draftPost = vi.fn(
       async () =>

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -421,9 +421,12 @@ describe("sendEmailWithHtml", () => {
         },
         createTestLogger(),
       ),
-    ).rejects.toThrow(
-      "Upload session completed without returning the created attachment",
-    );
+    ).rejects.toMatchObject({
+      error: expect.objectContaining({
+        message:
+          "Upload session returned 200 without nextExpectedRanges or a created item",
+      }),
+    });
 
     expect(sendPost).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@microsoft/microsoft-graph-types";
+import type { Message, UploadSession } from "@microsoft/microsoft-graph-types";
 import type { OutlookClient } from "@/utils/outlook/client";
 import type { Attachment } from "nodemailer/lib/mailer";
 import type { SendEmailBody } from "@/utils/gmail/mail";
@@ -655,12 +655,12 @@ async function uploadAttachmentViaSession({
     logger,
   );
 
-  const uploadUrl = (uploadSession as { uploadUrl?: string }).uploadUrl;
+  const uploadUrl = (uploadSession as UploadSession).uploadUrl;
   if (!uploadUrl) {
     throw new Error("Failed to create Outlook attachment upload session");
   }
 
-  const finalResponse = await uploadResumableChunks({
+  await uploadResumableChunks({
     uploadUrl,
     content,
     chunkSizeBytes: GRAPH_UPLOAD_CHUNK_SIZE_BYTES,
@@ -668,17 +668,4 @@ async function uploadAttachmentViaSession({
     action: "upload Outlook attachment chunk",
     statusAction: "fetch Outlook upload session status",
   });
-
-  // A 200 final response is only trusted as complete when its body is the
-  // created attachment; a false-complete would otherwise drop it silently.
-  if (finalResponse.status === 200) {
-    const createdAttachment = (await finalResponse.json()) as {
-      id?: string;
-    };
-    if (!createdAttachment.id) {
-      throw new Error(
-        "Upload session completed without returning the created attachment",
-      );
-    }
-  }
 }

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -15,6 +15,7 @@ import {
 import { withOutlookRetry } from "@/utils/outlook/retry";
 import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
+import { uploadResumableChunks } from "@/utils/microsoft/upload-session";
 import type { Logger } from "@/utils/logger";
 
 type GraphRecipient = {
@@ -659,137 +660,25 @@ async function uploadAttachmentViaSession({
     throw new Error("Failed to create Outlook attachment upload session");
   }
 
-  let start = 0;
-  while (start < content.length) {
-    const end = Math.min(start + GRAPH_UPLOAD_CHUNK_SIZE_BYTES, content.length);
-    const chunk = content.subarray(start, end);
-    start = await withOutlookRetry(
-      () =>
-        uploadAttachmentChunk({
-          uploadUrl,
-          chunk,
-          start,
-          end,
-          totalSize: content.length,
-        }),
-      logger,
-    );
-  }
-}
-
-async function uploadAttachmentChunk({
-  uploadUrl,
-  chunk,
-  start,
-  end,
-  totalSize,
-}: {
-  uploadUrl: string;
-  chunk: Buffer;
-  start: number;
-  end: number;
-  totalSize: number;
-}): Promise<number> {
-  const response = await fetch(uploadUrl, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/octet-stream",
-      "Content-Length": String(chunk.length),
-      "Content-Range": `bytes ${start}-${end - 1}/${totalSize}`,
-    },
-    body: new Uint8Array(chunk),
+  const finalResponse = await uploadResumableChunks({
+    uploadUrl,
+    content,
+    chunkSizeBytes: GRAPH_UPLOAD_CHUNK_SIZE_BYTES,
+    logger,
+    action: "upload Outlook attachment chunk",
+    statusAction: "fetch Outlook upload session status",
   });
 
-  if (response.status === 201) {
-    return totalSize;
-  }
-
-  if (response.status === 200 || response.status === 202) {
-    const uploadStatus = (await response.json()) as UploadSessionStatus;
-    const nextStart = getNextExpectedRangeStart(
-      uploadStatus.nextExpectedRanges,
-    );
-    if (typeof nextStart !== "number") {
+  // A 200 final response is only trusted as complete when its body is the
+  // created attachment; a false-complete would otherwise drop it silently.
+  if (finalResponse.status === 200) {
+    const createdAttachment = (await finalResponse.json()) as {
+      id?: string;
+    };
+    if (!createdAttachment.id) {
       throw new Error(
-        `Outlook upload session returned ${response.status} without nextExpectedRanges`,
+        "Upload session completed without returning the created attachment",
       );
     }
-
-    return nextStart;
   }
-
-  if (response.status === 416) {
-    const uploadStatus = await getUploadSessionStatus(uploadUrl);
-    if (!uploadStatus) {
-      return end;
-    }
-
-    const nextStart = getNextExpectedRangeStart(
-      uploadStatus.nextExpectedRanges,
-    );
-    if (typeof nextStart === "number" && nextStart > start) {
-      return nextStart;
-    }
-
-    throw new Error(
-      "Outlook upload session returned 416 without a usable resume range",
-    );
-  }
-
-  return await throwOutlookResponseError(
-    response,
-    "upload Outlook attachment chunk",
-  );
-}
-
-interface UploadSessionStatus {
-  nextExpectedRanges?: string[];
-}
-
-async function getUploadSessionStatus(
-  uploadUrl: string,
-): Promise<UploadSessionStatus | null> {
-  const response = await fetch(uploadUrl, { method: "GET" });
-
-  if (response.status === 404 || response.status === 405) {
-    return null;
-  }
-
-  if (!response.ok) {
-    return await throwOutlookResponseError(
-      response,
-      "fetch Outlook upload session status",
-    );
-  }
-
-  return (await response.json()) as UploadSessionStatus;
-}
-
-function getNextExpectedRangeStart(nextExpectedRanges?: string[]) {
-  const nextRange = nextExpectedRanges?.[0];
-  if (!nextRange) return null;
-
-  const [rangeStart] = nextRange.split("-");
-  if (!rangeStart) return null;
-
-  const parsedRangeStart = Number.parseInt(rangeStart, 10);
-  return Number.isNaN(parsedRangeStart) ? null : parsedRangeStart;
-}
-
-async function throwOutlookResponseError(
-  response: Response,
-  action: string,
-): Promise<never> {
-  const errorText = await response.text();
-  const error = new Error(
-    `Failed to ${action}: ${response.status} ${
-      errorText || response.statusText
-    }`,
-  );
-  Object.assign(error, {
-    status: response.status,
-    body: errorText,
-    response: { headers: response.headers, status: response.status },
-  });
-  throw error;
 }


### PR DESCRIPTION
## Summary
- add resumable OneDrive uploads for files above the simple-upload threshold
- share Microsoft upload-session chunking across OneDrive and Outlook
- retry timed-out requests, validate completion responses, and recover accepted final chunks without duplicate files
- preserve rename-on-conflict behavior with stable item-ID recovery

## Validation
- focused OneDrive and Outlook upload tests
- scoped formatting and lint checks
- secret scans on fix commits