### PR TITLE
fix(web): support Windows Turbopack drive roots

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -462,14 +462,11 @@ function commonAncestorPath(firstPath: string, secondPath: string) {
     commonParts.push(firstParts[index]);
   }
 
-  // POSIX root
   if (commonParts.length === 1 && commonParts[0] === "") {
     return path.sep;
   }
 
-  // Windows drive root (e.g. "D:") — path.sep is required so Next treats it
-  // as absolute. Without it Turbopack falls back to apps/web and cannot
-  // resolve next when pnpm's store lives outside the monorepo.
+  // A bare Windows drive is relative to that drive's current directory.
   if (commonParts.length === 1 && /^[A-Za-z]:$/.test(commonParts[0] ?? "")) {
     return `${commonParts[0]}${path.sep}`;
   }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -462,7 +462,17 @@ function commonAncestorPath(firstPath: string, secondPath: string) {
     commonParts.push(firstParts[index]);
   }
 
-  return commonParts.length === 1 && commonParts[0] === ""
-    ? path.sep
-    : commonParts.join(path.sep);
+  // POSIX root
+  if (commonParts.length === 1 && commonParts[0] === "") {
+    return path.sep;
+  }
+
+  // Windows drive root (e.g. "D:") — path.sep is required so Next treats it
+  // as absolute. Without it Turbopack falls back to apps/web and cannot
+  // resolve next when pnpm's store lives outside the monorepo.
+  if (commonParts.length === 1 && /^[A-Za-z]:$/.test(commonParts[0] ?? "")) {
+    return `${commonParts[0]}${path.sep}`;
+  }
+
+  return commonParts.join(path.sep);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260813-222916_pr-3258_47aceeb6675d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Handle drive-root ancestors as absolute paths on Windows so Turbopack can resolve workspace dependencies.

- preserve existing POSIX and nested-path behavior
- validate formatting and cross-platform path handling

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->