### PR TITLE
refactor(mcp): split integration data into its own module

### DIFF
--- a/apps/web/utils/mcp/integrations-data.ts
+++ b/apps/web/utils/mcp/integrations-data.ts
@@ -1,0 +1,190 @@
+export type McpIntegrationConfig = {
+  name: string;
+  serverUrl?: string;
+  authType: "oauth" | "api-token";
+  scopes: string[];
+  skipResourceParam?: boolean; // Some OAuth servers don't support RFC 8707 resource parameter
+  filterWriteTools?: boolean; // Require read-only annotations and names; new tools start disabled
+  ruleActionWriteTools?: string[];
+};
+
+export type McpIntegration = McpIntegrationConfig & {
+  displayName: string;
+  shortName?: string; // Short name for display in compact contexts (e.g. "Connected to X")
+  description: string; // Plain-English summary of the data this integration exposes, shown on the integrations page
+  url: string; // Domain URL for favicon display
+  allowedTools?: string[];
+  comingSoon?: boolean;
+  oauthConfig?: {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    registration_endpoint?: string;
+  };
+};
+
+export const NOTION_INTEGRATION: McpIntegration = {
+  name: "notion",
+  displayName: "Notion",
+  description: "Docs, wikis, and project notes",
+  url: "notion.com",
+  serverUrl: "https://mcp.notion.com/mcp",
+  authType: "oauth",
+  scopes: ["read"],
+  allowedTools: ["notion-search", "notion-fetch"],
+  // OAuth endpoints auto-discovered via RFC 8414/9728
+};
+
+export const STRIPE_INTEGRATION: McpIntegration = {
+  name: "stripe",
+  displayName: "Stripe",
+  description: "Customers, subscriptions, invoices, and payments",
+  url: "stripe.com",
+  serverUrl: "https://mcp.stripe.com",
+  authType: "oauth", // must request whitelisting of /api/mcp/stripe/callback from Stripe. localhost is whitelisted already.
+  scopes: [],
+  allowedTools: [
+    "list_customers",
+    "list_disputes",
+    "list_invoices",
+    "list_payment_intents",
+    "list_prices",
+    "list_products",
+    "list_subscriptions",
+    // "search_stripe_resources",
+  ],
+  // OAuth endpoints auto-discovered via RFC 8414/9728
+};
+
+export const LINEAR_INTEGRATION: McpIntegration = {
+  name: "linear",
+  displayName: "Linear",
+  description: "Issues, projects, and status",
+  url: "linear.app",
+  // Dedicated read-only endpoint; the server only exposes read tools here
+  serverUrl: "https://mcp.linear.app/mcp/readonly",
+  authType: "oauth",
+  scopes: ["read"],
+  // OAuth endpoints auto-discovered via RFC 8414/9728
+};
+
+export const ATTIO_INTEGRATION: McpIntegration = {
+  name: "attio",
+  displayName: "Attio",
+  description: "CRM records, contacts, notes, and meetings",
+  url: "attio.com",
+  serverUrl: "https://mcp.attio.com/mcp",
+  authType: "oauth",
+  scopes: [],
+  allowedTools: [
+    "search-records",
+    "list-records",
+    "get-records-by-ids",
+    "list-attribute-definitions",
+    "list-lists",
+    "list-list-attribute-definitions",
+    "list-records-in-list",
+    "search-notes-by-metadata",
+    "semantic-search-notes",
+    "get-note-body",
+    "list-tasks",
+    "search-meetings",
+    // Write tools intentionally excluded: create-record, upsert-record,
+    // update-record, merge-records, add-record-to-list, create-note, ...
+  ],
+  // OAuth endpoints auto-discovered via RFC 8414/9728
+};
+
+export const INTERCOM_INTEGRATION: McpIntegration = {
+  name: "intercom",
+  displayName: "Intercom",
+  description: "Support conversations, contacts, and help articles",
+  url: "intercom.com",
+  // US-hosted workspaces only; EU workspaces use mcp.eu.intercom.com (not supported yet)
+  serverUrl: "https://mcp.intercom.com/mcp",
+  authType: "oauth",
+  scopes: [],
+  allowedTools: [
+    "search",
+    "fetch",
+    "search_conversations",
+    "get_conversation",
+    "search_contacts",
+    "get_contact",
+    "list_companies",
+    "get_company",
+    "list_articles",
+    "search_articles",
+    "get_article",
+    // Write tools intentionally excluded: create_article, update_article
+  ],
+  // OAuth endpoints auto-discovered via RFC 8414/9728
+};
+
+export const MONDAY_INTEGRATION: McpIntegration = {
+  name: "monday",
+  displayName: "Monday.com",
+  description: "Boards, items, and workspaces",
+  url: "monday.com",
+  serverUrl: "https://mcp.monday.com/mcp",
+  authType: "oauth",
+  scopes: ["read", "write"],
+  allowedTools: [
+    "get_board_items_by_name",
+    // "create_item",
+    // "create_update",
+    // "get_board_activity",
+    "get_board_info",
+    // "list_users_and_teams",
+    // "create_board",
+    // "create_form",
+    // "update_form",
+    // "get_form",
+    // "form_questions_editor",
+    // "create_column",
+    // "create_group",
+    // "all_monday_api",
+    // "get_graphql_schema",
+    // "get_column_type_info",
+    // "get_type_details",
+    // "read_docs",
+    "workspace_info",
+    "list_workspaces",
+    // "create_doc",
+    // "update_workspace",
+    // "update_folder",
+    // "create_workspace",
+    // "create_folder",
+    // "move_object",
+    // "create_dashboard",
+    // "all_widgets_schema",
+    // "create_widget",
+  ],
+  // OAuth endpoints auto-discovered via RFC 8414
+};
+
+export const TODOIST_INTEGRATION: McpIntegration = {
+  name: "todoist",
+  displayName: "Todoist",
+  description: "Tasks and projects",
+  url: "todoist.com",
+  serverUrl: "https://ai.todoist.net/mcp",
+  authType: "oauth",
+  scopes: [],
+  allowedTools: [],
+  ruleActionWriteTools: ["add-tasks"],
+};
+
+export const PIPEDREAM_INTEGRATION: McpIntegration = {
+  name: "pipedream",
+  displayName: "HubSpot, Slack, Airtable, Todoist, and more (via Pipedream)",
+  shortName: "Pipedream",
+  description: "HubSpot, Slack, Airtable, and hundreds more apps",
+  url: "pipedream.com",
+  serverUrl: "https://mcp.pipedream.net/v2",
+  authType: "oauth",
+  scopes: ["mcp", "offline_access"],
+  skipResourceParam: true, // Pipedream doesn't support RFC 8707 resource parameter
+  filterWriteTools: true,
+  // No fixed allowlist because Pipedream's catalog is dynamic
+  // OAuth endpoints auto-discovered via RFC 8414
+};

