### PR TITLE
feat(mail): Add end-to-end snooze workflow

### DIFF
--- a/apps/web/__tests__/db/snoozed-thread-scheduler.test.ts
+++ b/apps/web/__tests__/db/snoozed-thread-scheduler.test.ts
@@ -1,0 +1,213 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@upstash/qstash", () => ({
+  Client: class {
+    publishJSON = vi.fn().mockResolvedValue({ messageId: "test-message" });
+  },
+}));
+
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
+
+describe.skipIf(!RUN_DB_TESTS)(
+  "snoozed thread scheduler (real database)",
+  { timeout: 30_000 },
+  () => {
+    let prisma: typeof import("@/utils/prisma").default;
+    let markSnoozedThreadAsExecuting: typeof import("@/utils/snooze/scheduler").markSnoozedThreadAsExecuting;
+    let scheduleSnoozedThread: typeof import("@/utils/snooze/scheduler").scheduleSnoozedThread;
+    let emailAccountId: string;
+
+    const accountEmail = "snoozed-thread-scheduler-test@example.com";
+
+    beforeAll(async () => {
+      prisma = (await import("@/utils/prisma")).default;
+      ({ markSnoozedThreadAsExecuting, scheduleSnoozedThread } = await import(
+        "@/utils/snooze/scheduler"
+      ));
+    });
+
+    beforeEach(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+      emailAccountId = await seedAccount(prisma, accountEmail);
+    });
+
+    afterAll(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+      await prisma.$disconnect();
+    });
+
+    test("keeps one active restore when the same thread is scheduled concurrently", async () => {
+      const scheduledFor = new Date("2026-08-17T09:00:00.000Z");
+
+      const results = await Promise.allSettled([
+        scheduleSnoozedThread({
+          emailAccountId,
+          scheduledFor,
+          threadId: "concurrent-thread",
+        }),
+        scheduleSnoozedThread({
+          emailAccountId,
+          scheduledFor,
+          threadId: "concurrent-thread",
+        }),
+      ]);
+
+      expect(results.some((result) => result.status === "fulfilled")).toBe(
+        true,
+      );
+      const active = await prisma.snoozedThread.findMany({
+        where: {
+          emailAccountId,
+          threadId: "concurrent-thread",
+          status: {
+            in: [SnoozedThreadStatus.PENDING, SnoozedThreadStatus.EXECUTING],
+          },
+        },
+      });
+      expect(active).toHaveLength(1);
+    });
+
+    test("allows only one pending or executing restore per thread", async () => {
+      const active = await prisma.snoozedThread.create({
+        data: {
+          emailAccountId,
+          scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+          threadId: "active-thread",
+        },
+      });
+
+      await expect(
+        prisma.snoozedThread.create({
+          data: {
+            emailAccountId,
+            scheduledFor: new Date("2026-08-17T10:00:00.000Z"),
+            threadId: "active-thread",
+          },
+        }),
+      ).rejects.toThrow();
+
+      await prisma.snoozedThread.update({
+        where: { id: active.id },
+        data: { status: SnoozedThreadStatus.EXECUTING },
+      });
+      await expect(
+        prisma.snoozedThread.create({
+          data: {
+            emailAccountId,
+            scheduledFor: new Date("2026-08-17T10:00:00.000Z"),
+            threadId: "active-thread",
+          },
+        }),
+      ).rejects.toThrow();
+
+      await prisma.snoozedThread.update({
+        where: { id: active.id },
+        data: { status: SnoozedThreadStatus.COMPLETED },
+      });
+      await expect(
+        prisma.snoozedThread.create({
+          data: {
+            emailAccountId,
+            scheduledFor: new Date("2026-08-17T10:00:00.000Z"),
+            threadId: "active-thread",
+          },
+        }),
+      ).resolves.toMatchObject({ status: SnoozedThreadStatus.PENDING });
+    });
+
+    test("does not claim a deferred retry before it is due", async () => {
+      const scheduledFor = new Date("2026-08-17T09:05:00.000Z");
+      const snoozedThread = await prisma.snoozedThread.create({
+        data: {
+          emailAccountId,
+          scheduledFor,
+          threadId: "deferred-retry-thread",
+        },
+      });
+
+      await expect(
+        markSnoozedThreadAsExecuting(
+          snoozedThread.id,
+          new Date("2026-08-17T09:00:00.000Z"),
+        ),
+      ).resolves.toBeNull();
+      await expect(
+        markSnoozedThreadAsExecuting(snoozedThread.id, scheduledFor),
+      ).resolves.toEqual(scheduledFor);
+    });
+
+    test("rolls back cancellation when replacement creation conflicts", async () => {
+      const pending = await prisma.snoozedThread.create({
+        data: {
+          id: "pending-before-conflict",
+          emailAccountId,
+          scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+          threadId: "rollback-thread",
+        },
+      });
+      await prisma.snoozedThread.create({
+        data: {
+          id: "duplicate-id",
+          emailAccountId,
+          scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+          status: SnoozedThreadStatus.COMPLETED,
+          threadId: "historical-thread",
+        },
+      });
+
+      await expect(
+        prisma.$transaction([
+          prisma.snoozedThread.updateMany({
+            where: {
+              emailAccountId,
+              threadId: "rollback-thread",
+              status: SnoozedThreadStatus.PENDING,
+            },
+            data: { status: SnoozedThreadStatus.CANCELLED },
+          }),
+          prisma.snoozedThread.create({
+            data: {
+              id: "duplicate-id",
+              emailAccountId,
+              scheduledFor: new Date("2026-08-17T10:00:00.000Z"),
+              threadId: "rollback-thread",
+            },
+          }),
+        ]),
+      ).rejects.toThrow();
+
+      await expect(
+        prisma.snoozedThread.findUniqueOrThrow({ where: { id: pending.id } }),
+      ).resolves.toMatchObject({ status: SnoozedThreadStatus.PENDING });
+    });
+  },
+);
+
+async function seedAccount(
+  prisma: typeof import("@/utils/prisma").default,
+  email: string,
+) {
+  const user = await prisma.user.create({ data: { email } });
+  const account = await prisma.account.create({
+    data: {
+      userId: user.id,
+      provider: "google",
+      providerAccountId: `provider-${email}`,
+      type: "oauth",
+    },
+  });
+  const emailAccount = await prisma.emailAccount.create({
+    data: { accountId: account.id, email, userId: user.id },
+  });
+  return emailAccount.id;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -22,6 +22,7 @@ import type {
   MailNavTarget,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
+import { buildMailCommandPalette } from "@/app/(app)/[emailAccountId]/mail/mail-command-palette";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
@@ -45,8 +46,11 @@ import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { useSidebar } from "@/components/ui/sidebar";
-import { useAtom } from "jotai";
-import { commandPaletteOpenAtom } from "@/store/command-palette";
+import { useAtom, useSetAtom } from "jotai";
+import {
+  commandPaletteOpenAtom,
+  mailCommandContextAtom,
+} from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
   isGoogleProvider,
@@ -112,6 +116,7 @@ export function MailShell() {
   const { setInput: setChatInput } = useChat();
   const { toggleSidebar } = useSidebar();
   const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
+  const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
   const { threadId: sidePanelThreadId } = useDisplayedEmail();
@@ -306,13 +311,15 @@ export function MailShell() {
   );
 
   const runOn = useCallback(
-    (action: (ids: string[]) => void) => {
+    (action: (ids: string[]) => void, removeFromList: boolean) => {
       if (isAllAccounts) return;
       const ids = selection.targetIds(
         focusedThread ? getListThreadKey(focusedThread) : undefined,
       );
       if (!ids.length) return;
-      if (openThreadId && ids.includes(openThreadId)) setOpenThreadId(null);
+      if (removeFromList && openThreadId && ids.includes(openThreadId)) {
+        setOpenThreadId(null);
+      }
       selection.clear();
       action(ids);
     },
@@ -359,7 +366,7 @@ export function MailShell() {
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
   const archiveTargets = useCallback(async () => {
     if (!isAllAccounts) {
-      runOn(archive);
+      runOn(archive, true);
       return;
     }
     if (!focusedThread || !("account" in focusedThread)) return;
@@ -388,7 +395,63 @@ export function MailShell() {
     restoreCombinedThread,
     runOn,
   ]);
-  const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
+  const trashTargets = useCallback(() => runOn(trash, true), [runOn, trash]);
+  const markReadTargets = useCallback(
+    () => runOn(markRead, false),
+    [runOn, markRead],
+  );
+  const markUnreadTargets = useCallback(
+    () => runOn((ids) => setReadState(ids, false), false),
+    [runOn, setReadState],
+  );
+  const commandTargetIds = useMemo(() => {
+    if (isAllAccounts) {
+      return focusedThread ? [getListThreadKey(focusedThread)] : [];
+    }
+    return selection.targetIds(
+      focusedThread ? getListThreadKey(focusedThread) : undefined,
+    );
+  }, [isAllAccounts, selection, focusedThread]);
+  const commandTargets = useMemo(() => {
+    const ids = new Set(commandTargetIds);
+    return threads.filter((thread) => ids.has(getListThreadKey(thread)));
+  }, [commandTargetIds, threads]);
+  const mailCommands = useMemo(
+    () =>
+      buildMailCommandPalette({
+        actions: isAllAccounts
+          ? { archive: archiveTargets }
+          : {
+              archive: archiveTargets,
+              markRead: markReadTargets,
+              markUnread: markUnreadTargets,
+              trash: trashTargets,
+            },
+        hasRead: commandTargets.some(
+          (thread) => !isThreadUnread(thread.messages),
+        ),
+        hasUnread: commandTargets.some((thread) =>
+          isThreadUnread(thread.messages),
+        ),
+        targetCount: commandTargetIds.length,
+      }),
+    [
+      archiveTargets,
+      commandTargetIds.length,
+      commandTargets,
+      isAllAccounts,
+      markReadTargets,
+      markUnreadTargets,
+      trashTargets,
+    ],
+  );
+
+  useEffect(() => {
+    setMailCommandContext(
+      mailCommands.length ? { commands: mailCommands } : null,
+    );
+    return () => setMailCommandContext(null);
+  }, [mailCommands, setMailCommandContext]);
   const isMailOverlayOpen =
     isHelpOpen ||
     isPaletteOpen ||
@@ -692,7 +755,7 @@ export function MailShell() {
                 isUnread={isOpenThreadUnread}
                 onToggleRead={() => {
                   if (openThreadId)
-                    setReadState(openThreadId, isOpenThreadUnread);
+                    setReadState([openThreadId], isOpenThreadUnread);
                 }}
                 open={isMenuOpen}
                 onOpenChange={setIsMenuOpen}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -49,6 +49,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useAtom, useSetAtom } from "jotai";
 import {
   commandPaletteOpenAtom,
+  commandPalettePageAtom,
   mailCommandContextAtom,
 } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -116,6 +117,7 @@ export function MailShell() {
   const { setInput: setChatInput } = useChat();
   const { toggleSidebar } = useSidebar();
   const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
+  const setCommandPalettePage = useSetAtom(commandPalettePageAtom);
   const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
@@ -235,12 +237,14 @@ export function MailShell() {
 
   const orderedIds = useMemo(() => threads.map(getListThreadKey), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, markRead, setReadState, undo } = useThreadActions({
-    emailAccountId,
-    removeThreads: accountThreadState.removeThreads,
-    restoreThreads: accountThreadState.restoreThreads,
-    optimisticallyUpdateThreads: accountThreadState.optimisticallyUpdateThreads,
-  });
+  const { archive, trash, markRead, setReadState, snooze, undo } =
+    useThreadActions({
+      emailAccountId,
+      removeThreads: accountThreadState.removeThreads,
+      restoreThreads: accountThreadState.restoreThreads,
+      optimisticallyUpdateThreads:
+        accountThreadState.optimisticallyUpdateThreads,
+    });
 
   const clampIndex = useCallback(
     (index: number) =>
@@ -404,6 +408,14 @@ export function MailShell() {
     () => runOn((ids) => setReadState(ids, false), false),
     [runOn, setReadState],
   );
+  const snoozeTargets = useCallback(
+    (until: Date) => runOn((ids) => snooze(ids, until), true),
+    [runOn, snooze],
+  );
+  const openSnoozePalette = useCallback(
+    () => setCommandPalettePage("snooze"),
+    [setCommandPalettePage],
+  );
   const commandTargetIds = useMemo(() => {
     if (isAllAccounts) {
       return focusedThread ? [getListThreadKey(focusedThread)] : [];
@@ -425,6 +437,7 @@ export function MailShell() {
               archive: archiveTargets,
               markRead: markReadTargets,
               markUnread: markUnreadTargets,
+              openSnooze: openSnoozePalette,
               trash: trashTargets,
             },
         hasRead: commandTargets.some(
@@ -442,16 +455,19 @@ export function MailShell() {
       isAllAccounts,
       markReadTargets,
       markUnreadTargets,
+      openSnoozePalette,
       trashTargets,
     ],
   );
 
   useEffect(() => {
     setMailCommandContext(
-      mailCommands.length ? { commands: mailCommands } : null,
+      mailCommands.length
+        ? { commands: mailCommands, snooze: snoozeTargets }
+        : null,
     );
     return () => setMailCommandContext(null);
-  }, [mailCommands, setMailCommandContext]);
+  }, [mailCommands, setMailCommandContext, snoozeTargets]);
   const isMailOverlayOpen =
     isHelpOpen ||
     isPaletteOpen ||

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMailCommandPalette } from "./mail-command-palette";
+
+const actions = {
+  archive: vi.fn(),
+  markRead: vi.fn(),
+  markUnread: vi.fn(),
+  trash: vi.fn(),
+};
+
+describe("buildMailCommandPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("targets the highlighted row when no checkbox selection exists", () => {
+    const commands = buildMailCommandPalette({
+      actions,
+      hasRead: false,
+      hasUnread: true,
+      targetCount: 1,
+    });
+
+    expect(
+      commands.find((command) => command.id === "mail-archive"),
+    ).toMatchObject({ label: "Archive conversation" });
+    expect(commands.map((command) => command.id)).toEqual(
+      expect.arrayContaining(["mail-mark-read"]),
+    );
+    expect(commands.map((command) => command.id)).not.toContain(
+      "mail-mark-unread",
+    );
+  });
+
+  it("labels commands for the full multi-selection", () => {
+    const commands = buildMailCommandPalette({
+      actions,
+      hasRead: true,
+      hasUnread: true,
+      targetCount: 3,
+    });
+
+    expect(
+      commands.find((command) => command.id === "mail-archive"),
+    ).toMatchObject({ label: "Archive 3 conversations" });
+    expect(commands.map((command) => command.id)).toEqual(
+      expect.arrayContaining(["mail-mark-read", "mail-mark-unread"]),
+    );
+  });
+
+  it("returns no mail actions for an empty list", () => {
+    expect(
+      buildMailCommandPalette({
+        actions,
+        hasRead: false,
+        hasUnread: false,
+        targetCount: 0,
+      }),
+    ).toEqual([]);
+  });
+
+  it("only exposes actions supported by the active mail source", () => {
+    const commands = buildMailCommandPalette({
+      actions: { archive: actions.archive },
+      hasRead: true,
+      hasUnread: true,
+      targetCount: 1,
+    });
+
+    expect(commands.map((command) => command.id)).toEqual(["mail-archive"]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -5,6 +5,7 @@ const actions = {
   archive: vi.fn(),
   markRead: vi.fn(),
   markUnread: vi.fn(),
+  openSnooze: vi.fn(),
   trash: vi.fn(),
 };
 
@@ -25,7 +26,7 @@ describe("buildMailCommandPalette", () => {
       commands.find((command) => command.id === "mail-archive"),
     ).toMatchObject({ label: "Archive conversation" });
     expect(commands.map((command) => command.id)).toEqual(
-      expect.arrayContaining(["mail-mark-read"]),
+      expect.arrayContaining(["mail-mark-read", "mail-snooze"]),
     );
     expect(commands.map((command) => command.id)).not.toContain(
       "mail-mark-unread",
@@ -44,8 +45,20 @@ describe("buildMailCommandPalette", () => {
       commands.find((command) => command.id === "mail-archive"),
     ).toMatchObject({ label: "Archive 3 conversations" });
     expect(commands.map((command) => command.id)).toEqual(
-      expect.arrayContaining(["mail-mark-read", "mail-mark-unread"]),
+      expect.arrayContaining([
+        "mail-mark-read",
+        "mail-mark-unread",
+        "mail-snooze",
+      ]),
     );
+
+    const snooze = commands.find((command) => command.id === "mail-snooze");
+    expect(snooze).toMatchObject({
+      label: "Snooze 3 conversations",
+      closeOnSelect: false,
+    });
+    snooze?.action();
+    expect(actions.openSnooze).toHaveBeenCalledOnce();
   });
 
   it("returns no mail actions for an empty list", () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -1,0 +1,82 @@
+import { ArchiveIcon, MailIcon, MailOpenIcon, Trash2Icon } from "lucide-react";
+import type { Command } from "@/lib/commands/types";
+
+type MailCommandActions = {
+  archive: () => void;
+  markRead?: () => void;
+  markUnread?: () => void;
+  trash?: () => void;
+};
+
+export function buildMailCommandPalette({
+  actions,
+  hasRead,
+  hasUnread,
+  targetCount,
+}: {
+  actions: MailCommandActions;
+  hasRead: boolean;
+  hasUnread: boolean;
+  targetCount: number;
+}): Command[] {
+  if (targetCount === 0) return [];
+
+  const commands: Command[] = [
+    {
+      id: "mail-archive",
+      label:
+        targetCount === 1
+          ? "Archive conversation"
+          : `Archive ${targetCount} conversations`,
+      icon: ArchiveIcon,
+      shortcut: "E",
+      section: "actions",
+      priority: 0,
+      keywords: ["archive", "remove", "inbox"],
+      action: actions.archive,
+    },
+  ];
+
+  if (hasUnread && actions.markRead) {
+    commands.push({
+      id: "mail-mark-read",
+      label: targetCount === 1 ? "Mark as read" : `Mark ${targetCount} as read`,
+      icon: MailOpenIcon,
+      section: "actions",
+      priority: 1,
+      keywords: ["read", "seen", "open"],
+      action: actions.markRead,
+    });
+  }
+
+  if (hasRead && actions.markUnread) {
+    commands.push({
+      id: "mail-mark-unread",
+      label:
+        targetCount === 1 ? "Mark as unread" : `Mark ${targetCount} as unread`,
+      icon: MailIcon,
+      section: "actions",
+      priority: 2,
+      keywords: ["unread", "unseen", "new"],
+      action: actions.markUnread,
+    });
+  }
+
+  if (actions.trash) {
+    commands.push({
+      id: "mail-delete",
+      label:
+        targetCount === 1
+          ? "Delete conversation"
+          : `Delete ${targetCount} conversations`,
+      icon: Trash2Icon,
+      shortcut: "#",
+      section: "actions",
+      priority: 10,
+      keywords: ["delete", "trash", "remove"],
+      action: actions.trash,
+    });
+  }
+
+  return commands;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -1,10 +1,17 @@
-import { ArchiveIcon, MailIcon, MailOpenIcon, Trash2Icon } from "lucide-react";
+import {
+  ArchiveIcon,
+  Clock3Icon,
+  MailIcon,
+  MailOpenIcon,
+  Trash2Icon,
+} from "lucide-react";
 import type { Command } from "@/lib/commands/types";
 
 type MailCommandActions = {
   archive: () => void;
   markRead?: () => void;
   markUnread?: () => void;
+  openSnooze?: () => void;
   trash?: () => void;
 };
 
@@ -59,6 +66,20 @@ export function buildMailCommandPalette({
       priority: 2,
       keywords: ["unread", "unseen", "new"],
       action: actions.markUnread,
+    });
+  }
+
+  if (actions.openSnooze) {
+    commands.push({
+      id: "mail-snooze",
+      label:
+        targetCount === 1 ? "Snooze" : `Snooze ${targetCount} conversations`,
+      icon: Clock3Icon,
+      section: "actions",
+      priority: 3,
+      keywords: ["snooze", "later", "remind"],
+      action: actions.openSnooze,
+      closeOnSelect: false,
     });
   }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSnoozeCommandPalette,
+  getSnoozePresets,
+  parseSnoozeDate,
+} from "./snooze-command-palette";
+
+describe("buildSnoozeCommandPalette", () => {
+  it("offers useful future presets with next week landing on Monday morning", () => {
+    const presets = getSnoozePresets(new Date(2026, 7, 15, 10));
+
+    expect(presets.map(({ id }) => id)).toEqual([
+      "three-hours",
+      "tomorrow",
+      "next-week",
+    ]);
+    expect(presets[0]?.until).toEqual(new Date(2026, 7, 15, 13));
+    expect(presets[1]?.until).toEqual(new Date(2026, 7, 16, 9));
+    expect(presets[2]?.until).toEqual(new Date(2026, 7, 17, 9));
+  });
+
+  it("turns natural language into one actionable result", () => {
+    const onSnooze = vi.fn();
+    const commands = buildSnoozeCommandPalette({
+      now: new Date(2026, 7, 15, 10),
+      onSnooze,
+      query: "tomorrow at 3pm",
+    });
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]?.label).toContain("Sun, Aug 16 at 3:00 PM");
+    commands[0]?.action();
+    expect(onSnooze).toHaveBeenCalledWith(new Date(2026, 7, 16, 15));
+  });
+
+  it("defaults date-only input to 9am", () => {
+    expect(parseSnoozeDate("next Friday", new Date(2026, 7, 15, 10))).toEqual(
+      new Date(2026, 7, 21, 9),
+    );
+  });
+
+  it("does not offer invalid or past dates", () => {
+    const now = new Date(2026, 7, 15, 10);
+
+    expect(parseSnoozeDate("not a date", now)).toBeNull();
+    expect(parseSnoozeDate("yesterday", now)).toBeNull();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.ts
@@ -1,0 +1,79 @@
+import { format } from "date-fns";
+import { Clock3Icon } from "lucide-react";
+import * as chrono from "chrono-node";
+import type { Command } from "@/lib/commands/types";
+
+export function buildSnoozeCommandPalette({
+  now = new Date(),
+  onSnooze,
+  query,
+}: {
+  now?: Date;
+  onSnooze: (until: Date) => void;
+  query: string;
+}): Command[] {
+  const naturalLanguageDate = parseSnoozeDate(query, now);
+  if (query.trim()) {
+    if (!naturalLanguageDate) return [];
+
+    return [
+      {
+        id: "mail-snooze-natural-language",
+        label: `Snooze until ${format(naturalLanguageDate, "EEE, MMM d 'at' p")}`,
+        icon: Clock3Icon,
+        section: "actions",
+        priority: 0,
+        keywords: [query],
+        action: () => onSnooze(naturalLanguageDate),
+      },
+    ];
+  }
+
+  return getSnoozePresets(now).map((preset, index) => ({
+    id: `mail-snooze-${preset.id}`,
+    label: preset.label,
+    icon: Clock3Icon,
+    section: "actions",
+    priority: index,
+    keywords: ["snooze", "later", "remind", preset.id],
+    action: () => onSnooze(preset.until),
+  }));
+}
+
+export function parseSnoozeDate(input: string, now = new Date()) {
+  const result = chrono.casual.parse(input.trim(), now, {
+    forwardDate: true,
+  })[0];
+  if (!result) return null;
+
+  const date = result.start.date();
+  if (!result.start.isCertain("hour")) date.setHours(9, 0, 0, 0);
+  if (date <= now) return null;
+
+  return date;
+}
+
+export function getSnoozePresets(now: Date) {
+  const tomorrowMorning = new Date(now);
+  tomorrowMorning.setDate(tomorrowMorning.getDate() + 1);
+  tomorrowMorning.setHours(9, 0, 0, 0);
+
+  const nextWeek = new Date(now);
+  const daysUntilMonday = (8 - nextWeek.getDay()) % 7 || 7;
+  nextWeek.setDate(nextWeek.getDate() + daysUntilMonday);
+  nextWeek.setHours(9, 0, 0, 0);
+
+  return [
+    {
+      id: "three-hours",
+      label: "In 3 hours",
+      until: new Date(now.getTime() + 3 * 60 * 60 * 1000),
+    },
+    {
+      id: "tomorrow",
+      label: "Tomorrow morning",
+      until: tomorrowMorning,
+    },
+    { id: "next-week", label: "Next week", until: nextWeek },
+  ];
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -146,7 +146,7 @@ describe("useThreadActions read state", () => {
       }),
     );
 
-    await act(() => result.current.setReadState("thread", false));
+    await act(() => result.current.setReadState(["thread"], false));
 
     expect(markReadThreadAction).toHaveBeenCalledWith("account", {
       threadId: "thread",
@@ -171,7 +171,7 @@ describe("useThreadActions read state", () => {
       }),
     );
 
-    await act(() => result.current.setReadState("thread", true));
+    await act(() => result.current.setReadState(["thread"], true));
 
     expect(transaction.rollback).toHaveBeenCalledWith(["thread"]);
     expect(transaction.commit).not.toHaveBeenCalled();

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -16,6 +16,7 @@ const notifications = vi.hoisted(() => ({
   success: vi.fn(),
 }));
 const markReadThreadAction = vi.hoisted(() => vi.fn());
+const snoozeThreadsAction = vi.hoisted(() => vi.fn());
 
 vi.mock("@/store/archive-queue", () => ({
   archiveEmails: queue.archive,
@@ -28,12 +29,16 @@ vi.mock("@/utils/actions/mail", () => ({
   unarchiveThreadAction: vi.fn(),
   untrashThreadAction: vi.fn(),
 }));
+vi.mock("@/utils/actions/snooze", () => ({ snoozeThreadsAction }));
 vi.mock("sonner", () => ({ toast: notifications }));
 
 describe("useThreadActions read state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markReadThreadAction.mockResolvedValue({});
+    snoozeThreadsAction.mockResolvedValue({
+      data: { failedThreadIds: [], succeededThreadIds: ["thread"] },
+    });
   });
 
   it("marks an unread row locally before queueing the provider update", () => {
@@ -176,6 +181,71 @@ describe("useThreadActions read state", () => {
     expect(transaction.rollback).toHaveBeenCalledWith(["thread"]);
     expect(transaction.commit).not.toHaveBeenCalled();
     expect(notifications.error).toHaveBeenCalledWith("Couldn't mark as read");
+  });
+
+  it("restores only rows that failed to snooze", async () => {
+    const removal = { entries: new Map(), viewIdentity: "view" };
+    const removeThreads = vi.fn(() => removal);
+    const restoreThreads = vi.fn();
+    snoozeThreadsAction.mockResolvedValue({
+      data: {
+        failedThreadIds: ["thread-two"],
+        succeededThreadIds: ["thread-one"],
+      },
+    });
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads,
+        restoreThreads,
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+    const until = new Date("2026-08-16T09:00:00.000Z");
+
+    await act(() => result.current.snooze(["thread-one", "thread-two"], until));
+
+    expect(removeThreads).toHaveBeenCalledWith(["thread-one", "thread-two"]);
+    expect(snoozeThreadsAction).toHaveBeenCalledWith("account", {
+      threadIds: ["thread-one", "thread-two"],
+      snoozedUntil: until,
+    });
+    expect(restoreThreads).toHaveBeenCalledWith(removal, ["thread-two"]);
+  });
+
+  it("chunks snooze actions at the server validation limit", async () => {
+    const threadIds = Array.from(
+      { length: 101 },
+      (_, index) => `thread-${index}`,
+    );
+    snoozeThreadsAction.mockImplementation(
+      async (_emailAccountId, input: { threadIds: string[] }) => ({
+        data: {
+          failedThreadIds: [],
+          succeededThreadIds: input.threadIds,
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads: vi.fn(() => ({
+          entries: new Map(),
+          viewIdentity: "view",
+        })),
+        restoreThreads: vi.fn(),
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+
+    await act(() =>
+      result.current.snooze(threadIds, new Date("2026-08-16T09:00:00.000Z")),
+    );
+
+    expect(snoozeThreadsAction).toHaveBeenCalledTimes(2);
+    expect(
+      snoozeThreadsAction.mock.calls.map((call) => call[1].threadIds),
+    ).toEqual([threadIds.slice(0, 100), threadIds.slice(100)]);
   });
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -20,6 +20,9 @@ import type {
   ThreadRemoval,
 } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import { mapWithConcurrency } from "@/utils/async";
+
+const THREAD_ACTION_CONCURRENCY = 10;
 
 type UndoableAction = "archive" | "delete";
 
@@ -69,11 +72,13 @@ export function useThreadActions({
       const reverse =
         batch.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
 
-      const reversed = await Promise.all(
-        notCancelled.map(async (threadId) => {
+      const reversed = await mapWithConcurrency(
+        notCancelled,
+        THREAD_ACTION_CONCURRENCY,
+        async (threadId) => {
           const result = await reverse(emailAccountId, { threadId });
           return { threadId, ok: !result?.serverError };
-        }),
+        },
       );
 
       // A thread the provider refused to unarchive is still archived, so
@@ -167,26 +172,50 @@ export function useThreadActions({
   );
 
   const setReadState = useCallback(
-    async (threadId: string, read: boolean) => {
-      const update = optimisticallyUpdateThreads([threadId], (thread) =>
+    async (threadIds: string[], read: boolean) => {
+      const update = optimisticallyUpdateThreads(threadIds, (thread) =>
         withThreadReadState(thread, read),
       );
       if (!update.threadIds.length) return;
 
-      try {
-        const result = await markReadThreadAction(emailAccountId, {
-          threadId,
-          read,
-        });
-        if (result?.serverError) throw new Error(result.serverError);
-      } catch {
-        update.rollback([threadId]);
-        toast.error(read ? "Couldn't mark as read" : "Couldn't mark as unread");
+      const results = await mapWithConcurrency(
+        update.threadIds,
+        THREAD_ACTION_CONCURRENCY,
+        async (threadId) => {
+          try {
+            const result = await markReadThreadAction(emailAccountId, {
+              threadId,
+              read,
+            });
+            return { failed: Boolean(result?.serverError), threadId };
+          } catch {
+            return { failed: true, threadId };
+          }
+        },
+      );
+      const failedThreadIds = results
+        .filter((result) => result.failed)
+        .map(({ threadId }) => threadId);
+
+      for (const threadId of update.threadIds) {
+        if (!failedThreadIds.includes(threadId)) update.commit(threadId);
+      }
+      update.rollback(failedThreadIds);
+
+      if (failedThreadIds.length) {
+        toast.error(
+          failedThreadIds.length === update.threadIds.length
+            ? `Couldn't mark as ${read ? "read" : "unread"}`
+            : `Couldn't mark ${failedThreadIds.length} of ${update.threadIds.length} as ${read ? "read" : "unread"}`,
+        );
         return;
       }
 
-      update.commit(threadId);
-      toast.success(read ? "Marked as read" : "Marked as unread");
+      toast.success(
+        update.threadIds.length === 1
+          ? `Marked as ${read ? "read" : "unread"}`
+          : `Marked ${update.threadIds.length} as ${read ? "read" : "unread"}`,
+      );
     },
     [emailAccountId, optimisticallyUpdateThreads],
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useRef } from "react";
+import { format } from "date-fns";
+import chunk from "lodash/chunk";
 import { toast } from "sonner";
 import {
   archiveEmails,
@@ -20,9 +22,12 @@ import type {
   ThreadRemoval,
 } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import { snoozeThreadsAction } from "@/utils/actions/snooze";
 import { mapWithConcurrency } from "@/utils/async";
 
 const THREAD_ACTION_CONCURRENCY = 10;
+const SNOOZE_ACTION_BATCH_CONCURRENCY = 2;
+const SNOOZE_ACTION_BATCH_SIZE = 100;
 
 type UndoableAction = "archive" | "delete";
 
@@ -220,11 +225,59 @@ export function useThreadActions({
     [emailAccountId, optimisticallyUpdateThreads],
   );
 
+  const snooze = useCallback(
+    async (threadIds: string[], snoozedUntil: Date) => {
+      if (!threadIds.length) return;
+      const removal = removeThreads(threadIds);
+      const results = await mapWithConcurrency(
+        chunk(threadIds, SNOOZE_ACTION_BATCH_SIZE),
+        SNOOZE_ACTION_BATCH_CONCURRENCY,
+        async (batch) => {
+          const result = await snoozeThreadsAction(emailAccountId, {
+            threadIds: batch,
+            snoozedUntil,
+          }).catch(() => null);
+          return (
+            result?.data ?? {
+              failedThreadIds: batch,
+              succeededThreadIds: [],
+            }
+          );
+        },
+      );
+      const failedThreadIds = results.flatMap(
+        (result) => result.failedThreadIds,
+      );
+      const succeededThreadIds = results.flatMap(
+        (result) => result.succeededThreadIds,
+      );
+
+      restoreThreads(removal, failedThreadIds);
+
+      if (succeededThreadIds.length) {
+        toast.success(
+          succeededThreadIds.length === 1
+            ? `Snoozed until ${format(snoozedUntil, "EEE, MMM d 'at' p")}`
+            : `Snoozed ${succeededThreadIds.length} conversations`,
+        );
+      }
+      if (failedThreadIds.length) {
+        toast.error(
+          failedThreadIds.length === 1
+            ? "Couldn't snooze conversation"
+            : `Couldn't snooze ${failedThreadIds.length} conversations`,
+        );
+      }
+    },
+    [emailAccountId, removeThreads, restoreThreads],
+  );
+
   return {
     archive: useCallback((ids: string[]) => run("archive", ids), [run]),
     trash: useCallback((ids: string[]) => run("delete", ids), [run]),
     markRead,
     setReadState,
+    snooze,
     undo,
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -110,6 +110,32 @@ describe("useThreadSelection", () => {
     expect(result.current.targetIds(undefined)).toEqual([]);
   });
 
+  it("drops selections that are no longer in the current mail view", () => {
+    const { result, rerender } = renderHook(
+      ({ ids }) => useThreadSelection(ids),
+      { initialProps: { ids: ["a", "b", "c"] } },
+    );
+
+    act(() => result.current.toggle(1));
+    rerender({ ids: ["c", "d"] });
+
+    expect(result.current.selectedCount).toBe(0);
+    expect(result.current.targetIds("c")).toEqual(["c"]);
+  });
+
+  it("resets positional range state when rows reorder", () => {
+    const { result, rerender } = renderHook(
+      ({ ids }) => useThreadSelection(ids),
+      { initialProps: { ids: ["a", "b", "c"] } },
+    );
+
+    act(() => result.current.toggle(0));
+    rerender({ ids: ["c", "b", "a"] });
+    act(() => result.current.selectRangeTo(1));
+
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
   it("ignores a toggle for an index outside the list", () => {
     const { result } = setup();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -136,6 +136,19 @@ describe("useThreadSelection", () => {
     expect([...result.current.selectedIds].sort()).toEqual(["a", "b"]);
   });
 
+  it("keeps the shift-click anchor when the same rows refresh", () => {
+    const { result, rerender } = renderHook(
+      ({ ids }) => useThreadSelection(ids),
+      { initialProps: { ids: ["a", "b", "c"] } },
+    );
+
+    act(() => result.current.toggle(0));
+    rerender({ ids: ["a", "b", "c"] });
+    act(() => result.current.selectRangeTo(2));
+
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "b", "c"]);
+  });
+
   it("ignores a toggle for an index outside the list", () => {
     const { result } = setup();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Row selection for the mail list.
@@ -28,6 +28,17 @@ export function useThreadSelection(orderedIds: string[]) {
     lastToggledIndex.current = null;
     setSelectedIds((current) => (current.size ? new Set() : current));
   }, [resetAnchor]);
+
+  useEffect(() => {
+    const visibleIds = new Set(orderedIds);
+    resetAnchor();
+    lastToggledIndex.current = null;
+    setSelectedIds((current) => {
+      if ([...current].every((id) => visibleIds.has(id))) return current;
+
+      return new Set([...current].filter((id) => visibleIds.has(id)));
+    });
+  }, [orderedIds, resetAnchor]);
 
   const toggle = useCallback(
     (index: number) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -17,6 +17,7 @@ export function useThreadSelection(orderedIds: string[]) {
   const anchorIndex = useRef<number | null>(null);
   const baseSelection = useRef<ReadonlySet<string> | null>(null);
   const lastToggledIndex = useRef<number | null>(null);
+  const previousOrderedIds = useRef(orderedIds);
 
   const resetAnchor = useCallback(() => {
     anchorIndex.current = null;
@@ -30,6 +31,10 @@ export function useThreadSelection(orderedIds: string[]) {
   }, [resetAnchor]);
 
   useEffect(() => {
+    const previousIds = previousOrderedIds.current;
+    previousOrderedIds.current = orderedIds;
+    if (hasSameOrder(previousIds, orderedIds)) return;
+
     const visibleIds = new Set(orderedIds);
     resetAnchor();
     lastToggledIndex.current = null;
@@ -110,6 +115,13 @@ export function useThreadSelection(orderedIds: string[]) {
       targetIds,
     }),
     [selectedIds, toggle, selectRangeTo, extendTo, clear, targetIds],
+  );
+}
+
+function hasSameOrder(previousIds: string[], currentIds: string[]) {
+  return (
+    previousIds.length === currentIds.length &&
+    previousIds.every((id, index) => id === currentIds[index])
   );
 }
 

--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -142,17 +142,14 @@ async function processScheduledActions(logger: Logger) {
   };
 }
 
-async function processAllScheduledMail(logger: Logger) {
-  const [scheduledActions, snoozedThreads] = await Promise.all([
-    processScheduledActions(logger),
-    processDueSnoozedThreads(logger),
-  ]);
-
-  return { scheduledActions, snoozedThreads };
-}
-
 async function processScheduledMail(logger: Logger) {
-  if (!env.QSTASH_TOKEN) return processAllScheduledMail(logger);
+  if (!env.QSTASH_TOKEN) {
+    const [scheduledActions, snoozedThreads] = await Promise.all([
+      processScheduledActions(logger),
+      processDueSnoozedThreads(logger),
+    ]);
+    return { scheduledActions, snoozedThreads };
+  }
 
   logger.info("QStash configured; checking snoozed thread fallback");
   return {

--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -12,6 +12,7 @@ import {
 import { markQStashActionAsExecuting } from "@/utils/scheduled-actions/scheduler";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
+import { processDueSnoozedThreads } from "@/utils/snooze/process-due";
 
 export const maxDuration = 300;
 
@@ -25,12 +26,7 @@ export const GET = withError("cron/scheduled-actions", async (request) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  if (env.QSTASH_TOKEN) {
-    request.logger.info("QStash configured, skipping cron fallback");
-    return NextResponse.json({ skipped: true, reason: "qstash-configured" });
-  }
-
-  const result = await processScheduledActions(request.logger);
+  const result = await processScheduledMail(request.logger);
 
   return NextResponse.json(result);
 });
@@ -43,12 +39,7 @@ export const POST = withError("cron/scheduled-actions", async (request) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  if (env.QSTASH_TOKEN) {
-    request.logger.info("QStash configured, skipping cron fallback");
-    return NextResponse.json({ skipped: true, reason: "qstash-configured" });
-  }
-
-  const result = await processScheduledActions(request.logger);
+  const result = await processScheduledMail(request.logger);
 
   return NextResponse.json(result);
 });
@@ -148,5 +139,24 @@ async function processScheduledActions(logger: Logger) {
     failed,
     skipped,
     total: scheduledActions.length,
+  };
+}
+
+async function processAllScheduledMail(logger: Logger) {
+  const [scheduledActions, snoozedThreads] = await Promise.all([
+    processScheduledActions(logger),
+    processDueSnoozedThreads(logger),
+  ]);
+
+  return { scheduledActions, snoozedThreads };
+}
+
+async function processScheduledMail(logger: Logger) {
+  if (!env.QSTASH_TOKEN) return processAllScheduledMail(logger);
+
+  logger.info("QStash configured; checking snoozed thread fallback");
+  return {
+    scheduledActions: { skipped: true, reason: "qstash-configured" },
+    snoozedThreads: await processDueSnoozedThreads(logger),
   };
 }

--- a/apps/web/app/api/snoozed-threads/execute/route.ts
+++ b/apps/web/app/api/snoozed-threads/execute/route.ts
@@ -32,6 +32,12 @@ export const POST = withError(
         status: 200,
       });
     }
+    if (
+      snoozedThread.status === SnoozedThreadStatus.PENDING &&
+      snoozedThread.scheduledFor.getTime() > Date.now()
+    ) {
+      return new Response("Snoozed thread retry is scheduled", { status: 200 });
+    }
 
     const result = await processSnoozedThread(snoozedThread, request.logger);
     if (result.status === "skipped") {
@@ -40,12 +46,7 @@ export const POST = withError(
       });
     }
     if (result.status === "failed") {
-      return new Response(
-        result.reason === "missing-provider"
-          ? "Email account or provider missing"
-          : "Failed to restore snoozed thread",
-        { status: 500 },
-      );
+      return new Response("Failed to restore snoozed thread", { status: 500 });
     }
 
     return new Response("Snoozed thread restored", { status: 200 });

--- a/apps/web/app/api/snoozed-threads/execute/route.ts
+++ b/apps/web/app/api/snoozed-threads/execute/route.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { withError } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { withQstashOrInternal } from "@/utils/qstash";
+import { processSnoozedThread } from "@/utils/snooze/process-due";
+
+export const maxDuration = 300;
+
+const bodySchema = z.object({ snoozedThreadId: z.string().min(1) });
+
+export const POST = withError(
+  "snoozed-threads/execute",
+  withQstashOrInternal(async (request) => {
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return new Response("Invalid payload structure", { status: 400 });
+    }
+
+    const snoozedThread = await prisma.snoozedThread.findUnique({
+      where: { id: parsed.data.snoozedThreadId },
+      include: { emailAccount: { include: { account: true } } },
+    });
+    if (!snoozedThread) {
+      return new Response("Snoozed thread not found", { status: 404 });
+    }
+    if (
+      snoozedThread.status !== SnoozedThreadStatus.PENDING &&
+      snoozedThread.status !== SnoozedThreadStatus.EXECUTING
+    ) {
+      return new Response("Snoozed thread is no longer active", {
+        status: 200,
+      });
+    }
+
+    const result = await processSnoozedThread(snoozedThread, request.logger);
+    if (result.status === "skipped") {
+      return new Response("Snoozed thread is already being processed", {
+        status: 503,
+      });
+    }
+    if (result.status === "failed") {
+      return new Response(
+        result.reason === "missing-provider"
+          ? "Email account or provider missing"
+          : "Failed to restore snoozed thread",
+        { status: 500 },
+      );
+    }
+
+    return new Response("Snoozed thread restored", { status: 200 });
+  }),
+);

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { Loader2Icon } from "lucide-react";
+import { ArrowLeftIcon, Loader2Icon } from "lucide-react";
 import { useAtom, useAtomValue } from "jotai";
+import { buildSnoozeCommandPalette } from "@/app/(app)/[emailAccountId]/mail/snooze-command-palette";
 import {
   CommandDialog,
   CommandEmpty,
@@ -16,6 +17,7 @@ import {
 import { useComposeModal } from "@/providers/ComposeModalProvider";
 import {
   commandPaletteOpenAtom,
+  commandPalettePageAtom,
   mailCommandContextAtom,
 } from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
@@ -63,7 +65,9 @@ export function CommandK() {
 
 function CommandPalette() {
   const [open, setOpen] = useAtom(commandPaletteOpenAtom);
+  const [page, setPage] = useAtom(commandPalettePageAtom);
   const [search, setSearch] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const mailCommandContext = useAtomValue(mailCommandContextAtom);
 
   const { emailAccountId } = useAccount();
@@ -100,26 +104,60 @@ function CommandPalette() {
     [shortcutHandlers],
   );
 
-  const actionCommands = React.useMemo(
-    () =>
-      activeMailContext
-        ? [
-            ...activeMailContext.commands,
-            ...shortcutCommands.filter((command) => command.id === "compose"),
-          ]
-        : shortcutCommands,
-    [activeMailContext, shortcutCommands],
-  );
+  const snoozeCommands = React.useMemo(() => {
+    if (page !== "snooze" || !activeMailContext) return [];
+
+    return buildSnoozeCommandPalette({
+      onSnooze: activeMailContext.snooze,
+      query: search,
+    });
+  }, [activeMailContext, page, search]);
+
+  const actionCommands = React.useMemo(() => {
+    if (page === "snooze" && activeMailContext) {
+      if (search.trim()) return snoozeCommands;
+
+      return [
+        {
+          id: "mail-snooze-back",
+          label: "Back to commands",
+          icon: ArrowLeftIcon,
+          section: "actions" as const,
+          priority: -1,
+          closeOnSelect: false,
+          action: () => setPage("root"),
+        },
+        ...snoozeCommands,
+      ];
+    }
+
+    return activeMailContext
+      ? [
+          ...activeMailContext.commands,
+          ...shortcutCommands.filter((command) => command.id === "compose"),
+        ]
+      : shortcutCommands;
+  }, [
+    activeMailContext,
+    page,
+    search,
+    setPage,
+    shortcutCommands,
+    snoozeCommands,
+  ]);
 
   const allCommands = React.useMemo(
-    () => [...actionCommands, ...commands],
-    [actionCommands, commands],
+    () =>
+      page === "snooze" ? actionCommands : [...actionCommands, ...commands],
+    [actionCommands, commands, page],
   );
 
   const filteredCommands = React.useMemo(() => {
-    if (!search.trim()) return allCommands;
+    if (page === "snooze" || !search.trim()) {
+      return allCommands;
+    }
     return fuzzySearch(search, allCommands);
-  }, [allCommands, search]);
+  }, [allCommands, page, search]);
 
   const groupedCommands = React.useMemo(() => {
     const groups: Record<CommandSection, Command[]> = {
@@ -139,30 +177,54 @@ function CommandPalette() {
 
   const executeCommand = React.useCallback(
     (command: Command) => {
-      setOpen(false);
       setSearch("");
+      if (command.closeOnSelect !== false) {
+        setOpen(false);
+        setPage("root");
+      }
       command.action();
     },
-    [setOpen],
+    [setOpen, setPage],
   );
 
   const handleOpenChange = React.useCallback(
     (isOpen: boolean) => {
       setOpen(isOpen);
-      if (!isOpen) setSearch("");
+      if (!isOpen) {
+        setPage("root");
+        setSearch("");
+      }
     },
-    [setOpen],
+    [setOpen, setPage],
   );
+
+  React.useEffect(() => {
+    if (page === "snooze" && !activeMailContext) {
+      setPage("root");
+      setSearch("");
+    }
+  }, [activeMailContext, page, setPage]);
+
+  React.useEffect(() => {
+    if (open && page === "snooze") inputRef.current?.focus();
+  }, [open, page]);
 
   const commandProps = React.useMemo(
     () => ({
       // disable cmdk's built-in filter since we use custom fuzzy search
       shouldFilter: false,
       onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === "Escape" && page === "snooze") {
+          e.preventDefault();
+          e.stopPropagation();
+          setPage("root");
+          setSearch("");
+          return;
+        }
         if (e.key !== "Escape") e.stopPropagation();
       },
     }),
-    [],
+    [page, setPage],
   );
 
   return (
@@ -172,7 +234,12 @@ function CommandPalette() {
       commandProps={commandProps}
     >
       <CommandInput
-        placeholder="Type a command or search..."
+        ref={inputRef}
+        placeholder={
+          page === "snooze"
+            ? "When should it return? Try Friday at 3pm"
+            : "Type a command or search..."
+        }
         value={search}
         onValueChange={setSearch}
       />
@@ -183,7 +250,11 @@ function CommandPalette() {
           </div>
         ) : (
           <>
-            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandEmpty>
+              {page === "snooze"
+                ? "Try a date like tomorrow at 3pm."
+                : "No results found."}
+            </CommandEmpty>
             {SECTION_ORDER.map((section, index) => {
               const sectionCommands = groupedCommands[section];
               if (sectionCommands.length === 0) return null;
@@ -197,7 +268,13 @@ function CommandPalette() {
               return (
                 <React.Fragment key={section}>
                   {showSeparator && <CommandSeparator />}
-                  <CommandGroup heading={SECTION_LABELS[section]}>
+                  <CommandGroup
+                    heading={
+                      page === "snooze" && section === "actions"
+                        ? "Snooze until"
+                        : SECTION_LABELS[section]
+                    }
+                  >
                     {sectionCommands.map((command) => (
                       <CommandItem
                         key={command.id}
@@ -237,7 +314,7 @@ function CommandPalette() {
           <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
             esc
           </kbd>
-          close
+          {page === "snooze" ? "back" : "close"}
         </span>
       </div>
     </CommandDialog>

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -214,23 +214,22 @@ function CommandPalette() {
       // disable cmdk's built-in filter since we use custom fuzzy search
       shouldFilter: false,
       onKeyDown: (e: React.KeyboardEvent) => {
-        if (e.key === "Escape" && page === "snooze") {
-          e.preventDefault();
-          e.stopPropagation();
-          setPage("root");
-          setSearch("");
-          return;
-        }
         if (e.key !== "Escape") e.stopPropagation();
       },
     }),
-    [page, setPage],
+    [],
   );
 
   return (
     <CommandDialog
       open={open}
       onOpenChange={handleOpenChange}
+      onEscapeKeyDown={(event) => {
+        if (page !== "snooze") return;
+        event.preventDefault();
+        setPage("root");
+        setSearch("");
+      }}
       commandProps={commandProps}
     >
       <CommandInput

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Loader2Icon } from "lucide-react";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import {
   CommandDialog,
   CommandEmpty,
@@ -14,7 +14,10 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
-import { commandPaletteOpenAtom } from "@/store/command-palette";
+import {
+  commandPaletteOpenAtom,
+  mailCommandContextAtom,
+} from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -61,11 +64,15 @@ export function CommandK() {
 function CommandPalette() {
   const [open, setOpen] = useAtom(commandPaletteOpenAtom);
   const [search, setSearch] = React.useState("");
+  const mailCommandContext = useAtomValue(mailCommandContextAtom);
 
   const { emailAccountId } = useAccount();
   const { threadId, showEmail } = useDisplayedEmail();
   const { onOpen: onOpenComposeModal } = useComposeModal();
-  const { commands, isLoading } = useCommandPaletteCommands();
+  const activeMailContext = threadId ? null : mailCommandContext;
+  const { commands, isLoading } = useCommandPaletteCommands({
+    enabled: !activeMailContext,
+  });
 
   const onArchive = React.useCallback(() => {
     if (threadId) {
@@ -88,26 +95,32 @@ function CommandPalette() {
   useShortcuts(shortcutHandlers);
 
   // the registry decides which shortcuts surface as palette entries
-  const actionCommands = React.useMemo<Command[]>(
+  const shortcutCommands = React.useMemo<Command[]>(
     () => buildShortcutPaletteCommands(shortcutHandlers),
     [shortcutHandlers],
   );
 
-  // combine action commands with dynamic commands
+  const actionCommands = React.useMemo(
+    () =>
+      activeMailContext
+        ? [
+            ...activeMailContext.commands,
+            ...shortcutCommands.filter((command) => command.id === "compose"),
+          ]
+        : shortcutCommands,
+    [activeMailContext, shortcutCommands],
+  );
+
   const allCommands = React.useMemo(
     () => [...actionCommands, ...commands],
     [actionCommands, commands],
   );
 
-  // filter commands with fuzzy search
   const filteredCommands = React.useMemo(() => {
-    if (!search.trim()) {
-      return allCommands;
-    }
+    if (!search.trim()) return allCommands;
     return fuzzySearch(search, allCommands);
   }, [allCommands, search]);
 
-  // group commands by section
   const groupedCommands = React.useMemo(() => {
     const groups: Record<CommandSection, Command[]> = {
       actions: [],
@@ -124,7 +137,6 @@ function CommandPalette() {
     return groups;
   }, [filteredCommands]);
 
-  // execute command
   const executeCommand = React.useCallback(
     (command: Command) => {
       setOpen(false);
@@ -134,7 +146,6 @@ function CommandPalette() {
     [setOpen],
   );
 
-  // memoized handlers to avoid re-renders
   const handleOpenChange = React.useCallback(
     (isOpen: boolean) => {
       setOpen(isOpen);
@@ -148,9 +159,7 @@ function CommandPalette() {
       // disable cmdk's built-in filter since we use custom fuzzy search
       shouldFilter: false,
       onKeyDown: (e: React.KeyboardEvent) => {
-        if (e.key !== "Escape") {
-          e.stopPropagation();
-        }
+        if (e.key !== "Escape") e.stopPropagation();
       },
     }),
     [],
@@ -198,14 +207,7 @@ function CommandPalette() {
                         {command.icon && (
                           <command.icon className="mr-2 h-4 w-4" />
                         )}
-                        <div className="flex flex-1 flex-col">
-                          <span>{command.label}</span>
-                          {command.description && (
-                            <span className="text-xs text-muted-foreground">
-                              {command.description}
-                            </span>
-                          )}
-                        </div>
+                        <span className="flex-1">{command.label}</span>
                         {command.shortcut && (
                           <CommandShortcut>{command.shortcut}</CommandShortcut>
                         )}

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -23,17 +23,24 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+interface CommandDialogProps extends DialogProps {
+  commandProps: React.ComponentPropsWithoutRef<typeof CommandPrimitive>;
+  onEscapeKeyDown?: React.ComponentPropsWithoutRef<
+    typeof DialogContent
+  >["onEscapeKeyDown"];
+}
 
 const CommandDialog = ({
   children,
   commandProps,
+  onEscapeKeyDown,
   ...props
-}: CommandDialogProps & {
-  commandProps: React.ComponentPropsWithoutRef<typeof CommandPrimitive>;
-}) => (
+}: CommandDialogProps) => (
   <Dialog {...props}>
-    <DialogContent className="overflow-hidden p-0 shadow-lg">
+    <DialogContent
+      className="overflow-hidden p-0 shadow-lg"
+      onEscapeKeyDown={onEscapeKeyDown}
+    >
       <Command
         className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground dark:[&_[cmdk-group-heading]]:text-slate-400 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
         {...commandProps}

--- a/apps/web/hooks/useCommandPaletteCommands.ts
+++ b/apps/web/hooks/useCommandPaletteCommands.ts
@@ -115,11 +115,18 @@ function useNavigationItems(): NavigationItem[] {
   );
 }
 
-export function useCommandPaletteCommands() {
+export function useCommandPaletteCommands({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) {
   const router = useRouter();
   const { emailAccountId } = useAccount();
-  const { data: rulesData, isLoading: rulesLoading } = useRules();
-  const { data: user, isLoading: userLoading } = useUser();
+  const { data: rulesData, isLoading: rulesLoading } = useRules(
+    undefined,
+    enabled,
+  );
+  const { data: user, isLoading: userLoading } = useUser(enabled);
   const navigationItems = useNavigationItems();
 
   const navigationCommands = useMemo<Command[]>(
@@ -227,21 +234,26 @@ export function useCommandPaletteCommands() {
   }, [user?.emailAccounts, router, emailAccountId]);
 
   const allCommands = useMemo(
-    () => [
-      ...navigationCommands,
-      ...settingsCommands,
-      ...ruleCommands,
-      ...accountCommands,
+    () =>
+      enabled
+        ? [
+            ...navigationCommands,
+            ...settingsCommands,
+            ...ruleCommands,
+            ...accountCommands,
+          ]
+        : [],
+    [
+      enabled,
+      navigationCommands,
+      settingsCommands,
+      ruleCommands,
+      accountCommands,
     ],
-    [navigationCommands, settingsCommands, ruleCommands, accountCommands],
   );
 
   return {
     commands: allCommands,
-    isLoading: rulesLoading || userLoading,
-    navigationCommands,
-    settingsCommands,
-    ruleCommands,
-    accountCommands,
+    isLoading: enabled && (rulesLoading || userLoading),
   };
 }

--- a/apps/web/hooks/useRules.tsx
+++ b/apps/web/hooks/useRules.tsx
@@ -2,10 +2,10 @@ import useSWR from "swr";
 import type { RulesResponse } from "@/app/api/user/rules/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
-export function useRules(emailAccountId?: string) {
+export function useRules(emailAccountId?: string, enabled = true) {
   const { emailAccountId: contextId } = useAccount();
   const id = emailAccountId ?? contextId;
   return useSWR<RulesResponse, { error: string }>(
-    id ? ["/api/user/rules", id] : null,
+    enabled && id ? ["/api/user/rules", id] : null,
   );
 }

--- a/apps/web/hooks/useUser.ts
+++ b/apps/web/hooks/useUser.ts
@@ -2,8 +2,10 @@ import useSWR from "swr";
 import type { UserResponse } from "@/app/api/user/me/route";
 import { processSWRResponse } from "@/utils/swr";
 
-export function useUser() {
-  const swrResult = useSWR<UserResponse | { error: string }>("/api/user/me");
+export function useUser(enabled = true) {
+  const swrResult = useSWR<UserResponse | { error: string }>(
+    enabled ? "/api/user/me" : null,
+  );
   const processed = processSWRResponse<UserResponse>(swrResult);
 
   // Treat 401 as "not authenticated" — return null data without error

--- a/apps/web/lib/commands/types.ts
+++ b/apps/web/lib/commands/types.ts
@@ -9,6 +9,7 @@ export type CommandSection =
 
 export interface Command {
   action: () => void | Promise<void>;
+  closeOnSelect?: boolean;
   description?: string;
   icon?: LucideIcon;
   id: string;

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -194,9 +194,9 @@ describe("buildShortcutPaletteCommands", () => {
   });
 
   it("leaves shortcuts without palette metadata out", () => {
-    const commands = buildShortcutPaletteCommands({ compose: vi.fn() });
+    const commands = buildShortcutPaletteCommands({ reply: vi.fn() });
 
-    expect(commands.map((command) => command.id)).not.toContain("compose");
+    expect(commands.map((command) => command.id)).not.toContain("reply");
   });
 });
 

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -219,7 +219,6 @@ const SHORTCUT_DEFINITIONS = [
     label: "New message",
     palette: {
       section: "actions",
-      description: "Compose a new email",
       keywords: ["compose", "write", "email"],
       priority: 20,
       icon: PenLineIcon,

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -1,4 +1,4 @@
-import { ArchiveIcon, type LucideIcon } from "lucide-react";
+import { ArchiveIcon, PenLineIcon, type LucideIcon } from "lucide-react";
 import type { Command, CommandSection } from "@/lib/commands/types";
 import { createClientLogger } from "@/utils/logger-client";
 
@@ -217,6 +217,13 @@ const SHORTCUT_DEFINITIONS = [
     scope: "global",
     group: "Assistant & rules",
     label: "New message",
+    palette: {
+      section: "actions",
+      description: "Compose a new email",
+      keywords: ["compose", "write", "email"],
+      priority: 20,
+      icon: PenLineIcon,
+    },
   },
   {
     id: "send",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -136,6 +136,7 @@
     "capital-case": "2.0.0",
     "chat": "4.28.1",
     "cheerio": "1.2.0",
+    "chrono-node": "2.10.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
+++ b/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "SnoozedThreadStatus" AS ENUM ('PENDING', 'EXECUTING', 'COMPLETED', 'FAILED', 'CANCELLED');
+CREATE TYPE "SnoozedThreadStatus" AS ENUM ('PENDING', 'EXECUTING', 'COMPLETED', 'CANCELLED');
 
 -- CreateTable
 CREATE TABLE "SnoozedThread" (

--- a/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
+++ b/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "SnoozedThreadStatus" AS ENUM ('PENDING', 'EXECUTING', 'COMPLETED', 'FAILED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "SnoozedThread" (
+    "id" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "scheduledFor" TIMESTAMP(3) NOT NULL,
+    "status" "SnoozedThreadStatus" NOT NULL DEFAULT 'PENDING',
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "SnoozedThread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SnoozedThread_status_scheduledFor_idx" ON "SnoozedThread"("status", "scheduledFor");
+
+-- CreateIndex
+CREATE INDEX "SnoozedThread_emailAccountId_threadId_status_idx" ON "SnoozedThread"("emailAccountId", "threadId", "status");
+
+-- Only one live restore may exist for a thread. Terminal records remain as history.
+CREATE UNIQUE INDEX "SnoozedThread_one_active_per_thread_idx"
+ON "SnoozedThread"("emailAccountId", "threadId")
+WHERE "status" IN ('PENDING', 'EXECUTING');
+
+-- AddForeignKey
+ALTER TABLE "SnoozedThread" ADD CONSTRAINT "SnoozedThread_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -2085,7 +2085,6 @@ enum SnoozedThreadStatus {
   PENDING
   EXECUTING
   COMPLETED
-  FAILED
   CANCELLED
 }
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -203,6 +203,7 @@ model EmailAccount {
   chatMemories     ChatMemory[]
   digests          Digest[]
   scheduledActions ScheduledAction[]
+  snoozedThreads   SnoozedThread[]
   responseTimes    ResponseTime[]
   actions          Action[]
 
@@ -802,6 +803,20 @@ model ScheduledAction {
   @@index([executedRuleId])
   @@index([status, scheduledFor])
   @@index([emailAccountId, messageId])
+}
+
+model SnoozedThread {
+  id           String              @id @default(cuid())
+  updatedAt    DateTime            @updatedAt
+  threadId     String
+  scheduledFor DateTime
+  status       SnoozedThreadStatus @default(PENDING)
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  @@index([status, scheduledFor])
+  @@index([emailAccountId, threadId, status])
 }
 
 // Notes:
@@ -2059,6 +2074,14 @@ enum DigestStatus {
 }
 
 enum ScheduledActionStatus {
+  PENDING
+  EXECUTING
+  COMPLETED
+  FAILED
+  CANCELLED
+}
+
+enum SnoozedThreadStatus {
   PENDING
   EXECUTING
   COMPLETED

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -8,8 +8,13 @@ import type { Command } from "@/lib/commands/types";
  */
 export const commandPaletteOpenAtom = atom(false);
 
+type CommandPalettePage = "root" | "snooze";
+
+export const commandPalettePageAtom = atom<CommandPalettePage>("root");
+
 type MailCommandContext = {
   commands: Command[];
+  snooze: (until: Date) => void;
 };
 
 /**

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import type { Command } from "@/lib/commands/types";
 
 /**
  * Open state for the command palette. It lives outside CommandK so surfaces
@@ -6,3 +7,13 @@ import { atom } from "jotai";
  * faking a ⌘K keystroke.
  */
 export const commandPaletteOpenAtom = atom(false);
+
+type MailCommandContext = {
+  commands: Command[];
+};
+
+/**
+ * Commands owned by the active mail list. Keeping the callbacks here lets the
+ * app-wide palette act on list state without duplicating selection state.
+ */
+export const mailCommandContextAtom = atom<MailCommandContext | null>(null);

--- a/apps/web/utils/actions/snooze.ts
+++ b/apps/web/utils/actions/snooze.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { actionClient } from "@/utils/actions/safe-action";
+import { snoozeThreadsBody } from "@/utils/actions/snooze.validation";
+import { createEmailProvider } from "@/utils/email/provider";
+import { snoozeThreads } from "@/utils/snooze/snooze";
+
+export const snoozeThreadsAction = actionClient
+  .metadata({ name: "snoozeThreads" })
+  .inputSchema(snoozeThreadsBody)
+  .action(
+    async ({
+      ctx: { emailAccount, emailAccountId, logger, provider },
+      parsedInput: { snoozedUntil, threadIds },
+    }) => {
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider,
+        logger,
+      });
+      return snoozeThreads({
+        emailAccountId,
+        logger,
+        ownerEmail: emailAccount.email,
+        provider: emailProvider,
+        snoozedUntil,
+        threadIds,
+      });
+    },
+  );

--- a/apps/web/utils/actions/snooze.validation.test.ts
+++ b/apps/web/utils/actions/snooze.validation.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { snoozeThreadsBody } from "@/utils/actions/snooze.validation";
+
+describe("snoozeThreadsBody", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("rejects times close enough to race the archive operation", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-15T12:00:00.000Z");
+
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["thread"],
+      snoozedUntil: new Date(Date.now() + 60_000 - 1),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a time beyond the scheduling buffer", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-15T12:00:00.000Z");
+
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["thread"],
+      snoozedUntil: new Date(Date.now() + 60_000),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects oversized provider thread IDs", () => {
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["x".repeat(513)],
+      snoozedUntil: new Date(Date.now() + 60_000),
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/utils/actions/snooze.validation.ts
+++ b/apps/web/utils/actions/snooze.validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+const MIN_SNOOZE_DELAY_MS = 60_000;
+
+export const snoozeThreadsBody = z.object({
+  threadIds: z.array(z.string().min(1).max(512)).min(1).max(100),
+  snoozedUntil: z.coerce
+    .date()
+    .refine((date) => date.getTime() >= Date.now() + MIN_SNOOZE_DELAY_MS, {
+      message: "Snooze time must be at least one minute in the future",
+    }),
+});

--- a/apps/web/utils/snooze/executor.test.ts
+++ b/apps/web/utils/snooze/executor.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import prisma from "@/utils/__mocks__/prisma";
+import { releaseSnoozedThreadForRetry } from "@/utils/snooze/scheduler";
+import { executeSnoozedThread } from "./executor";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/snooze/scheduler", () => ({
+  releaseSnoozedThreadForRetry: vi.fn(),
+}));
+
+const logger = createTestLogger();
+const snoozedThread = {
+  id: "snooze",
+  threadId: "thread",
+} as never;
+const leaseStartedAt = new Date("2026-08-16T09:30:00.000Z");
+
+describe("executeSnoozedThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("restores the thread and completes the snooze", async () => {
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      leaseStartedAt,
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+        updatedAt: leaseStartedAt,
+      },
+      data: { status: SnoozedThreadStatus.COMPLETED },
+    });
+  });
+
+  it("records a failed provider restoration", async () => {
+    const provider = createMockEmailProvider({
+      unarchiveThread: vi.fn().mockRejectedValue(new Error("offline")),
+    });
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      leaseStartedAt,
+    );
+
+    expect(result.success).toBe(false);
+    expect(releaseSnoozedThreadForRetry).toHaveBeenCalledWith(
+      "snooze",
+      leaseStartedAt,
+    );
+  });
+
+  it("leaves a restored thread claim for stale recovery when finalization fails", async () => {
+    prisma.snoozedThread.updateMany.mockRejectedValue(new Error("offline"));
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      leaseStartedAt,
+    );
+
+    expect(result.success).toBe(false);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(releaseSnoozedThreadForRetry).not.toHaveBeenCalled();
+  });
+
+  it("reports failure when another execution owns the completion claim", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      leaseStartedAt,
+    );
+
+    expect(result.success).toBe(false);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(releaseSnoozedThreadForRetry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/snooze/executor.ts
+++ b/apps/web/utils/snooze/executor.ts
@@ -1,0 +1,47 @@
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import type { SnoozedThread } from "@/generated/prisma/client";
+import type { EmailProvider } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { releaseSnoozedThreadForRetry } from "@/utils/snooze/scheduler";
+
+export async function executeSnoozedThread(
+  snoozedThread: SnoozedThread,
+  provider: EmailProvider,
+  logger: Logger,
+  leaseStartedAt: Date,
+) {
+  try {
+    await provider.unarchiveThread(snoozedThread.threadId);
+  } catch (error) {
+    await releaseSnoozedThreadForRetry(snoozedThread.id, leaseStartedAt);
+    logger.error("Failed to restore snoozed thread", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return { success: false as const, error };
+  }
+
+  try {
+    const completed = await prisma.snoozedThread.updateMany({
+      where: {
+        id: snoozedThread.id,
+        status: SnoozedThreadStatus.EXECUTING,
+        updatedAt: leaseStartedAt,
+      },
+      data: { status: SnoozedThreadStatus.COMPLETED },
+    });
+    if (completed.count !== 1) {
+      throw new Error("Snoozed thread execution claim was lost");
+    }
+    return { success: true as const };
+  } catch (error) {
+    // Keep EXECUTING so a quick duplicate cannot repeat the provider call.
+    // Stale execution recovery will retry and reconcile this record later.
+    logger.error("Restored snoozed thread but failed to record completion", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return { success: false as const, error };
+  }
+}

--- a/apps/web/utils/snooze/process-due.test.ts
+++ b/apps/web/utils/snooze/process-due.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
-import { SnoozedThreadStatus } from "@/generated/prisma/enums";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import prisma from "@/utils/__mocks__/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -52,29 +51,6 @@ describe("processDueSnoozedThreads", () => {
       expect.anything(),
       leaseStartedAt,
     );
-  });
-
-  it("fails records whose email provider no longer exists", async () => {
-    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
-    prisma.snoozedThread.findMany.mockResolvedValue([
-      {
-        id: "snooze",
-        emailAccountId: "account",
-        emailAccount: null,
-      },
-    ] as never);
-
-    const result = await processDueSnoozedThreads(logger);
-
-    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
-    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
-      where: {
-        id: "snooze",
-        status: SnoozedThreadStatus.EXECUTING,
-        updatedAt: leaseStartedAt,
-      },
-      data: { status: SnoozedThreadStatus.FAILED },
-    });
   });
 
   it("skips work claimed by another worker", async () => {

--- a/apps/web/utils/snooze/process-due.test.ts
+++ b/apps/web/utils/snooze/process-due.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import prisma from "@/utils/__mocks__/prisma";
+import { createEmailProvider } from "@/utils/email/provider";
+import { executeSnoozedThread } from "@/utils/snooze/executor";
+import {
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+} from "@/utils/snooze/scheduler";
+import { processDueSnoozedThreads } from "./process-due";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({ createEmailProvider: vi.fn() }));
+vi.mock("@/utils/snooze/executor", () => ({
+  executeSnoozedThread: vi.fn(),
+}));
+vi.mock("@/utils/snooze/scheduler", () => ({
+  markSnoozedThreadAsExecuting: vi.fn(),
+  releaseSnoozedThreadForRetry: vi.fn(),
+  SNOOZE_EXECUTION_LEASE_MS: 15 * 60 * 1000,
+}));
+
+const logger = createTestLogger();
+const leaseStartedAt = new Date("2026-08-16T09:30:00.000Z");
+
+describe("processDueSnoozedThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(markSnoozedThreadAsExecuting).mockResolvedValue(leaseStartedAt);
+    vi.mocked(createEmailProvider).mockResolvedValue(createMockEmailProvider());
+    vi.mocked(executeSnoozedThread).mockResolvedValue({ success: true });
+  });
+
+  it("restores due pending threads", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 1, failed: 0, skipped: 0, total: 1 });
+    expect(markSnoozedThreadAsExecuting).toHaveBeenCalledWith("snooze");
+    expect(executeSnoozedThread).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "snooze" }),
+      expect.anything(),
+      expect.anything(),
+      leaseStartedAt,
+    );
+  });
+
+  it("fails records whose email provider no longer exists", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: null,
+      },
+    ] as never);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+        updatedAt: leaseStartedAt,
+      },
+      data: { status: SnoozedThreadStatus.FAILED },
+    });
+  });
+
+  it("skips work claimed by another worker", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(markSnoozedThreadAsExecuting).mockResolvedValue(null);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 0, skipped: 1, total: 1 });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+    expect(executeSnoozedThread).not.toHaveBeenCalled();
+  });
+
+  it("counts provider restoration failures", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(executeSnoozedThread).mockResolvedValue({
+      success: false,
+      error: new Error("offline"),
+    });
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+  });
+
+  it("releases a claim when provider creation throws", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(createEmailProvider).mockRejectedValue(new Error("offline"));
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+    expect(releaseSnoozedThreadForRetry).toHaveBeenCalledWith(
+      "snooze",
+      leaseStartedAt,
+    );
+  });
+});

--- a/apps/web/utils/snooze/process-due.ts
+++ b/apps/web/utils/snooze/process-due.ts
@@ -21,7 +21,7 @@ type SnoozedThreadWithAccount = Prisma.SnoozedThreadGetPayload<{
 export type SnoozedThreadProcessResult =
   | { status: "processed" }
   | { status: "skipped" }
-  | { status: "failed"; reason: "missing-provider" | "restore" };
+  | { status: "failed"; reason: "restore" };
 
 export async function processDueSnoozedThreads(logger: Logger) {
   const now = new Date();
@@ -81,25 +81,10 @@ export async function processSnoozedThread(
     return { status: "skipped" };
   }
 
-  const providerType = snoozedThread.emailAccount?.account?.provider;
-  if (!providerType) {
-    const failed = await prisma.snoozedThread.updateMany({
-      where: {
-        id: snoozedThread.id,
-        status: SnoozedThreadStatus.EXECUTING,
-        updatedAt: leaseStartedAt,
-      },
-      data: { status: SnoozedThreadStatus.FAILED },
-    });
-    return failed.count === 1
-      ? { status: "failed", reason: "missing-provider" }
-      : { status: "skipped" };
-  }
-
   try {
     const provider = await createEmailProvider({
       emailAccountId: snoozedThread.emailAccountId,
-      provider: providerType,
+      provider: snoozedThread.emailAccount.account.provider,
       logger: itemLogger,
     });
     const result = await executeSnoozedThread(

--- a/apps/web/utils/snooze/process-due.ts
+++ b/apps/web/utils/snooze/process-due.ts
@@ -1,0 +1,119 @@
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import type { Prisma } from "@/generated/prisma/client";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { mapWithConcurrency } from "@/utils/async";
+import { executeSnoozedThread } from "@/utils/snooze/executor";
+import {
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+  SNOOZE_EXECUTION_LEASE_MS,
+} from "@/utils/snooze/scheduler";
+
+const BATCH_SIZE = 100;
+const RESTORE_CONCURRENCY = 10;
+
+type SnoozedThreadWithAccount = Prisma.SnoozedThreadGetPayload<{
+  include: { emailAccount: { include: { account: true } } };
+}>;
+
+export type SnoozedThreadProcessResult =
+  | { status: "processed" }
+  | { status: "skipped" }
+  | { status: "failed"; reason: "missing-provider" | "restore" };
+
+export async function processDueSnoozedThreads(logger: Logger) {
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - SNOOZE_EXECUTION_LEASE_MS);
+  const snoozedThreads = await prisma.snoozedThread.findMany({
+    where: {
+      scheduledFor: { lte: now },
+      OR: [
+        { status: SnoozedThreadStatus.PENDING },
+        {
+          status: SnoozedThreadStatus.EXECUTING,
+          updatedAt: { lte: staleBefore },
+        },
+      ],
+    },
+    orderBy: { scheduledFor: "asc" },
+    take: BATCH_SIZE,
+    include: {
+      emailAccount: { include: { account: true } },
+    },
+  });
+
+  const results = await mapWithConcurrency(
+    snoozedThreads,
+    RESTORE_CONCURRENCY,
+    async (snoozedThread) => {
+      try {
+        return await processSnoozedThread(snoozedThread, logger);
+      } catch (error) {
+        logger.error("Failed to process snoozed thread", {
+          error,
+          snoozedThreadId: snoozedThread.id,
+        });
+        return { status: "failed", reason: "restore" } as const;
+      }
+    },
+  );
+
+  return {
+    processed: results.filter((result) => result.status === "processed").length,
+    failed: results.filter((result) => result.status === "failed").length,
+    skipped: results.filter((result) => result.status === "skipped").length,
+    total: snoozedThreads.length,
+  };
+}
+
+export async function processSnoozedThread(
+  snoozedThread: SnoozedThreadWithAccount,
+  logger: Logger,
+): Promise<SnoozedThreadProcessResult> {
+  const itemLogger = logger.with({
+    emailAccountId: snoozedThread.emailAccountId,
+    snoozedThreadId: snoozedThread.id,
+  });
+  const leaseStartedAt = await markSnoozedThreadAsExecuting(snoozedThread.id);
+  if (!leaseStartedAt) {
+    return { status: "skipped" };
+  }
+
+  const providerType = snoozedThread.emailAccount?.account?.provider;
+  if (!providerType) {
+    const failed = await prisma.snoozedThread.updateMany({
+      where: {
+        id: snoozedThread.id,
+        status: SnoozedThreadStatus.EXECUTING,
+        updatedAt: leaseStartedAt,
+      },
+      data: { status: SnoozedThreadStatus.FAILED },
+    });
+    return failed.count === 1
+      ? { status: "failed", reason: "missing-provider" }
+      : { status: "skipped" };
+  }
+
+  try {
+    const provider = await createEmailProvider({
+      emailAccountId: snoozedThread.emailAccountId,
+      provider: providerType,
+      logger: itemLogger,
+    });
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      itemLogger,
+      leaseStartedAt,
+    );
+    return result.success
+      ? { status: "processed" }
+      : { status: "failed", reason: "restore" };
+  } catch (error) {
+    await releaseSnoozedThreadForRetry(snoozedThread.id, leaseStartedAt);
+    itemLogger.error("Failed to process snoozed thread", { error });
+    return { status: "failed", reason: "restore" };
+  }
+}

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SnoozedThreadStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
-  cancelSnoozedThread,
   markSnoozedThreadAsExecuting,
   releaseSnoozedThreadForRetry,
   scheduleSnoozedThread,
@@ -67,7 +66,10 @@ describe("snoozed thread scheduler", () => {
       where: {
         id: "snooze",
         OR: [
-          { status: SnoozedThreadStatus.PENDING },
+          {
+            status: SnoozedThreadStatus.PENDING,
+            scheduledFor: { lte: now },
+          },
           {
             status: SnoozedThreadStatus.EXECUTING,
             updatedAt: { lte: expect.any(Date) },
@@ -96,23 +98,6 @@ describe("snoozed thread scheduler", () => {
         }),
       }),
     );
-  });
-
-  it("cancels pending work in the database", async () => {
-    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
-
-    expect(await cancelSnoozedThread("snooze")).toBe(true);
-
-    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
-      where: { id: "snooze", status: SnoozedThreadStatus.PENDING },
-      data: { status: SnoozedThreadStatus.CANCELLED },
-    });
-  });
-
-  it("does not cancel work that another worker already claimed", async () => {
-    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
-
-    expect(await cancelSnoozedThread("snooze")).toBe(false);
   });
 
   it("replaces pending snoozes and creates the new restore atomically", async () => {
@@ -144,8 +129,9 @@ describe("snoozed thread scheduler", () => {
 
   it("releases claimed work for a later retry", async () => {
     const leaseStartedAt = new Date("2026-08-16T09:30:00.000Z");
+    const failedAt = new Date("2026-08-16T09:31:00.000Z");
 
-    await releaseSnoozedThreadForRetry("snooze", leaseStartedAt);
+    await releaseSnoozedThreadForRetry("snooze", leaseStartedAt, failedAt);
 
     expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
       where: {
@@ -153,7 +139,10 @@ describe("snoozed thread scheduler", () => {
         status: SnoozedThreadStatus.EXECUTING,
         updatedAt: leaseStartedAt,
       },
-      data: { status: SnoozedThreadStatus.PENDING },
+      data: {
+        scheduledFor: new Date("2026-08-16T09:36:00.000Z"),
+        status: SnoozedThreadStatus.PENDING,
+      },
     });
   });
 

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -7,7 +7,8 @@ import {
   scheduleSnoozedThread,
 } from "./scheduler";
 
-const { env, publishJSON } = vi.hoisted(() => ({
+const { cancelMessages, env, publishJSON } = vi.hoisted(() => ({
+  cancelMessages: vi.fn(),
   env: {
     CRON_SECRET: "cron-secret",
     INTERNAL_API_URL: "https://inbox-zero.test",
@@ -21,6 +22,7 @@ vi.mock("@/utils/prisma");
 vi.mock("@/env", () => ({ env }));
 vi.mock("@upstash/qstash", () => ({
   Client: class {
+    messages = { cancel: cancelMessages };
     publishJSON = publishJSON;
   },
 }));
@@ -29,6 +31,9 @@ describe("snoozed thread scheduler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     env.QSTASH_TOKEN = "";
+    cancelMessages.mockResolvedValue({ cancelled: 1 });
+    prisma.snoozedThread.count.mockResolvedValue(1);
+    prisma.snoozedThread.findMany.mockResolvedValue([]);
     prisma.$transaction.mockImplementation(async (operations) =>
       Promise.all(operations as Promise<unknown>[]),
     );
@@ -101,9 +106,13 @@ describe("snoozed thread scheduler", () => {
   });
 
   it("replaces pending snoozes and creates the new restore atomically", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const replacedSnoozes = [{ id: "old-snooze" }];
     const newSnooze = { id: "new-snooze" } as never;
+    prisma.snoozedThread.findMany.mockResolvedValue(replacedSnoozes as never);
     prisma.snoozedThread.updateMany.mockResolvedValue({ count: 2 });
     prisma.snoozedThread.create.mockResolvedValue(newSnooze);
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
     const scheduledFor = new Date("2026-08-17T09:00:00.000Z");
 
     const result = await scheduleSnoozedThread({
@@ -113,6 +122,14 @@ describe("snoozed thread scheduler", () => {
     });
 
     expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.snoozedThread.findMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account",
+        threadId: "thread",
+        status: SnoozedThreadStatus.PENDING,
+      },
+      select: { id: true },
+    });
     expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
       where: {
         emailAccountId: "account",
@@ -124,6 +141,12 @@ describe("snoozed thread scheduler", () => {
     expect(prisma.snoozedThread.create).toHaveBeenCalledWith({
       data: { emailAccountId: "account", scheduledFor, threadId: "thread" },
     });
+    expect(cancelMessages).toHaveBeenCalledWith({
+      filter: { label: ["snoozed-thread-old-snooze"] },
+    });
+    expect(prisma.$transaction.mock.invocationCallOrder[0]).toBeLessThan(
+      cancelMessages.mock.invocationCallOrder[0],
+    );
     expect(result).toBe(newSnooze);
   });
 
@@ -167,8 +190,50 @@ describe("snoozed thread scheduler", () => {
       deduplicationId: "snoozed-thread-snooze",
       contentBasedDeduplication: false,
       headers: new Headers({ authorization: "Bearer cron-secret" }),
+      label: "snoozed-thread-snooze",
     });
     expect(result).toBe(record);
+  });
+
+  it("cancels a published delivery when the snooze was replaced concurrently", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "snooze" } as never;
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    prisma.snoozedThread.count.mockResolvedValue(0);
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(cancelMessages).toHaveBeenCalledWith({
+      filter: { label: ["snoozed-thread-snooze"] },
+    });
+  });
+
+  it("publishes the replacement when cancelling the old delivery fails", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "new-snooze" } as never;
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      { id: "old-snooze" },
+    ] as never);
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    cancelMessages.mockRejectedValue(new Error("offline"));
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    await expect(
+      scheduleSnoozedThread({
+        emailAccountId: "account",
+        scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+        threadId: "thread",
+      }),
+    ).resolves.toBe(record);
+
+    expect(publishJSON).toHaveBeenCalledOnce();
   });
 
   it("keeps the cron fallback when QStash publishing fails", async () => {

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  cancelSnoozedThread,
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+  scheduleSnoozedThread,
+} from "./scheduler";
+
+const { env, publishJSON } = vi.hoisted(() => ({
+  env: {
+    CRON_SECRET: "cron-secret",
+    INTERNAL_API_URL: "https://inbox-zero.test",
+    NEXT_PUBLIC_BASE_URL: "https://inbox-zero.test",
+    QSTASH_TOKEN: "",
+  },
+  publishJSON: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+vi.mock("@/env", () => ({ env }));
+vi.mock("@upstash/qstash", () => ({
+  Client: class {
+    publishJSON = publishJSON;
+  },
+}));
+
+describe("snoozed thread scheduler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env.QSTASH_TOKEN = "";
+    prisma.$transaction.mockImplementation(async (operations) =>
+      Promise.all(operations as Promise<unknown>[]),
+    );
+  });
+
+  it("persists work for the cron fallback", async () => {
+    const record = { id: "snooze" } as never;
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    const scheduledFor = new Date("2026-08-16T09:00:00.000Z");
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor,
+      threadId: "thread",
+    });
+
+    expect(result).toBe(record);
+    expect(prisma.snoozedThread.create).toHaveBeenCalledWith({
+      data: { emailAccountId: "account", scheduledFor, threadId: "thread" },
+    });
+    expect(publishJSON).not.toHaveBeenCalled();
+  });
+
+  it("claims pending work only once", async () => {
+    prisma.snoozedThread.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+    const now = new Date("2026-08-16T09:30:00.000Z");
+
+    expect(await markSnoozedThreadAsExecuting("snooze", now)).toBe(now);
+    expect(await markSnoozedThreadAsExecuting("snooze", now)).toBeNull();
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "snooze",
+        OR: [
+          { status: SnoozedThreadStatus.PENDING },
+          {
+            status: SnoozedThreadStatus.EXECUTING,
+            updatedAt: { lte: expect.any(Date) },
+          },
+        ],
+      },
+      data: { status: SnoozedThreadStatus.EXECUTING, updatedAt: now },
+    });
+  });
+
+  it("reclaims an execution after its lease becomes stale", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    const now = new Date("2026-08-16T09:30:00.000Z");
+
+    expect(await markSnoozedThreadAsExecuting("snooze", now)).toBe(now);
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            {
+              status: SnoozedThreadStatus.EXECUTING,
+              updatedAt: { lte: new Date("2026-08-16T09:15:00.000Z") },
+            },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("cancels pending work in the database", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+
+    expect(await cancelSnoozedThread("snooze")).toBe(true);
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: { id: "snooze", status: SnoozedThreadStatus.PENDING },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+    });
+  });
+
+  it("does not cancel work that another worker already claimed", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+
+    expect(await cancelSnoozedThread("snooze")).toBe(false);
+  });
+
+  it("replaces pending snoozes and creates the new restore atomically", async () => {
+    const newSnooze = { id: "new-snooze" } as never;
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 2 });
+    prisma.snoozedThread.create.mockResolvedValue(newSnooze);
+    const scheduledFor = new Date("2026-08-17T09:00:00.000Z");
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor,
+      threadId: "thread",
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account",
+        threadId: "thread",
+        status: SnoozedThreadStatus.PENDING,
+      },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+    });
+    expect(prisma.snoozedThread.create).toHaveBeenCalledWith({
+      data: { emailAccountId: "account", scheduledFor, threadId: "thread" },
+    });
+    expect(result).toBe(newSnooze);
+  });
+
+  it("releases claimed work for a later retry", async () => {
+    const leaseStartedAt = new Date("2026-08-16T09:30:00.000Z");
+
+    await releaseSnoozedThreadForRetry("snooze", leaseStartedAt);
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+        updatedAt: leaseStartedAt,
+      },
+      data: { status: SnoozedThreadStatus.PENDING },
+    });
+  });
+
+  it("publishes precise delivery through QStash", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const scheduledFor = new Date("2026-08-17T09:00:00.000Z");
+    const record = { id: "snooze" } as never;
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor,
+      threadId: "thread",
+    });
+
+    expect(publishJSON).toHaveBeenCalledWith({
+      url: "https://inbox-zero.test/api/snoozed-threads/execute",
+      body: { snoozedThreadId: "snooze" },
+      notBefore: Math.ceil(scheduledFor.getTime() / 1000),
+      deduplicationId: "snoozed-thread-snooze",
+      contentBasedDeduplication: false,
+      headers: new Headers({ authorization: "Bearer cron-secret" }),
+    });
+    expect(result).toBe(record);
+  });
+
+  it("keeps the cron fallback when QStash publishing fails", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "snooze" } as never;
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    publishJSON.mockRejectedValue(new Error("offline"));
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(publishJSON).toHaveBeenCalledOnce();
+    expect(result).toBe(record);
+  });
+});

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -1,0 +1,109 @@
+import { Client } from "@upstash/qstash";
+import { env } from "@/env";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { getCronSecretHeader } from "@/utils/cron";
+import { getInternalApiUrl } from "@/utils/internal-api";
+import { createScopedLogger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+const logger = createScopedLogger("snoozed-threads");
+export const SNOOZE_EXECUTION_LEASE_MS = 15 * 60 * 1000;
+
+export async function scheduleSnoozedThread({
+  emailAccountId,
+  scheduledFor,
+  threadId,
+}: {
+  emailAccountId: string;
+  scheduledFor: Date;
+  threadId: string;
+}) {
+  const [, snoozedThread] = await prisma.$transaction([
+    prisma.snoozedThread.updateMany({
+      where: {
+        emailAccountId,
+        threadId,
+        status: SnoozedThreadStatus.PENDING,
+      },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+    }),
+    prisma.snoozedThread.create({
+      data: { emailAccountId, scheduledFor, threadId },
+    }),
+  ]);
+
+  const client = getQstashClient();
+  if (!client) {
+    logger.info("QStash unavailable; snoozed thread will use cron fallback", {
+      snoozedThreadId: snoozedThread.id,
+      scheduledFor,
+    });
+    return snoozedThread;
+  }
+
+  try {
+    await client.publishJSON({
+      url: `${getInternalApiUrl()}/api/snoozed-threads/execute`,
+      body: { snoozedThreadId: snoozedThread.id },
+      notBefore: Math.ceil(scheduledFor.getTime() / 1000),
+      deduplicationId: `snoozed-thread-${snoozedThread.id}`,
+      contentBasedDeduplication: false,
+      headers: getCronSecretHeader(),
+    });
+  } catch (error) {
+    logger.error("QStash scheduling failed; using cron fallback", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+  }
+
+  return snoozedThread;
+}
+
+export async function cancelSnoozedThread(id: string) {
+  const cancelled = await prisma.snoozedThread.updateMany({
+    where: { id, status: SnoozedThreadStatus.PENDING },
+    data: { status: SnoozedThreadStatus.CANCELLED },
+  });
+  return cancelled.count === 1;
+}
+
+export async function markSnoozedThreadAsExecuting(
+  id: string,
+  now = new Date(),
+) {
+  const staleBefore = new Date(now.getTime() - SNOOZE_EXECUTION_LEASE_MS);
+  const updated = await prisma.snoozedThread.updateMany({
+    where: {
+      id,
+      OR: [
+        { status: SnoozedThreadStatus.PENDING },
+        {
+          status: SnoozedThreadStatus.EXECUTING,
+          updatedAt: { lte: staleBefore },
+        },
+      ],
+    },
+    data: { status: SnoozedThreadStatus.EXECUTING, updatedAt: now },
+  });
+  return updated.count === 1 ? now : null;
+}
+
+export async function releaseSnoozedThreadForRetry(
+  id: string,
+  leaseStartedAt: Date,
+) {
+  await prisma.snoozedThread.updateMany({
+    where: {
+      id,
+      status: SnoozedThreadStatus.EXECUTING,
+      updatedAt: leaseStartedAt,
+    },
+    data: { status: SnoozedThreadStatus.PENDING },
+  });
+}
+
+function getQstashClient() {
+  if (!env.QSTASH_TOKEN) return null;
+  return new Client({ token: env.QSTASH_TOKEN });
+}

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -8,6 +8,7 @@ import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("snoozed-threads");
 export const SNOOZE_EXECUTION_LEASE_MS = 15 * 60 * 1000;
+const SNOOZE_RETRY_DELAY_MS = 5 * 60 * 1000;
 
 export async function scheduleSnoozedThread({
   emailAccountId,
@@ -60,14 +61,6 @@ export async function scheduleSnoozedThread({
   return snoozedThread;
 }
 
-export async function cancelSnoozedThread(id: string) {
-  const cancelled = await prisma.snoozedThread.updateMany({
-    where: { id, status: SnoozedThreadStatus.PENDING },
-    data: { status: SnoozedThreadStatus.CANCELLED },
-  });
-  return cancelled.count === 1;
-}
-
 export async function markSnoozedThreadAsExecuting(
   id: string,
   now = new Date(),
@@ -77,7 +70,10 @@ export async function markSnoozedThreadAsExecuting(
     where: {
       id,
       OR: [
-        { status: SnoozedThreadStatus.PENDING },
+        {
+          status: SnoozedThreadStatus.PENDING,
+          scheduledFor: { lte: now },
+        },
         {
           status: SnoozedThreadStatus.EXECUTING,
           updatedAt: { lte: staleBefore },
@@ -92,6 +88,7 @@ export async function markSnoozedThreadAsExecuting(
 export async function releaseSnoozedThreadForRetry(
   id: string,
   leaseStartedAt: Date,
+  now = new Date(),
 ) {
   await prisma.snoozedThread.updateMany({
     where: {
@@ -99,7 +96,10 @@ export async function releaseSnoozedThreadForRetry(
       status: SnoozedThreadStatus.EXECUTING,
       updatedAt: leaseStartedAt,
     },
-    data: { status: SnoozedThreadStatus.PENDING },
+    data: {
+      scheduledFor: new Date(now.getTime() + SNOOZE_RETRY_DELAY_MS),
+      status: SnoozedThreadStatus.PENDING,
+    },
   });
 }
 

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -19,13 +19,18 @@ export async function scheduleSnoozedThread({
   scheduledFor: Date;
   threadId: string;
 }) {
-  const [, snoozedThread] = await prisma.$transaction([
+  const pendingSnooze = {
+    emailAccountId,
+    threadId,
+    status: SnoozedThreadStatus.PENDING,
+  };
+  const [replacedSnoozes, , snoozedThread] = await prisma.$transaction([
+    prisma.snoozedThread.findMany({
+      where: pendingSnooze,
+      select: { id: true },
+    }),
     prisma.snoozedThread.updateMany({
-      where: {
-        emailAccountId,
-        threadId,
-        status: SnoozedThreadStatus.PENDING,
-      },
+      where: pendingSnooze,
       data: { status: SnoozedThreadStatus.CANCELLED },
     }),
     prisma.snoozedThread.create({
@@ -42,17 +47,41 @@ export async function scheduleSnoozedThread({
     return snoozedThread;
   }
 
+  await cancelQstashMessages(
+    client,
+    replacedSnoozes.map(({ id }) => id),
+  );
+
+  const schedulerLabel = getSchedulerLabel(snoozedThread.id);
   try {
     await client.publishJSON({
       url: `${getInternalApiUrl()}/api/snoozed-threads/execute`,
       body: { snoozedThreadId: snoozedThread.id },
       notBefore: Math.ceil(scheduledFor.getTime() / 1000),
-      deduplicationId: `snoozed-thread-${snoozedThread.id}`,
+      deduplicationId: schedulerLabel,
       contentBasedDeduplication: false,
       headers: getCronSecretHeader(),
+      label: schedulerLabel,
     });
   } catch (error) {
     logger.error("QStash scheduling failed; using cron fallback", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+  }
+
+  try {
+    const isStillPending = await prisma.snoozedThread.count({
+      where: {
+        id: snoozedThread.id,
+        status: SnoozedThreadStatus.PENDING,
+      },
+    });
+    if (!isStillPending) {
+      await cancelQstashMessages(client, [snoozedThread.id]);
+    }
+  } catch (error) {
+    logger.warn("Failed to reconcile snoozed thread scheduling", {
       error,
       snoozedThreadId: snoozedThread.id,
     });
@@ -106,4 +135,32 @@ export async function releaseSnoozedThreadForRetry(
 function getQstashClient() {
   if (!env.QSTASH_TOKEN) return null;
   return new Client({ token: env.QSTASH_TOKEN });
+}
+
+async function cancelQstashMessages(
+  client: InstanceType<typeof Client>,
+  snoozedThreadIds: string[],
+) {
+  if (!snoozedThreadIds.length) return;
+
+  try {
+    const result = await client.messages.cancel({
+      filter: {
+        label: snoozedThreadIds.map(getSchedulerLabel),
+      },
+    });
+    logger.info("Cancelled superseded snooze deliveries", {
+      cancelled: result.cancelled,
+      snoozedThreadIds,
+    });
+  } catch (error) {
+    logger.warn("Failed to cancel superseded snooze deliveries", {
+      error,
+      snoozedThreadIds,
+    });
+  }
+}
+
+function getSchedulerLabel(snoozedThreadId: string) {
+  return `snoozed-thread-${snoozedThreadId}`;
 }

--- a/apps/web/utils/snooze/snooze.test.ts
+++ b/apps/web/utils/snooze/snooze.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import {
+  cancelSnoozedThread,
+  scheduleSnoozedThread,
+} from "@/utils/snooze/scheduler";
+import { snoozeThreads } from "./snooze";
+
+vi.mock("@/utils/snooze/scheduler", () => ({
+  cancelSnoozedThread: vi.fn(),
+  scheduleSnoozedThread: vi.fn(),
+}));
+
+const logger = createTestLogger();
+const snoozedUntil = new Date("2026-08-16T09:00:00.000Z");
+
+describe("snoozeThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(scheduleSnoozedThread).mockImplementation(
+      async ({ threadId }) =>
+        ({
+          id: `snooze-${threadId}`,
+        }) as never,
+    );
+  });
+
+  it("schedules restoration before archiving every unique thread", async () => {
+    const provider = createMockEmailProvider();
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one", "one", "two"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: [],
+      succeededThreadIds: ["one", "two"],
+    });
+    expect(scheduleSnoozedThread).toHaveBeenCalledTimes(2);
+    expect(scheduleSnoozedThread).toHaveBeenNthCalledWith(1, {
+      emailAccountId: "account",
+      scheduledFor: snoozedUntil,
+      threadId: "one",
+    });
+    expect(
+      vi.mocked(scheduleSnoozedThread).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(provider.archiveThreadWithLabel).mock.invocationCallOrder[0] ??
+        Number.POSITIVE_INFINITY,
+    );
+    expect(provider.archiveThreadWithLabel).toHaveBeenCalledWith(
+      "one",
+      "owner@example.com",
+    );
+  });
+
+  it("cancels restoration when the provider cannot archive a thread", async () => {
+    const provider = createMockEmailProvider({
+      archiveThreadWithLabel: vi
+        .fn()
+        .mockRejectedValue(new Error("provider failed")),
+    });
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: ["one"],
+      succeededThreadIds: [],
+    });
+    expect(cancelSnoozedThread).toHaveBeenCalledWith("snooze-one");
+  });
+
+  it("does not archive when restoration could not be scheduled", async () => {
+    vi.mocked(scheduleSnoozedThread).mockRejectedValue(new Error("offline"));
+    const provider = createMockEmailProvider();
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one"],
+    });
+
+    expect(result.failedThreadIds).toEqual(["one"]);
+    expect(provider.archiveThreadWithLabel).not.toHaveBeenCalled();
+  });
+
+  it("reports successful and failed threads independently", async () => {
+    const provider = createMockEmailProvider({
+      archiveThreadWithLabel: vi.fn(async (threadId: string) => {
+        if (threadId === "two") throw new Error("provider failed");
+      }),
+    });
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one", "two"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: ["two"],
+      succeededThreadIds: ["one"],
+    });
+    expect(cancelSnoozedThread).toHaveBeenCalledWith("snooze-two");
+  });
+});

--- a/apps/web/utils/snooze/snooze.test.ts
+++ b/apps/web/utils/snooze/snooze.test.ts
@@ -1,14 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
-import {
-  cancelSnoozedThread,
-  scheduleSnoozedThread,
-} from "@/utils/snooze/scheduler";
+import { scheduleSnoozedThread } from "@/utils/snooze/scheduler";
 import { snoozeThreads } from "./snooze";
 
 vi.mock("@/utils/snooze/scheduler", () => ({
-  cancelSnoozedThread: vi.fn(),
   scheduleSnoozedThread: vi.fn(),
 }));
 
@@ -60,7 +56,7 @@ describe("snoozeThreads", () => {
     );
   });
 
-  it("cancels restoration when the provider cannot archive a thread", async () => {
+  it("keeps restoration scheduled when the archive outcome is uncertain", async () => {
     const provider = createMockEmailProvider({
       archiveThreadWithLabel: vi
         .fn()
@@ -80,7 +76,7 @@ describe("snoozeThreads", () => {
       failedThreadIds: ["one"],
       succeededThreadIds: [],
     });
-    expect(cancelSnoozedThread).toHaveBeenCalledWith("snooze-one");
+    expect(scheduleSnoozedThread).toHaveBeenCalledOnce();
   });
 
   it("does not archive when restoration could not be scheduled", async () => {
@@ -120,6 +116,5 @@ describe("snoozeThreads", () => {
       failedThreadIds: ["two"],
       succeededThreadIds: ["one"],
     });
-    expect(cancelSnoozedThread).toHaveBeenCalledWith("snooze-two");
   });
 });

--- a/apps/web/utils/snooze/snooze.ts
+++ b/apps/web/utils/snooze/snooze.ts
@@ -1,10 +1,7 @@
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { mapWithConcurrency } from "@/utils/async";
-import {
-  cancelSnoozedThread,
-  scheduleSnoozedThread,
-} from "@/utils/snooze/scheduler";
+import { scheduleSnoozedThread } from "@/utils/snooze/scheduler";
 
 const SNOOZE_CONCURRENCY = 10;
 
@@ -65,16 +62,10 @@ async function snoozeThread({
   snoozedUntil: Date;
   threadId: string;
 }) {
-  const snoozedThread = await scheduleSnoozedThread({
+  await scheduleSnoozedThread({
     emailAccountId,
     scheduledFor: snoozedUntil,
     threadId,
   });
-
-  try {
-    await provider.archiveThreadWithLabel(threadId, ownerEmail);
-  } catch (error) {
-    await cancelSnoozedThread(snoozedThread.id);
-    throw error;
-  }
+  await provider.archiveThreadWithLabel(threadId, ownerEmail);
 }

--- a/apps/web/utils/snooze/snooze.ts
+++ b/apps/web/utils/snooze/snooze.ts
@@ -1,0 +1,80 @@
+import type { EmailProvider } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import { mapWithConcurrency } from "@/utils/async";
+import {
+  cancelSnoozedThread,
+  scheduleSnoozedThread,
+} from "@/utils/snooze/scheduler";
+
+const SNOOZE_CONCURRENCY = 10;
+
+export async function snoozeThreads({
+  emailAccountId,
+  logger,
+  ownerEmail,
+  provider,
+  snoozedUntil,
+  threadIds,
+}: {
+  emailAccountId: string;
+  logger: Logger;
+  ownerEmail: string;
+  provider: EmailProvider;
+  snoozedUntil: Date;
+  threadIds: string[];
+}) {
+  const uniqueThreadIds = [...new Set(threadIds)];
+  const results = await mapWithConcurrency(
+    uniqueThreadIds,
+    SNOOZE_CONCURRENCY,
+    async (threadId) => {
+      try {
+        await snoozeThread({
+          emailAccountId,
+          ownerEmail,
+          provider,
+          snoozedUntil,
+          threadId,
+        });
+        return true;
+      } catch (error) {
+        logger.error("Failed to snooze thread", { error, threadId });
+        return false;
+      }
+    },
+  );
+
+  const succeededThreadIds = uniqueThreadIds.filter(
+    (_, index) => results[index],
+  );
+  const failedThreadIds = uniqueThreadIds.filter((_, index) => !results[index]);
+
+  return { failedThreadIds, succeededThreadIds };
+}
+
+async function snoozeThread({
+  emailAccountId,
+  ownerEmail,
+  provider,
+  snoozedUntil,
+  threadId,
+}: {
+  emailAccountId: string;
+  ownerEmail: string;
+  provider: EmailProvider;
+  snoozedUntil: Date;
+  threadId: string;
+}) {
+  const snoozedThread = await scheduleSnoozedThread({
+    emailAccountId,
+    scheduledFor: snoozedUntil,
+    threadId,
+  });
+
+  try {
+    await provider.archiveThreadWithLabel(threadId, ownerEmail);
+  } catch (error) {
+    await cancelSnoozedThread(snoozedThread.id);
+    throw error;
+  }
+}

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -145,7 +145,7 @@ The bundled Compose service does **not** run the two daily cleanup endpoints. Sc
 **If you're not using Docker Compose** you need to set up cron jobs manually:
 
 ```bash
-# Scheduled actions and snooze fallback - every 15 minutes
+# Scheduled actions (without QStash) and snooze fallback (always) - every 15 minutes
 */15 * * * * curl -s -X GET "https://yourdomain.com/api/cron/scheduled-actions" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Automation jobs - every 15 minutes

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -145,7 +145,7 @@ The bundled Compose service does **not** run the two daily cleanup endpoints. Sc
 **If you're not using Docker Compose** you need to set up cron jobs manually:
 
 ```bash
-# Scheduled actions - every 15 minutes (only needed when QStash is not configured)
+# Scheduled actions and snooze fallback - every 15 minutes
 */15 * * * * curl -s -X GET "https://yourdomain.com/api/cron/scheduled-actions" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Automation jobs - every 15 minutes

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -132,7 +132,7 @@ The Docker Compose setup includes a `cron` container that handles these schedule
 
 | Task | Interval | Endpoint | Description |
 |------|----------|----------|-------------|
-| **Scheduled actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed/scheduled actions when QStash is not configured |
+| **Scheduled mail actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed actions when QStash is not configured, and restores snoozed threads |
 | **Automation jobs** | Every 15 minutes | `/api/cron/automation-jobs` | Processes due automation jobs |
 | **Email digests** | Every 30 minutes | `/api/resend/digest/all` | Sends due email digests |
 | **Email watch renewal** | Every 6 hours | `/api/watch/all` | Renews Gmail/Outlook push notification subscriptions |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
+      chrono-node:
+        specifier: 2.10.1
+        version: 2.10.1
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -7222,6 +7225,10 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chrono-node@2.10.1:
+    resolution: {integrity: sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
@@ -19535,6 +19542,8 @@ snapshots:
   chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
+
+  chrono-node@2.10.1: {}
 
   citty@0.2.2: {}
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260815-232340_pr-3277_b12471389dbd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds the complete mail snooze workflow in one reviewable PR.

- makes Command K contextual to the highlighted row or multi-selection, with single-line archive/read/snooze actions
- adds a second-level snooze picker with presets and natural-language dates
- archives through the email provider and persists a minimal snooze record
- restores through QStash in production with the existing cron fallback for self-hosted deployments
- fences duplicate workers using the record timestamp rather than extra scheduling/token fields
- covers selection, palette construction, date parsing, action behavior, scheduling, retries, and restoration

Validation: 82 focused Command K/snooze tests pass; Prisma schema validation and a fresh 239-migration deploy pass.

Follow-up: emulator-backed Playwright infrastructure and browser coverage will remain a separate stacked test PR.