### PR TITLE
feat: clean ai labels

### DIFF
--- a/apps/web/__tests__/eval/clean-ai-label.test.ts
+++ b/apps/web/__tests__/eval/clean-ai-label.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect, afterAll } from "vitest";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { aiClean } from "@/utils/ai/clean/ai-clean";
+import type { EmailForLLM } from "@/utils/types";
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 60_000;
+
+const labels = [
+  { id: "label-newsletters", name: "Newsletters" },
+  { id: "label-receipts", name: "Receipts" },
+  { id: "label-finance", name: "Finance" },
+  { id: "label-personal", name: "Personal" },
+];
+
+const skips = { reply: false, receipt: true };
+
+type TestCase = {
+  name: string;
+  message: EmailForLLM;
+  expectedArchive: boolean;
+  expectedLabel: string | null;
+};
+
+const testCases: TestCase[] = [
+  {
+    name: "newsletter → Newsletters",
+    message: getEmail({
+      from: "hello@morningbrew.com",
+      subject: "☕ Mar 10 — Markets rally on jobs data, OpenAI's new model",
+      content:
+        "Good morning. US markets closed higher Friday after the February jobs report showed 275K new positions. Meanwhile, OpenAI quietly released a new reasoning model. Here's your daily briefing.",
+    }),
+    expectedArchive: true,
+    expectedLabel: "Newsletters",
+  },
+  {
+    name: "receipt → Receipts",
+    // Reachable in production via the maybe-receipt path: the sender and
+    // subject avoid the deterministic isReceipt lists in find-receipts.ts
+    // ("receipt@", "invoice@", "billing@", "Payment receipt", ...), but the
+    // subject contains "purchase" so isMaybeReceipt sends it to the AI.
+    message: getEmail({
+      from: "noreply@gumroad.com",
+      subject: "You've purchased: Design System Checklist",
+      content:
+        "Thanks for your purchase! Design System Checklist by Sarah K. Amount: $24.00. Payment: Visa ending in 4242. Download your file here. If you have any issues, reply to this email.",
+    }),
+    expectedArchive: false,
+    expectedLabel: "Receipts",
+  },
+  {
+    name: "bank statement → Finance",
+    message: getEmail({
+      from: "statements@revolut.com",
+      subject: "Your monthly statement is ready",
+      content:
+        "Your Revolut account statement for February 2026 is now available. It contains a summary of your transactions, balances, and fees for the month.",
+    }),
+    expectedArchive: false,
+    expectedLabel: "Finance",
+  },
+  {
+    name: "personal email needing reply → no label, keep",
+    message: getEmail({
+      from: "sarah@gmail.com",
+      subject: "Dinner on Friday?",
+      content:
+        "Hey! Are you free for dinner on Friday night? I was thinking of trying that new Italian place downtown. Let me know what time works for you.",
+    }),
+    expectedArchive: false,
+    expectedLabel: null,
+  },
+  {
+    name: "GitHub notification without matching label → no label",
+    message: getEmail({
+      from: "notifications@github.com",
+      subject: "[inbox-zero] Issue #42: Cleaner fails on empty inbox",
+      content:
+        "elie222 opened issue #42. The cleaner fails when the inbox is empty. Assignees: none. Labels: bug. Comment here or open the issue in your dashboard.",
+    }),
+    expectedArchive: true,
+    expectedLabel: null,
+  },
+  {
+    name: "vague teaser without clear category → no label",
+    message: getEmail({
+      from: "info@newstartup.io",
+      subject: "Thanks for your interest",
+      content:
+        "Hi there, thanks for stopping by. We're building something we think you'll love. Stay tuned for updates — we'll be in touch soon with more details.",
+    }),
+    expectedArchive: true,
+    expectedLabel: null,
+  },
+];
+
+describe.runIf(shouldRunEval)("Eval: Clean AI labels", () => {
+  const evalReporter = createEvalReporter({ evalName: "clean-ai-label" });
+
+  describeEvalMatrix("clean-ai", (model, emailAccount) => {
+    for (const tc of testCases) {
+      test(
+        `${tc.name} [archive=${tc.expectedArchive}, label=${tc.expectedLabel ?? "none"}]`,
+        async () => {
+          const result = await aiClean({
+            emailAccount,
+            messageId: tc.message.id,
+            messages: [tc.message],
+            skips,
+            labels,
+          });
+
+          const actual = result.label ?? "none";
+          const expected = tc.expectedLabel ?? "none";
+          const pass =
+            actual === expected && result.archive === tc.expectedArchive;
+          evalReporter.record({
+            testName: tc.name,
+            model: model.label,
+            pass,
+            expected: `archive=${tc.expectedArchive}, label=${expected}`,
+            actual: `archive=${result.archive}, label=${actual}`,
+          });
+
+          expect(result.label).toBe(expected);
+          expect(result.archive).toBe(tc.expectedArchive);
+        },
+        TIMEOUT,
+      );
+    }
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+function getEmail({
+  from,
+  subject,
+  content,
+}: {
+  from: string;
+  subject: string;
+  content: string;
+}): EmailForLLM {
+  return {
+    id: "msg-1",
+    from,
+    to: "user@gmail.com",
+    subject,
+    content,
+    date: new Date("2026-03-10T09:00:00Z"),
+  };
+}

--- a/apps/web/__tests__/eval/clean-ai-label.test.ts
+++ b/apps/web/__tests__/eval/clean-ai-label.test.ts
@@ -127,7 +127,7 @@ describe.runIf(shouldRunEval)("Eval: Clean AI labels", () => {
             actual: `archive=${result.archive}, label=${actual}`,
           });
 
-          expect(result.label).toBe(expected);
+          expect(result.label ?? "none").toBe(expected);
           expect(result.archive).toBe(tc.expectedArchive);
         },
         TIMEOUT,

--- a/apps/web/app/(app)/[emailAccountId]/clean/CleanRun.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/CleanRun.tsx
@@ -25,6 +25,7 @@ export function CleanRun({
           threads={threads.filter((t) => t.status !== "processing")}
           stats={{ total, done }}
           action={job.action}
+          jobId={job.id}
         />
       </Card>
     </div>

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
@@ -33,6 +33,9 @@ export function EmailFirehose({
   const [undoStates, setUndoStates] = useState<
     Record<string, "undoing" | "undone">
   >({});
+  // Track threads whose AI-applied label was removed: unlike undo, this only
+  // hides the label locally and must not mark the whole thread as undone
+  const [removedLabels, setRemovedLabels] = useState<Record<string, true>>({});
 
   const { emails } = useEmailStream(emailAccountId, isPaused, threads, tab);
 
@@ -139,6 +142,15 @@ export function EmailFirehose({
                       setUndoStates((prev) => ({
                         ...prev,
                         [threadId]: "undone",
+                      }));
+                    }}
+                    labelRemoved={
+                      !!removedLabels[emails[virtualItem.index].threadId]
+                    }
+                    setLabelRemoved={(threadId) => {
+                      setRemovedLabels((prev) => ({
+                        ...prev,
+                        [threadId]: true,
                       }));
                     }}
                   />

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
@@ -14,6 +14,7 @@ export function EmailFirehose({
   threads,
   stats,
   action,
+  jobId,
 }: {
   threads: CleanThread[];
   stats: {
@@ -21,6 +22,7 @@ export function EmailFirehose({
     done: number;
   };
   action: CleanAction;
+  jobId: string;
 }) {
   const { userEmail, emailAccountId } = useAccount();
 
@@ -118,6 +120,7 @@ export function EmailFirehose({
                     userEmail={userEmail}
                     emailAccountId={emailAccountId}
                     action={action}
+                    jobId={jobId}
                     undoState={undoStates[emails[virtualItem.index].threadId]}
                     setUndoing={(threadId) => {
                       setUndoStates((prev) => ({

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
@@ -128,6 +128,13 @@ export function EmailFirehose({
                         [threadId]: "undoing",
                       }));
                     }}
+                    resetUndoing={(threadId) => {
+                      setUndoStates((prev) => {
+                        const next = { ...prev };
+                        delete next[threadId];
+                        return next;
+                      });
+                    }}
                     setUndone={(threadId) => {
                       setUndoStates((prev) => ({
                         ...prev,

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
@@ -209,10 +209,10 @@ function StatusBadge({
 
               if (result?.serverError) {
                 toastError({ description: result.serverError });
-                resetUndoing(email.threadId);
               } else {
                 setLabelRemoved(email.threadId);
               }
+              resetUndoing(email.threadId);
             }}
           />
         )}
@@ -271,10 +271,10 @@ function StatusBadge({
 
           if (result?.serverError) {
             toastError({ description: result.serverError });
-            resetUndoing(email.threadId);
           } else {
             setLabelRemoved(email.threadId);
           }
+          resetUndoing(email.threadId);
         }}
       />
     );

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
@@ -34,6 +34,8 @@ export function EmailItem({
   setUndoing,
   setUndone,
   resetUndoing,
+  labelRemoved,
+  setLabelRemoved,
 }: {
   email: CleanThread;
   userEmail: string;
@@ -44,11 +46,17 @@ export function EmailItem({
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
   resetUndoing: (threadId: string) => void;
+  labelRemoved: boolean;
+  setLabelRemoved: (threadId: string) => void;
 }) {
-  const status = getStatus(email);
+  // Locally hide the label once it's been removed, mirroring the state Redis
+  // will converge to via SSE — without marking the whole thread as undone.
+  const effectiveEmail =
+    email.label && labelRemoved ? { ...email, label: undefined } : email;
+  const status = getStatus(effectiveEmail);
   const pending = isPending(email);
-  const archive = email.archive === true;
-  const label = !!email.label;
+  const archive = effectiveEmail.archive === true;
+  const label = !!effectiveEmail.label;
 
   return (
     <div
@@ -79,13 +87,14 @@ export function EmailItem({
       <div className="ml-2 flex items-center space-x-2">
         <StatusBadge
           status={status}
-          email={email}
+          email={effectiveEmail}
           action={action}
           jobId={jobId}
           undoState={undoState}
           setUndoing={setUndoing}
           setUndone={setUndone}
           resetUndoing={resetUndoing}
+          setLabelRemoved={setLabelRemoved}
           emailAccountId={emailAccountId}
         />
       </div>
@@ -115,6 +124,7 @@ function StatusBadge({
   setUndoing,
   setUndone,
   resetUndoing,
+  setLabelRemoved,
   emailAccountId,
 }: {
   status: Status;
@@ -125,6 +135,7 @@ function StatusBadge({
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
   resetUndoing: (threadId: string) => void;
+  setLabelRemoved: (threadId: string) => void;
   emailAccountId: string;
 }) {
   if (status === "processing") {
@@ -200,7 +211,7 @@ function StatusBadge({
                 toastError({ description: result.serverError });
                 resetUndoing(email.threadId);
               } else {
-                setUndone(email.threadId);
+                setLabelRemoved(email.threadId);
               }
             }}
           />
@@ -262,7 +273,7 @@ function StatusBadge({
             toastError({ description: result.serverError });
             resetUndoing(email.threadId);
           } else {
-            setUndone(email.threadId);
+            setLabelRemoved(email.threadId);
           }
         }}
       />
@@ -271,8 +282,10 @@ function StatusBadge({
 }
 
 // Swaps a status badge for an action button on hover/focus. The button is
-// overlaid over the badge (which keeps its footprint invisible) so the row
-// never reflows, and it stays visible on touch devices that have no hover.
+// overlaid over the badge (which keeps its footprint) so the row never
+// reflows, and it stays visible on touch devices that have no hover. The
+// button stays in the tab order while hidden (opacity + pointer-events, not
+// visibility) so keyboard users can reach it: focusing it reveals the action.
 function HoverAction({
   badge,
   icon,
@@ -286,11 +299,16 @@ function HoverAction({
 }) {
   return (
     <div className="group relative">
-      <span className="block group-hover:invisible group-focus-within:invisible [@media(hover:none)]:invisible">
+      <span className="pointer-events-none block transition-opacity group-hover:opacity-0 group-focus-within:opacity-0 [@media(hover:none)]:opacity-0">
         {badge}
       </span>
-      <div className="invisible absolute inset-0 flex items-center justify-center whitespace-nowrap group-hover:visible group-focus-within:visible [@media(hover:none)]:visible">
-        <Button size="xs" variant="ghost" onClick={onClick}>
+      <div className="absolute inset-0 flex items-center justify-center whitespace-nowrap opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100">
+        <Button
+          size="xs"
+          variant="ghost"
+          onClick={onClick}
+          className="pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto [@media(hover:none)]:pointer-events-auto"
+        >
           {icon}
           {text}
         </Button>

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
@@ -33,6 +33,7 @@ export function EmailItem({
   undoState,
   setUndoing,
   setUndone,
+  resetUndoing,
 }: {
   email: CleanThread;
   userEmail: string;
@@ -42,6 +43,7 @@ export function EmailItem({
   undoState?: "undoing" | "undone";
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
+  resetUndoing: (threadId: string) => void;
 }) {
   const status = getStatus(email);
   const pending = isPending(email);
@@ -83,6 +85,7 @@ export function EmailItem({
           undoState={undoState}
           setUndoing={setUndoing}
           setUndone={setUndone}
+          resetUndoing={resetUndoing}
           emailAccountId={emailAccountId}
         />
       </div>
@@ -111,6 +114,7 @@ function StatusBadge({
   undoState,
   setUndoing,
   setUndone,
+  resetUndoing,
   emailAccountId,
 }: {
   status: Status;
@@ -120,6 +124,7 @@ function StatusBadge({
   undoState?: "undoing" | "undone";
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
+  resetUndoing: (threadId: string) => void;
   emailAccountId: string;
 }) {
   if (status === "processing") {
@@ -142,8 +147,8 @@ function StatusBadge({
   if (status === "markedDone" || status === "markingDone") {
     return (
       <>
-        <div className="group">
-          <span className="group-hover:hidden">
+        <HoverAction
+          badge={
             <Badge color="green">
               {status === "markingDone"
                 ? action === CleanAction.MARK_READ
@@ -153,94 +158,34 @@ function StatusBadge({
                   ? "Marked read"
                   : "Archived"}
             </Badge>
-          </span>
-          <div className="hidden group-hover:inline-flex">
-            <Button
-              size="xs"
-              variant="ghost"
-              onClick={async () => {
-                if (undoState) return;
+          }
+          icon={<Undo2Icon className="size-3" />}
+          text="Undo"
+          onClick={async () => {
+            if (undoState) return;
 
-                setUndoing(email.threadId);
+            setUndoing(email.threadId);
 
-                const result = await undoCleanInboxAction(emailAccountId, {
-                  threadId: email.threadId,
-                  markedDone: !!email.archive,
-                  action,
-                  jobId,
-                });
+            const result = await undoCleanInboxAction(emailAccountId, {
+              threadId: email.threadId,
+              markedDone: !!email.archive,
+              action,
+              jobId,
+            });
 
-                if (result?.serverError) {
-                  toastError({ description: result.serverError });
-                } else {
-                  setUndone(email.threadId);
-                }
-              }}
-            >
-              <Undo2Icon className="size-3" />
-              Undo
-            </Button>
-          </div>
-        </div>
-        {email.label && <Badge color="yellow">{email.label}</Badge>}
-      </>
-    );
-  }
-
-  if (status === "keep") {
-    return (
-      <div className="group">
-        <span className="group-hover:hidden">
-          <Badge color="blue">Keep</Badge>
-        </span>
-        <div className="hidden group-hover:inline-flex">
-          <Button
-            size="xs"
-            variant="ghost"
-            onClick={async () => {
-              if (undoState) return;
-
-              setUndoing(email.threadId);
-
-              const result = await changeKeepToDoneAction(emailAccountId, {
-                threadId: email.threadId,
-                action,
-              });
-
-              if (result?.serverError) {
-                toastError({ description: result.serverError });
-              } else {
-                setUndone(email.threadId);
-              }
-            }}
-          >
-            {action === CleanAction.ARCHIVE ? (
-              <>
-                <ArchiveIcon className="mr-1 size-3" />
-                Archive
-              </>
-            ) : (
-              <>
-                <CheckIcon className="mr-1 size-3" />
-                Mark Read
-              </>
-            )}
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (status === "labelled") {
-    return (
-      <div className="group">
-        <span className="group-hover:hidden">
-          <Badge color="yellow">{email.label}</Badge>
-        </span>
-        <div className="hidden group-hover:inline-flex">
-          <Button
-            size="xs"
-            variant="ghost"
+            if (result?.serverError) {
+              toastError({ description: result.serverError });
+              resetUndoing(email.threadId);
+            } else {
+              setUndone(email.threadId);
+            }
+          }}
+        />
+        {email.label && (
+          <HoverAction
+            badge={<Badge color="yellow">{email.label}</Badge>}
+            icon={<XIcon className="size-3" />}
+            text="Remove label"
             onClick={async () => {
               if (undoState) return;
 
@@ -253,18 +198,105 @@ function StatusBadge({
 
               if (result?.serverError) {
                 toastError({ description: result.serverError });
+                resetUndoing(email.threadId);
               } else {
                 setUndone(email.threadId);
               }
             }}
-          >
-            <XIcon className="size-3" />
-            Remove label
-          </Button>
-        </div>
-      </div>
+          />
+        )}
+      </>
     );
   }
+
+  if (status === "keep") {
+    return (
+      <HoverAction
+        badge={<Badge color="blue">Keep</Badge>}
+        icon={
+          action === CleanAction.ARCHIVE ? (
+            <ArchiveIcon className="size-3" />
+          ) : (
+            <CheckIcon className="size-3" />
+          )
+        }
+        text={action === CleanAction.ARCHIVE ? "Archive" : "Mark Read"}
+        onClick={async () => {
+          if (undoState) return;
+
+          setUndoing(email.threadId);
+
+          const result = await changeKeepToDoneAction(emailAccountId, {
+            threadId: email.threadId,
+            action,
+          });
+
+          if (result?.serverError) {
+            toastError({ description: result.serverError });
+            resetUndoing(email.threadId);
+          } else {
+            setUndone(email.threadId);
+          }
+        }}
+      />
+    );
+  }
+
+  if (status === "labelled") {
+    return (
+      <HoverAction
+        badge={<Badge color="yellow">{email.label}</Badge>}
+        icon={<XIcon className="size-3" />}
+        text="Remove label"
+        onClick={async () => {
+          if (undoState) return;
+
+          setUndoing(email.threadId);
+
+          const result = await removeLabelFromThreadAction(emailAccountId, {
+            threadId: email.threadId,
+            jobId,
+          });
+
+          if (result?.serverError) {
+            toastError({ description: result.serverError });
+            resetUndoing(email.threadId);
+          } else {
+            setUndone(email.threadId);
+          }
+        }}
+      />
+    );
+  }
+}
+
+// Swaps a status badge for an action button on hover/focus. The button is
+// overlaid over the badge (which keeps its footprint invisible) so the row
+// never reflows, and it stays visible on touch devices that have no hover.
+function HoverAction({
+  badge,
+  icon,
+  text,
+  onClick,
+}: {
+  badge: React.ReactNode;
+  icon: React.ReactNode;
+  text: string;
+  onClick: () => void;
+}) {
+  return (
+    <div className="group relative">
+      <span className="block group-hover:invisible group-focus-within:invisible [@media(hover:none)]:invisible">
+        {badge}
+      </span>
+      <div className="invisible absolute inset-0 flex items-center justify-center whitespace-nowrap group-hover:visible group-focus-within:visible [@media(hover:none)]:visible">
+        <Button size="xs" variant="ghost" onClick={onClick}>
+          {icon}
+          {text}
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function getStatus(email: CleanThread): Status {

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehoseItem.tsx
@@ -6,6 +6,7 @@ import {
   Undo2Icon,
   ArchiveIcon,
   CheckIcon,
+  XIcon,
 } from "lucide-react";
 import { Badge } from "@/components/Badge";
 import { cn } from "@/utils";
@@ -15,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import {
   undoCleanInboxAction,
   changeKeepToDoneAction,
+  removeLabelFromThreadAction,
 } from "@/utils/actions/clean";
 import { toastError } from "@/components/Toast";
 import { getGmailUrl } from "@/utils/url";
@@ -27,6 +29,7 @@ export function EmailItem({
   userEmail,
   emailAccountId,
   action,
+  jobId,
   undoState,
   setUndoing,
   setUndone,
@@ -35,6 +38,7 @@ export function EmailItem({
   userEmail: string;
   emailAccountId: string;
   action: CleanAction;
+  jobId: string;
   undoState?: "undoing" | "undone";
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
@@ -75,6 +79,7 @@ export function EmailItem({
           status={status}
           email={email}
           action={action}
+          jobId={jobId}
           undoState={undoState}
           setUndoing={setUndoing}
           setUndone={setUndone}
@@ -102,6 +107,7 @@ function StatusBadge({
   status,
   email,
   action,
+  jobId,
   undoState,
   setUndoing,
   setUndone,
@@ -110,6 +116,7 @@ function StatusBadge({
   status: Status;
   email: CleanThread;
   action: CleanAction;
+  jobId: string;
   undoState?: "undoing" | "undone";
   setUndoing: (threadId: string) => void;
   setUndone: (threadId: string) => void;
@@ -134,45 +141,49 @@ function StatusBadge({
 
   if (status === "markedDone" || status === "markingDone") {
     return (
-      <div className="group">
-        <span className="group-hover:hidden">
-          <Badge color="green">
-            {status === "markingDone"
-              ? action === CleanAction.MARK_READ
-                ? "Marking read..."
-                : "Archiving..."
-              : action === CleanAction.MARK_READ
-                ? "Marked read"
-                : "Archived"}
-          </Badge>
-        </span>
-        <div className="hidden group-hover:inline-flex">
-          <Button
-            size="xs"
-            variant="ghost"
-            onClick={async () => {
-              if (undoState) return;
+      <>
+        <div className="group">
+          <span className="group-hover:hidden">
+            <Badge color="green">
+              {status === "markingDone"
+                ? action === CleanAction.MARK_READ
+                  ? "Marking read..."
+                  : "Archiving..."
+                : action === CleanAction.MARK_READ
+                  ? "Marked read"
+                  : "Archived"}
+            </Badge>
+          </span>
+          <div className="hidden group-hover:inline-flex">
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={async () => {
+                if (undoState) return;
 
-              setUndoing(email.threadId);
+                setUndoing(email.threadId);
 
-              const result = await undoCleanInboxAction(emailAccountId, {
-                threadId: email.threadId,
-                markedDone: !!email.archive,
-                action,
-              });
+                const result = await undoCleanInboxAction(emailAccountId, {
+                  threadId: email.threadId,
+                  markedDone: !!email.archive,
+                  action,
+                  jobId,
+                });
 
-              if (result?.serverError) {
-                toastError({ description: result.serverError });
-              } else {
-                setUndone(email.threadId);
-              }
-            }}
-          >
-            <Undo2Icon className="size-3" />
-            Undo
-          </Button>
+                if (result?.serverError) {
+                  toastError({ description: result.serverError });
+                } else {
+                  setUndone(email.threadId);
+                }
+              }}
+            >
+              <Undo2Icon className="size-3" />
+              Undo
+            </Button>
+          </div>
         </div>
-      </div>
+        {email.label && <Badge color="yellow">{email.label}</Badge>}
+      </>
     );
   }
 
@@ -221,7 +232,38 @@ function StatusBadge({
   }
 
   if (status === "labelled") {
-    return <Badge color="yellow">{email.label}</Badge>;
+    return (
+      <div className="group">
+        <span className="group-hover:hidden">
+          <Badge color="yellow">{email.label}</Badge>
+        </span>
+        <div className="hidden group-hover:inline-flex">
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={async () => {
+              if (undoState) return;
+
+              setUndoing(email.threadId);
+
+              const result = await removeLabelFromThreadAction(emailAccountId, {
+                threadId: email.threadId,
+                jobId,
+              });
+
+              if (result?.serverError) {
+                toastError({ description: result.serverError });
+              } else {
+                setUndone(email.threadId);
+              }
+            }}
+          >
+            <XIcon className="size-3" />
+            Remove label
+          </Button>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/apps/web/app/api/clean/controller.ts
+++ b/apps/web/app/api/clean/controller.ts
@@ -13,7 +13,6 @@ import { getThreadMessages } from "@/utils/gmail/thread";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { Logger } from "@/utils/logger";
 import { MAX_CLEAN_LABELS } from "@/utils/clean/consts";
-import { findLabelByName } from "@/utils/label/find-label-by-name";
 import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import { getCalendarEventStatus } from "@/utils/parse/calender-event";
 import { findUnsubscribeLink } from "@/utils/parse/parseHtml.server";
@@ -224,7 +223,8 @@ export async function cleanThread({
 }
 
 // Exact name match first; normalized match as fallback for labels that differ
-// only in case or punctuation.
+// only in case or punctuation. Ambiguous normalized matches are rejected so a
+// model output can't silently resolve to the wrong Gmail label.
 function findCleanLabel(
   labels: { id: string; name: string }[] | undefined,
   name: string | null | undefined,
@@ -232,12 +232,11 @@ function findCleanLabel(
   if (!name || !labels?.length) return;
   const exactMatch = labels.find((label) => label.name === name);
   if (exactMatch) return exactMatch;
-  return findLabelByName({
-    labels,
-    name,
-    getLabelName: (label) => label.name,
-    normalize: normalizeLabelName,
-  });
+  const normalized = normalizeLabelName(name);
+  const normalizedMatches = labels.filter(
+    (label) => normalizeLabelName(label.name) === normalized,
+  );
+  return normalizedMatches.length === 1 ? normalizedMatches[0] : undefined;
 }
 
 function getPublish({
@@ -275,7 +274,7 @@ function getPublish({
       markDone,
       action,
       labelId,
-      labelName,
+      labelName: labelName ?? undefined,
       markedDoneLabelId,
       processedLabelId,
       jobId,

--- a/apps/web/app/api/clean/controller.ts
+++ b/apps/web/app/api/clean/controller.ts
@@ -12,6 +12,9 @@ import { GmailLabel } from "@/utils/gmail/label";
 import { getThreadMessages } from "@/utils/gmail/thread";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { Logger } from "@/utils/logger";
+import { MAX_CLEAN_LABELS } from "@/utils/clean/consts";
+import { findLabelByName } from "@/utils/label/find-label-by-name";
+import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import { getCalendarEventStatus } from "@/utils/parse/calender-event";
 import { findUnsubscribeLink } from "@/utils/parse/parseHtml.server";
 import { isActivePremium } from "@/utils/premium";
@@ -39,7 +42,10 @@ export const cleanThreadBody = z.object({
     attachment: z.boolean().default(false).nullish(),
     conversation: z.boolean().default(false).nullish(),
   }),
-  // labels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+  labels: z
+    .array(z.object({ id: z.string(), name: z.string() }))
+    .max(MAX_CLEAN_LABELS)
+    .optional(),
 });
 
 export type CleanThreadBody = z.infer<typeof cleanThreadBody>;
@@ -53,6 +59,7 @@ export async function cleanThread({
   action,
   instructions,
   skips,
+  labels,
   logger,
 }: CleanThreadBody & { logger: Logger }) {
   assertCleanerApiEnabled();
@@ -204,9 +211,33 @@ export async function cleanThread({
     messages: messages.map((m) => getEmailForLLM(m)),
     instructions,
     skips,
+    labels,
   });
 
-  await publish({ markDone: aiResult.archive });
+  const matchedLabel = findCleanLabel(labels, aiResult.label);
+
+  await publish({
+    markDone: aiResult.archive,
+    labelId: matchedLabel?.id,
+    labelName: matchedLabel?.name,
+  });
+}
+
+// Exact name match first; normalized match as fallback for labels that differ
+// only in case or punctuation.
+function findCleanLabel(
+  labels: { id: string; name: string }[] | undefined,
+  name: string | null | undefined,
+) {
+  if (!name || !labels?.length) return;
+  const exactMatch = labels.find((label) => label.name === name);
+  if (exactMatch) return exactMatch;
+  return findLabelByName({
+    labels,
+    name,
+    getLabelName: (label) => label.name,
+    normalize: normalizeLabelName,
+  });
 }
 
 function getPublish({
@@ -226,7 +257,15 @@ function getPublish({
   action: CleanAction;
   logger: Logger;
 }) {
-  return async ({ markDone }: { markDone: boolean }) => {
+  return async ({
+    markDone,
+    labelId,
+    labelName,
+  }: {
+    markDone: boolean;
+    labelId?: string;
+    labelName?: string | null;
+  }) => {
     const actionCount = 2;
     const maxRatePerSecond = Math.ceil(12 / actionCount);
 
@@ -235,7 +274,8 @@ function getPublish({
       threadId,
       markDone,
       action,
-      // label: aiResult.label,
+      labelId,
+      labelName,
       markedDoneLabelId,
       processedLabelId,
       jobId,
@@ -246,6 +286,7 @@ function getPublish({
       threadId,
       maxRatePerSecond,
       markDone,
+      labelName,
     });
 
     await Promise.all([
@@ -260,7 +301,7 @@ function getPublish({
         update: {
           archive: markDone,
           status: "applying",
-          // label: "",
+          ...(labelName ? { label: labelName } : {}),
         },
       }),
     ]);

--- a/apps/web/app/api/clean/controller.ts
+++ b/apps/web/app/api/clean/controller.ts
@@ -215,10 +215,17 @@ export async function cleanThread({
 
   const matchedLabel = findCleanLabel(labels, aiResult.label);
 
+  // A label that's already on the thread would make the Gmail add a no-op;
+  // record that so undo never removes a label this run didn't add.
+  const labelAlreadyOnThread =
+    !!matchedLabel &&
+    messages.some((message) => message.labelIds?.includes(matchedLabel.id));
+
   await publish({
     markDone: aiResult.archive,
     labelId: matchedLabel?.id,
     labelName: matchedLabel?.name,
+    labelAdded: matchedLabel ? !labelAlreadyOnThread : false,
   });
 }
 
@@ -260,10 +267,12 @@ function getPublish({
     markDone,
     labelId,
     labelName,
+    labelAdded,
   }: {
     markDone: boolean;
     labelId?: string;
     labelName?: string | null;
+    labelAdded?: boolean;
   }) => {
     const actionCount = 2;
     const maxRatePerSecond = Math.ceil(12 / actionCount);
@@ -275,6 +284,7 @@ function getPublish({
       action,
       labelId,
       labelName: labelName ?? undefined,
+      labelAdded,
       markedDoneLabelId,
       processedLabelId,
       jobId,

--- a/apps/web/app/api/clean/gmail/route.test.ts
+++ b/apps/web/app/api/clean/gmail/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import prisma from "@/utils/__mocks__/prisma";
+import { GmailLabel } from "@/utils/gmail/label";
+import { CleanAction } from "@/generated/prisma/enums";
+
+vi.mock("@/utils/prisma");
+
+const { cleanerEnv } = vi.hoisted(() => ({
+  cleanerEnv: {
+    NEXT_PUBLIC_CLEANER_ENABLED: true,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: cleanerEnv,
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ handleSafeErrors: true });
+});
+
+vi.mock("@/utils/qstash", () => ({
+  withQstashOrInternal: (handler: unknown) => handler,
+}));
+
+const mockGetGmailClientWithRefresh = vi.fn();
+vi.mock("@/utils/gmail/client", () => ({
+  getGmailClientWithRefresh: (...args: unknown[]) =>
+    mockGetGmailClientWithRefresh(...args),
+}));
+
+const mockGetThread = vi.fn();
+const mockUpdateThread = vi.fn();
+vi.mock("@/utils/redis/clean", () => ({
+  getThread: (...args: unknown[]) => mockGetThread(...args),
+  updateThread: (...args: unknown[]) => mockUpdateThread(...args),
+}));
+
+const mockLabelThread = vi.fn();
+vi.mock("@/utils/gmail/label", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/utils/gmail/label")>();
+  return {
+    ...original,
+    labelThread: (...args: unknown[]) => mockLabelThread(...args),
+  };
+});
+
+import { POST } from "./route";
+
+function getBody(overrides: Record<string, unknown> = {}) {
+  return {
+    emailAccountId: "email-account-id",
+    threadId: "thread-1",
+    markDone: true,
+    action: CleanAction.ARCHIVE,
+    labelId: "label-finance",
+    labelName: "Finance",
+    markedDoneLabelId: "marked-done-label",
+    processedLabelId: "processed-label",
+    jobId: "job-1",
+    ...overrides,
+  };
+}
+
+function getRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost:3000/api/clean/gmail", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("POST /api/clean/gmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "email-account-id",
+      account: {
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_at: new Date(Date.now() + 3_600_000),
+      },
+    } as any);
+
+    mockGetGmailClientWithRefresh.mockResolvedValue({});
+    mockGetThread.mockResolvedValue(undefined);
+    mockUpdateThread.mockResolvedValue(undefined);
+    mockLabelThread.mockResolvedValue(undefined);
+  });
+
+  it("applies the AI label and persists its labelId", async () => {
+    const response = await POST(getRequest(getBody()));
+
+    expect(response.status).toBe(200);
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: ["processed-label", "marked-done-label"],
+      removeLabelIds: [GmailLabel.INBOX],
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: ["label-finance"],
+      removeLabelIds: [],
+    });
+
+    expect(mockUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { status: "completed" },
+    });
+
+    expect(prisma.cleanupThread.create).toHaveBeenCalledWith({
+      data: {
+        emailAccount: { connect: { id: "email-account-id" } },
+        threadId: "thread-1",
+        archived: true,
+        label: "Finance",
+        labelId: "label-finance",
+        job: { connect: { id: "job-1" } },
+      },
+    });
+  });
+
+  it("reverts the action when the thread was undone while the job was in flight", async () => {
+    mockGetThread.mockResolvedValue({
+      threadId: "thread-1",
+      jobId: "job-1",
+      archive: false,
+      label: null,
+      undone: true,
+      status: "processing",
+    });
+
+    const response = await POST(getRequest(getBody()));
+
+    expect(response.status).toBe(200);
+
+    // No core label application: the undo already moved the thread back
+    expect(mockLabelThread).toHaveBeenCalledTimes(1);
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [],
+      removeLabelIds: ["label-finance"],
+    });
+
+    expect(mockUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { status: "completed", label: null },
+    });
+
+    expect(prisma.cleanupThread.create).toHaveBeenCalledWith({
+      data: {
+        emailAccount: { connect: { id: "email-account-id" } },
+        threadId: "thread-1",
+        archived: false,
+        label: undefined,
+        labelId: undefined,
+        job: { connect: { id: "job-1" } },
+      },
+    });
+  });
+
+  it("does not clear the label when the thread has no AI label", async () => {
+    const response = await POST(getRequest(getBody({ labelId: undefined })));
+
+    expect(response.status).toBe(200);
+
+    expect(mockLabelThread).toHaveBeenCalledTimes(1);
+
+    expect(mockUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { status: "completed" },
+    });
+  });
+});

--- a/apps/web/app/api/clean/gmail/route.test.ts
+++ b/apps/web/app/api/clean/gmail/route.test.ts
@@ -60,6 +60,7 @@ function getBody(overrides: Record<string, unknown> = {}) {
     action: CleanAction.ARCHIVE,
     labelId: "label-finance",
     labelName: "Finance",
+    labelAdded: true,
     markedDoneLabelId: "marked-done-label",
     processedLabelId: "processed-label",
     jobId: "job-1",
@@ -126,6 +127,7 @@ describe("POST /api/clean/gmail", () => {
         archived: true,
         label: "Finance",
         labelId: "label-finance",
+        labelAdded: true,
         job: { connect: { id: "job-1" } },
       },
     });
@@ -185,6 +187,65 @@ describe("POST /api/clean/gmail", () => {
       jobId: "job-1",
       threadId: "thread-1",
       update: { status: "completed" },
+    });
+  });
+
+  it("keeps a pre-existing label when the thread was undone while in flight", async () => {
+    mockGetThread.mockResolvedValue({
+      threadId: "thread-1",
+      jobId: "job-1",
+      archive: false,
+      label: null,
+      undone: true,
+      status: "processing",
+    });
+
+    const response = await POST(getRequest(getBody({ labelAdded: false })));
+
+    expect(response.status).toBe(200);
+
+    // The label was already on the thread before this run, so the in-flight
+    // undo must not remove it: Gmail's add was a no-op and the run never
+    // actually added the label.
+    expect(mockLabelThread).toHaveBeenCalledTimes(1);
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [],
+      removeLabelIds: [],
+    });
+  });
+
+  it("returns 200 and records no label when applying the AI label fails", async () => {
+    mockLabelThread
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("stale label"));
+
+    const response = await POST(getRequest(getBody()));
+
+    expect(response.status).toBe(200);
+
+    // The core action still succeeded; only the best-effort AI label failed
+    expect(mockLabelThread).toHaveBeenCalledTimes(2);
+
+    // Redis must not keep the optimistic label, and the DB row must not
+    // record a label Gmail never got
+    expect(mockUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { status: "completed", label: null },
+    });
+
+    expect(prisma.cleanupThread.create).toHaveBeenCalledWith({
+      data: {
+        emailAccount: { connect: { id: "email-account-id" } },
+        threadId: "thread-1",
+        archived: true,
+        label: undefined,
+        labelId: undefined,
+        job: { connect: { id: "job-1" } },
+      },
     });
   });
 });

--- a/apps/web/app/api/clean/gmail/route.ts
+++ b/apps/web/app/api/clean/gmail/route.ts
@@ -17,7 +17,8 @@ const cleanGmailSchema = z.object({
   threadId: z.string(),
   markDone: z.boolean(),
   action: z.enum([CleanAction.ARCHIVE, CleanAction.MARK_READ]),
-  // labelId: z.string().optional(),
+  labelId: z.string().optional(),
+  labelName: z.string().optional(),
   markedDoneLabelId: z.string().optional(),
   processedLabelId: z.string().optional(),
   jobId: z.string(),
@@ -28,7 +29,8 @@ async function performGmailAction({
   emailAccountId,
   threadId,
   markDone,
-  // labelId,
+  labelId,
+  labelName,
   markedDoneLabelId,
   processedLabelId,
   jobId,
@@ -63,10 +65,9 @@ async function performGmailAction({
   const shouldArchive = markDone && action === CleanAction.ARCHIVE;
   const shouldMarkAsRead = markDone && action === CleanAction.MARK_READ;
 
-  const addLabelIds = [
+  const coreAddLabelIds = [
     processedLabelId,
     markDone ? markedDoneLabelId : undefined,
-    // labelId,
   ].filter(isDefined);
   const removeLabelIds = [
     shouldArchive ? GmailLabel.INBOX : undefined,
@@ -78,14 +79,38 @@ async function performGmailAction({
   await labelThread({
     gmail,
     threadId,
-    addLabelIds,
+    addLabelIds: coreAddLabelIds,
     removeLabelIds,
   });
+
+  // The AI-chosen label is best-effort: it may have been deleted or renamed
+  // since the run started, so a stale labelId must not fail the thread action.
+  let labelApplied = false;
+  if (labelId) {
+    try {
+      await labelThread({
+        gmail,
+        threadId,
+        addLabelIds: [labelId],
+      });
+      labelApplied = true;
+    } catch (error) {
+      logger.warn("Failed to apply AI-chosen label, continuing", {
+        threadId,
+        labelId,
+        error,
+      });
+    }
+  }
 
   await saveCleanResult({
     emailAccountId,
     threadId,
     markDone,
+    labelName: labelApplied ? labelName : undefined,
+    // Redis holds the label optimistically from publish time; clear it when
+    // Gmail never got it so the UI doesn't show a label that doesn't exist
+    clearLabel: !!labelId && !labelApplied,
     jobId,
   });
 }
@@ -94,11 +119,15 @@ async function saveCleanResult({
   emailAccountId,
   threadId,
   markDone,
+  labelName,
+  clearLabel,
   jobId,
 }: {
   emailAccountId: string;
   threadId: string;
   markDone: boolean;
+  labelName?: string;
+  clearLabel: boolean;
   jobId: string;
 }) {
   await Promise.all([
@@ -106,12 +135,13 @@ async function saveCleanResult({
       emailAccountId,
       jobId,
       threadId,
-      update: { status: "completed" },
+      update: { status: "completed", ...(clearLabel ? { label: null } : {}) },
     }),
     saveToDatabase({
       emailAccountId,
       threadId,
       archive: markDone,
+      labelName,
       jobId,
     }),
   ]);
@@ -121,11 +151,13 @@ async function saveToDatabase({
   emailAccountId,
   threadId,
   archive,
+  labelName,
   jobId,
 }: {
   emailAccountId: string;
   threadId: string;
   archive: boolean;
+  labelName?: string;
   jobId: string;
 }) {
   await prisma.cleanupThread.create({
@@ -133,6 +165,7 @@ async function saveToDatabase({
       emailAccount: { connect: { id: emailAccountId } },
       threadId,
       archived: archive,
+      label: labelName,
       job: { connect: { id: jobId } },
     },
   });

--- a/apps/web/app/api/clean/gmail/route.ts
+++ b/apps/web/app/api/clean/gmail/route.ts
@@ -8,7 +8,7 @@ import prisma from "@/utils/prisma";
 import { isDefined } from "@/utils/types";
 import type { Logger } from "@/utils/logger";
 import { CleanAction } from "@/generated/prisma/enums";
-import { updateThread } from "@/utils/redis/clean";
+import { getThread, updateThread } from "@/utils/redis/clean";
 import { withQstashOrInternal } from "@/utils/qstash";
 import { assertCleanerApiEnabled } from "@/utils/cleaner-feature";
 
@@ -62,42 +62,57 @@ async function performGmailAction({
     logger,
   });
 
-  const shouldArchive = markDone && action === CleanAction.ARCHIVE;
-  const shouldMarkAsRead = markDone && action === CleanAction.MARK_READ;
+  // If the user undid this thread while the job was in flight, applying the
+  // action again would re-archive it and re-persist the label after the undo.
+  const thread = await getThread({ emailAccountId, jobId, threadId });
+  const isUndone = thread?.undone === true;
 
-  const coreAddLabelIds = [
-    processedLabelId,
-    markDone ? markedDoneLabelId : undefined,
-  ].filter(isDefined);
-  const removeLabelIds = [
-    shouldArchive ? GmailLabel.INBOX : undefined,
-    shouldMarkAsRead ? GmailLabel.UNREAD : undefined,
-  ].filter(isDefined);
+  if (!isUndone) {
+    const shouldArchive = markDone && action === CleanAction.ARCHIVE;
+    const shouldMarkAsRead = markDone && action === CleanAction.MARK_READ;
 
-  logger.info("Handling thread", { threadId, shouldArchive, shouldMarkAsRead });
+    const coreAddLabelIds = [
+      processedLabelId,
+      markDone ? markedDoneLabelId : undefined,
+    ].filter(isDefined);
+    const removeLabelIds = [
+      shouldArchive ? GmailLabel.INBOX : undefined,
+      shouldMarkAsRead ? GmailLabel.UNREAD : undefined,
+    ].filter(isDefined);
 
-  await labelThread({
-    gmail,
-    threadId,
-    addLabelIds: coreAddLabelIds,
-    removeLabelIds,
-  });
+    logger.info("Handling thread", {
+      threadId,
+      shouldArchive,
+      shouldMarkAsRead,
+    });
+
+    await labelThread({
+      gmail,
+      threadId,
+      addLabelIds: coreAddLabelIds,
+      removeLabelIds,
+    });
+  }
 
   // The AI-chosen label is best-effort: it may have been deleted or renamed
   // since the run started, so a stale labelId must not fail the thread action.
+  // When the thread was undone, remove the label from Gmail instead of
+  // applying it so it can't reappear after an undo.
   let labelApplied = false;
   if (labelId) {
     try {
       await labelThread({
         gmail,
         threadId,
-        addLabelIds: [labelId],
+        addLabelIds: isUndone ? [] : [labelId],
+        removeLabelIds: isUndone ? [labelId] : [],
       });
-      labelApplied = true;
+      labelApplied = !isUndone;
     } catch (error) {
-      logger.warn("Failed to apply AI-chosen label, continuing", {
+      logger.warn("Failed to apply or remove AI-chosen label, continuing", {
         threadId,
         labelId,
+        isUndone,
         error,
       });
     }
@@ -106,8 +121,9 @@ async function performGmailAction({
   await saveCleanResult({
     emailAccountId,
     threadId,
-    markDone,
+    markDone: isUndone ? false : markDone,
     labelName: labelApplied ? labelName : undefined,
+    labelId: labelApplied ? labelId : undefined,
     // Redis holds the label optimistically from publish time; clear it when
     // Gmail never got it so the UI doesn't show a label that doesn't exist
     clearLabel: !!labelId && !labelApplied,
@@ -120,6 +136,7 @@ async function saveCleanResult({
   threadId,
   markDone,
   labelName,
+  labelId,
   clearLabel,
   jobId,
 }: {
@@ -127,6 +144,7 @@ async function saveCleanResult({
   threadId: string;
   markDone: boolean;
   labelName?: string;
+  labelId?: string;
   clearLabel: boolean;
   jobId: string;
 }) {
@@ -142,6 +160,7 @@ async function saveCleanResult({
       threadId,
       archive: markDone,
       labelName,
+      labelId,
       jobId,
     }),
   ]);
@@ -152,12 +171,14 @@ async function saveToDatabase({
   threadId,
   archive,
   labelName,
+  labelId,
   jobId,
 }: {
   emailAccountId: string;
   threadId: string;
   archive: boolean;
   labelName?: string;
+  labelId?: string;
   jobId: string;
 }) {
   await prisma.cleanupThread.create({
@@ -166,6 +187,7 @@ async function saveToDatabase({
       threadId,
       archived: archive,
       label: labelName,
+      labelId,
       job: { connect: { id: jobId } },
     },
   });

--- a/apps/web/app/api/clean/gmail/route.ts
+++ b/apps/web/app/api/clean/gmail/route.ts
@@ -19,6 +19,7 @@ const cleanGmailSchema = z.object({
   action: z.enum([CleanAction.ARCHIVE, CleanAction.MARK_READ]),
   labelId: z.string().optional(),
   labelName: z.string().optional(),
+  labelAdded: z.boolean().optional(),
   markedDoneLabelId: z.string().optional(),
   processedLabelId: z.string().optional(),
   jobId: z.string(),
@@ -31,6 +32,7 @@ async function performGmailAction({
   markDone,
   labelId,
   labelName,
+  labelAdded,
   markedDoneLabelId,
   processedLabelId,
   jobId,
@@ -97,7 +99,8 @@ async function performGmailAction({
   // The AI-chosen label is best-effort: it may have been deleted or renamed
   // since the run started, so a stale labelId must not fail the thread action.
   // When the thread was undone, remove the label from Gmail instead of
-  // applying it so it can't reappear after an undo.
+  // applying it so it can't reappear after an undo — but only if this run
+  // actually added it: a pre-existing label must survive an in-flight undo.
   let labelApplied = false;
   if (labelId) {
     try {
@@ -105,7 +108,7 @@ async function performGmailAction({
         gmail,
         threadId,
         addLabelIds: isUndone ? [] : [labelId],
-        removeLabelIds: isUndone ? [labelId] : [],
+        removeLabelIds: isUndone && labelAdded ? [labelId] : [],
       });
       labelApplied = !isUndone;
     } catch (error) {
@@ -124,6 +127,7 @@ async function performGmailAction({
     markDone: isUndone ? false : markDone,
     labelName: labelApplied ? labelName : undefined,
     labelId: labelApplied ? labelId : undefined,
+    labelAdded: labelApplied ? labelAdded : undefined,
     // Redis holds the label optimistically from publish time; clear it when
     // Gmail never got it so the UI doesn't show a label that doesn't exist
     clearLabel: !!labelId && !labelApplied,
@@ -137,6 +141,7 @@ async function saveCleanResult({
   markDone,
   labelName,
   labelId,
+  labelAdded,
   clearLabel,
   jobId,
 }: {
@@ -145,6 +150,7 @@ async function saveCleanResult({
   markDone: boolean;
   labelName?: string;
   labelId?: string;
+  labelAdded?: boolean;
   clearLabel: boolean;
   jobId: string;
 }) {
@@ -161,6 +167,7 @@ async function saveCleanResult({
       archive: markDone,
       labelName,
       labelId,
+      labelAdded,
       jobId,
     }),
   ]);
@@ -172,6 +179,7 @@ async function saveToDatabase({
   archive,
   labelName,
   labelId,
+  labelAdded,
   jobId,
 }: {
   emailAccountId: string;
@@ -179,6 +187,7 @@ async function saveToDatabase({
   archive: boolean;
   labelName?: string;
   labelId?: string;
+  labelAdded?: boolean;
   jobId: string;
 }) {
   await prisma.cleanupThread.create({
@@ -188,6 +197,7 @@ async function saveToDatabase({
       archived: archive,
       label: labelName,
       labelId,
+      labelAdded,
       job: { connect: { id: jobId } },
     },
   });

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -45,9 +45,10 @@ vi.mock("@/utils/user/get", () => ({
   getUserPremium: (...args: unknown[]) => mockGetUserPremium(...args),
 }));
 
+const mockUpdateThread = vi.fn();
 vi.mock("@/utils/redis/clean", () => ({
   saveThread: vi.fn().mockResolvedValue(undefined),
-  updateThread: vi.fn().mockResolvedValue(undefined),
+  updateThread: (...args: unknown[]) => mockUpdateThread(...args),
 }));
 
 vi.mock("@/utils/qstash", () => ({
@@ -101,6 +102,10 @@ function getDefaultParams() {
       attachment: true,
       conversation: true,
     },
+    labels: [
+      { id: "label-newsletters", name: "Newsletters" },
+      { id: "label-finance", name: "Finance" },
+    ],
     logger,
   };
 }
@@ -126,7 +131,7 @@ describe("cleanThread", () => {
     });
 
     mockPublishToQstash.mockResolvedValue(undefined);
-    mockAiClean.mockResolvedValue({ archive: true });
+    mockAiClean.mockResolvedValue({ archive: true, label: null });
   });
 
   describe("maybe-receipt should not break loop early", () => {
@@ -257,6 +262,113 @@ describe("cleanThread", () => {
       await cleanThread(getDefaultParams());
 
       expect(mockAiClean).toHaveBeenCalled();
+    });
+  });
+
+  describe("AI-chosen labels", () => {
+    function getSingleMessageThread() {
+      return [
+        getMockMessage({
+          id: "msg-1",
+          from: "newsletter@example.com",
+          to: "user@example.com",
+          subject: "Weekly digest",
+          labelIds: [],
+        }),
+      ];
+    }
+
+    it("passes labels to aiClean", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+
+      await cleanThread(getDefaultParams());
+
+      expect(mockAiClean).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: [
+            { id: "label-newsletters", name: "Newsletters" },
+            { id: "label-finance", name: "Finance" },
+          ],
+        }),
+      );
+    });
+
+    it("publishes the resolved labelId and saves the label name to redis", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+      mockAiClean.mockResolvedValue({ archive: true, label: "Finance" });
+
+      await cleanThread(getDefaultParams());
+
+      expect(mockPublishToQstash).toHaveBeenCalledWith(
+        "/api/clean/gmail",
+        expect.objectContaining({
+          markDone: true,
+          labelId: "label-finance",
+          labelName: "Finance",
+        }),
+        expect.any(Object),
+      );
+
+      const update = mockUpdateThread.mock.calls[0][0].update;
+      expect(update).toMatchObject({ archive: true, label: "Finance" });
+    });
+
+    it("persists the canonical label name when the AI returns a non-canonical match", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+      mockAiClean.mockResolvedValue({ archive: false, label: "  finance " });
+
+      await cleanThread(getDefaultParams());
+
+      expect(mockPublishToQstash).toHaveBeenCalledWith(
+        "/api/clean/gmail",
+        expect.objectContaining({
+          labelId: "label-finance",
+          labelName: "Finance",
+        }),
+        expect.any(Object),
+      );
+
+      const update = mockUpdateThread.mock.calls[0][0].update;
+      expect(update.label).toBe("Finance");
+    });
+
+    it("prefers an exact label name match over a normalized one", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+      mockAiClean.mockResolvedValue({ archive: false, label: "Q1-Report" });
+
+      await cleanThread({
+        ...getDefaultParams(),
+        labels: [
+          { id: "label-q1-space", name: "Q1 Report" },
+          { id: "label-q1-dash", name: "Q1-Report" },
+        ],
+      });
+
+      expect(mockPublishToQstash).toHaveBeenCalledWith(
+        "/api/clean/gmail",
+        expect.objectContaining({
+          labelId: "label-q1-dash",
+          labelName: "Q1-Report",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("omits labelId when the label name doesn't match any provided label", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+      mockAiClean.mockResolvedValue({ archive: false, label: "Unknown label" });
+
+      await cleanThread(getDefaultParams());
+
+      const cleanGmailBody = mockPublishToQstash.mock.calls[0][1] as {
+        labelId?: string;
+        labelName?: string;
+      };
+      expect(cleanGmailBody.labelId).toBeUndefined();
+      expect(cleanGmailBody.labelName).toBeUndefined();
+
+      const update = mockUpdateThread.mock.calls[0][0].update;
+      expect(update.label).toBeUndefined();
     });
   });
 

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -354,6 +354,26 @@ describe("cleanThread", () => {
       );
     });
 
+    it("rejects ambiguous normalized label matches", async () => {
+      mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
+      mockAiClean.mockResolvedValue({ archive: false, label: "q1-report" });
+
+      await cleanThread({
+        ...getDefaultParams(),
+        labels: [
+          { id: "label-q1-space", name: "Q1 Report" },
+          { id: "label-q1-dash", name: "Q1-Report" },
+        ],
+      });
+
+      const cleanGmailBody = mockPublishToQstash.mock.calls[0][1] as {
+        labelId?: string;
+        labelName?: string;
+      };
+      expect(cleanGmailBody.labelId).toBeUndefined();
+      expect(cleanGmailBody.labelName).toBeUndefined();
+    });
+
     it("omits labelId when the label name doesn't match any provided label", async () => {
       mockGetThreadMessages.mockResolvedValue(getSingleMessageThread());
       mockAiClean.mockResolvedValue({ archive: false, label: "Unknown label" });

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -305,12 +305,37 @@ describe("cleanThread", () => {
           markDone: true,
           labelId: "label-finance",
           labelName: "Finance",
+          labelAdded: true,
         }),
         expect.any(Object),
       );
 
       const update = mockUpdateThread.mock.calls[0][0].update;
       expect(update).toMatchObject({ archive: true, label: "Finance" });
+    });
+
+    it("marks a label that was already on the thread as not added by this run", async () => {
+      mockGetThreadMessages.mockResolvedValue([
+        getMockMessage({
+          id: "msg-1",
+          from: "newsletter@example.com",
+          to: "user@example.com",
+          subject: "Weekly digest",
+          labelIds: ["label-finance"],
+        }),
+      ]);
+      mockAiClean.mockResolvedValue({ archive: true, label: "Finance" });
+
+      await cleanThread(getDefaultParams());
+
+      expect(mockPublishToQstash).toHaveBeenCalledWith(
+        "/api/clean/gmail",
+        expect.objectContaining({
+          labelId: "label-finance",
+          labelAdded: false,
+        }),
+        expect.any(Object),
+      );
     });
 
     it("persists the canonical label name when the AI returns a non-canonical match", async () => {

--- a/apps/web/prisma/migrations/20260814120000_add_cleanup_thread_label/migration.sql
+++ b/apps/web/prisma/migrations/20260814120000_add_cleanup_thread_label/migration.sql
@@ -1,3 +1,4 @@
 -- AlterTable
 ALTER TABLE "CleanupThread" ADD COLUMN     "label" TEXT;
+ALTER TABLE "CleanupThread" ADD COLUMN     "labelId" TEXT;
 

--- a/apps/web/prisma/migrations/20260814120000_add_cleanup_thread_label/migration.sql
+++ b/apps/web/prisma/migrations/20260814120000_add_cleanup_thread_label/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "CleanupThread" ADD COLUMN     "label" TEXT;
+

--- a/apps/web/prisma/migrations/20260814220000_add_cleanup_thread_label_added/migration.sql
+++ b/apps/web/prisma/migrations/20260814220000_add_cleanup_thread_label_added/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CleanupThread" ADD COLUMN     "labelAdded" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1028,6 +1028,7 @@ model CleanupThread {
   threadId  String
   archived  Boolean // this can also mean "mark as read". depends on CleanupJob.action
   label     String? // AI-applied Gmail label name
+  labelId   String? // Gmail label ID, used to remove the label even if it gets renamed
   jobId     String
   job       CleanupJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1029,6 +1029,7 @@ model CleanupThread {
   archived  Boolean // this can also mean "mark as read". depends on CleanupJob.action
   label     String? // AI-applied Gmail label name
   labelId   String? // Gmail label ID, used to remove the label even if it gets renamed
+  labelAdded Boolean @default(true) // whether this clean run added the label (vs. it already existed)
   jobId     String
   job       CleanupJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1027,6 +1027,7 @@ model CleanupThread {
   updatedAt DateTime   @updatedAt
   threadId  String
   archived  Boolean // this can also mean "mark as read". depends on CleanupJob.action
+  label     String? // AI-applied Gmail label name
   jobId     String
   job       CleanupJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
 

--- a/apps/web/utils/actions/clean.test.ts
+++ b/apps/web/utils/actions/clean.test.ts
@@ -32,12 +32,14 @@ vi.mock("@/utils/email-account-client", () => ({
 }));
 
 const mockGetLabel = vi.fn();
+const mockGetLabels = vi.fn();
 const mockLabelThread = vi.fn();
 vi.mock("@/utils/gmail/label", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/utils/gmail/label")>();
   return {
     ...original,
     getLabel: (...args: unknown[]) => mockGetLabel(...args),
+    getLabels: (...args: unknown[]) => mockGetLabels(...args),
     labelThread: (...args: unknown[]) => mockLabelThread(...args),
   };
 });
@@ -62,22 +64,23 @@ describe("undoCleanInboxAction", () => {
     mockGetGmailClientForEmail.mockResolvedValue({});
     mockLabelThread.mockResolvedValue(undefined);
     mockGetLabel.mockResolvedValue({ id: "archived-label", name: "Archived" });
+    mockGetLabels.mockResolvedValue([]);
   });
 
-  it("removes the AI-applied label on undo", async () => {
+  it("removes the AI-applied label by stored labelId on undo", async () => {
     prisma.cleanupThread.findFirst.mockResolvedValue({
       jobId: "job-1",
       label: "Finance",
+      labelId: "label-finance",
     } as any);
-    mockGetLabel
-      .mockResolvedValueOnce({ id: "archived-label" })
-      .mockResolvedValueOnce({ id: "label-finance" });
 
     await undoCleanInboxAction("email-account-id", {
       threadId: "thread-1",
       markedDone: true,
       action: CleanAction.ARCHIVE,
     });
+
+    expect(mockGetLabels).not.toHaveBeenCalled();
 
     expect(mockLabelThread).toHaveBeenCalledWith({
       gmail: {},
@@ -92,12 +95,44 @@ describe("undoCleanInboxAction", () => {
       threadId: "thread-1",
       update: { undone: true, archive: false, label: null },
     });
+
+    expect(prisma.cleanupThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        threadId: "thread-1",
+        jobId: "job-1",
+      },
+      data: { label: null, labelId: null },
+    });
+  });
+
+  it("resolves the AI-applied label by exact name when no labelId is stored", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+      labelId: null,
+    } as any);
+    mockGetLabels.mockResolvedValue([{ id: "label-finance", name: "Finance" }]);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [GmailLabel.INBOX],
+      removeLabelIds: ["archived-label", "label-finance"],
+    });
   });
 
   it("only removes the Inbox Zero label when no AI label was applied", async () => {
     prisma.cleanupThread.findFirst.mockResolvedValue({
       jobId: "job-1",
       label: null,
+      labelId: null,
     } as any);
 
     await undoCleanInboxAction("email-account-id", {
@@ -113,6 +148,7 @@ describe("undoCleanInboxAction", () => {
       removeLabelIds: ["archived-label"],
     });
     expect(mockGetLabel).toHaveBeenCalledTimes(1);
+    expect(mockGetLabels).not.toHaveBeenCalled();
 
     const update = mockedUpdateThread.mock.calls[0][0].update;
     expect(update).toEqual({ undone: true, archive: false });
@@ -122,10 +158,10 @@ describe("undoCleanInboxAction", () => {
     prisma.cleanupThread.findFirst.mockResolvedValue({
       jobId: "job-1",
       label: "Renamed Label",
+      labelId: null,
     } as any);
-    mockGetLabel
-      .mockResolvedValueOnce({ id: "archived-label" })
-      .mockRejectedValueOnce(new Error("Gmail error"));
+    mockGetLabel.mockResolvedValueOnce({ id: "archived-label" });
+    mockGetLabels.mockRejectedValueOnce(new Error("Gmail error"));
 
     await undoCleanInboxAction("email-account-id", {
       threadId: "thread-1",
@@ -142,6 +178,31 @@ describe("undoCleanInboxAction", () => {
 
     const update = mockedUpdateThread.mock.calls[0][0].update;
     expect(update).toEqual({ undone: true, archive: false });
+  });
+
+  it("scopes the record lookup to the job being undone", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-2",
+      label: null,
+      labelId: null,
+    } as any);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+      jobId: "job-2",
+    });
+
+    expect(prisma.cleanupThread.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        threadId: "thread-1",
+        jobId: "job-2",
+      },
+      orderBy: { createdAt: "desc" },
+      select: { jobId: true, label: true, labelId: true },
+    });
   });
 
   it("updates Redis via the fallback jobId when the DB row is missing", async () => {
@@ -188,17 +249,21 @@ describe("removeLabelFromThreadAction", () => {
     mockGetGmailClientForEmail.mockResolvedValue({});
     mockLabelThread.mockResolvedValue(undefined);
     mockGetLabel.mockResolvedValue({ id: "label-finance", name: "Finance" });
+    mockGetLabels.mockResolvedValue([]);
   });
 
-  it("removes the AI-applied label and clears Redis and DB", async () => {
+  it("removes the AI-applied label by stored labelId and clears Redis and DB", async () => {
     prisma.cleanupThread.findFirst.mockResolvedValue({
       jobId: "job-1",
       label: "Finance",
+      labelId: "label-finance",
     } as any);
 
     await removeLabelFromThreadAction("email-account-id", {
       threadId: "thread-1",
     });
+
+    expect(mockGetLabels).not.toHaveBeenCalled();
 
     expect(mockLabelThread).toHaveBeenCalledWith({
       gmail: {},
@@ -214,8 +279,62 @@ describe("removeLabelFromThreadAction", () => {
     });
 
     expect(prisma.cleanupThread.updateMany).toHaveBeenCalledWith({
-      where: { emailAccountId: "email-account-id", threadId: "thread-1" },
-      data: { label: null },
+      where: {
+        emailAccountId: "email-account-id",
+        threadId: "thread-1",
+        jobId: "job-1",
+      },
+      data: { label: null, labelId: null },
+    });
+  });
+
+  it("resolves the label by name when no labelId is stored", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+      labelId: null,
+    } as any);
+    mockGetLabels.mockResolvedValue([{ id: "label-finance", name: "Finance" }]);
+
+    await removeLabelFromThreadAction("email-account-id", {
+      threadId: "thread-1",
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      removeLabelIds: ["label-finance"],
+    });
+  });
+
+  it("clears local state when the label no longer exists in Gmail", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+      labelId: null,
+    } as any);
+    mockGetLabels.mockResolvedValue([{ id: "other", name: "Other" }]);
+
+    await removeLabelFromThreadAction("email-account-id", {
+      threadId: "thread-1",
+    });
+
+    expect(mockLabelThread).not.toHaveBeenCalled();
+
+    expect(mockedUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { label: null },
+    });
+
+    expect(prisma.cleanupThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        threadId: "thread-1",
+        jobId: "job-1",
+      },
+      data: { label: null, labelId: null },
     });
   });
 
@@ -223,13 +342,14 @@ describe("removeLabelFromThreadAction", () => {
     prisma.cleanupThread.findFirst.mockResolvedValue({
       jobId: "job-1",
       label: null,
+      labelId: null,
     } as any);
 
     await removeLabelFromThreadAction("email-account-id", {
       threadId: "thread-1",
     });
 
-    expect(mockGetLabel).not.toHaveBeenCalled();
+    expect(mockGetLabels).not.toHaveBeenCalled();
     expect(mockLabelThread).not.toHaveBeenCalled();
     expect(mockedUpdateThread).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/actions/clean.test.ts
+++ b/apps/web/utils/actions/clean.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  removeLabelFromThreadAction,
+  undoCleanInboxAction,
+} from "@/utils/actions/clean";
+import { CleanAction } from "@/generated/prisma/enums";
+import { GmailLabel } from "@/utils/gmail/label";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+const { envMock } = vi.hoisted(() => ({
+  envMock: {
+    NODE_ENV: "test",
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+const mockGetGmailClientForEmail = vi.fn();
+vi.mock("@/utils/email-account-client", () => ({
+  getGmailClientForEmail: (...args: unknown[]) =>
+    mockGetGmailClientForEmail(...args),
+}));
+
+const mockGetLabel = vi.fn();
+const mockLabelThread = vi.fn();
+vi.mock("@/utils/gmail/label", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/utils/gmail/label")>();
+  return {
+    ...original,
+    getLabel: (...args: unknown[]) => mockGetLabel(...args),
+    labelThread: (...args: unknown[]) => mockLabelThread(...args),
+  };
+});
+
+vi.mock("@/utils/redis/clean", () => ({
+  updateThread: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { updateThread } from "@/utils/redis/clean";
+
+const mockedUpdateThread = vi.mocked(updateThread);
+
+describe("undoCleanInboxAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: { userId: "user-1", provider: "google" },
+    } as any);
+
+    mockGetGmailClientForEmail.mockResolvedValue({});
+    mockLabelThread.mockResolvedValue(undefined);
+    mockGetLabel.mockResolvedValue({ id: "archived-label", name: "Archived" });
+  });
+
+  it("removes the AI-applied label on undo", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+    } as any);
+    mockGetLabel
+      .mockResolvedValueOnce({ id: "archived-label" })
+      .mockResolvedValueOnce({ id: "label-finance" });
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [GmailLabel.INBOX],
+      removeLabelIds: ["archived-label", "label-finance"],
+    });
+
+    expect(mockedUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { undone: true, archive: false, label: null },
+    });
+  });
+
+  it("only removes the Inbox Zero label when no AI label was applied", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: null,
+    } as any);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.MARK_READ,
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [GmailLabel.UNREAD],
+      removeLabelIds: ["archived-label"],
+    });
+    expect(mockGetLabel).toHaveBeenCalledTimes(1);
+
+    const update = mockedUpdateThread.mock.calls[0][0].update;
+    expect(update).toEqual({ undone: true, archive: false });
+  });
+
+  it("still undoes when the AI-applied label lookup fails", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Renamed Label",
+    } as any);
+    mockGetLabel
+      .mockResolvedValueOnce({ id: "archived-label" })
+      .mockRejectedValueOnce(new Error("Gmail error"));
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [GmailLabel.INBOX],
+      removeLabelIds: ["archived-label"],
+    });
+
+    const update = mockedUpdateThread.mock.calls[0][0].update;
+    expect(update).toEqual({ undone: true, archive: false });
+  });
+
+  it("updates Redis via the fallback jobId when the DB row is missing", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue(null);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+      jobId: "job-from-ui",
+    });
+
+    const update = mockedUpdateThread.mock.calls[0][0];
+    expect(update).toEqual({
+      emailAccountId: "email-account-id",
+      jobId: "job-from-ui",
+      threadId: "thread-1",
+      update: { undone: true, archive: false },
+    });
+  });
+
+  it("does not update Redis when no jobId is known", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue(null);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+    });
+
+    expect(mockedUpdateThread).not.toHaveBeenCalled();
+  });
+});
+
+describe("removeLabelFromThreadAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: { userId: "user-1", provider: "google" },
+    } as any);
+
+    mockGetGmailClientForEmail.mockResolvedValue({});
+    mockLabelThread.mockResolvedValue(undefined);
+    mockGetLabel.mockResolvedValue({ id: "label-finance", name: "Finance" });
+  });
+
+  it("removes the AI-applied label and clears Redis and DB", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+    } as any);
+
+    await removeLabelFromThreadAction("email-account-id", {
+      threadId: "thread-1",
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      removeLabelIds: ["label-finance"],
+    });
+
+    expect(mockedUpdateThread).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      jobId: "job-1",
+      threadId: "thread-1",
+      update: { label: null },
+    });
+
+    expect(prisma.cleanupThread.updateMany).toHaveBeenCalledWith({
+      where: { emailAccountId: "email-account-id", threadId: "thread-1" },
+      data: { label: null },
+    });
+  });
+
+  it("does nothing when no AI-applied label is on the thread", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: null,
+    } as any);
+
+    await removeLabelFromThreadAction("email-account-id", {
+      threadId: "thread-1",
+    });
+
+    expect(mockGetLabel).not.toHaveBeenCalled();
+    expect(mockLabelThread).not.toHaveBeenCalled();
+    expect(mockedUpdateThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/clean.test.ts
+++ b/apps/web/utils/actions/clean.test.ts
@@ -102,8 +102,34 @@ describe("undoCleanInboxAction", () => {
         threadId: "thread-1",
         jobId: "job-1",
       },
-      data: { label: null, labelId: null },
+      data: { label: null, labelId: null, labelAdded: false },
     });
+  });
+
+  it("does not remove the label when the clean run didn't add it", async () => {
+    prisma.cleanupThread.findFirst.mockResolvedValue({
+      jobId: "job-1",
+      label: "Finance",
+      labelId: "label-finance",
+      labelAdded: false,
+    } as any);
+
+    await undoCleanInboxAction("email-account-id", {
+      threadId: "thread-1",
+      markedDone: true,
+      action: CleanAction.ARCHIVE,
+    });
+
+    expect(mockLabelThread).toHaveBeenCalledWith({
+      gmail: {},
+      threadId: "thread-1",
+      addLabelIds: [GmailLabel.INBOX],
+      removeLabelIds: ["archived-label"],
+    });
+
+    const update = mockedUpdateThread.mock.calls[0][0].update;
+    expect(update).toEqual({ undone: true, archive: false });
+    expect(prisma.cleanupThread.updateMany).not.toHaveBeenCalled();
   });
 
   it("resolves the AI-applied label by exact name when no labelId is stored", async () => {
@@ -201,7 +227,7 @@ describe("undoCleanInboxAction", () => {
         jobId: "job-2",
       },
       orderBy: { createdAt: "desc" },
-      select: { jobId: true, label: true, labelId: true },
+      select: { jobId: true, label: true, labelId: true, labelAdded: true },
     });
   });
 
@@ -284,7 +310,7 @@ describe("removeLabelFromThreadAction", () => {
         threadId: "thread-1",
         jobId: "job-1",
       },
-      data: { label: null, labelId: null },
+      data: { label: null, labelId: null, labelAdded: false },
     });
   });
 
@@ -334,7 +360,7 @@ describe("removeLabelFromThreadAction", () => {
         threadId: "thread-1",
         jobId: "job-1",
       },
-      data: { label: null, labelId: null },
+      data: { label: null, labelId: null, labelAdded: false },
     });
   });
 

--- a/apps/web/utils/actions/clean.ts
+++ b/apps/web/utils/actions/clean.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import type { gmail_v1 } from "@googleapis/gmail";
 import { after } from "next/server";
 import {
   cleanInboxSchema,
@@ -10,10 +11,12 @@ import {
 import { bulkPublishToQstash } from "@/utils/upstash";
 import {
   getLabel,
+  getLabels,
   getOrCreateInboxZeroLabel,
   GmailLabel,
   labelThread,
 } from "@/utils/gmail/label";
+import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import type { CleanThreadBody } from "@/app/api/clean/controller";
 import { MAX_CLEAN_LABELS } from "@/utils/clean/consts";
 import { isDefined } from "@/utils/types";
@@ -177,6 +180,29 @@ function isMaxEmailsReached(totalEmailsProcessed: number, maxEmails?: number) {
   return totalEmailsProcessed >= maxEmails;
 }
 
+// Resolve a stored label name to its current Gmail label ID. Exact name match
+// first; normalized match as a fallback that rejects ambiguity so we never
+// remove a different label that merely differs by case or punctuation.
+async function getLabelIdByName({
+  gmail,
+  name,
+}: {
+  gmail: gmail_v1.Gmail;
+  name: string;
+}): Promise<string | undefined> {
+  const labels = await getLabels(gmail);
+  const exactMatch = labels?.find((label) => label.name === name);
+  if (exactMatch?.id) return exactMatch.id;
+  const normalized = normalizeLabelName(name);
+  const normalizedMatches =
+    labels?.filter(
+      (label) => label.name && normalizeLabelName(label.name) === normalized,
+    ) ?? [];
+  return normalizedMatches.length === 1
+    ? (normalizedMatches[0]?.id ?? undefined)
+    : undefined;
+}
+
 const CLEAN_EXCLUDED_LABEL_NAMES = [
   ...Object.values(inboxZeroLabels).map((label) => label.name),
   FOLLOW_UP_LABEL,
@@ -220,16 +246,26 @@ export const undoCleanInboxAction = actionClient
       let appliedLabelId: string | undefined;
       let jobId: string | undefined;
       try {
+        // Scope to the run the UI is undoing from: the same thread can appear
+        // in multiple cleanup runs, each with its own label.
         const thread = await prisma.cleanupThread.findFirst({
-          where: { emailAccountId, threadId },
+          where: {
+            emailAccountId,
+            threadId,
+            ...(inputJobId ? { jobId: inputJobId } : {}),
+          },
           orderBy: { createdAt: "desc" },
-          select: { jobId: true, label: true },
+          select: { jobId: true, label: true, labelId: true },
         });
 
         jobId = thread?.jobId;
-        if (thread?.label) {
-          const appliedLabel = await getLabel({ gmail, name: thread.label });
-          appliedLabelId = appliedLabel?.id;
+        if (thread?.labelId) {
+          appliedLabelId = thread.labelId;
+        } else if (thread?.label) {
+          appliedLabelId = await getLabelIdByName({
+            gmail,
+            name: thread.label,
+          });
         }
       } catch (error) {
         logger.error("Failed to resolve AI-applied label for undo", {
@@ -280,8 +316,12 @@ export const undoCleanInboxAction = actionClient
       try {
         if (appliedLabelId) {
           await prisma.cleanupThread.updateMany({
-            where: { emailAccountId, threadId },
-            data: { label: null },
+            where: {
+              emailAccountId,
+              threadId,
+              ...(jobId ? { jobId } : {}),
+            },
+            data: { label: null, labelId: null },
           });
         }
       } catch (error) {
@@ -307,20 +347,37 @@ export const removeLabelFromThreadAction = actionClient
 
       // Resolve the AI-applied label (if any). Unlike undo there is no core
       // action to fall back to, so failures surface as errors.
-      let appliedLabel: { id: string } | null | undefined;
+      let appliedLabelId: string | undefined;
       let jobId: string | undefined;
       try {
+        // Scope to the run the UI is removing from: the same thread can appear
+        // in multiple cleanup runs, each with its own label.
         const thread = await prisma.cleanupThread.findFirst({
-          where: { emailAccountId, threadId },
+          where: {
+            emailAccountId,
+            threadId,
+            ...(inputJobId ? { jobId: inputJobId } : {}),
+          },
           orderBy: { createdAt: "desc" },
-          select: { jobId: true, label: true },
+          select: { jobId: true, label: true, labelId: true },
         });
 
         jobId = thread?.jobId ?? inputJobId;
-        if (thread?.label) {
-          appliedLabel = await getLabel({ gmail, name: thread.label });
-        } else if (!inputJobId) {
-          logger.info("No AI-applied label found to remove", { threadId });
+
+        if (!thread?.label && !thread?.labelId) {
+          if (!inputJobId) {
+            logger.info("No AI-applied label found to remove", { threadId });
+          }
+          return { success: true };
+        }
+
+        if (thread.labelId) {
+          appliedLabelId = thread.labelId;
+        } else if (thread.label) {
+          appliedLabelId = await getLabelIdByName({
+            gmail,
+            name: thread.label,
+          });
         }
       } catch (error) {
         logger.error("Failed to resolve AI-applied label for removal", {
@@ -330,15 +387,21 @@ export const removeLabelFromThreadAction = actionClient
         throw new SafeError("Failed to remove label");
       }
 
-      if (!appliedLabel) return { success: true };
+      if (appliedLabelId) {
+        await labelThread({
+          gmail,
+          threadId,
+          removeLabelIds: [appliedLabelId],
+        });
+      } else {
+        logger.info(
+          "AI-applied label no longer exists in Gmail; clearing local state",
+          { threadId },
+        );
+      }
 
-      await labelThread({
-        gmail,
-        threadId,
-        removeLabelIds: [appliedLabel.id],
-      });
-
-      // Clear Redis so the UI stops showing the label
+      // Clear Redis and DB even when the label is already gone from Gmail so
+      // the UI doesn't keep showing a label that no longer exists.
       if (jobId) {
         try {
           await updateThread({
@@ -359,8 +422,12 @@ export const removeLabelFromThreadAction = actionClient
       // Sync the DB record with Gmail: the label is gone
       try {
         await prisma.cleanupThread.updateMany({
-          where: { emailAccountId, threadId },
-          data: { label: null },
+          where: {
+            emailAccountId,
+            threadId,
+            ...(jobId ? { jobId } : {}),
+          },
+          data: { label: null, labelId: null },
         });
       } catch (error) {
         logger.error("Failed to clear label from DB", { error, threadId });

--- a/apps/web/utils/actions/clean.ts
+++ b/apps/web/utils/actions/clean.ts
@@ -255,13 +255,22 @@ export const undoCleanInboxAction = actionClient
             ...(inputJobId ? { jobId: inputJobId } : {}),
           },
           orderBy: { createdAt: "desc" },
-          select: { jobId: true, label: true, labelId: true },
+          select: {
+            jobId: true,
+            label: true,
+            labelId: true,
+            labelAdded: true,
+          },
         });
 
         jobId = thread?.jobId;
-        if (thread?.labelId) {
+        // Only remove the label when this run added it: the AI may have picked
+        // a label that was already on the thread, and undo must not touch
+        // labels the clean run didn't apply. Legacy rows default to added.
+        const addedByRun = thread?.labelAdded ?? true;
+        if (addedByRun && thread?.labelId) {
           appliedLabelId = thread.labelId;
-        } else if (thread?.label) {
+        } else if (addedByRun && thread?.label) {
           appliedLabelId = await getLabelIdByName({
             gmail,
             name: thread.label,
@@ -321,7 +330,7 @@ export const undoCleanInboxAction = actionClient
               threadId,
               ...(jobId ? { jobId } : {}),
             },
-            data: { label: null, labelId: null },
+            data: { label: null, labelId: null, labelAdded: false },
           });
         }
       } catch (error) {
@@ -427,7 +436,7 @@ export const removeLabelFromThreadAction = actionClient
             threadId,
             ...(jobId ? { jobId } : {}),
           },
-          data: { label: null, labelId: null },
+          data: { label: null, labelId: null, labelAdded: false },
         });
       } catch (error) {
         logger.error("Failed to clear label from DB", { error, threadId });

--- a/apps/web/utils/actions/clean.ts
+++ b/apps/web/utils/actions/clean.ts
@@ -5,6 +5,7 @@ import {
   cleanInboxSchema,
   undoCleanInboxSchema,
   changeKeepToDoneSchema,
+  removeLabelFromThreadSchema,
 } from "@/utils/actions/clean.validation";
 import { bulkPublishToQstash } from "@/utils/upstash";
 import {
@@ -14,10 +15,12 @@ import {
   labelThread,
 } from "@/utils/gmail/label";
 import type { CleanThreadBody } from "@/app/api/clean/controller";
+import { MAX_CLEAN_LABELS } from "@/utils/clean/consts";
 import { isDefined } from "@/utils/types";
-import { inboxZeroLabels } from "@/utils/label";
+import { FOLLOW_UP_LABEL, inboxZeroLabels } from "@/utils/label";
 import prisma from "@/utils/prisma";
-import { CleanAction } from "@/generated/prisma/enums";
+import { CleanAction, SystemType } from "@/generated/prisma/enums";
+import { getRuleLabel } from "@/utils/rule/consts";
 import { updateThread } from "@/utils/redis/clean";
 import { getUnhandledCount } from "@/utils/assess";
 import { getGmailClientForEmail } from "@/utils/email-account-client";
@@ -25,6 +28,7 @@ import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
 import { createEmailProvider } from "@/utils/email/provider";
 import { isGoogleProvider } from "@/utils/email/provider-types";
+import type { EmailProvider } from "@/utils/email/types";
 import { getUserPremium } from "@/utils/user/get";
 import { isActivePremium } from "@/utils/premium";
 import { ONE_DAY_MS } from "@/utils/date";
@@ -53,11 +57,15 @@ export const cleanInboxAction = actionClient
         logger,
       });
 
-      const [markedDoneLabel, processedLabel] = await Promise.all([
+      const [markedDoneLabel, processedLabel, labels] = await Promise.all([
         emailProvider.getOrCreateInboxZeroLabel(
           action === CleanAction.ARCHIVE ? "archived" : "marked_read",
         ),
         emailProvider.getOrCreateInboxZeroLabel("processed"),
+        getCleanLabels(emailProvider).catch((error) => {
+          logger.warn("Failed to fetch labels for clean", { error });
+          return [];
+        }),
       ]);
 
       const markedDoneLabelId = markedDoneLabel?.id;
@@ -136,6 +144,7 @@ export const cleanInboxAction = actionClient
                   action,
                   instructions,
                   skips,
+                  labels,
                 } satisfies CleanThreadBody,
                 // give every user their own queue for ai processing. if we get too many parallel users we may need more
                 // api keys or a global queue
@@ -168,13 +177,29 @@ function isMaxEmailsReached(totalEmailsProcessed: number, maxEmails?: number) {
   return totalEmailsProcessed >= maxEmails;
 }
 
+const CLEAN_EXCLUDED_LABEL_NAMES = [
+  ...Object.values(inboxZeroLabels).map((label) => label.name),
+  FOLLOW_UP_LABEL,
+  ...Object.values(SystemType).map((type) => getRuleLabel(type)),
+];
+
+async function getCleanLabels(emailProvider: EmailProvider) {
+  const labels = await emailProvider.getLabels();
+
+  return labels
+    .filter((label) => !CLEAN_EXCLUDED_LABEL_NAMES.includes(label.name))
+    .sort((a, b) => (b.threadsTotal ?? 0) - (a.threadsTotal ?? 0))
+    .slice(0, MAX_CLEAN_LABELS)
+    .map((label) => ({ id: label.id, name: label.name }));
+}
+
 export const undoCleanInboxAction = actionClient
   .metadata({ name: "undoCleanInbox" })
   .inputSchema(undoCleanInboxSchema)
   .action(
     async ({
       ctx: { emailAccountId, logger },
-      parsedInput: { threadId, markedDone, action },
+      parsedInput: { threadId, markedDone, action, jobId: inputJobId },
     }) => {
       const gmail = await getGmailClientForEmail({ emailAccountId, logger });
 
@@ -190,6 +215,33 @@ export const undoCleanInboxAction = actionClient
         gmail,
       });
 
+      // Resolve the AI-applied label (if any) so undo removes it too.
+      // Best-effort: if the record or label lookup fails, the core undo still proceeds.
+      let appliedLabelId: string | undefined;
+      let jobId: string | undefined;
+      try {
+        const thread = await prisma.cleanupThread.findFirst({
+          where: { emailAccountId, threadId },
+          orderBy: { createdAt: "desc" },
+          select: { jobId: true, label: true },
+        });
+
+        jobId = thread?.jobId;
+        if (thread?.label) {
+          const appliedLabel = await getLabel({ gmail, name: thread.label });
+          appliedLabelId = appliedLabel?.id;
+        }
+      } catch (error) {
+        logger.error("Failed to resolve AI-applied label for undo", {
+          error,
+          threadId,
+        });
+      }
+
+      // Fall back to the job the run page knows about: the DB row may not exist
+      // yet while Qstash is still applying the action.
+      if (!jobId) jobId = inputJobId;
+
       await labelThread({
         gmail,
         threadId,
@@ -198,35 +250,120 @@ export const undoCleanInboxAction = actionClient
           action === CleanAction.ARCHIVE
             ? [GmailLabel.INBOX]
             : [GmailLabel.UNREAD],
-        // undo our own labelling
-        removeLabelIds: markedDoneLabel?.id ? [markedDoneLabel.id] : undefined,
+        removeLabelIds: [markedDoneLabel?.id, appliedLabelId].filter(isDefined),
       });
 
       // Update Redis to mark this thread as undone
-      try {
-        // We need to get the thread first to get the jobId
-        const thread = await prisma.cleanupThread.findFirst({
-          where: { emailAccountId, threadId },
-          orderBy: { createdAt: "desc" },
-        });
-
-        if (thread) {
+      if (jobId) {
+        try {
           await updateThread({
             emailAccountId,
-            jobId: thread.jobId,
+            jobId,
             threadId,
             update: {
               undone: true,
               archive: false, // Reset the archive status since we've undone it
+              // Clear the AI-applied label so the UI matches Gmail
+              ...(appliedLabelId ? { label: null } : {}),
             },
+          });
+        } catch (error) {
+          logger.error("Failed to update Redis for undone thread", {
+            error,
+            threadId,
+          });
+          // Continue even if Redis update fails
+        }
+      }
+
+      // Sync the DB record with Gmail: the applied label is gone
+      try {
+        if (appliedLabelId) {
+          await prisma.cleanupThread.updateMany({
+            where: { emailAccountId, threadId },
+            data: { label: null },
           });
         }
       } catch (error) {
-        logger.error("Failed to update Redis for undone thread", {
+        logger.error("Failed to clear label from DB for undone thread", {
           error,
           threadId,
         });
-        // Continue even if Redis update fails
+      }
+
+      return { success: true };
+    },
+  );
+
+export const removeLabelFromThreadAction = actionClient
+  .metadata({ name: "removeLabelFromThread" })
+  .inputSchema(removeLabelFromThreadSchema)
+  .action(
+    async ({
+      ctx: { emailAccountId, logger },
+      parsedInput: { threadId, jobId: inputJobId },
+    }) => {
+      const gmail = await getGmailClientForEmail({ emailAccountId, logger });
+
+      // Resolve the AI-applied label (if any). Unlike undo there is no core
+      // action to fall back to, so failures surface as errors.
+      let appliedLabel: { id: string } | null | undefined;
+      let jobId: string | undefined;
+      try {
+        const thread = await prisma.cleanupThread.findFirst({
+          where: { emailAccountId, threadId },
+          orderBy: { createdAt: "desc" },
+          select: { jobId: true, label: true },
+        });
+
+        jobId = thread?.jobId ?? inputJobId;
+        if (thread?.label) {
+          appliedLabel = await getLabel({ gmail, name: thread.label });
+        } else if (!inputJobId) {
+          logger.info("No AI-applied label found to remove", { threadId });
+        }
+      } catch (error) {
+        logger.error("Failed to resolve AI-applied label for removal", {
+          error,
+          threadId,
+        });
+        throw new SafeError("Failed to remove label");
+      }
+
+      if (!appliedLabel) return { success: true };
+
+      await labelThread({
+        gmail,
+        threadId,
+        removeLabelIds: [appliedLabel.id],
+      });
+
+      // Clear Redis so the UI stops showing the label
+      if (jobId) {
+        try {
+          await updateThread({
+            emailAccountId,
+            jobId,
+            threadId,
+            update: { label: null },
+          });
+        } catch (error) {
+          logger.error("Failed to update Redis for removed label", {
+            error,
+            threadId,
+          });
+          // Continue even if Redis update fails
+        }
+      }
+
+      // Sync the DB record with Gmail: the label is gone
+      try {
+        await prisma.cleanupThread.updateMany({
+          where: { emailAccountId, threadId },
+          data: { label: null },
+        });
+      } catch (error) {
+        logger.error("Failed to clear label from DB", { error, threadId });
       }
 
       return { success: true };

--- a/apps/web/utils/actions/clean.validation.ts
+++ b/apps/web/utils/actions/clean.validation.ts
@@ -21,8 +21,18 @@ export const undoCleanInboxSchema = z.object({
   threadId: z.string(),
   markedDone: z.boolean(),
   action: z.enum([CleanAction.ARCHIVE, CleanAction.MARK_READ]),
+  // Fallback used when the DB record does not exist yet (Qstash still applying)
+  jobId: z.string().optional(),
 });
 export type UndoCleanInboxBody = z.infer<typeof undoCleanInboxSchema>;
+
+export const removeLabelFromThreadSchema = z.object({
+  threadId: z.string(),
+  jobId: z.string().optional(),
+});
+export type RemoveLabelFromThreadBody = z.infer<
+  typeof removeLabelFromThreadSchema
+>;
 
 export const changeKeepToDoneSchema = z.object({
   threadId: z.string(),

--- a/apps/web/utils/ai/clean/ai-clean.ts
+++ b/apps/web/utils/ai/clean/ai-clean.ts
@@ -8,12 +8,9 @@ import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createGenerateObject } from "@/utils/llms";
 // import { Braintrust } from "@/utils/braintrust";
 
-// TODO: allow specific labels
-// Pass in prompt labels
 const schema = z.object({
   archive: z.preprocess(preprocessBooleanLike, z.boolean()),
-  // label: z.string().optional(),
-  // reasoning: z.string(),
+  label: z.string().nullish(),
 });
 
 // const braintrust = new Braintrust("cleaner-1");
@@ -24,6 +21,7 @@ export async function aiClean({
   messages,
   instructions,
   skips,
+  labels,
 }: {
   emailAccount: EmailAccountWithAI;
   messageId: string;
@@ -33,14 +31,15 @@ export async function aiClean({
     reply?: boolean | null;
     receipt?: boolean | null;
   };
-}): Promise<{ archive: boolean }> {
+  labels?: { id: string; name: string }[];
+}): Promise<{ archive: boolean; label: string | null }> {
   const lastMessage = messages.at(-1);
 
   if (!lastMessage) throw new Error("No messages");
 
   const system =
     `You are an AI assistant designed to help users achieve inbox zero by analyzing emails and deciding whether they should be archived or not.
-  
+
 Examples of emails to archive:
 - Newsletters
 - Marketing
@@ -76,6 +75,17 @@ ${
   instructions
     ? `Additional user instructions:
 <instructions>${instructions}</instructions>`
+    : ""
+}
+${
+  labels?.length
+    ? `The user has these Gmail labels available:
+<labels>
+${labels.map((label) => `- ${label.name}`).join("\n")}
+</labels>
+
+If the email can be classified into one of these labels, return its exact name in the "label" field. Otherwise return null for "label".
+Only label the email when the fit is clear. Prefer no label over an incorrect one. Choose at most one label. Never return a label that is not listed above.`
     : ""
 }
 
@@ -115,5 +125,8 @@ The current date is ${currentDate}.
   //   expected: aiResponse.object,
   // });
 
-  return aiResponse.object as { archive: boolean };
+  return {
+    archive: aiResponse.object.archive,
+    label: aiResponse.object.label ?? null,
+  };
 }

--- a/apps/web/utils/clean/consts.ts
+++ b/apps/web/utils/clean/consts.ts
@@ -1,0 +1,1 @@
+export const MAX_CLEAN_LABELS = 30;

--- a/apps/web/utils/redis/clean.ts
+++ b/apps/web/utils/redis/clean.ts
@@ -84,7 +84,7 @@ export async function publishThread({
   await redis.publish(key, JSON.stringify(thread));
 }
 
-async function getThread({
+export async function getThread({
   emailAccountId,
   jobId,
   threadId,

--- a/apps/web/utils/redis/clean.types.ts
+++ b/apps/web/utils/redis/clean.types.ts
@@ -10,6 +10,6 @@ export type CleanThread = {
   date: Date;
 
   archive?: boolean;
-  label?: string;
+  label?: string | null;
   undone?: boolean;
 };

--- a/docs/changelog-entries/2026-08-14.mdx
+++ b/docs/changelog-entries/2026-08-14.mdx
@@ -1,0 +1,9 @@
+---
+description: "AI Clean, label-aware"
+---
+
+AI Clean now spots which of your Gmail labels fit each thread and applies them as it runs — newsletters get filed, receipts get tagged, and you can see exactly what happened thread by thread. Labels are picked for every clean, whether the thread is archived or left in your inbox.
+
+- The run view shows the label AI Clean applied on each thread, right next to its status, and lets you remove it again
+- Undo restores your thread and removes the AI-applied label, so nothing is left behind
+- Your Inbox Zero and rule-based labels are never offered to the AI

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Latest updates and improvements to Inbox Zero"
 ---
 
+<Update label="August 14, 2026" description="AI Clean, label-aware">
+  AI Clean now spots which of your Gmail labels fit each thread and applies them as it runs — newsletters get filed, receipts get tagged, and you can see exactly what happened thread by thread. Labels are picked for every clean, whether the thread is archived or left in your inbox.
+
+  - The run view shows the label AI Clean applied on each thread, right next to its status, and lets you remove it again
+  - Undo restores your thread and removes the AI-applied label, so nothing is left behind
+  - Your Inbox Zero and rule-based labels are never offered to the AI
+</Update>
+
 <Update label="August 12, 2026" description="Mail, Rebuilt">
   The Mail screen has a new look — a cleaner three-column layout with keyboard shortcuts, split views, and threads that read as a flat message list instead of stacked cards. Opening your inbox feels faster too, thanks to a local cache that shows your mail right away while it refreshes in the background.
 


### PR DESCRIPTION
## Summary
AI Clean now picks a fitting Gmail label per thread and applies it, whether or not the thread is archived.

## What changed

- Model — aiClean receives the user's labels (up to 30, excluding Inbox Zero and rule labels) and returns a label name or null
- Pipeline — the controller resolves the model's choice to a real label; the Gmail route applies it best-effort after the core action (stale/deleted label IDs can't fail a thread), and Redis/DB never record a label Gmail didn't get
- UI — the run view shows the applied label per thread with a hover action to remove it again
- Undo — removes the AI-applied label from Gmail, Redis, and DB; falls back to the run's job ID while the action is still applying so Redis stays in sync
- Tests — eval suite (6 cases) for label selection, plus unit tests for apply/undo/remove flows
- Docs — changelog entry


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

