### PR TITLE
INB-324: Restrict billing access to organization admins

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
@@ -28,7 +28,15 @@ import { getActionErrorMessage } from "@/utils/error";
 import { updateStripeInvoiceEmailsAction } from "@/utils/actions/premium";
 
 export function BillingSection() {
-  const { data, premium, isPremium, isLoading, tier, mutate } = usePremium();
+  const {
+    data,
+    premium,
+    isPremium,
+    isLoading,
+    tier,
+    mutate,
+    canManageBilling,
+  } = usePremium();
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
   const hasAppleSubscription = hasActiveAppleSubscription(
     premium?.appleExpiresAt || null,
@@ -63,6 +71,8 @@ export function BillingSection() {
     );
     execute({ enabled });
   };
+
+  if (!canManageBilling) return null;
 
   return (
     <LoadingContent loading={isLoading}>
@@ -106,7 +116,7 @@ export function BillingSection() {
         </Item>
       )}
 
-      {premium?.stripeCustomerId && premium.isAdmin && (
+      {premium?.stripeCustomerId && (
         <>
           <ItemSeparator />
           <Item size="sm">

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -47,7 +47,8 @@ export type PricingProps = {
 
 export default function Pricing(props: PricingProps) {
   const posthog = usePostHog();
-  const { premium, isPremium, isLoading, error, data } = usePremium();
+  const { premium, isPremium, isLoading, error, data, canManageBilling } =
+    usePremium();
   const hasTrackedPricingView = useRef(false);
 
   const isLoggedIn = !!data?.id;
@@ -117,6 +118,18 @@ export default function Pricing(props: PricingProps) {
     pricingSource,
     props.showSkipUpgrade,
   ]);
+
+  if (isLoggedIn && !canManageBilling) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-12">
+        <AlertBasic
+          variant="blue"
+          title="Billing access restricted"
+          description="Only organization owners and admins can manage billing."
+        />
+      </div>
+    );
+  }
 
   return (
     <LoadingContent loading={isLoading} error={error}>

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/item";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
+import { usePremium } from "@/hooks/usePremium";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { cn } from "@/utils";
 import { env } from "@/env";
@@ -54,6 +55,7 @@ import { env } from "@/env";
 export default function SettingsPage() {
   const { emailAccountId: activeEmailAccountId } = useAccount();
   const { data, isLoading, error } = useAccounts();
+  const { canManageBilling } = usePremium();
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(
     null,
   );
@@ -118,7 +120,7 @@ export default function SettingsPage() {
           </LoadingContent>
         </SettingsGroup>
 
-        {!env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS && (
+        {!env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS && canManageBilling && (
           <SettingsGroup
             icon={<CreditCardIcon className="size-5" />}
             title="Billing"

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -100,6 +100,48 @@ describe("user/me route", () => {
         name: "Example User",
       },
     ]);
+    expect(body.canManageBilling).toBe(true);
+  });
+
+  it("denies billing access to an organization member even when they are a plan admin", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      aiProvider: null,
+      aiModel: null,
+      aiApiKey: null,
+      webhookSecret: null,
+      announcementDismissedAt: null,
+      dismissedHints: [],
+      premium: {
+        id: "premium-1",
+        admins: [{ id: "user-1" }],
+      },
+      emailAccounts: [
+        {
+          id: "acc-1",
+          email: "member@example.com",
+          name: "Example Member",
+          members: [
+            {
+              organizationId: "org-1",
+              role: "member",
+              organization: { name: "Example Org" },
+            },
+          ],
+        },
+      ],
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/user/me"),
+      {} as never,
+    );
+
+    const body = await response.json();
+
+    expect(body.premium.isAdmin).toBe(false);
+    expect(body.canManageBilling).toBe(false);
   });
 
   it("does not expose backend-only Apple subscription identifiers", async () => {

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -115,7 +115,16 @@ describe("user/me route", () => {
       dismissedHints: [],
       premium: {
         id: "premium-1",
-        admins: [{ id: "user-1" }],
+        admins: [
+          {
+            id: "user-1",
+            emailAccounts: [
+              {
+                members: [{ organizationId: "org-1", role: "member" }],
+              },
+            ],
+          },
+        ],
       },
       emailAccounts: [
         {

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -5,9 +5,12 @@ import { SafeError } from "@/utils/error";
 import { auth } from "@/utils/auth";
 import {
   getRemainingUnsubscribeCredits,
-  isAdminForPremium,
   premiumEntitlementSelect,
 } from "@/utils/premium";
+import {
+  billingAccessPremiumSelect,
+  canManageBilling,
+} from "@/utils/premium/billing-access";
 
 export type UserResponse = Awaited<ReturnType<typeof getUser>> | null;
 
@@ -31,6 +34,7 @@ async function getUser({
       dismissedHints: true,
       premium: {
         select: {
+          ...billingAccessPremiumSelect,
           ...premiumEntitlementSelect,
           lemonSqueezyCustomerId: true,
           lemonSqueezySubscriptionId: true,
@@ -43,7 +47,6 @@ async function getUser({
           emailAccountsAccess: true,
           lemonLicenseKey: true,
           pendingInvites: true,
-          admins: { select: { id: true } },
         },
       },
       emailAccounts: {
@@ -78,12 +81,13 @@ async function getUser({
   );
 
   const { aiApiKey, webhookSecret, emailAccounts } = user;
+  const canManageBillingAccess = canManageBilling(user.id, user);
   let premium = null;
   if (user.premium) {
-    const { admins, ...premiumData } = user.premium;
+    const { admins: _admins, id: _premiumId, ...premiumData } = user.premium;
     premium = {
       ...premiumData,
-      isAdmin: isAdminForPremium(admins, user.id),
+      isAdmin: canManageBillingAccess,
     };
   }
 
@@ -104,6 +108,7 @@ async function getUser({
     })),
     hasAiApiKey: !!aiApiKey,
     hasWebhookSecret: !!webhookSecret,
+    canManageBilling: canManageBillingAccess,
     members,
   };
 }

--- a/apps/web/hooks/usePremium.ts
+++ b/apps/web/hooks/usePremium.ts
@@ -15,6 +15,7 @@ export function usePremium() {
 
   const premium = data?.premium;
   const hasAiApiKey = data?.hasAiApiKey;
+  const canManageBilling = data?.canManageBilling ?? false;
 
   const unsubscribeCreditsRemaining = data?.unsubscribeCreditsRemaining;
 
@@ -22,6 +23,7 @@ export function usePremium() {
     return {
       ...swrResponse,
       premium,
+      canManageBilling,
       isPremium: true,
       hasUnsubscribeAccess: true,
       unsubscribeCreditsRemaining,
@@ -40,6 +42,7 @@ export function usePremium() {
   return {
     ...swrResponse,
     premium,
+    canManageBilling,
     isPremium: isUserPremium,
     hasUnsubscribeAccess:
       isUserPremium ||

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -111,9 +111,22 @@ describe("getBillingPortalUrlAction", () => {
         stripeSubscriptionItemId: "si_test",
         stripeSubscriptionStatus: "active",
         users: [{ _count: { emailAccounts: 1 } }],
-        admins: [{ id: "user-1" }],
+        admins: [
+          {
+            id: "user-1",
+            emailAccounts: [
+              {
+                members: [{ organizationId: "billing-org", role: "member" }],
+              },
+            ],
+          },
+        ],
       },
-      emailAccounts: [{ members: [{ role: "member" }] }],
+      emailAccounts: [
+        {
+          members: [{ organizationId: "billing-org", role: "member" }],
+        },
+      ],
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createBillingPortalSession.mockResolvedValue({
       url: "https://billing.stripe.test",
@@ -137,9 +150,18 @@ describe("getBillingPortalUrlAction", () => {
         stripeSubscriptionItemId: "si_test",
         stripeSubscriptionStatus: "active",
         users: [{ _count: { emailAccounts: 1 } }],
-        admins: [{ id: "another-user" }],
+        admins: [
+          {
+            id: "another-user",
+            emailAccounts: [
+              {
+                members: [{ organizationId: "billing-org", role: "owner" }],
+              },
+            ],
+          },
+        ],
       },
-      emailAccounts: [{ members: [{ role }] }],
+      emailAccounts: [{ members: [{ organizationId: "billing-org", role }] }],
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createBillingPortalSession.mockResolvedValue({
       url: "https://billing.stripe.test",

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -42,6 +42,7 @@ describe("updateStripeInvoiceEmailsAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -65,6 +66,7 @@ describe("updateStripeInvoiceEmailsAction", () => {
 
   it("rejects a non-admin user", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -80,6 +82,7 @@ describe("updateStripeInvoiceEmailsAction", () => {
 
   it("rejects a user without a Stripe billing account", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: null,
@@ -99,8 +102,57 @@ describe("getBillingPortalUrlAction", () => {
     vi.clearAllMocks();
   });
 
+  it("rejects an organization member even when they are a plan admin", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionItemId: "si_test",
+        stripeSubscriptionStatus: "active",
+        users: [{ _count: { emailAccounts: 1 } }],
+        admins: [{ id: "user-1" }],
+      },
+      emailAccounts: [{ members: [{ role: "member" }] }],
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+    mocks.createBillingPortalSession.mockResolvedValue({
+      url: "https://billing.stripe.test",
+    });
+
+    const result = await getBillingPortalUrlAction({});
+
+    expect(result?.serverError).toBe("Not admin");
+    expect(mocks.createBillingPortalSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "admin",
+    "owner",
+  ])("allows an organization %s who is not a plan admin", async (role) => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        stripeSubscriptionId: "sub_test",
+        stripeSubscriptionItemId: "si_test",
+        stripeSubscriptionStatus: "active",
+        users: [{ _count: { emailAccounts: 1 } }],
+        admins: [{ id: "another-user" }],
+      },
+      emailAccounts: [{ members: [{ role }] }],
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+    mocks.createBillingPortalSession.mockResolvedValue({
+      url: "https://billing.stripe.test",
+    });
+
+    const result = await getBillingPortalUrlAction({});
+
+    expect(result?.data).toEqual({ url: "https://billing.stripe.test" });
+  });
+
   it("rejects a non-admin shared plan member", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -121,6 +173,7 @@ describe("getBillingPortalUrlAction", () => {
 
   it("allows the original owner of a legacy premium record", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "user-1",
         stripeCustomerId: "cus_test",
@@ -142,6 +195,7 @@ describe("getBillingPortalUrlAction", () => {
 
   it("rejects a member of a legacy shared plan without recorded admins", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "original-owner",
         stripeCustomerId: "cus_test",
@@ -170,6 +224,7 @@ describe("endStripeTrialAction", () => {
 
   it("rejects a non-admin shared plan member", async () => {
     prisma.user.findUnique.mockResolvedValue({
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeSubscriptionId: "sub_test",
@@ -194,7 +249,7 @@ describe("generateCheckoutSessionAction", () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
-      _count: { emailAccounts: 1 },
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -224,7 +279,7 @@ describe("generateCheckoutSessionAction", () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
-      _count: { emailAccounts: 2 },
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -250,7 +305,7 @@ describe("generateCheckoutSessionAction", () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
-      _count: { emailAccounts: 2 },
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",
@@ -291,7 +346,7 @@ describe("generateCheckoutSessionAction", () => {
         ({
           email: "user@example.com",
           utms: null,
-          _count: { emailAccounts },
+          emailAccounts: [],
           premium: {
             id: "premium-1",
             stripeCustomerId: "cus_test",
@@ -321,7 +376,7 @@ describe("generateCheckoutSessionAction", () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
-      _count: { emailAccounts: 2 },
+      emailAccounts: [],
       premium: {
         id: "premium-1",
         stripeCustomerId: "cus_test",

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -24,6 +24,11 @@ import {
   getStripeBillingQuantity,
   syncPremiumSeats,
 } from "@/utils/premium/seats";
+import {
+  assertCanManageBilling,
+  billingAccessPremiumSelect,
+  billingAccessSelect,
+} from "@/utils/premium/billing-access";
 import { changePremiumStatusSchema } from "@/app/(app)/admin/validation";
 import { activateLemonLicenseKey } from "@/ee/billing/lemon/index";
 import { PremiumTier } from "@/generated/prisma/enums";
@@ -374,21 +379,22 @@ export const updateStripeInvoiceEmailsAction = actionClientUser
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
+        ...billingAccessSelect,
         premium: {
           select: {
-            id: true,
+            ...billingAccessPremiumSelect,
             stripeCustomerId: true,
-            admins: { select: { id: true } },
           },
         },
       },
     });
 
-    if (!user?.premium?.stripeCustomerId) {
-      throw new SafeError("Stripe billing account not found");
+    if (!user) {
+      throw new SafeError("User not found");
     }
-    if (!isAdminForPremium(user.premium.admins, userId)) {
-      throw new SafeError("Not admin");
+    assertCanManageBilling(userId, user);
+    if (!user.premium?.stripeCustomerId) {
+      throw new SafeError("Stripe billing account not found");
     }
 
     await prisma.premium.update({
@@ -408,10 +414,10 @@ export const getBillingPortalUrlAction = actionClientUser
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
+        ...billingAccessSelect,
         premium: {
           select: {
-            admins: { select: { id: true } },
-            id: true,
+            ...billingAccessPremiumSelect,
             stripeCustomerId: true,
             stripeSubscriptionId: true,
             stripeSubscriptionItemId: true,
@@ -427,11 +433,9 @@ export const getBillingPortalUrlAction = actionClientUser
     if (!user) {
       throw new SafeError("User not found");
     }
+    assertCanManageBilling(userId, user);
     if (!user.premium) {
       throw new SafeError("Premium subscription not found");
-    }
-    if (!isPremiumBillingAdmin(user.premium, userId)) {
-      throw new SafeError("Not admin");
     }
     if (!user.premium.stripeCustomerId) {
       logger.error("Stripe customer id not found");
@@ -498,10 +502,10 @@ export const endStripeTrialAction = actionClientUser
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
+        ...billingAccessSelect,
         premium: {
           select: {
-            admins: { select: { id: true } },
-            id: true,
+            ...billingAccessPremiumSelect,
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
           },
@@ -509,14 +513,13 @@ export const endStripeTrialAction = actionClientUser
       },
     });
 
-    const premium = user?.premium;
-    if (!premium) {
-      throw new SafeError("Stripe subscription not found");
+    if (!user) {
+      throw new SafeError("User not found");
     }
-    if (!isPremiumBillingAdmin(premium, userId)) {
-      throw new SafeError("Not admin");
-    }
-    if (!premium.stripeSubscriptionId) {
+    assertCanManageBilling(userId, user);
+
+    const premium = user.premium;
+    if (!premium?.stripeSubscriptionId) {
       throw new SafeError("Stripe subscription not found");
     }
 
@@ -555,13 +558,12 @@ export const generateCheckoutSessionAction = actionClientUser
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
+        ...billingAccessSelect,
         email: true,
         utms: true,
-        _count: { select: { emailAccounts: true } },
         premium: {
           select: {
-            admins: { select: { id: true } },
-            id: true,
+            ...billingAccessPremiumSelect,
             stripeCustomerId: true,
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
@@ -577,9 +579,7 @@ export const generateCheckoutSessionAction = actionClientUser
       logger.error("User not found");
       throw new SafeError("User not found");
     }
-    if (user.premium && !isPremiumBillingAdmin(user.premium, userId)) {
-      throw new SafeError("Not admin");
-    }
+    assertCanManageBilling(userId, user);
 
     if (
       user.premium?.stripeSubscriptionId &&
@@ -619,7 +619,9 @@ export const generateCheckoutSessionAction = actionClientUser
 
     const quantity = getStripeBillingQuantity({
       priceId,
-      users: user.premium?.users || [{ _count: user._count }],
+      users: user.premium?.users || [
+        { _count: { emailAccounts: user.emailAccounts.length } },
+      ],
     });
     const cookieStore = await cookies();
     const conversionAttributionId = cookieStore.get(
@@ -689,16 +691,4 @@ function getCheckoutPriceId({
   }
 
   return getStripePriceId({ tier });
-}
-
-function isPremiumBillingAdmin(
-  premium: { id: string; admins: { id: string }[] },
-  userId: string,
-) {
-  if (premium.admins.length) {
-    return isAdminForPremium(premium.admins, userId);
-  }
-
-  // The initial premium migration used the owner's user ID as the premium ID.
-  return premium.id === userId;
 }

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { canManageBilling } from "./billing-access";
+
+describe("canManageBilling", () => {
+  it("does not use an admin role from an unrelated organization", () => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [
+          {
+            id: "premium-owner",
+            emailAccounts: [
+              {
+                members: [{ organizationId: "billing-org", role: "owner" }],
+              },
+            ],
+          },
+        ],
+      },
+      emailAccounts: [
+        {
+          members: [{ organizationId: "other-org", role: "admin" }],
+        },
+        {
+          members: [{ organizationId: "billing-org", role: "member" }],
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it } from "vitest";
 import { canManageBilling } from "./billing-access";
 
 describe("canManageBilling", () => {
+  it("denies an organization member without a premium record", () => {
+    const result = canManageBilling("user-1", {
+      premium: null,
+      emailAccounts: [
+        {
+          members: [{ organizationId: "org-1", role: "member" }],
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("allows an individual user without a premium record", () => {
+    const result = canManageBilling("user-1", {
+      premium: null,
+      emailAccounts: [],
+    });
+
+    expect(result).toBe(true);
+  });
+
   it("does not use an admin role from an unrelated organization", () => {
     const result = canManageBilling("user-1", {
       premium: {

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -65,6 +65,9 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
     (membership) => premiumOrganizationIds.has(membership.organizationId),
   );
 
+  if (!premium && organizationMemberships.length > 0) {
+    return isOrganizationAdmin(organizationMemberships);
+  }
   if (premiumOrganizationMemberships.length > 0) {
     return isOrganizationAdmin(premiumOrganizationMemberships);
   }

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -5,33 +5,70 @@ import { isOrganizationAdmin } from "@/utils/organizations/roles";
 export const billingAccessSelect = {
   emailAccounts: {
     select: {
-      members: { select: { role: true } },
+      members: { select: { organizationId: true, role: true } },
     },
   },
 } as const;
 
-// Spread inside a `premium: { select: ... } }` alongside billingAccessSelect —
-// canManageBilling needs both halves.
 export const billingAccessPremiumSelect = {
   id: true,
-  admins: { select: { id: true } },
+  admins: {
+    select: {
+      id: true,
+      emailAccounts: {
+        select: {
+          members: { select: { organizationId: true, role: true } },
+        },
+      },
+    },
+  },
 } as const;
 
+type OrganizationMembership = { organizationId: string; role: string };
+
 type BillingAccessUser = {
-  premium: { id: string; admins: { id: string }[] } | null | undefined;
-  emailAccounts: Array<{ members: Array<{ role: string }> }>;
+  premium:
+    | {
+        id: string;
+        admins: Array<{
+          id: string;
+          emailAccounts: Array<{ members: OrganizationMembership[] }>;
+        }>;
+      }
+    | null
+    | undefined;
+  emailAccounts: Array<{ members: OrganizationMembership[] }>;
 };
 
 export function canManageBilling(userId: string, user: BillingAccessUser) {
+  const { premium } = user;
   const organizationMemberships = user.emailAccounts.flatMap(
     (emailAccount) => emailAccount.members,
   );
+  const premiumAdminMemberships =
+    premium?.admins.flatMap((admin) =>
+      (admin.emailAccounts ?? []).flatMap(
+        (emailAccount) => emailAccount.members,
+      ),
+    ) ?? [];
+  const ownerOrganizationIds = new Set(
+    premiumAdminMemberships
+      .filter((membership) => membership.role === "owner")
+      .map((membership) => membership.organizationId),
+  );
+  const premiumOrganizationIds = ownerOrganizationIds.size
+    ? ownerOrganizationIds
+    : new Set(
+        premiumAdminMemberships.map((membership) => membership.organizationId),
+      );
+  const premiumOrganizationMemberships = organizationMemberships.filter(
+    (membership) => premiumOrganizationIds.has(membership.organizationId),
+  );
 
-  if (organizationMemberships.length > 0) {
-    return isOrganizationAdmin(organizationMemberships);
+  if (premiumOrganizationMemberships.length > 0) {
+    return isOrganizationAdmin(premiumOrganizationMemberships);
   }
 
-  const { premium } = user;
   if (!premium) return true;
   if (premium.admins.length > 0) {
     return isAdminForPremium(premium.admins, userId);

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -1,0 +1,51 @@
+import { SafeError } from "@/utils/error";
+import { isAdminForPremium } from "@/utils/premium";
+import { isOrganizationAdmin } from "@/utils/organizations/roles";
+
+export const billingAccessSelect = {
+  emailAccounts: {
+    select: {
+      members: { select: { role: true } },
+    },
+  },
+} as const;
+
+// Spread inside a `premium: { select: ... } }` alongside billingAccessSelect —
+// canManageBilling needs both halves.
+export const billingAccessPremiumSelect = {
+  id: true,
+  admins: { select: { id: true } },
+} as const;
+
+type BillingAccessUser = {
+  premium: { id: string; admins: { id: string }[] } | null | undefined;
+  emailAccounts: Array<{ members: Array<{ role: string }> }>;
+};
+
+export function canManageBilling(userId: string, user: BillingAccessUser) {
+  const organizationMemberships = user.emailAccounts.flatMap(
+    (emailAccount) => emailAccount.members,
+  );
+
+  if (organizationMemberships.length > 0) {
+    return isOrganizationAdmin(organizationMemberships);
+  }
+
+  const { premium } = user;
+  if (!premium) return true;
+  if (premium.admins.length > 0) {
+    return isAdminForPremium(premium.admins, userId);
+  }
+
+  // The initial premium migration used the owner's user ID as the premium ID.
+  return premium.id === userId;
+}
+
+export function assertCanManageBilling(
+  userId: string,
+  user: BillingAccessUser,
+) {
+  if (!canManageBilling(userId, user)) {
+    throw new SafeError("Not admin");
+  }
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260813-221151_pr-3257_d7c7efbd2ba7/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restricts billing management to organization owners and admins while preserving existing individual and legacy premium access.

- Centralizes server-side billing authorization across checkout, subscription, and invoice actions.
- Hides billing settings and pricing actions for organization members without billing permission.
- Tests: focused Vitest suites passed (24 tests); targeted Ultracite checks passed.
- Performance: reuses existing user queries with membership-role selection; adds no database round trips or external network calls and has low hot-path risk.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-324/non-admin-organization-members-can-access-billing-settings