--- a/apps/web/utils/mcp/integrations.ts
+++ b/apps/web/utils/mcp/integrations.ts
@@ -1,188 +1,24 @@
-type McpIntegrationConfig = {
-  name: string;
-  serverUrl?: string;
-  authType: "oauth" | "api-token";
-  scopes: string[];
-  skipResourceParam?: boolean; // Some OAuth servers don't support RFC 8707 resource parameter
-  filterWriteTools?: boolean; // Require read-only annotations and names; new tools start disabled
-  ruleActionWriteTools?: string[];
-};
+import {
+  ATTIO_INTEGRATION,
+  INTERCOM_INTEGRATION,
+  LINEAR_INTEGRATION,
+  MONDAY_INTEGRATION,
+  NOTION_INTEGRATION,
+  PIPEDREAM_INTEGRATION,
+  STRIPE_INTEGRATION,
+  TODOIST_INTEGRATION,
+  type McpIntegration,
+} from "./integrations-data";
 
-export const MCP_INTEGRATIONS: Record<
-  string,
-  McpIntegrationConfig & {
-    displayName: string;
-    shortName?: string; // Short name for display in compact contexts (e.g. "Connected to X")
-    description: string; // Plain-English summary of the data this integration exposes, shown on the integrations page
-    url: string; // Domain URL for favicon display
-    allowedTools?: string[];
-    comingSoon?: boolean;
-    oauthConfig?: {
-      authorization_endpoint: string;
-      token_endpoint: string;
-      registration_endpoint?: string;
-    };
-  }
-> = {
-  notion: {
-    name: "notion",
-    displayName: "Notion",
-    description: "Docs, wikis, and project notes",
-    url: "notion.com",
-    serverUrl: "https://mcp.notion.com/mcp",
-    authType: "oauth",
-    scopes: ["read"],
-    allowedTools: ["notion-search", "notion-fetch"],
-    // OAuth endpoints auto-discovered via RFC 8414/9728
-  },
-  stripe: {
-    name: "stripe",
-    displayName: "Stripe",
-    description: "Customers, subscriptions, invoices, and payments",
-    url: "stripe.com",
-    serverUrl: "https://mcp.stripe.com",
-    authType: "oauth", // must request whitelisting of /api/mcp/stripe/callback from Stripe. localhost is whitelisted already.
-    scopes: [],
-    allowedTools: [
-      "list_customers",
-      "list_disputes",
-      "list_invoices",
-      "list_payment_intents",
-      "list_prices",
-      "list_products",
-      "list_subscriptions",
-      // "search_stripe_resources",
-    ],
-    // OAuth endpoints auto-discovered via RFC 8414/9728
-  },
-  linear: {
-    name: "linear",
-    displayName: "Linear",
-    description: "Issues, projects, and status",
-    url: "linear.app",
-    // Dedicated read-only endpoint; the server only exposes read tools here
-    serverUrl: "https://mcp.linear.app/mcp/readonly",
-    authType: "oauth",
-    scopes: ["read"],
-    // OAuth endpoints auto-discovered via RFC 8414/9728
-  },
-  attio: {
-    name: "attio",
-    displayName: "Attio",
-    description: "CRM records, contacts, notes, and meetings",
-    url: "attio.com",
-    serverUrl: "https://mcp.attio.com/mcp",
-    authType: "oauth",
-    scopes: [],
-    allowedTools: [
-      "search-records",
-      "list-records",
-      "get-records-by-ids",
-      "list-attribute-definitions",
-      "list-lists",
-      "list-list-attribute-definitions",
-      "list-records-in-list",
-      "search-notes-by-metadata",
-      "semantic-search-notes",
-      "get-note-body",
-      "list-tasks",
-      "search-meetings",
-      // Write tools intentionally excluded: create-record, upsert-record,
-      // update-record, merge-records, add-record-to-list, create-note, ...
-    ],
-    // OAuth endpoints auto-discovered via RFC 8414/9728
-  },
-  intercom: {
-    name: "intercom",
-    displayName: "Intercom",
-    description: "Support conversations, contacts, and help articles",
-    url: "intercom.com",
-    // US-hosted workspaces only; EU workspaces use mcp.eu.intercom.com (not supported yet)
-    serverUrl: "https://mcp.intercom.com/mcp",
-    authType: "oauth",
-    scopes: [],
-    allowedTools: [
-      "search",
-      "fetch",
-      "search_conversations",
-      "get_conversation",
-      "search_contacts",
-      "get_contact",
-      "list_companies",
-      "get_company",
-      "list_articles",
-      "search_articles",
-      "get_article",
-      // Write tools intentionally excluded: create_article, update_article
-    ],
-    // OAuth endpoints auto-discovered via RFC 8414/9728
-  },
-  monday: {
-    name: "monday",
-    displayName: "Monday.com",
-    description: "Boards, items, and workspaces",
-    url: "monday.com",
-    serverUrl: "https://mcp.monday.com/mcp",
-    authType: "oauth",
-    scopes: ["read", "write"],
-    allowedTools: [
-      "get_board_items_by_name",
-      // "create_item",
-      // "create_update",
-      // "get_board_activity",
-      "get_board_info",
-      // "list_users_and_teams",
-      // "create_board",
-      // "create_form",
-      // "update_form",
-      // "get_form",
-      // "form_questions_editor",
-      // "create_column",
-      // "create_group",
-      // "all_monday_api",
-      // "get_graphql_schema",
-      // "get_column_type_info",
-      // "get_type_details",
-      // "read_docs",
-      "workspace_info",
-      "list_workspaces",
-      // "create_doc",
-      // "update_workspace",
-      // "update_folder",
-      // "create_workspace",
-      // "create_folder",
-      // "move_object",
-      // "create_dashboard",
-      // "all_widgets_schema",
-      // "create_widget",
-    ],
-    // OAuth endpoints auto-discovered via RFC 8414
-  },
-  todoist: {
-    name: "todoist",
-    displayName: "Todoist",
-    description: "Tasks and projects",
-    url: "todoist.com",
-    serverUrl: "https://ai.todoist.net/mcp",
-    authType: "oauth",
-    scopes: [],
-    allowedTools: [],
-    ruleActionWriteTools: ["add-tasks"],
-  },
-  pipedream: {
-    name: "pipedream",
-    displayName: "HubSpot, Slack, Airtable, Todoist, and more (via Pipedream)",
-    shortName: "Pipedream",
-    description: "HubSpot, Slack, Airtable, and hundreds more apps",
-    url: "pipedream.com",
-    serverUrl: "https://mcp.pipedream.net/v2",
-    authType: "oauth",
-    scopes: ["mcp", "offline_access"],
-    skipResourceParam: true, // Pipedream doesn't support RFC 8707 resource parameter
-    filterWriteTools: true,
-    // No fixed allowlist because Pipedream's catalog is dynamic
-    // OAuth endpoints auto-discovered via RFC 8414
-  },
+export const MCP_INTEGRATIONS: Record<string, McpIntegration> = {
+  notion: NOTION_INTEGRATION,
+  stripe: STRIPE_INTEGRATION,
+  linear: LINEAR_INTEGRATION,
+  attio: ATTIO_INTEGRATION,
+  intercom: INTERCOM_INTEGRATION,
+  monday: MONDAY_INTEGRATION,
+  todoist: TODOIST_INTEGRATION,
+  pipedream: PIPEDREAM_INTEGRATION,
 };
 
 export type IntegrationKey = keyof typeof MCP_INTEGRATIONS;


### PR DESCRIPTION
Extract static MCP integration configs from utils/mcp/integrations.ts
into integrations-data.ts. Pure data move; public API unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

