### PR TITLE
fix(mail): improve unified inbox interactions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -68,6 +68,7 @@ import {
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 import {
+  archiveThreadAction,
   createLabelAction,
   removeThreadLabelAction,
 } from "@/utils/actions/mail";
@@ -219,6 +220,11 @@ export function MailShell() {
     enabled: isAllAccounts,
     isUnread: activeSplitId === "unread",
   });
+  const {
+    labelsByAccount,
+    removeThread: removeCombinedThread,
+    restoreThread: restoreCombinedThread,
+  } = combinedThreadState;
   const { threads, isLoading, error, hasMore, isLoadingMore, loadMore } =
     isAllAccounts ? combinedThreadState : accountThreadState;
 
@@ -351,7 +357,37 @@ export function MailShell() {
   );
 
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
-  const archiveTargets = useCallback(() => runOn(archive), [runOn, archive]);
+  const archiveTargets = useCallback(async () => {
+    if (!isAllAccounts) {
+      runOn(archive);
+      return;
+    }
+    if (!focusedThread || !("account" in focusedThread)) return;
+
+    const removal = removeCombinedThread(getListThreadKey(focusedThread));
+    if (!removal) return;
+
+    try {
+      const result = await archiveThreadAction(focusedThread.account.id, {
+        threadId: focusedThread.id,
+      });
+      if (result?.serverError || result?.validationErrors) {
+        throw new Error("Archive action failed");
+      }
+    } catch {
+      restoreCombinedThread(removal);
+      toast.error("There was an error archiving");
+      return;
+    }
+    toast.success("Archived");
+  }, [
+    archive,
+    focusedThread,
+    isAllAccounts,
+    removeCombinedThread,
+    restoreCombinedThread,
+    runOn,
+  ]);
   const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
   const isMailOverlayOpen =
     isHelpOpen ||
