### PR TITLE
Improve meeting recording status UX

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -24,9 +24,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { MeetingRecordingStatus } from "@/generated/prisma/enums";
 import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/meeting-detail-state";
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
+import { STILL_CAPTURING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
 
 export function MeetingDetail({
@@ -44,6 +44,9 @@ export function MeetingDetail({
 
   const summary = data?.summary;
   const transcript = data?.recording?.transcript;
+  const isStillCapturing =
+    !!data?.recording?.status &&
+    STILL_CAPTURING_STATUSES.includes(data.recording.status);
 
   const state = getMeetingDetailState({
     hasSummary: !!summary,
@@ -101,8 +104,7 @@ export function MeetingDetail({
 
           {state === "processing" && (
             <MutedText>
-              {data?.recording?.status === MeetingRecordingStatus.IN_CALL ||
-              data?.recording?.status === MeetingRecordingStatus.RECORDING
+              {isStillCapturing
                 ? "The notetaker is recording this call. The transcript and notes will appear here after it ends."
                 : "The call has ended. The transcript and notes are being prepared, and this view will update automatically."}
             </MutedText>

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -24,6 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MeetingRecordingStatus } from "@/generated/prisma/enums";
 import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/meeting-detail-state";
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
@@ -100,8 +101,10 @@ export function MeetingDetail({
 
           {state === "processing" && (
             <MutedText>
-              The recording is in progress or being processed. Notes will appear
-              here when they are ready.
+              {data?.recording?.status === MeetingRecordingStatus.IN_CALL ||
+              data?.recording?.status === MeetingRecordingStatus.RECORDING
+                ? "The notetaker is recording this call. The transcript and notes will appear here after it ends."
+                : "The call has ended. The transcript and notes are being prepared, and this view will update automatically."}
             </MutedText>
           )}
 
@@ -180,7 +183,7 @@ export function MeetingDetail({
           )}
 
           {!!transcript?.length && (
-            <Collapsible>
+            <Collapsible defaultOpen>
               <Card>
                 <CollapsibleTrigger className="group flex w-full items-center gap-3 p-4 text-left hover:bg-accent/50">
                   <TextQuoteIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingsList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingsList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { useState } from "react";
 import { MicIcon } from "lucide-react";
 import { ListCard } from "@/components/ListCard";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -14,14 +13,16 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Skeleton } from "@/components/ui/skeleton";
-import { MeetingDetail } from "@/app/(app)/[emailAccountId]/meetings/MeetingDetail";
 import { MeetingListItem } from "@/app/(app)/[emailAccountId]/meetings/MeetingListItem";
 import { useMeetingRecorderMeetings } from "@/hooks/useMeetingRecorder";
 
-export function MeetingsList() {
+export function MeetingsList({
+  onOpenMeeting,
+}: {
+  onOpenMeeting: (meetingId: string) => void;
+}) {
   const { emailAccountId } = useAccount();
   const { data, isLoading, error } = useMeetingRecorderMeetings(emailAccountId);
-  const [openMeetingId, setOpenMeetingId] = useState<string | null>(null);
 
   return (
     <div>
@@ -51,7 +52,7 @@ export function MeetingsList() {
                 endTime={meeting.endTime}
                 status={meeting.recording?.status}
                 failureReason={meeting.recording?.failureReason}
-                onClick={() => setOpenMeetingId(meeting.id)}
+                onClick={() => onOpenMeeting(meeting.id)}
               >
                 {meeting.followUpDraftId && (
                   <Badge variant="secondary">Draft ready</Badge>
@@ -61,11 +62,6 @@ export function MeetingsList() {
           </ListCard>
         )}
       </LoadingContent>
-
-      <MeetingDetail
-        meetingId={openMeetingId}
-        onClose={() => setOpenMeetingId(null)}
-      />
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
@@ -19,6 +19,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import type { GetMeetingRecorderUpcomingResponse } from "@/app/api/user/meeting-recorder/upcoming/route";
 import { MeetingListItem } from "@/app/(app)/[emailAccountId]/meetings/MeetingListItem";
+import { MEETING_DETAIL_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { useMeetingRecorderUpcoming } from "@/hooks/useMeetingRecorder";
 import { setMeetingJoinOverrideAction } from "@/utils/actions/meeting-recorder";
 import { getActionErrorMessage } from "@/utils/error";
@@ -27,8 +28,10 @@ type UpcomingEvent = GetMeetingRecorderUpcomingResponse["events"][number];
 
 export function UpcomingMeetingsToggleList({
   emailAccountId,
+  onOpenMeeting,
 }: {
   emailAccountId: string;
+  onOpenMeeting: (meetingId: string) => void;
 }) {
   const { data, isLoading, error, mutate } =
     useMeetingRecorderUpcoming(emailAccountId);
@@ -91,6 +94,12 @@ export function UpcomingMeetingsToggleList({
           <ListCard className="mt-4">
             {events.map((event) => {
               const joining = isJoining(event);
+              const detailMeetingId =
+                event.meetingId &&
+                event.recordingStatus &&
+                MEETING_DETAIL_STATUSES.includes(event.recordingStatus)
+                  ? event.meetingId
+                  : null;
 
               return (
                 <MeetingListItem
@@ -100,18 +109,25 @@ export function UpcomingMeetingsToggleList({
                   endTime={event.endTime}
                   status={event.recordingStatus}
                   failureReason={event.failureReason}
+                  onClick={
+                    detailMeetingId
+                      ? () => onOpenMeeting(detailMeetingId)
+                      : undefined
+                  }
                 >
-                  <Toggle
-                    name={`join-${event.id}`}
-                    ariaLabel={`Record ${event.title}`}
-                    enabled={joining}
-                    // A downgraded user must still be able to cancel a booked
-                    // meeting; only creating a new booking is gated.
-                    disabled={
-                      pendingEventId === event.id || (isLocked && !joining)
-                    }
-                    onChange={(join) => toggleEvent(event, join)}
-                  />
+                  {!detailMeetingId && (
+                    <Toggle
+                      name={`join-${event.id}`}
+                      ariaLabel={`Record ${event.title}`}
+                      enabled={joining}
+                      // A downgraded user must still be able to cancel a booked
+                      // meeting; only creating a new booking is gated.
+                      disabled={
+                        pendingEventId === event.id || (isLocked && !joining)
+                      }
+                      onChange={(join) => toggleEvent(event, join)}
+                    />
+                  )}
                 </MeetingListItem>
               );
             })}

--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -20,6 +20,7 @@ import { updateMeetingRecorderSettingsAction } from "@/utils/actions/meeting-rec
 import { getActionErrorMessage } from "@/utils/error";
 import { MeetingRecorderOnboarding } from "@/app/(app)/[emailAccountId]/meetings/MeetingRecorderOnboarding";
 import { MeetingRecorderSettingsDialog } from "@/app/(app)/[emailAccountId]/meetings/MeetingRecorderSettingsDialog";
+import { MeetingDetail } from "@/app/(app)/[emailAccountId]/meetings/MeetingDetail";
 import { MeetingsList } from "@/app/(app)/[emailAccountId]/meetings/MeetingsList";
 import { UpcomingMeetingsToggleList } from "@/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList";
 import { hasConnectedCalendar } from "@/app/(app)/[emailAccountId]/meetings/calendar-connection-state";
@@ -56,6 +57,7 @@ export default function MeetingsPage() {
 function MeetingRecorderPageContent() {
   const { emailAccountId } = useAccount();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [openMeetingId, setOpenMeetingId] = useState<string | null>(null);
 
   const {
     data: calendarsData,
@@ -156,10 +158,18 @@ function MeetingRecorderPageContent() {
           />
         )}
 
-        <UpcomingMeetingsToggleList emailAccountId={emailAccountId} />
+        <UpcomingMeetingsToggleList
+          emailAccountId={emailAccountId}
+          onOpenMeeting={setOpenMeetingId}
+        />
 
-        <MeetingsList />
+        <MeetingsList onOpenMeeting={setOpenMeetingId} />
       </div>
+
+      <MeetingDetail
+        meetingId={openMeetingId}
+        onClose={() => setOpenMeetingId(null)}
+      />
 
       <MeetingRecorderSettingsDialog
         emailAccountId={emailAccountId}

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
@@ -5,7 +5,7 @@ import { getRecordingStatusBadge } from "@/app/(app)/[emailAccountId]/meetings/r
 const NOW = new Date("2026-07-30T17:15:00.000Z");
 
 describe("getRecordingStatusBadge", () => {
-  it("shows an ongoing meeting from its time range even while the recorder status is stale", () => {
+  it("makes it clear when an ongoing call is still waiting for the bot", () => {
     expect(
       getRecordingStatusBadge({
         status: MeetingRecordingStatus.SCHEDULED,
@@ -13,7 +13,18 @@ describe("getRecordingStatusBadge", () => {
         endTime: new Date("2026-07-30T17:30:00.000Z"),
         now: NOW,
       }),
-    ).toEqual({ label: "Ongoing", variant: "green" });
+    ).toEqual({ label: "Waiting to join", variant: "secondary" });
+  });
+
+  it("shows when the calendar event is in progress before a bot status exists", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: undefined,
+        startTime: new Date("2026-07-30T17:00:00.000Z"),
+        endTime: new Date("2026-07-30T17:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Call in progress", variant: "secondary" });
   });
 
   it("shows that an ended meeting has no recording when capture failed", () => {
@@ -50,6 +61,17 @@ describe("getRecordingStatusBadge", () => {
         now: NOW,
       }),
     ).toEqual({ label: "Waiting to be let in", variant: "default" });
+  });
+
+  it("shows when the notetaker has joined the call", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.IN_CALL,
+        startTime: new Date("2026-07-30T17:00:00.000Z"),
+        endTime: new Date("2026-07-30T17:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Notetaker joined", variant: "default" });
   });
 
   it("hides a past booking the recorder never engaged with", () => {

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
@@ -10,13 +10,6 @@ type StatusBadge = {
   variant: "default" | "secondary" | "green" | "red";
 };
 
-// The recorder has reported no progress in these states, so during the meeting
-// the event's own time window is fresher information than the status.
-const NO_PROGRESS_STATUSES: MeetingRecordingStatus[] = [
-  MeetingRecordingStatus.PENDING,
-  MeetingRecordingStatus.SCHEDULED,
-];
-
 // Waiting-room and failure states are the ones users need to act on, so they
 // are called out rather than folded into a generic "recording" state.
 const STATUS_BADGES: Record<MeetingRecordingStatus, StatusBadge> = {
@@ -38,7 +31,7 @@ const STATUS_BADGES: Record<MeetingRecordingStatus, StatusBadge> = {
     variant: "default",
   },
   [MeetingRecordingStatus.IN_CALL]: {
-    label: "In the call",
+    label: "Notetaker joined",
     variant: "default",
   },
   [MeetingRecordingStatus.RECORDING]: { label: "Recording", variant: "green" },
@@ -68,12 +61,13 @@ export function getRecordingStatusBadge({
   const start = new Date(startTime);
   const end = new Date(endTime);
 
-  if (
-    start <= now &&
-    now < end &&
-    (!status || NO_PROGRESS_STATUSES.includes(status))
-  ) {
-    return { label: "Ongoing", variant: "green" };
+  if (start <= now && now < end) {
+    if (!status) {
+      return { label: "Call in progress", variant: "secondary" };
+    }
+    if (status === MeetingRecordingStatus.SCHEDULED) {
+      return { label: "Waiting to join", variant: "secondary" };
+    }
   }
 
   if (end <= now && status) {

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.test.ts
@@ -73,6 +73,7 @@ describe("meeting recorder upcoming route", () => {
   it("exposes an existing booking after plan access is lost", async () => {
     prisma.meeting.findMany.mockResolvedValue([
       {
+        id: "meeting-1",
         calendarEventId: "event-1",
         joinOverride: null,
         recording: {
@@ -92,6 +93,7 @@ describe("meeting recorder upcoming route", () => {
     expect(body.events).toEqual([
       expect.objectContaining({
         id: "event-1",
+        meetingId: "meeting-1",
         hasCancellableBooking: true,
         joinOverride: null,
         willRecord: false,
@@ -102,6 +104,7 @@ describe("meeting recorder upcoming route", () => {
   it("does not expose a terminal recording as an active booking", async () => {
     prisma.meeting.findMany.mockResolvedValue([
       {
+        id: "meeting-1",
         calendarEventId: "event-1",
         joinOverride: null,
         recording: {
@@ -121,6 +124,7 @@ describe("meeting recorder upcoming route", () => {
     expect(body.events).toEqual([
       expect.objectContaining({
         id: "event-1",
+        meetingId: "meeting-1",
         hasCancellableBooking: false,
         willRecord: false,
       }),

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
@@ -66,6 +66,7 @@ async function getData({
       calendarEventId: { in: videoEvents.map((event) => event.id) },
     },
     select: {
+      id: true,
       calendarEventId: true,
       joinOverride: true,
       recording: { select: { status: true, failureReason: true } },
@@ -85,6 +86,7 @@ async function getData({
 
       return {
         id: event.id,
+        meetingId: meeting?.id,
         title: event.title,
         startTime: event.startTime,
         endTime: event.endTime,

--- a/apps/web/hooks/useMeetingRecorder.ts
+++ b/apps/web/hooks/useMeetingRecorder.ts
@@ -3,9 +3,12 @@ import type { GetMeetingRecorderSettingsResponse } from "@/app/api/user/meeting-
 import type { GetMeetingRecorderMeetingsResponse } from "@/app/api/user/meeting-recorder/meetings/route";
 import type { GetMeetingRecorderMeetingResponse } from "@/app/api/user/meeting-recorder/meetings/[meetingId]/route";
 import type { GetMeetingRecorderUpcomingResponse } from "@/app/api/user/meeting-recorder/upcoming/route";
+import { MeetingProcessingStatus } from "@/generated/prisma/enums";
+import { CAPTURED_MEETING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { getAccountScopedKey } from "@/utils/swr";
 
 const MEETING_STATUS_REFRESH_INTERVAL = 30_000;
+const MEETING_DETAIL_REFRESH_INTERVAL = 5000;
 
 export function useMeetingRecorderSettings(emailAccountId?: string | null) {
   return useSWR<GetMeetingRecorderSettingsResponse>(
@@ -31,6 +34,10 @@ export function useMeetingRecorderMeeting(
           emailAccountId,
         )
       : null,
+    {
+      refreshInterval: (data) =>
+        shouldRefreshMeetingDetail(data) ? MEETING_DETAIL_REFRESH_INTERVAL : 0,
+    },
   );
 }
 
@@ -44,4 +51,18 @@ export function useMeetingRecorderUpcoming(emailAccountId?: string | null) {
         data && data.events.length === 0 ? 0 : MEETING_STATUS_REFRESH_INTERVAL,
     },
   );
+}
+
+function shouldRefreshMeetingDetail(
+  data: GetMeetingRecorderMeetingResponse | undefined,
+) {
+  if (!data?.recording) return false;
+  if (
+    data.processingStatus === MeetingProcessingStatus.COMPLETED ||
+    data.processingStatus === MeetingProcessingStatus.FAILED
+  ) {
+    return false;
+  }
+
+  return CAPTURED_MEETING_STATUSES.includes(data.recording.status);
 }

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -48,6 +48,14 @@ export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.DONE,
 ];
 
+// These outcomes have useful details to show even when the calendar event's
+// scheduled end is still in the future.
+export const MEETING_DETAIL_STATUSES: MeetingRecordingStatus[] = [
+  MeetingRecordingStatus.CALL_ENDED,
+  MeetingRecordingStatus.DONE,
+  MeetingRecordingStatus.FAILED,
+];
+
 // A booked bot is not a recorded meeting. The Recorded section only shows
 // calls the bot engaged with or that produced media; untouched scheduled
 // bookings are no-shows.

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -53,7 +53,6 @@ export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
 export const MEETING_DETAIL_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.CALL_ENDED,
   MeetingRecordingStatus.DONE,
-  MeetingRecordingStatus.FAILED,
 ];
 
 // A booked bot is not a recorded meeting. The Recorded section only shows


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260814-101805_pr-3263_b756e143df47/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- distinguish a live calendar call from a notetaker that is still waiting to join
- let users open processing, completed, or failed recordings directly from Up next before the scheduled calendar end
- automatically refresh an open meeting while its transcript and notes are processing
- expand completed transcripts by default

## Testing

- `pnpm test 'app/api/user/meeting-recorder/upcoming/route.test.ts' 'app/api/user/meeting-recorder/meetings/route.test.ts' 'app/(app)/[emailAccountId]/meetings/recording-status.test.ts' 'app/(app)/[emailAccountId]/meetings/meeting-detail-state.test.ts' 'utils/meeting-recorder/recording-lifecycle.test.ts'`
- focused Ultracite check on all changed files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->