### PR TITLE
fix(mail): Keep keyboard selection on screen and autoload threads

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -542,6 +542,7 @@ export function MailShell() {
                 showLoadMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMore}
+                listKey={JSON.stringify(query)}
               />
             </LoadingContent>
           </section>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -68,11 +68,6 @@ export function ThreadList({
   onLoadMoreRef.current = onLoadMore;
   const focusedThreadId = threads[focusedIndex]?.id;
 
-  if (prefetchListKey.current !== listKey) {
-    prefetchListKey.current = listKey;
-    prefetchForCount.current = null;
-  }
-
   // Keep the J/K cursor on screen without centering every row. Layout phase so
   // a held arrow key never paints a selected row that's already off-screen.
   useLayoutEffect(() => {
@@ -83,6 +78,10 @@ export function ThreadList({
   }, [focusedIndex, focusedThreadId, scrollRoot]);
 
   useEffect(() => {
+    if (prefetchListKey.current !== listKey) {
+      prefetchListKey.current = listKey;
+      prefetchForCount.current = null;
+    }
     if (
       !shouldPrefetchMoreThreads({
         hasMore: showLoadMore,
@@ -97,7 +96,7 @@ export function ThreadList({
     if (prefetchForCount.current === threads.length) return;
     prefetchForCount.current = threads.length;
     onLoadMoreRef.current();
-  }, [focusedIndex, isLoadingMore, showLoadMore, threads.length]);
+  }, [focusedIndex, isLoadingMore, listKey, showLoadMore, threads.length]);
 
   useEffect(() => {
     if (!showLoadMore || !scrollRoot || threads.length === 0) return;

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -35,6 +35,8 @@ export type ThreadListProps = {
   showLoadMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
+  /** Identity of the current view so prefetch state does not leak across splits. */
+  listKey: string;
 };
 
 export function ThreadList({
@@ -55,12 +57,21 @@ export function ThreadList({
   showLoadMore,
   isLoadingMore,
   onLoadMore,
+  listKey,
 }: ThreadListProps) {
   const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
   const focusedRowRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const prefetchForCount = useRef<number | null>(null);
+  const prefetchListKey = useRef(listKey);
+  const onLoadMoreRef = useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
   const focusedThreadId = threads[focusedIndex]?.id;
+
+  if (prefetchListKey.current !== listKey) {
+    prefetchListKey.current = listKey;
+    prefetchForCount.current = null;
+  }
 
   // Keep the J/K cursor on screen without centering every row. Layout phase so
   // a held arrow key never paints a selected row that's already off-screen.
@@ -85,23 +96,25 @@ export function ThreadList({
     // A failed page doesn't grow the list; don't retry it in a loop.
     if (prefetchForCount.current === threads.length) return;
     prefetchForCount.current = threads.length;
-    onLoadMore();
-  }, [focusedIndex, isLoadingMore, onLoadMore, showLoadMore, threads.length]);
+    onLoadMoreRef.current();
+  }, [focusedIndex, isLoadingMore, showLoadMore, threads.length]);
 
   useEffect(() => {
-    if (!showLoadMore || !scrollRoot) return;
+    if (!showLoadMore || !scrollRoot || threads.length === 0) return;
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
+        if (entries.some((entry) => entry.isIntersecting)) {
+          onLoadMoreRef.current();
+        }
       },
       { root: scrollRoot, rootMargin: THREAD_LOAD_MORE_ROOT_MARGIN },
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [onLoadMore, scrollRoot, showLoadMore]);
+  }, [scrollRoot, showLoadMore, threads.length]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -1,11 +1,18 @@
 "use client";
 
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { SelectionBar } from "@/app/(app)/[emailAccountId]/mail/SelectionBar";
 import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
 import type {
   ListThread,
   MailLayoutMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
+import {
+  scrollElementIntoContainer,
+  shouldPrefetchMoreThreads,
+  THREAD_LOAD_MORE_ROOT_MARGIN,
+} from "@/app/(app)/[emailAccountId]/mail/thread-list-behavior";
+import { LoadingMiniSpinner } from "@/components/Loading";
 import { Button } from "@/components/ui/button";
 import type { EmailLabels } from "@/providers/email-label-types";
 
@@ -49,6 +56,53 @@ export function ThreadList({
   isLoadingMore,
   onLoadMore,
 }: ThreadListProps) {
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
+  const focusedRowRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const prefetchForCount = useRef<number | null>(null);
+  const focusedThreadId = threads[focusedIndex]?.id;
+
+  // Keep the J/K cursor on screen without centering every row. Layout phase so
+  // a held arrow key never paints a selected row that's already off-screen.
+  useLayoutEffect(() => {
+    if (!scrollRoot || focusedIndex < 0 || !focusedThreadId) return;
+    const row = focusedRowRef.current;
+    if (!row) return;
+    scrollElementIntoContainer(scrollRoot, row);
+  }, [focusedIndex, focusedThreadId, scrollRoot]);
+
+  useEffect(() => {
+    if (
+      !shouldPrefetchMoreThreads({
+        hasMore: showLoadMore,
+        isLoadingMore,
+        focusedIndex,
+        threadCount: threads.length,
+      })
+    ) {
+      return;
+    }
+    // A failed page doesn't grow the list; don't retry it in a loop.
+    if (prefetchForCount.current === threads.length) return;
+    prefetchForCount.current = threads.length;
+    onLoadMore();
+  }, [focusedIndex, isLoadingMore, onLoadMore, showLoadMore, threads.length]);
+
+  useEffect(() => {
+    if (!showLoadMore || !scrollRoot) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
+      },
+      { root: scrollRoot, rootMargin: THREAD_LOAD_MORE_ROOT_MARGIN },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [onLoadMore, scrollRoot, showLoadMore]);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <SelectionBar
@@ -58,7 +112,10 @@ export function ThreadList({
         selectedCount={selectedCount}
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+      <div
+        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+        ref={setScrollRoot}
+      >
         {threads.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <div className="text-foreground text-sm">{emptyTitle}</div>
@@ -80,6 +137,7 @@ export function ThreadList({
                   onOpen={onOpenThread}
                   onSelectRangeTo={onSelectRangeTo}
                   onToggleSelect={onToggleSelect}
+                  rowRef={index === focusedIndex ? focusedRowRef : undefined}
                   thread={thread}
                   userEmail={userEmail}
                   userLabels={userLabels}
@@ -88,15 +146,20 @@ export function ThreadList({
             </div>
 
             {showLoadMore ? (
-              <div className="flex justify-center px-4 py-5">
-                <Button
-                  loading={isLoadingMore}
-                  onClick={onLoadMore}
-                  size="sm"
-                  variant="outline"
-                >
-                  Load more
-                </Button>
+              <div className="flex justify-center px-4 py-5" ref={sentinelRef}>
+                {isLoadingMore ? (
+                  <div
+                    aria-live="polite"
+                    className="flex items-center gap-2 text-muted-foreground text-xs"
+                  >
+                    <LoadingMiniSpinner />
+                    Loading more
+                  </div>
+                ) : (
+                  <Button onClick={onLoadMore} size="sm" variant="outline">
+                    Load more
+                  </Button>
+                )}
               </div>
             ) : (
               <div className="px-4 pt-5 pb-10 text-center text-muted-foreground text-xs">

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo } from "react";
+import { memo, useMemo, type Ref } from "react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import type {
@@ -34,6 +34,7 @@ export type ThreadRowProps = {
   onOpen: (index: number) => void;
   onToggleSelect: (index: number) => void;
   onSelectRangeTo: (index: number) => void;
+  rowRef?: Ref<HTMLDivElement>;
 };
 
 export const ThreadRow = memo(function ThreadRow({
@@ -48,6 +49,7 @@ export const ThreadRow = memo(function ThreadRow({
   onOpen,
   onToggleSelect,
   onSelectRangeTo,
+  rowRef,
 }: ThreadRowProps) {
   const message = thread.messages.at(-1);
 
@@ -119,6 +121,7 @@ export const ThreadRow = memo(function ThreadRow({
   return (
     <div
       aria-selected={isSelected}
+      ref={rowRef}
       className={cn(
         "group relative flex cursor-pointer border-b border-border/60 outline-none",
         isWide

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  scrollElementIntoContainer,
+  shouldPrefetchMoreThreads,
+  THREAD_PREFETCH_REMAINING,
+} from "./thread-list-behavior";
+
+describe("shouldPrefetchMoreThreads", () => {
+  it("does not prefetch when there is no next page", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: false,
+        isLoadingMore: false,
+        focusedIndex: 49,
+        threadCount: 50,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not prefetch while a page is already loading", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: true,
+        focusedIndex: 49,
+        threadCount: 50,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not prefetch an empty list", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: false,
+        focusedIndex: 0,
+        threadCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not prefetch when the cursor is still far from the end", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: false,
+        focusedIndex: 0,
+        threadCount: 50,
+      }),
+    ).toBe(false);
+  });
+
+  it("prefetches when the cursor enters the remaining-thread window", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: false,
+        focusedIndex: 50 - THREAD_PREFETCH_REMAINING,
+        threadCount: 50,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not prefetch one row before the remaining-thread window", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: false,
+        focusedIndex: 50 - THREAD_PREFETCH_REMAINING - 1,
+        threadCount: 50,
+      }),
+    ).toBe(false);
+  });
+
+  it("prefetches when the list is shorter than the remaining-thread window", () => {
+    expect(
+      shouldPrefetchMoreThreads({
+        hasMore: true,
+        isLoadingMore: false,
+        focusedIndex: 0,
+        threadCount: 3,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("scrollElementIntoContainer", () => {
+  it("leaves a fully visible row where it is", () => {
+    const container = createBox({ top: 100, bottom: 500, scrollTop: 80 });
+    const element = createBox({ top: 180, bottom: 220 });
+
+    scrollElementIntoContainer(container, element, 8);
+
+    expect(container.scrollTop).toBe(80);
+  });
+
+  it("scrolls down just enough when the row sits below the fold", () => {
+    const container = createBox({ top: 100, bottom: 500, scrollTop: 80 });
+    const element = createBox({ top: 520, bottom: 560 });
+
+    scrollElementIntoContainer(container, element, 8);
+
+    expect(container.scrollTop).toBe(148);
+  });
+
+  it("scrolls up just enough when the row sits above the fold", () => {
+    const container = createBox({ top: 100, bottom: 500, scrollTop: 80 });
+    const element = createBox({ top: 60, bottom: 100 });
+
+    scrollElementIntoContainer(container, element, 8);
+
+    expect(container.scrollTop).toBe(32);
+  });
+
+  it("aligns to the top when the row is taller than the container", () => {
+    const container = createBox({ top: 100, bottom: 200, scrollTop: 40 });
+    const element = createBox({ top: 80, bottom: 260 });
+
+    scrollElementIntoContainer(container, element, 8);
+
+    expect(container.scrollTop).toBe(12);
+  });
+});
+
+function createBox({
+  top,
+  bottom,
+  scrollTop = 0,
+}: {
+  top: number;
+  bottom: number;
+  scrollTop?: number;
+}): HTMLElement {
+  return {
+    scrollTop,
+    getBoundingClientRect: () => ({
+      top,
+      bottom,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: bottom - top,
+      x: 0,
+      y: top,
+      toJSON() {},
+    }),
+  } as HTMLElement;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -1,0 +1,38 @@
+export const THREAD_PREFETCH_REMAINING = 8;
+export const THREAD_SCROLL_PADDING_PX = 8;
+export const THREAD_LOAD_MORE_ROOT_MARGIN = "400px 0px";
+
+export function shouldPrefetchMoreThreads({
+  hasMore,
+  isLoadingMore,
+  focusedIndex,
+  threadCount,
+  remainingThreshold = THREAD_PREFETCH_REMAINING,
+}: {
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  focusedIndex: number;
+  threadCount: number;
+  remainingThreshold?: number;
+}): boolean {
+  if (!hasMore || isLoadingMore || threadCount === 0) return false;
+  return focusedIndex >= threadCount - remainingThreshold;
+}
+
+export function scrollElementIntoContainer(
+  container: HTMLElement,
+  element: HTMLElement,
+  padding = THREAD_SCROLL_PADDING_PX,
+): void {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+
+  const topOverflow = containerRect.top + padding - elementRect.top;
+  const bottomOverflow = elementRect.bottom - (containerRect.bottom - padding);
+
+  if (topOverflow > 0) {
+    container.scrollTop -= topOverflow;
+  } else if (bottomOverflow > 0) {
+    container.scrollTop += bottomOverflow;
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -377,6 +377,104 @@ describe("useMailThreads", () => {
     );
   });
 
+  it("does not request two pages when load more is called twice before the next page arrives", async () => {
+    const secondPage = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        threads: [createThread("one")],
+        nextPageToken: "page-2",
+      })
+      .mockReturnValueOnce(secondPage.promise)
+      .mockResolvedValueOnce({ threads: [createThread("three")] });
+
+    const { result } = renderHook(
+      () =>
+        useMailThreads({
+          emailAccountId: "account-double-load",
+          query: { type: "inbox" },
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+    await waitFor(() => expect(result.current.threads[0]?.id).toBe("one"));
+
+    act(() => {
+      result.current.loadMore();
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(fetcher.mock.calls[1]?.[0][0]).toContain("nextPageToken=page-2");
+
+    await act(async () => {
+      secondPage.resolve({
+        threads: [createThread("two")],
+        nextPageToken: "page-3",
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "one",
+        "two",
+      ]),
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads a later page after the previous extra page has arrived", async () => {
+    const secondPage = Promise.withResolvers<unknown>();
+    const thirdPage = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        threads: [createThread("one")],
+        nextPageToken: "page-2",
+      })
+      .mockReturnValueOnce(secondPage.promise)
+      .mockReturnValueOnce(thirdPage.promise);
+
+    const { result } = renderHook(
+      () =>
+        useMailThreads({
+          emailAccountId: "account-sequential-load",
+          query: { type: "inbox" },
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+    await waitFor(() => expect(result.current.threads[0]?.id).toBe("one"));
+
+    act(() => result.current.loadMore());
+    await act(async () => {
+      secondPage.resolve({
+        threads: [createThread("two")],
+        nextPageToken: "page-3",
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "one",
+        "two",
+      ]),
+    );
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(3));
+    expect(fetcher.mock.calls[2]?.[0][0]).toContain("nextPageToken=page-3");
+
+    await act(async () => {
+      thirdPage.resolve({ threads: [createThread("three")] });
+    });
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "one",
+        "two",
+        "three",
+      ]),
+    );
+  });
+
   it("retries a failed first page before loading more from cache", async () => {
     cache.read.mockResolvedValue({
       cachedAt: 100,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -475,6 +475,42 @@ describe("useMailThreads", () => {
     );
   });
 
+  it("retries the next page after a failed load more", async () => {
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        threads: [createThread("one")],
+        nextPageToken: "page-2",
+      })
+      .mockRejectedValueOnce(new Error("page two failed"))
+      .mockResolvedValueOnce({
+        threads: [createThread("two")],
+      });
+
+    const { result } = renderHook(
+      () =>
+        useMailThreads({
+          emailAccountId: "account-load-more-retry",
+          query: { type: "inbox" },
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+    await waitFor(() => expect(result.current.threads[0]?.id).toBe("one"));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.isLoadingMore).toBe(false));
+
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "one",
+        "two",
+      ]),
+    );
+    expect(fetcher.mock.calls[2]?.[0][0]).toContain("nextPageToken=page-2");
+  });
+
   it("retries a failed first page before loading more from cache", async () => {
     cache.read.mockResolvedValue({
       cachedAt: 100,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -99,6 +99,9 @@ export function useMailThreads({
   const pendingReconciliationWrites = useRef(0);
   const [, renderHiddenChanges] = useReducer((version) => version + 1, 0);
   const remoteIdentity = useRef<string | undefined>(undefined);
+  // Auto-load can fire from the cursor and the bottom sentinel in the same
+  // tick; two setSize(+1) calls would skip a page token.
+  const loadMoreLock = useRef(false);
 
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
 
@@ -445,6 +448,12 @@ export function useMailThreads({
     ? Boolean(data.at(-1)?.nextPageToken)
     : persistent?.identity === viewIdentity && persistent.hasMore;
 
+  useEffect(() => {
+    const latestPageLoaded = !data || data.length === size;
+    const paginationIdle = paginationRequestIdentity !== viewIdentity;
+    if (latestPageLoaded && paginationIdle) loadMoreLock.current = false;
+  }, [data, paginationRequestIdentity, size, viewIdentity]);
+
   return {
     threads,
     isLoading: isLoading && !sourceThreads,
@@ -454,9 +463,14 @@ export function useMailThreads({
       paginationRequestIdentity === viewIdentity ||
       (size > 1 && !data?.[size - 1]),
     loadMore: useCallback(() => {
+      if (loadMoreLock.current) return;
+
       if (data) {
+        if (!data.at(-1)?.nextPageToken) return;
+        loadMoreLock.current = true;
         setSize((current) => current + 1).catch(() => {});
       } else {
+        loadMoreLock.current = true;
         paginationRetryIdentity.current = undefined;
         setPaginationRequestIdentity(viewIdentity);
       }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -449,10 +449,17 @@ export function useMailThreads({
     : persistent?.identity === viewIdentity && persistent.hasMore;
 
   useEffect(() => {
+    const loadedPageCount = data?.length ?? 0;
+    if (error && size > 1 && size > loadedPageCount) {
+      loadMoreLock.current = false;
+      setSize(Math.max(loadedPageCount, 1)).catch(() => {});
+      return;
+    }
+
     const latestPageLoaded = !data || data.length === size;
     const paginationIdle = paginationRequestIdentity !== viewIdentity;
     if (latestPageLoaded && paginationIdle) loadMoreLock.current = false;
-  }, [data, paginationRequestIdentity, size, viewIdentity]);
+  }, [data, error, paginationRequestIdentity, setSize, size, viewIdentity]);
 
   return {
     threads,
@@ -468,7 +475,11 @@ export function useMailThreads({
       if (data) {
         if (!data.at(-1)?.nextPageToken) return;
         loadMoreLock.current = true;
-        setSize((current) => current + 1).catch(() => {});
+        const loadedPageCount = data.length;
+        setSize(loadedPageCount + 1).catch(() => {
+          loadMoreLock.current = false;
+          setSize(loadedPageCount).catch(() => {});
+        });
       } else {
         loadMoreLock.current = true;
         paginationRetryIdentity.current = undefined;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260814-131521_pr-3262_41968b1e3937/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
J/K and arrow keys now keep the focused conversation in view, and the thread list fetches the next page as you approach the bottom instead of waiting for a click.

- Scroll the focused row just far enough into the list viewport (`block: nearest` behavior) so the cursor cannot sit below the fold
- Prefetch the next page when the cursor is within 8 rows of the end, and when the bottom sentinel enters view while scrolling
- Keep Load more as a fallback/retry control; show a spinner while the next page is in flight
- Guard `loadMore` so overlapping cursor + sentinel triggers cannot skip a page token

Validation: `pnpm test` for `thread-list-behavior.test.ts`, `use-mail-threads.test.tsx`, and `use-mail-threads.undo.test.ts` (32 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c85029b4-d767-47a5-bebc-691fa8d71f3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c85029b4-d767-47a5-bebc-691fa8d71f3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->