@@ -383,7 +419,7 @@ export function MailShell() {
       // re-extends from the same row and the range never grows.
       extendSelectionDown: isAllAccounts ? undefined : () => extendSelection(1),
       extendSelectionUp: isAllAccounts ? undefined : () => extendSelection(-1),
-      archive: isAllAccounts ? undefined : archiveTargets,
+      archive: archiveTargets,
       delete: isAllAccounts ? undefined : trashTargets,
       reply: isAllAccounts
         ? undefined
@@ -598,6 +634,7 @@ export function MailShell() {
                 layout={layout}
                 userEmail={userEmail}
                 userLabels={isAllAccounts ? NO_LABELS : userLabels}
+                labelsByAccount={labelsByAccount}
                 focusedIndex={clampedIndex}
                 isSelected={selection.isSelected}
                 selectedCount={selection.selectedCount}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -23,6 +23,7 @@ export type ThreadListProps = {
   layout: MailLayoutMode;
   userEmail: string;
   userLabels: EmailLabels;
+  labelsByAccount?: Record<string, EmailLabels>;
   selectionEnabled?: boolean;
   /** The row `J`/`K` sits on. */
   focusedIndex: number;
@@ -47,6 +48,7 @@ export function ThreadList({
   layout,
   userEmail,
   userLabels,
+  labelsByAccount,
   selectionEnabled = true,
   focusedIndex,
   isSelected,
@@ -180,7 +182,11 @@ export function ThreadList({
                     selectionEnabled={selectionEnabled}
                     thread={thread}
                     userEmail={userEmail}
-                    userLabels={userLabels}
+                    userLabels={
+                      "account" in thread
+                        ? (labelsByAccount?.[thread.account.id] ?? {})
+                        : userLabels
+                    }
                   />
                 );
               })}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -11,6 +11,11 @@ import { EmailDate } from "@/components/email-list/EmailDate";
 import { getEmailThreadLabels } from "@/components/EmailMessageCellLabels";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Avatar,
+  AvatarFallbackColor,
+  AvatarImage,
+} from "@/components/ui/avatar";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { cn } from "@/utils";
 import { internalDateToDate } from "@/utils/date";
@@ -174,11 +179,7 @@ export const ThreadRow = memo(function ThreadRow({
             {draftMarker}
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2.5">
-            {account ? (
-              <span className="max-w-28 shrink-0 truncate rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs">
-                {account.name || account.email}
-              </span>
-            ) : null}
+            {account ? <AccountAvatar account={account} /> : null}
             {chips.map((label) => (
               <MailLabelChip
                 color={label.color}
@@ -230,9 +231,8 @@ export const ThreadRow = memo(function ThreadRow({
             {snippet}
           </div>
           {account ? (
-            <div className="flex min-w-0 items-center gap-1.5 pt-1 text-muted-foreground text-xs">
-              <span className="size-1.5 shrink-0 rounded-full bg-primary" />
-              <span className="truncate">{account.name || account.email}</span>
+            <div className="pt-1">
+              <AccountAvatar account={account} />
             </div>
           ) : null}
           {chips.length ? (
@@ -251,6 +251,29 @@ export const ThreadRow = memo(function ThreadRow({
     </div>
   );
 });
+
+function AccountAvatar({
+  account,
+}: {
+  account: { email: string; image: string | null; name: string | null };
+}) {
+  const label = account.name || account.email;
+  const initial = label.trim().at(0)?.toUpperCase() || "A";
+
+  return (
+    <Avatar
+      aria-label={`Inbox: ${label}`}
+      className="size-5"
+      title={account.email}
+    >
+      <AvatarImage alt="" src={account.image || undefined} />
+      <AvatarFallbackColor
+        className="text-[10px] font-medium"
+        content={initial}
+      />
+    </Avatar>
+  );
+}
 
 function rowBackground({
   isSelected,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -3,8 +3,16 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import useSWRInfinite from "swr/infinite";
 import type { GetAllThreadsResponse } from "@/app/api/threads/all/route";
+import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
+import type { EmailLabels } from "@/providers/email-label-types";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 import { createSearchParams } from "@/utils/url";
+
+type CombinedThreadRemoval = {
+  thread: GetAllThreadsResponse["threads"][number];
+  pageIndex: number;
+  index: number;
+};
 
 export function useCombinedMailThreads({
   enabled,
@@ -27,7 +35,7 @@ export function useCombinedMailThreads({
     },
     [enabled, isUnread],
   );
-  const { data, error, isLoading, size, setSize } =
+  const { data, error, isLoading, size, setSize, mutate } =
     useSWRInfinite<GetAllThreadsResponse>(getKey, {
       keepPreviousData: false,
       revalidateFirstPage: false,
@@ -46,6 +54,69 @@ export function useCombinedMailThreads({
   }, [data]);
   const hasMore = Boolean(data?.at(-1)?.nextPageToken);
   const isLoadingMore = size > 1 && !data?.[size - 1];
+  const labelsByAccount = useMemo(() => {
+    const merged: Record<string, EmailLabels> = {};
+    for (const page of data ?? []) {
+      for (const [accountId, labels] of Object.entries(page.labelsByAccount)) {
+        merged[accountId] = { ...(merged[accountId] ?? {}), ...labels };
+      }
+    }
+    return merged;
+  }, [data]);
+
+  const removeThread = useCallback(
+    (threadKey: string): CombinedThreadRemoval | undefined => {
+      for (const [pageIndex, page] of (data ?? []).entries()) {
+        const index = page.threads.findIndex(
+          (thread) => getListThreadKey(thread) === threadKey,
+        );
+        const thread = page.threads[index];
+        if (!thread) continue;
+
+        mutate(
+          (pages) =>
+            pages?.map((currentPage) => ({
+              ...currentPage,
+              threads: currentPage.threads.filter(
+                (item) => getListThreadKey(item) !== threadKey,
+              ),
+            })),
+          { populateCache: true, revalidate: false },
+        ).catch(() => {});
+        return { thread, pageIndex, index };
+      }
+    },
+    [data, mutate],
+  );
+
+  const restoreThread = useCallback(
+    (removal: CombinedThreadRemoval) => {
+      mutate(
+        (pages) =>
+          pages?.map((page, pageIndex) => {
+            if (pageIndex !== removal.pageIndex) return page;
+            if (
+              page.threads.some(
+                (thread) =>
+                  getListThreadKey(thread) === getListThreadKey(removal.thread),
+              )
+            ) {
+              return page;
+            }
+
+            const threads = [...page.threads];
+            threads.splice(
+              Math.min(removal.index, threads.length),
+              0,
+              removal.thread,
+            );
+            return { ...page, threads };
+          }),
+        { populateCache: true, revalidate: false },
+      ).catch(() => {});
+    },
+    [mutate],
+  );
 
   useEffect(() => {
     const loadedPageCount = data?.length ?? 0;
@@ -66,6 +137,9 @@ export function useCombinedMailThreads({
     failedAccountIds: [
       ...new Set(data?.flatMap((page) => page.failedAccountIds) ?? []),
     ],
+    labelsByAccount,
+    removeThread,
+    restoreThread,
     loadMore: useCallback(() => {
       if (loadMoreLock.current || !hasMore) return;
       loadMoreLock.current = true;

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -5,6 +5,7 @@ import useSWRInfinite from "swr/infinite";
 import type { GetAllThreadsResponse } from "@/app/api/threads/all/route";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { EmailLabels } from "@/providers/email-label-types";
+import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 import { createSearchParams } from "@/utils/url";
 
@@ -12,6 +13,7 @@ type CombinedThreadRemoval = {
   thread: GetAllThreadsResponse["threads"][number];
   pageIndex: number;
   index: number;
+  threadOrder: readonly string[];
 };
 
 export function useCombinedMailThreads({
@@ -72,6 +74,7 @@ export function useCombinedMailThreads({
         );
         const thread = page.threads[index];
         if (!thread) continue;
+        const threadOrder = page.threads.map(getListThreadKey);
 
         mutate(
           (pages) =>
@@ -83,7 +86,7 @@ export function useCombinedMailThreads({
             })),
           { populateCache: true, revalidate: false },
         ).catch(() => {});
-        return { thread, pageIndex, index };
+        return { thread, pageIndex, index, threadOrder };
       }
     },
     [data, mutate],
@@ -104,13 +107,29 @@ export function useCombinedMailThreads({
               return page;
             }
 
-            const threads = [...page.threads];
-            threads.splice(
-              Math.min(removal.index, threads.length),
-              0,
-              removal.thread,
+            const threadsByKey = new Map(
+              [...page.threads, removal.thread].map((thread) => [
+                getListThreadKey(thread),
+                thread,
+              ]),
             );
-            return { ...page, threads };
+            const threadKeys = restoreThreadOrder(
+              page.threads.map(getListThreadKey),
+              [
+                {
+                  threadId: getListThreadKey(removal.thread),
+                  index: removal.index,
+                  threadOrder: removal.threadOrder,
+                },
+              ],
+            );
+            return {
+              ...page,
+              threads: threadKeys.flatMap((key) => {
+                const thread = threadsByKey.get(key);
+                return thread ? [thread] : [];
+              }),
+            };
           }),
         { populateCache: true, revalidate: false },
       ).catch(() => {});

--- a/apps/web/app/api/threads/all/route.test.ts
+++ b/apps/web/app/api/threads/all/route.test.ts
@@ -34,6 +34,8 @@ vi.mock("@/utils/middleware", async () => {
 import { GET } from "./route";
 
 describe("GET /api/threads/all", () => {
+  const getLabelsMock = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
     getConnectedEmailAccountsMock.mockResolvedValue([
@@ -45,7 +47,13 @@ describe("GET /api/threads/all", () => {
         provider: "google",
       },
     ]);
-    createEmailProviderMock.mockResolvedValue({ name: "google" });
+    getLabelsMock.mockResolvedValue([
+      { id: "label-1", name: "Important", type: "user" },
+    ]);
+    createEmailProviderMock.mockResolvedValue({
+      name: "google",
+      getLabels: getLabelsMock,
+    });
     loadThreadsMock.mockResolvedValue({
       threads: [
         {
@@ -89,6 +97,7 @@ describe("GET /api/threads/all", () => {
         },
       }),
     );
+    expect(getLabelsMock).toHaveBeenCalledOnce();
     await expect(response.json()).resolves.toMatchObject({
       threads: [
         {
@@ -97,6 +106,11 @@ describe("GET /api/threads/all", () => {
         },
       ],
       failedAccountIds: [],
+      labelsByAccount: {
+        "account-1": {
+          "label-1": { id: "label-1", name: "Important", type: "user" },
+        },
+      },
       nextPageToken: expect.any(String),
     });
   });
@@ -124,6 +138,21 @@ describe("GET /api/threads/all", () => {
       threads: [],
       failedAccountIds: ["account-1"],
       nextPageToken: expect.any(String),
+    });
+  });
+
+  it("keeps account threads when its labels cannot be loaded", async () => {
+    getLabelsMock.mockRejectedValue(new Error("Labels unavailable"));
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/threads/all"),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      threads: [{ id: "thread-1" }],
+      labelsByAccount: { "account-1": {} },
+      failedAccountIds: [],
     });
   });
 });

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -41,18 +41,24 @@ export const GET = withAuth("threads/all", async (request) => {
         provider: account.provider,
         logger,
       });
-      const loaded = await loadThreads({
-        query: threadsQuery.parse({
-          type: "inbox",
-          isUnread,
-          limit,
-          nextPageToken: pageToken,
+      const [loaded, labels] = await Promise.all([
+        loadThreads({
+          query: threadsQuery.parse({
+            type: "inbox",
+            isUnread,
+            limit,
+            nextPageToken: pageToken,
+          }),
+          emailAccountId: account.id,
+          emailProvider,
+          messageFormat: "metadata",
         }),
-        emailAccountId: account.id,
-        emailProvider,
-        messageFormat: "metadata",
-      });
-      return toListThreads(loaded);
+        emailProvider.getLabels().catch((error) => {
+          logger.warn("Failed to load labels for combined mailbox", { error });
+          return [];
+        }),
+      ]);
+      return { ...toListThreads(loaded), labels };
     },
   });
 

--- a/apps/web/components/ui/avatar.tsx
+++ b/apps/web/components/ui/avatar.tsx
@@ -68,7 +68,9 @@ const AvatarFallbackColor = React.forwardRef<
   ];
 
   const charCode = content.toUpperCase().charCodeAt(0);
-  const colorIndex = (charCode - 65) % colors.length;
+  const colorIndex = Number.isNaN(charCode)
+    ? 0
+    : (((charCode - 65) % colors.length) + colors.length) % colors.length;
 
   return (
     <AvatarFallback

--- a/apps/web/utils/threads/load-combined.test.ts
+++ b/apps/web/utils/threads/load-combined.test.ts
@@ -32,6 +32,43 @@ describe("loadCombinedThreads", () => {
     expect(result.failedAccountIds).toEqual([]);
   });
 
+  it("returns each account's labels for its combined rows", async () => {
+    const result = await loadCombinedThreads({
+      accounts: [account("account-1"), account("account-2")],
+      cursor: null,
+      limit: 20,
+      loadPage: vi.fn(async ({ account }) => ({
+        threads: [thread(`${account.id}-thread`, "2026-08-13T10:00:00.000Z")],
+        nextPageToken: null,
+        labels: [
+          {
+            id: `${account.id}-label`,
+            name: `${account.id} label`,
+            type: "user",
+          },
+        ],
+      })),
+      logger,
+    });
+
+    expect(result.labelsByAccount).toEqual({
+      "account-1": {
+        "account-1-label": {
+          id: "account-1-label",
+          name: "account-1 label",
+          type: "user",
+        },
+      },
+      "account-2": {
+        "account-2-label": {
+          id: "account-2-label",
+          name: "account-2 label",
+          type: "user",
+        },
+      },
+    });
+  });
+
   it("continues each account independently and does not restart exhausted accounts", async () => {
     const loadPage = vi.fn(async ({ account }: { account: Account }) => ({
       threads: [thread(`${account.id}-thread`, "2026-08-13T10:00:00.000Z")],

--- a/apps/web/utils/threads/load-combined.ts
+++ b/apps/web/utils/threads/load-combined.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "@/utils/logger";
 import { mapWithConcurrency } from "@/utils/async";
+import type { EmailLabel, EmailLabels } from "@/providers/email-label-types";
 import type { ThreadListItem } from "@/utils/threads/load";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 
@@ -54,6 +55,7 @@ export async function loadCombinedThreads({
   }) => Promise<{
     threads: ThreadListItem[];
     nextPageToken?: string | null;
+    labels?: EmailLabel[];
   }>;
   logger: Logger;
 }) {
@@ -90,11 +92,18 @@ export async function loadCombinedThreads({
 
   const failedAccountIds: string[] = [];
   const candidates: CombinedListThread[] = [];
+  const labelsByAccount: Record<string, EmailLabels> = {};
 
   for (const { account, cursorState, page } of accountPages) {
     if (!page) {
       failedAccountIds.push(account.id);
       continue;
+    }
+
+    if (page.labels) {
+      labelsByAccount[account.id] = Object.fromEntries(
+        page.labels.map((label) => [label.id, label]),
+      );
     }
 
     const consumedThreadIds = new Set(cursorState.consumedThreadIds);
@@ -160,6 +169,7 @@ export async function loadCombinedThreads({
 
   return {
     threads,
+    labelsByAccount,
     nextPageToken: Object.values(nextCursor.accounts).some(
       (state) => !state.done,
     )


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260815-191307_pr-3276_55fc03e32031/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improve unified inbox interactions with account-scoped archiving and per-account labels.

- Replace account chips with compact avatars and restore failed optimistic archives.
- Load labels alongside threads while keeping label failures non-blocking.
- Validate with focused unit tests and repository lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->