### PR TITLE
INB-326: Open follow-up drafts in the native email client

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -28,6 +28,7 @@ import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/mee
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
 import { STILL_CAPTURING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
+import { getEmailDraftUrl } from "@/utils/url";
 
 export function MeetingDetail({
   meetingId,
@@ -36,7 +37,7 @@ export function MeetingDetail({
   meetingId: string | null;
   onClose: () => void;
 }) {
-  const { emailAccountId } = useAccount();
+  const { emailAccountId, provider, userEmail } = useAccount();
   const { data, isLoading, error } = useMeetingRecorderMeeting(
     meetingId,
     emailAccountId,
@@ -176,7 +177,14 @@ export function MeetingDetail({
                   attendees. Nothing was sent for you.
                 </MutedText>
                 <Button asChild variant="outline" size="sm">
-                  <Link href={`/${emailAccountId}/mail?type=draft`}>
+                  <Link
+                    href={getEmailDraftUrl(
+                      data.followUpDraftId,
+                      userEmail,
+                      provider,
+                    )}
+                    target="_blank"
+                  >
                     Go to drafts
                   </Link>
                 </Button>

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   createSearchParams,
+  getEmailDraftUrl,
   getEmailUrl,
   getEmailUrlForMessage,
   getEmailUrlForOptionalMessage,
@@ -162,6 +163,40 @@ describe("getEmailUrl", () => {
     expect(getEmailUrl(messageOrThreadId, emailAddress, provider)).toBe(
       expected,
     );
+  });
+});
+
+describe("getEmailDraftUrl", () => {
+  it.each([
+    {
+      name: "Google account",
+      draftId: "draft-123",
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-123",
+    },
+    {
+      name: "personal Microsoft account",
+      draftId: "draft-123",
+      emailAddress: "user@outlook.com",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/drafts/id/draft-123",
+    },
+    {
+      name: "business Microsoft account",
+      draftId: "draft+123/abc",
+      emailAddress: "user@contoso.com",
+      provider: "microsoft",
+      expected: "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
+    },
+  ])("opens the draft for a $name", ({
+    draftId,
+    emailAddress,
+    provider,
+    expected,
+  }) => {
+    expect(getEmailDraftUrl(draftId, emailAddress, provider)).toBe(expected);
   });
 });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -52,6 +52,7 @@ const PROVIDER_CONFIG: Record<
       messageOrThreadId: string,
       emailAddress?: string | null,
     ) => string;
+    buildDraftUrl: (draftId: string, emailAddress?: string | null) => string;
     selectId: (messageId: string, threadId: string) => string;
     buildSearchUrl: (from: string, emailAddress?: string | null) => string;
   }
@@ -62,6 +63,8 @@ const PROVIDER_CONFIG: Record<
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
+    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
+      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draftId)}`,
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
@@ -72,6 +75,11 @@ const PROVIDER_CONFIG: Record<
     requiresMessageId: false,
     buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
       getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
+    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
+      getGmailUrlForFragment(
+        `drafts/${encodeURIComponent(draftId)}`,
+        emailAddress,
+      ),
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) =>
       getGmailUrlForFragment(
@@ -83,6 +91,11 @@ const PROVIDER_CONFIG: Record<
     requiresMessageId: false,
     buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
       getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
+    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
+      getGmailUrlForFragment(
+        `drafts/${encodeURIComponent(draftId)}`,
+        emailAddress,
+      ),
     selectId: (_messageId: string, threadId: string) => threadId,
     buildSearchUrl: (from: string, emailAddress?: string | null) =>
       getGmailUrlForFragment(
@@ -106,6 +119,15 @@ export function getEmailUrl(
 ): string {
   const config = getProviderConfig(provider);
   return config.buildUrl(messageOrThreadId, emailAddress);
+}
+
+export function getEmailDraftUrl(
+  draftId: string,
+  emailAddress?: string | null,
+  provider?: string,
+): string {
+  const config = getProviderConfig(provider);
+  return config.buildDraftUrl(draftId, emailAddress);
 }
 
 /**


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260815-015627_pr-3272_7e6e741be071/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates the meeting follow-up action to open the saved draft directly in the connected email provider. Adds provider-specific draft URLs for Google and Microsoft accounts.

- Opens the native webmail draft in a new tab, including personal and work Microsoft hosts
- Encodes draft identifiers and adds focused provider URL coverage
- Tests: `pnpm test utils/url.test.ts` (43 passed); an initial root-relative test path matched no files before correction
- Formatting/lint: focused Ultracite check passed
- Performance: client-side URL construction only; no new database or network calls and negligible hot-path risk

Linear: https://linear.app/inbox-zero-ai/issue/INB-326/go-to-drafts-button-opens-inbox-zero-mail-instead-of-native


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->