### PR TITLE
INB-325: Restrict organization member invitations to admins

### DIFF
--- a/apps/web/app/(app)/settings/TeamSection.tsx
+++ b/apps/web/app/(app)/settings/TeamSection.tsx
@@ -10,10 +10,8 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { InviteMemberModal } from "@/components/InviteMemberModal";
-import { useCurrentOrganization } from "@/hooks/useCurrentOrganization";
 
-export function TeamSection() {
-  const organization = useCurrentOrganization();
+export function TeamSection({ organizationId }: { organizationId?: string }) {
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   return (
@@ -37,7 +35,7 @@ export function TeamSection() {
       </Item>
 
       <InviteMemberModal
-        organizationId={organization?.id}
+        organizationId={organizationId}
         open={isInviteDialogOpen}
         onOpenChange={setIsInviteDialogOpen}
         trigger={null}

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -69,6 +69,7 @@ export default function SettingsPage() {
   // No membership means no organization yet — the invite modal then creates one.
   const canInviteMembers =
     !!user &&
+    !!activeEmailAccountId &&
     (!organizationMembership ||
       hasOrganizationAdminRole(organizationMembership.role));
 

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -48,17 +48,29 @@ import {
 import { useAccounts } from "@/hooks/useAccounts";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
 import { usePremium } from "@/hooks/usePremium";
+import { useUser } from "@/hooks/useUser";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { cn } from "@/utils";
 import { env } from "@/env";
+import { hasOrganizationAdminRole } from "@/utils/organizations/roles";
 
 export default function SettingsPage() {
   const { emailAccountId: activeEmailAccountId } = useAccount();
   const { data, isLoading, error } = useAccounts();
   const { canManageBilling } = usePremium();
+  const { data: user } = useUser();
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(
     null,
   );
+
+  const organizationMembership = user?.members?.find(
+    (member) => member.emailAccountId === activeEmailAccountId,
+  );
+  // No membership means no organization yet — the invite modal then creates one.
+  const canInviteMembers =
+    !!user &&
+    (!organizationMembership ||
+      hasOrganizationAdminRole(organizationMembership.role));
 
   const handleSlackConnected = useCallback(
     (connectedEmailAccountId: string | null) => {
@@ -131,11 +143,15 @@ export default function SettingsPage() {
           </SettingsGroup>
         )}
 
-        <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
-          <ItemCard>
-            <TeamSection />
-          </ItemCard>
-        </SettingsGroup>
+        {canInviteMembers && (
+          <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
+            <ItemCard>
+              <TeamSection
+                organizationId={organizationMembership?.organizationId}
+              />
+            </ItemCard>
+          </SettingsGroup>
+        )}
 
         {!env.NEXT_PUBLIC_AI_MODEL_SETTINGS_DISABLED && (
           <SettingsGroup

--- a/apps/web/utils/actions/__tests__/invitation-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/invitation-actions.test.ts
@@ -96,6 +96,25 @@ describe("createInvitationAction", () => {
     });
   });
 
+  it("rejects invitations from organization members without admin access", async () => {
+    prisma.member.findFirst.mockResolvedValueOnce({
+      organizationId: "org_1",
+      emailAccountId: "ea_inviter",
+      role: "member",
+    } as any);
+
+    const res = await inviteMembersAction({
+      organizationId: "org_1",
+      invitations: [{ email: "user@test.com", role: "member" }],
+    });
+
+    expect(res?.serverError).toBe(
+      "Only organization owners or admins can invite members.",
+    );
+    expect(prisma.invitation.create).not.toHaveBeenCalled();
+    expect(mockSendOrganizationInvitation).not.toHaveBeenCalled();
+  });
+
   it("rolls back the pending invitation when sending the email fails", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       id: "ea_inviter",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260814-235701_pr-3271_77503be38312/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restricts organization invitations in Settings to organization owners and admins while preserving first-organization setup. Adds regression coverage for the server-side authorization boundary.

- Hide the Team invitation section from non-admin organization members
- Pass the active membership organization directly to the invitation modal
- Test that non-admin invitation attempts create no invitation or email
- Tests: `pnpm test utils/actions/__tests__/invitation-actions.test.ts`
- Formatting: `pnpm check apps/web/app/\(app\)/settings/TeamSection.tsx apps/web/app/\(app\)/settings/page.tsx apps/web/utils/actions/__tests__/invitation-actions.test.ts`

Linear: https://linear.app/inbox-zero-ai/issue/INB-325/non-admin-organization-members-can-invite-new-members

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->