### PR TITLE
ai: Use OpenRouter web search server tool

### DIFF
--- a/apps/web/__tests__/ai-regression/ai-meeting-briefing.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-meeting-briefing.test.ts
@@ -54,7 +54,7 @@ describe("buildPrompt", () => {
 
   test("builds prompt with meeting title and description", () => {
     const data = getMeetingBriefingData();
-    const prompt = buildPrompt(data, mockEmailAccount);
+    const prompt = buildPrompt(data, mockEmailAccount, []);
 
     expect(prompt).toContain("Product Discussion");
     expect(prompt).toContain("Q1 roadmap");
@@ -64,7 +64,7 @@ describe("buildPrompt", () => {
     const data = getMeetingBriefingData({
       externalGuests: [{ email: "bob@company.com", name: "Bob Smith" }],
     });
-    const prompt = buildPrompt(data, mockEmailAccountNoTz);
+    const prompt = buildPrompt(data, mockEmailAccountNoTz, []);
 
     expect(prompt).toContain("bob@company.com");
     expect(prompt).toContain("Bob Smith");
@@ -76,7 +76,7 @@ describe("buildPrompt", () => {
       emailThreads: [],
       pastMeetings: [],
     });
-    const prompt = buildPrompt(data, mockEmailAccountNoTz);
+    const prompt = buildPrompt(data, mockEmailAccountNoTz, []);
 
     expect(prompt).toContain("<no_prior_context>");
     expect(prompt).toContain("New Contact");
@@ -100,7 +100,7 @@ describe("buildPrompt", () => {
         },
       ],
     });
-    const prompt = buildPrompt(data, mockEmailAccountNoTz);
+    const prompt = buildPrompt(data, mockEmailAccountNoTz, []);
 
     expect(prompt).toContain("<recent_emails>");
     expect(prompt).toContain("Partnership proposal");
@@ -122,7 +122,7 @@ describe("buildPrompt", () => {
       externalGuests: [{ email: "alice@external.com", name: "Alice External" }],
       pastMeetings: [pastMeeting],
     });
-    const prompt = buildPrompt(data, mockEmailAccount);
+    const prompt = buildPrompt(data, mockEmailAccount, []);
 
     expect(prompt).toContain("<recent_meetings>");
     expect(prompt).toContain("Initial Discussion");
@@ -135,7 +135,7 @@ describe("buildPrompt", () => {
         { email: "bob@acme.com", name: "Bob Jones" },
       ],
     });
-    const prompt = buildPrompt(data, mockEmailAccountNoTz);
+    const prompt = buildPrompt(data, mockEmailAccountNoTz, []);
 
     expect(prompt).toContain("alice@acme.com");
     expect(prompt).toContain("Alice Smith");

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -102,7 +102,10 @@ describe("buildPrompt timezone handling", () => {
       ],
     };
 
-    const prompt = buildPrompt(briefingData, mockEmailAccount);
+    const prompt = buildPrompt(briefingData, mockEmailAccount, [
+      "perplexitySearch",
+      "webSearch",
+    ]);
 
     // The past meeting should show "4:00 PM" (Brazil time), NOT "7:00 PM" (UTC)
     expect(prompt).toMatchInlineSnapshot(`
@@ -163,7 +166,10 @@ describe("buildPrompt timezone handling", () => {
       pastMeetings: [],
     };
 
-    const prompt = buildPrompt(briefingData, mockEmailAccount);
+    const prompt = buildPrompt(briefingData, mockEmailAccount, [
+      "perplexitySearch",
+      "webSearch",
+    ]);
 
     expect(prompt).toMatchInlineSnapshot(`
       "Prepare a concise briefing for this upcoming meeting.
@@ -198,15 +204,7 @@ describe("buildPrompt timezone handling", () => {
     `);
   });
 
-  it("uses the account's meeting web search provider to decide availability", () => {
-    mockGetModel.mockReturnValue({
-      provider: "anthropic",
-      modelName: "claude-haiku-4-5-20251001",
-      model: { id: "model" },
-      fallbackModels: [],
-      hasUserApiKey: true,
-    });
-
+  it("only advertises the search tools built for the account", () => {
     const briefingData: MeetingBriefingData = {
       event: {
         id: "upcoming",
@@ -224,9 +222,10 @@ describe("buildPrompt timezone handling", () => {
       pastMeetings: [],
     };
 
-    const prompt = buildPrompt(briefingData, mockEmailAccount);
+    const prompt = buildPrompt(briefingData, mockEmailAccount, [
+      "perplexitySearch",
+    ]);
 
-    expect(mockGetModel).toHaveBeenCalledWith(mockEmailAccount.user, "economy");
     expect(prompt).toContain("Available search tools: perplexitySearch");
     expect(prompt).not.toContain("webSearch");
   });

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -230,7 +230,7 @@ describe("buildPrompt timezone handling", () => {
     expect(prompt).not.toContain("webSearch");
   });
 
-  it("uses the capped OpenRouter server web search tool", () => {
+  it("requires one OpenRouter server web search", () => {
     const config = getWebSearchConfig("openrouter");
     const tools = config?.getSearchTools?.();
 
@@ -242,5 +242,6 @@ describe("buildPrompt timezone handling", () => {
     expect(config?.providerOptions).toEqual({
       openrouter: { max_tool_calls: 1 },
     });
+    expect(config?.toolChoice).toBe("required");
   });
 });

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { MeetingBriefingData } from "@/utils/meeting-briefs/gather-context";
 
+const { mockOpenRouterWebSearch } = vi.hoisted(() => ({
+  mockOpenRouterWebSearch: vi.fn(() => ({ type: "provider" })),
+}));
+
 vi.mock("@/env", () => ({
   env: {
     PERPLEXITY_API_KEY: "test-key",
@@ -17,6 +21,9 @@ vi.mock("@/utils/llms/model", () => ({
   getModel: vi.fn(),
 }));
 vi.mock("@/utils/llms", () => ({ createGenerateObject: vi.fn() }));
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  openrouter: { tools: { webSearch: mockOpenRouterWebSearch } },
+}));
 vi.mock("@/utils/ai/helpers", () => ({
   getUserInfoPrompt: vi.fn(
     ({ emailAccount }) =>
@@ -43,7 +50,7 @@ vi.mock("@/utils/get-email-from-message", () => ({
 
 vi.doUnmock("@/utils/date");
 
-import { buildPrompt } from "./generate-briefing";
+import { buildPrompt, getWebSearchConfig } from "./generate-briefing";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
 
@@ -233,5 +240,24 @@ describe("buildPrompt timezone handling", () => {
     );
     expect(prompt).toContain("Available search tools: perplexitySearch");
     expect(prompt).not.toContain("webSearch");
+  });
+
+  it("uses the capped OpenRouter server web search tool", () => {
+    vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockReturnValue({
+      provider: "openrouter",
+      modelName: "openai/gpt-5.4-nano",
+    });
+
+    const config = getWebSearchConfig();
+    const tools = config?.getSearchTools?.();
+
+    expect(mockOpenRouterWebSearch).toHaveBeenCalledWith({
+      engine: "auto",
+      maxResults: 5,
+    });
+    expect(tools).toHaveProperty("web_search");
+    expect(config?.providerOptions).toEqual({
+      openrouter: { max_tool_calls: 1 },
+    });
   });
 });

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { MeetingBriefingData } from "@/utils/meeting-briefs/gather-context";
 
-const { mockOpenRouterWebSearch } = vi.hoisted(() => ({
+const { mockGetModel, mockOpenRouterWebSearch } = vi.hoisted(() => ({
+  mockGetModel: vi.fn(),
   mockOpenRouterWebSearch: vi.fn(() => ({ type: "provider" })),
 }));
 
@@ -14,11 +15,7 @@ vi.mock("@/env", () => ({
   },
 }));
 vi.mock("@/utils/llms/model", () => ({
-  getResolvedDeploymentRolePrimaryModelEntry: vi.fn(() => ({
-    provider: "openai",
-    modelName: "gpt-5.4-mini",
-  })),
-  getModel: vi.fn(),
+  getModel: mockGetModel,
 }));
 vi.mock("@/utils/llms", () => ({ createGenerateObject: vi.fn() }));
 vi.mock("@openrouter/ai-sdk-provider", () => ({
@@ -52,13 +49,15 @@ vi.doUnmock("@/utils/date");
 
 import { buildPrompt, getWebSearchConfig } from "./generate-briefing";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
-import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockReturnValue({
+  mockGetModel.mockReturnValue({
     provider: "openai",
     modelName: "gpt-5.4-mini",
+    model: { id: "model" },
+    fallbackModels: [],
+    hasUserApiKey: false,
   });
 });
 
@@ -199,22 +198,14 @@ describe("buildPrompt timezone handling", () => {
     `);
   });
 
-  it("uses the meeting web search role to decide web search availability", () => {
-    vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockImplementation(
-      (modelType) => {
-        if (modelType === "economy") {
-          return {
-            provider: "anthropic",
-            modelName: "claude-haiku-4-5-20251001",
-          };
-        }
-
-        return {
-          provider: "openai",
-          modelName: "gpt-5.4-mini",
-        };
-      },
-    );
+  it("uses the account's meeting web search provider to decide availability", () => {
+    mockGetModel.mockReturnValue({
+      provider: "anthropic",
+      modelName: "claude-haiku-4-5-20251001",
+      model: { id: "model" },
+      fallbackModels: [],
+      hasUserApiKey: true,
+    });
 
     const briefingData: MeetingBriefingData = {
       event: {
@@ -235,20 +226,13 @@ describe("buildPrompt timezone handling", () => {
 
     const prompt = buildPrompt(briefingData, mockEmailAccount);
 
-    expect(getResolvedDeploymentRolePrimaryModelEntry).toHaveBeenCalledWith(
-      "economy",
-    );
+    expect(mockGetModel).toHaveBeenCalledWith(mockEmailAccount.user, "economy");
     expect(prompt).toContain("Available search tools: perplexitySearch");
     expect(prompt).not.toContain("webSearch");
   });
 
   it("uses the capped OpenRouter server web search tool", () => {
-    vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockReturnValue({
-      provider: "openrouter",
-      modelName: "openai/gpt-5.4-nano",
-    });
-
-    const config = getWebSearchConfig();
+    const config = getWebSearchConfig("openrouter");
     const tools = config?.getSearchTools?.();
 
     expect(mockOpenRouterWebSearch).toHaveBeenCalledWith({

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
@@ -101,7 +101,10 @@ export async function aiGenerateMeetingBriefing({
     );
   }
 
-  const prompt = buildPrompt(briefingData, emailAccount);
+  const availableSearchTools = ["perplexitySearch", "webSearch"].filter(
+    (toolName) => toolName in searchTools,
+  );
+  const prompt = buildPrompt(briefingData, emailAccount, availableSearchTools);
   const modelOptions = getModelForUseCase(
     emailAccount.user,
     LlmUseCase.MeetingBriefing,
@@ -409,6 +412,7 @@ function createWebSearchTool({
 export function buildPrompt(
   briefingData: MeetingBriefingData,
   emailAccount: EmailAccountWithAI,
+  availableSearchTools: string[],
 ): string {
   const { event, externalGuests, emailThreads, pastMeetings } = briefingData;
 
@@ -424,20 +428,9 @@ export function buildPrompt(
     }),
   );
 
-  // List available search tools for the prompt
-  const availableTools: string[] = [];
-  if (env.PERPLEXITY_API_KEY) availableTools.push("perplexitySearch");
-  const webSearchModelOptions = getModelForUseCase(
-    emailAccount.user,
-    LlmUseCase.MeetingWebSearch,
-  );
-  if (getWebSearchConfig(webSearchModelOptions.provider)) {
-    availableTools.push("webSearch");
-  }
-
   const toolsNote =
-    availableTools.length > 0
-      ? `\nAvailable search tools: ${availableTools.join(", ")}`
+    availableSearchTools.length > 0
+      ? `\nAvailable search tools: ${availableSearchTools.join(", ")}`
       : "";
 
   const prompt = `Prepare a concise briefing for this upcoming meeting.

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createPerplexity } from "@ai-sdk/perplexity";
 import { openai } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
+import { openrouter } from "@openrouter/ai-sdk-provider";
 import { env } from "@/env";
 import { createGenerateText } from "@/utils/llms";
 import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
@@ -264,7 +265,7 @@ async function buildSearchTools({
       logger,
       providerName: webSearchConfig.providerName,
       getSearchTools: webSearchConfig.getSearchTools,
-      useOnlineVariant: webSearchConfig.useOnlineVariant,
+      providerOptions: webSearchConfig.providerOptions,
     });
   }
 
@@ -293,24 +294,22 @@ async function buildSearchTools({
 
 type WebSearchConfig = {
   providerName: string;
-  useOnlineVariant: boolean;
   getSearchTools?: () => ToolSet;
+  providerOptions?: Record<string, Record<string, number>>;
 };
 
-function getWebSearchConfig(): WebSearchConfig | null {
+export function getWebSearchConfig(): WebSearchConfig | null {
   const webSearchProvider = getMeetingWebSearchProvider();
 
   switch (webSearchProvider) {
     case Provider.OPEN_AI:
       return {
         providerName: "OpenAI",
-        useOnlineVariant: false,
         getSearchTools: () => ({ web_search: openai.tools.webSearch({}) }),
       };
     case Provider.GOOGLE:
       return {
         providerName: "Google",
-        useOnlineVariant: false,
         getSearchTools: () => ({
           google_search: google.tools.googleSearch({}),
         }),
@@ -318,7 +317,13 @@ function getWebSearchConfig(): WebSearchConfig | null {
     case Provider.OPENROUTER:
       return {
         providerName: "OpenRouter",
-        useOnlineVariant: true,
+        getSearchTools: () => ({
+          web_search: openrouter.tools.webSearch({
+            engine: "auto",
+            maxResults: 5,
+          }),
+        }),
+        providerOptions: { openrouter: { max_tool_calls: 1 } },
       };
     default:
       return null;
@@ -330,13 +335,13 @@ function createWebSearchTool({
   logger,
   providerName,
   getSearchTools,
-  useOnlineVariant,
+  providerOptions,
 }: {
   emailAccount: EmailAccountWithAI;
   logger: Logger;
   providerName: string;
   getSearchTools?: () => ToolSet;
-  useOnlineVariant: boolean;
+  providerOptions?: Record<string, Record<string, number>>;
 }) {
   return tool({
     description: "Search the web for information",
@@ -359,7 +364,6 @@ function createWebSearchTool({
         const modelOptions = getModelForUseCase(
           emailAccount.user,
           LlmUseCase.MeetingWebSearch,
-          useOnlineVariant,
         );
 
         const webGenerateText = createGenerateText({
@@ -373,6 +377,7 @@ function createWebSearchTool({
           model: modelOptions.model,
           prompt: query,
           ...(getSearchTools && { tools: getSearchTools() }),
+          providerOptions,
         });
 
         const text = searchResult.text;

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
@@ -6,12 +6,7 @@ import { google } from "@ai-sdk/google";
 import { openrouter } from "@openrouter/ai-sdk-provider";
 import { env } from "@/env";
 import { createGenerateText } from "@/utils/llms";
-import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
-import {
-  getModelForUseCase,
-  LLM_USE_CASE_MODEL_TYPES,
-  LlmUseCase,
-} from "@/utils/llms/use-cases";
+import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getUserInfoPrompt } from "@/utils/ai/helpers";
 import type { CalendarEvent } from "@/utils/calendar/event-types";
@@ -258,11 +253,23 @@ async function buildSearchTools({
   }
 
   // Web search (OpenAI, Google, or OpenRouter - if configured)
-  const webSearchConfig = getWebSearchConfig();
+  const resolvedWebSearchModelOptions = getModelForUseCase(
+    emailAccount.user,
+    LlmUseCase.MeetingWebSearch,
+  );
+  const webSearchModelOptions = {
+    ...resolvedWebSearchModelOptions,
+    fallbackModels: resolvedWebSearchModelOptions.fallbackModels.filter(
+      (fallback) =>
+        fallback.provider === resolvedWebSearchModelOptions.provider,
+    ),
+  };
+  const webSearchConfig = getWebSearchConfig(webSearchModelOptions.provider);
   if (webSearchConfig) {
     tools.webSearch = createWebSearchTool({
       emailAccount,
       logger,
+      modelOptions: webSearchModelOptions,
       providerName: webSearchConfig.providerName,
       getSearchTools: webSearchConfig.getSearchTools,
       providerOptions: webSearchConfig.providerOptions,
@@ -298,9 +305,9 @@ type WebSearchConfig = {
   providerOptions?: Record<string, Record<string, number>>;
 };
 
-export function getWebSearchConfig(): WebSearchConfig | null {
-  const webSearchProvider = getMeetingWebSearchProvider();
-
+export function getWebSearchConfig(
+  webSearchProvider: string | undefined,
+): WebSearchConfig | null {
   switch (webSearchProvider) {
     case Provider.OPEN_AI:
       return {
@@ -333,12 +340,14 @@ export function getWebSearchConfig(): WebSearchConfig | null {
 function createWebSearchTool({
   emailAccount,
   logger,
+  modelOptions,
   providerName,
   getSearchTools,
   providerOptions,
 }: {
   emailAccount: EmailAccountWithAI;
   logger: Logger;
+  modelOptions: ReturnType<typeof getModelForUseCase>;
   providerName: string;
   getSearchTools?: () => ToolSet;
   providerOptions?: Record<string, Record<string, number>>;
@@ -361,11 +370,6 @@ function createWebSearchTool({
       }
 
       try {
-        const modelOptions = getModelForUseCase(
-          emailAccount.user,
-          LlmUseCase.MeetingWebSearch,
-        );
-
         const webGenerateText = createGenerateText({
           emailAccount,
           label: "Web Search",
@@ -423,7 +427,11 @@ export function buildPrompt(
   // List available search tools for the prompt
   const availableTools: string[] = [];
   if (env.PERPLEXITY_API_KEY) availableTools.push("perplexitySearch");
-  if (getWebSearchConfig()) {
+  const webSearchModelOptions = getModelForUseCase(
+    emailAccount.user,
+    LlmUseCase.MeetingWebSearch,
+  );
+  if (getWebSearchConfig(webSearchModelOptions.provider)) {
     availableTools.push("webSearch");
   }
 
@@ -452,12 +460,6 @@ For each guest listed above:
 3. Once you have all information, call finalizeBriefing with the complete briefing`;
 
   return prompt;
-}
-
-function getMeetingWebSearchProvider(): string | undefined {
-  return getResolvedDeploymentRolePrimaryModelEntry(
-    LLM_USE_CASE_MODEL_TYPES[LlmUseCase.MeetingWebSearch],
-  )?.provider;
 }
 
 type GuestContextForPrompt = {

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
@@ -276,6 +276,7 @@ async function buildSearchTools({
       providerName: webSearchConfig.providerName,
       getSearchTools: webSearchConfig.getSearchTools,
       providerOptions: webSearchConfig.providerOptions,
+      toolChoice: webSearchConfig.toolChoice,
     });
   }
 
@@ -306,6 +307,7 @@ type WebSearchConfig = {
   providerName: string;
   getSearchTools?: () => ToolSet;
   providerOptions?: Record<string, Record<string, number>>;
+  toolChoice?: "required";
 };
 
 export function getWebSearchConfig(
@@ -334,6 +336,7 @@ export function getWebSearchConfig(
           }),
         }),
         providerOptions: { openrouter: { max_tool_calls: 1 } },
+        toolChoice: "required",
       };
     default:
       return null;
@@ -347,6 +350,7 @@ function createWebSearchTool({
   providerName,
   getSearchTools,
   providerOptions,
+  toolChoice,
 }: {
   emailAccount: EmailAccountWithAI;
   logger: Logger;
@@ -354,6 +358,7 @@ function createWebSearchTool({
   providerName: string;
   getSearchTools?: () => ToolSet;
   providerOptions?: Record<string, Record<string, number>>;
+  toolChoice?: "required";
 }) {
   return tool({
     description: "Search the web for information",
@@ -385,6 +390,7 @@ function createWebSearchTool({
           prompt: query,
           ...(getSearchTools && { tools: getSearchTools() }),
           providerOptions,
+          toolChoice,
         });
 
         const text = searchResult.text;

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -64,14 +64,13 @@ type ModelEntryWarningMessages = {
 export function getModel(
   userAi: UserAIFields,
   modelType: ModelType = "default",
-  online = false,
 ): SelectModel {
   const selectedModel = userAi.aiApiKey
     ? {
-        primaryModel: selectUserModel(userAi, modelType, online),
+        primaryModel: selectUserModel(userAi, modelType),
         fallbackModels: [],
       }
-    : selectDeploymentModelByType(modelType, online);
+    : selectDeploymentModelByType(modelType);
   const { primaryModel, fallbackModels } = selectedModel;
 
   logger.info("Using model", {
@@ -100,7 +99,6 @@ function selectModel(
   modelType: ModelType,
   // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
   providerOptions?: Record<string, any>,
-  online = false,
 ): ResolvedModel {
   switch (aiProvider) {
     case Provider.OPEN_AI: {
@@ -228,8 +226,7 @@ function selectModel(
       };
     }
     case Provider.OPENROUTER: {
-      let modelName = aiModel || "anthropic/claude-sonnet-4.6";
-      if (online) modelName += ":online";
+      const modelName = aiModel || "anthropic/claude-sonnet-4.6";
 
       const openrouter = createOpenRouter({
         apiKey: resolveApiKey(aiApiKey, env.OPENROUTER_API_KEY),
@@ -374,14 +371,14 @@ function createOpenRouterProviderOptions(
   };
 }
 
-function selectDeploymentModelByType(
-  modelType: ModelType,
-  online = false,
-): { primaryModel: ResolvedModel; fallbackModels: ResolvedModel[] } {
+function selectDeploymentModelByType(modelType: ModelType): {
+  primaryModel: ResolvedModel;
+  fallbackModels: ResolvedModel[];
+} {
   const selectedModel =
-    resolveRoleModelList(modelType, online) ??
+    resolveRoleModelList(modelType) ??
     getDeploymentModelFallbackTypes(modelType)
-      .map((fallbackType) => resolveRoleModelList(fallbackType, online))
+      .map((fallbackType) => resolveRoleModelList(fallbackType))
       .find((modelList) => !!modelList);
 
   if (!selectedModel) {
@@ -407,7 +404,6 @@ function getDeploymentModelFallbackTypes(modelType: ModelType): ModelType[] {
 function selectUserModel(
   userAi: UserAIFields,
   modelType: ModelType,
-  online = false,
 ): ResolvedModel {
   const configuredDefault = getFirstSupportedModelListEntry("default");
   const aiProvider = userAi.aiProvider || configuredDefault?.provider;
@@ -427,21 +423,19 @@ function selectUserModel(
     },
     modelType,
     getOpenRouterProviderOptions(modelType, aiProvider),
-    online,
   );
 }
 
-function resolveRoleModelList(
-  modelType: ModelType,
-  online = false,
-): { primaryModel: ResolvedModel; fallbackModels: ResolvedModel[] } | null {
+function resolveRoleModelList(modelType: ModelType): {
+  primaryModel: ResolvedModel;
+  fallbackModels: ResolvedModel[];
+} | null {
   const modelListConfig = getConfiguredModelListByType(modelType);
   if (!modelListConfig) return null;
 
   const resolvedModels = resolveDeploymentModelEntries({
     entries: parseModelListConfig(modelListConfig),
     modelType,
-    online,
     getOpenRouterProviderOptions,
     warningMessages: {
       unsupportedProvider: "Skipping unsupported LLM list provider",
@@ -463,9 +457,8 @@ function resolveRoleModelList(
 
 export function getConfiguredRolePrimaryModel(
   modelType: ModelType,
-  online = false,
 ): ResolvedModel | null {
-  return resolveRoleModelList(modelType, online)?.primaryModel ?? null;
+  return resolveRoleModelList(modelType)?.primaryModel ?? null;
 }
 
 export function getConfiguredRolePrimaryModelEntry(
@@ -795,14 +788,12 @@ function resolveDeploymentModelEntries({
   entries,
   modelType,
   primaryModel,
-  online,
   getOpenRouterProviderOptions,
   warningMessages,
 }: {
   entries: ParsedModelEntry[];
   modelType: ModelType;
   primaryModel?: ResolvedModel;
-  online: boolean;
   getOpenRouterProviderOptions: (
     modelType: ModelType,
     provider: string,
@@ -851,7 +842,6 @@ function resolveDeploymentModelEntries({
       },
       modelType,
       providerOptions,
-      online,
     );
 
     if (

--- a/apps/web/utils/llms/use-cases.test.ts
+++ b/apps/web/utils/llms/use-cases.test.ts
@@ -163,16 +163,6 @@ describe("LLM use cases", () => {
       modelSnapshot(getModel(userAi, modelType)),
     );
   });
-
-  it("preserves the online model variant option", () => {
-    const userAi = defaultUserAi();
-
-    expect(
-      modelSnapshot(
-        getModelForUseCase(userAi, LlmUseCase.MeetingWebSearch, true),
-      ),
-    ).toEqual(modelSnapshot(getModel(userAi, "economy", true)));
-  });
 });
 
 function defaultUserAi(overrides?: Partial<UserAIFields>): UserAIFields {

--- a/apps/web/utils/llms/use-cases.ts
+++ b/apps/web/utils/llms/use-cases.ts
@@ -97,7 +97,6 @@ export const LLM_USE_CASE_MODEL_TYPES = {
 export function getModelForUseCase(
   userAi: UserAIFields,
   useCase: LlmUseCase,
-  online = false,
 ): SelectModel {
-  return getModel(userAi, LLM_USE_CASE_MODEL_TYPES[useCase], online);
+  return getModel(userAi, LLM_USE_CASE_MODEL_TYPES[useCase]);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260814-155434_pr-3265_0a4f24e88775/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Replace the deprecated OpenRouter `:online` model suffix with the provider-defined web search server tool.

- cap meeting-brief searches at one tool call and five results
- remove obsolete online-model selection plumbing
- validate the OpenRouter tool configuration and existing model routing with 84 focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->