### PR TITLE
feat(mail): Restore due snoozed threads

### DIFF
--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -12,6 +12,7 @@ import {
 import { markQStashActionAsExecuting } from "@/utils/scheduled-actions/scheduler";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
+import { processDueSnoozedThreads } from "@/utils/snooze/process-due";
 
 export const maxDuration = 300;
 
@@ -25,12 +26,7 @@ export const GET = withError("cron/scheduled-actions", async (request) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  if (env.QSTASH_TOKEN) {
-    request.logger.info("QStash configured, skipping cron fallback");
-    return NextResponse.json({ skipped: true, reason: "qstash-configured" });
-  }
-
-  const result = await processScheduledActions(request.logger);
+  const result = await processScheduledMail(request.logger);
 
   return NextResponse.json(result);
 });
@@ -43,12 +39,7 @@ export const POST = withError("cron/scheduled-actions", async (request) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  if (env.QSTASH_TOKEN) {
-    request.logger.info("QStash configured, skipping cron fallback");
-    return NextResponse.json({ skipped: true, reason: "qstash-configured" });
-  }
-
-  const result = await processScheduledActions(request.logger);
+  const result = await processScheduledMail(request.logger);
 
   return NextResponse.json(result);
 });
@@ -148,5 +139,24 @@ async function processScheduledActions(logger: Logger) {
     failed,
     skipped,
     total: scheduledActions.length,
+  };
+}
+
+async function processAllScheduledMail(logger: Logger) {
+  const [scheduledActions, snoozedThreads] = await Promise.all([
+    processScheduledActions(logger),
+    processDueSnoozedThreads(logger),
+  ]);
+
+  return { scheduledActions, snoozedThreads };
+}
+
+async function processScheduledMail(logger: Logger) {
+  if (!env.QSTASH_TOKEN) return processAllScheduledMail(logger);
+
+  logger.info("QStash configured; checking snoozed thread fallback");
+  return {
+    scheduledActions: { skipped: true, reason: "qstash-configured" },
+    snoozedThreads: await processDueSnoozedThreads(logger),
   };
 }

--- a/apps/web/app/api/snoozed-threads/execute/route.ts
+++ b/apps/web/app/api/snoozed-threads/execute/route.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { withError } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { withQstashOrInternal } from "@/utils/qstash";
+import { processSnoozedThread } from "@/utils/snooze/process-due";
+
+export const maxDuration = 300;
+
+const bodySchema = z.object({ snoozedThreadId: z.string().min(1) });
+
+export const POST = withError(
+  "snoozed-threads/execute",
+  withQstashOrInternal(async (request) => {
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return new Response("Invalid payload structure", { status: 400 });
+    }
+
+    const snoozedThread = await prisma.snoozedThread.findUnique({
+      where: { id: parsed.data.snoozedThreadId },
+      include: { emailAccount: { include: { account: true } } },
+    });
+    if (!snoozedThread) {
+      return new Response("Snoozed thread not found", { status: 404 });
+    }
+    if (
+      snoozedThread.status !== SnoozedThreadStatus.PENDING &&
+      snoozedThread.status !== SnoozedThreadStatus.EXECUTING
+    ) {
+      return new Response("Snoozed thread is no longer active", {
+        status: 200,
+      });
+    }
+
+    const result = await processSnoozedThread(snoozedThread, request.logger);
+    if (result.status === "skipped") {
+      return new Response("Snoozed thread is already being processed", {
+        status: 503,
+      });
+    }
+    if (result.status === "failed") {
+      return new Response(
+        result.reason === "missing-provider"
+          ? "Email account or provider missing"
+          : "Failed to restore snoozed thread",
+        { status: 500 },
+      );
+    }
+
+    return new Response("Snoozed thread restored", { status: 200 });
+  }),
+);

--- a/apps/web/utils/snooze/executor.test.ts
+++ b/apps/web/utils/snooze/executor.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import prisma from "@/utils/__mocks__/prisma";
+import { releaseSnoozedThreadForRetry } from "@/utils/snooze/scheduler";
+import { executeSnoozedThread } from "./executor";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/snooze/scheduler", () => ({
+  releaseSnoozedThreadForRetry: vi.fn(),
+}));
+
+const logger = createTestLogger();
+const snoozedThread = {
+  id: "snooze",
+  threadId: "thread",
+} as never;
+
+describe("executeSnoozedThread", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("restores the thread and completes the snooze", async () => {
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      "claim-token",
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        executionToken: "claim-token",
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+      data: {
+        executionToken: null,
+        executedAt: expect.any(Date),
+        status: SnoozedThreadStatus.COMPLETED,
+      },
+    });
+  });
+
+  it("records a failed provider restoration", async () => {
+    const provider = createMockEmailProvider({
+      unarchiveThread: vi.fn().mockRejectedValue(new Error("offline")),
+    });
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      "claim-token",
+    );
+
+    expect(result.success).toBe(false);
+    expect(releaseSnoozedThreadForRetry).toHaveBeenCalledWith(
+      "snooze",
+      "claim-token",
+    );
+  });
+
+  it("leaves a restored thread claim for stale recovery when finalization fails", async () => {
+    prisma.snoozedThread.updateMany.mockRejectedValue(new Error("offline"));
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      "claim-token",
+    );
+
+    expect(result.success).toBe(false);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(releaseSnoozedThreadForRetry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/snooze/executor.test.ts
+++ b/apps/web/utils/snooze/executor.test.ts
@@ -18,7 +18,10 @@ const snoozedThread = {
 } as never;
 
 describe("executeSnoozedThread", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+  });
 
   it("restores the thread and completes the snooze", async () => {
     const provider = createMockEmailProvider();
@@ -67,6 +70,22 @@ describe("executeSnoozedThread", () => {
 
   it("leaves a restored thread claim for stale recovery when finalization fails", async () => {
     prisma.snoozedThread.updateMany.mockRejectedValue(new Error("offline"));
+    const provider = createMockEmailProvider();
+
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      logger,
+      "claim-token",
+    );
+
+    expect(result.success).toBe(false);
+    expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+    expect(releaseSnoozedThreadForRetry).not.toHaveBeenCalled();
+  });
+
+  it("reports failure when another execution owns the completion claim", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
     const provider = createMockEmailProvider();
 
     const result = await executeSnoozedThread(

--- a/apps/web/utils/snooze/executor.ts
+++ b/apps/web/utils/snooze/executor.ts
@@ -23,7 +23,7 @@ export async function executeSnoozedThread(
   }
 
   try {
-    await prisma.snoozedThread.updateMany({
+    const completed = await prisma.snoozedThread.updateMany({
       where: {
         id: snoozedThread.id,
         executionToken,
@@ -35,6 +35,9 @@ export async function executeSnoozedThread(
         status: SnoozedThreadStatus.COMPLETED,
       },
     });
+    if (completed.count !== 1) {
+      throw new Error("Snoozed thread execution claim was lost");
+    }
     return { success: true as const };
   } catch (error) {
     // Keep EXECUTING so a quick duplicate cannot repeat the provider call.

--- a/apps/web/utils/snooze/executor.ts
+++ b/apps/web/utils/snooze/executor.ts
@@ -1,0 +1,48 @@
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import type { SnoozedThread } from "@/generated/prisma/client";
+import type { EmailProvider } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { releaseSnoozedThreadForRetry } from "@/utils/snooze/scheduler";
+
+export async function executeSnoozedThread(
+  snoozedThread: SnoozedThread,
+  provider: EmailProvider,
+  logger: Logger,
+  executionToken: string,
+) {
+  try {
+    await provider.unarchiveThread(snoozedThread.threadId);
+  } catch (error) {
+    await releaseSnoozedThreadForRetry(snoozedThread.id, executionToken);
+    logger.error("Failed to restore snoozed thread", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return { success: false as const, error };
+  }
+
+  try {
+    await prisma.snoozedThread.updateMany({
+      where: {
+        id: snoozedThread.id,
+        executionToken,
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+      data: {
+        executionToken: null,
+        executedAt: new Date(),
+        status: SnoozedThreadStatus.COMPLETED,
+      },
+    });
+    return { success: true as const };
+  } catch (error) {
+    // Keep EXECUTING so a quick duplicate cannot repeat the provider call.
+    // Stale execution recovery will retry and reconcile this record later.
+    logger.error("Restored snoozed thread but failed to record completion", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return { success: false as const, error };
+  }
+}

--- a/apps/web/utils/snooze/process-due.test.ts
+++ b/apps/web/utils/snooze/process-due.test.ts
@@ -54,6 +54,7 @@ describe("processDueSnoozedThreads", () => {
   });
 
   it("fails records whose email provider no longer exists", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
     prisma.snoozedThread.findMany.mockResolvedValue([
       {
         id: "snooze",
@@ -65,9 +66,16 @@ describe("processDueSnoozedThreads", () => {
     const result = await processDueSnoozedThreads(logger);
 
     expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
-    expect(prisma.snoozedThread.update).toHaveBeenCalledWith({
-      where: { id: "snooze" },
-      data: { status: SnoozedThreadStatus.FAILED },
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        executionToken: "claim-token",
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+      data: {
+        executionToken: null,
+        status: SnoozedThreadStatus.FAILED,
+      },
     });
   });
 

--- a/apps/web/utils/snooze/process-due.test.ts
+++ b/apps/web/utils/snooze/process-due.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import prisma from "@/utils/__mocks__/prisma";
+import { createEmailProvider } from "@/utils/email/provider";
+import { executeSnoozedThread } from "@/utils/snooze/executor";
+import {
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+} from "@/utils/snooze/scheduler";
+import { processDueSnoozedThreads } from "./process-due";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({ createEmailProvider: vi.fn() }));
+vi.mock("@/utils/snooze/executor", () => ({
+  executeSnoozedThread: vi.fn(),
+}));
+vi.mock("@/utils/snooze/scheduler", () => ({
+  markSnoozedThreadAsExecuting: vi.fn(),
+  releaseSnoozedThreadForRetry: vi.fn(),
+  SNOOZE_EXECUTION_LEASE_MS: 15 * 60 * 1000,
+}));
+
+const logger = createTestLogger();
+
+describe("processDueSnoozedThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(markSnoozedThreadAsExecuting).mockResolvedValue("claim-token");
+    vi.mocked(createEmailProvider).mockResolvedValue(createMockEmailProvider());
+    vi.mocked(executeSnoozedThread).mockResolvedValue({ success: true });
+  });
+
+  it("restores due pending threads", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 1, failed: 0, skipped: 0, total: 1 });
+    expect(markSnoozedThreadAsExecuting).toHaveBeenCalledWith("snooze");
+    expect(executeSnoozedThread).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "snooze" }),
+      expect.anything(),
+      expect.anything(),
+      "claim-token",
+    );
+  });
+
+  it("fails records whose email provider no longer exists", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: null,
+      },
+    ] as never);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+    expect(prisma.snoozedThread.update).toHaveBeenCalledWith({
+      where: { id: "snooze" },
+      data: { status: SnoozedThreadStatus.FAILED },
+    });
+  });
+
+  it("skips work claimed by another worker", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(markSnoozedThreadAsExecuting).mockResolvedValue(null);
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 0, skipped: 1, total: 1 });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+    expect(executeSnoozedThread).not.toHaveBeenCalled();
+  });
+
+  it("counts provider restoration failures", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(executeSnoozedThread).mockResolvedValue({
+      success: false,
+      error: new Error("offline"),
+    });
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+  });
+
+  it("releases a claim when provider creation throws", async () => {
+    prisma.snoozedThread.findMany.mockResolvedValue([
+      {
+        id: "snooze",
+        emailAccountId: "account",
+        emailAccount: { account: { provider: "google" } },
+      },
+    ] as never);
+    vi.mocked(createEmailProvider).mockRejectedValue(new Error("offline"));
+
+    const result = await processDueSnoozedThreads(logger);
+
+    expect(result).toEqual({ processed: 0, failed: 1, skipped: 0, total: 1 });
+    expect(releaseSnoozedThreadForRetry).toHaveBeenCalledWith(
+      "snooze",
+      "claim-token",
+    );
+  });
+});

--- a/apps/web/utils/snooze/process-due.ts
+++ b/apps/web/utils/snooze/process-due.ts
@@ -1,0 +1,114 @@
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import type { Prisma } from "@/generated/prisma/client";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { mapWithConcurrency } from "@/utils/async";
+import { executeSnoozedThread } from "@/utils/snooze/executor";
+import {
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+  SNOOZE_EXECUTION_LEASE_MS,
+} from "@/utils/snooze/scheduler";
+
+const BATCH_SIZE = 100;
+const RESTORE_CONCURRENCY = 10;
+
+type SnoozedThreadWithAccount = Prisma.SnoozedThreadGetPayload<{
+  include: { emailAccount: { include: { account: true } } };
+}>;
+
+export type SnoozedThreadProcessResult =
+  | { status: "processed" }
+  | { status: "skipped" }
+  | { status: "failed"; reason: "missing-provider" | "restore" };
+
+export async function processDueSnoozedThreads(logger: Logger) {
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - SNOOZE_EXECUTION_LEASE_MS);
+  const snoozedThreads = await prisma.snoozedThread.findMany({
+    where: {
+      scheduledFor: { lte: now },
+      OR: [
+        { status: SnoozedThreadStatus.PENDING },
+        {
+          status: SnoozedThreadStatus.EXECUTING,
+          updatedAt: { lte: staleBefore },
+        },
+      ],
+    },
+    orderBy: { scheduledFor: "asc" },
+    take: BATCH_SIZE,
+    include: {
+      emailAccount: { include: { account: true } },
+    },
+  });
+
+  const results = await mapWithConcurrency(
+    snoozedThreads,
+    RESTORE_CONCURRENCY,
+    async (snoozedThread) => {
+      try {
+        return await processSnoozedThread(snoozedThread, logger);
+      } catch (error) {
+        logger.error("Failed to process snoozed thread", {
+          error,
+          snoozedThreadId: snoozedThread.id,
+        });
+        return { status: "failed", reason: "restore" } as const;
+      }
+    },
+  );
+
+  return {
+    processed: results.filter((result) => result.status === "processed").length,
+    failed: results.filter((result) => result.status === "failed").length,
+    skipped: results.filter((result) => result.status === "skipped").length,
+    total: snoozedThreads.length,
+  };
+}
+
+export async function processSnoozedThread(
+  snoozedThread: SnoozedThreadWithAccount,
+  logger: Logger,
+): Promise<SnoozedThreadProcessResult> {
+  const itemLogger = logger.with({
+    emailAccountId: snoozedThread.emailAccountId,
+    snoozedThreadId: snoozedThread.id,
+  });
+  const providerType = snoozedThread.emailAccount?.account?.provider;
+
+  if (!providerType) {
+    await prisma.snoozedThread.update({
+      where: { id: snoozedThread.id },
+      data: { status: SnoozedThreadStatus.FAILED },
+    });
+    return { status: "failed", reason: "missing-provider" };
+  }
+
+  const executionToken = await markSnoozedThreadAsExecuting(snoozedThread.id);
+  if (!executionToken) {
+    return { status: "skipped" };
+  }
+
+  try {
+    const provider = await createEmailProvider({
+      emailAccountId: snoozedThread.emailAccountId,
+      provider: providerType,
+      logger: itemLogger,
+    });
+    const result = await executeSnoozedThread(
+      snoozedThread,
+      provider,
+      itemLogger,
+      executionToken,
+    );
+    return result.success
+      ? { status: "processed" }
+      : { status: "failed", reason: "restore" };
+  } catch (error) {
+    await releaseSnoozedThreadForRetry(snoozedThread.id, executionToken);
+    itemLogger.error("Failed to process snoozed thread", { error });
+    return { status: "failed", reason: "restore" };
+  }
+}

--- a/apps/web/utils/snooze/process-due.ts
+++ b/apps/web/utils/snooze/process-due.ts
@@ -76,19 +76,27 @@ export async function processSnoozedThread(
     emailAccountId: snoozedThread.emailAccountId,
     snoozedThreadId: snoozedThread.id,
   });
-  const providerType = snoozedThread.emailAccount?.account?.provider;
-
-  if (!providerType) {
-    await prisma.snoozedThread.update({
-      where: { id: snoozedThread.id },
-      data: { status: SnoozedThreadStatus.FAILED },
-    });
-    return { status: "failed", reason: "missing-provider" };
-  }
-
   const executionToken = await markSnoozedThreadAsExecuting(snoozedThread.id);
   if (!executionToken) {
     return { status: "skipped" };
+  }
+
+  const providerType = snoozedThread.emailAccount?.account?.provider;
+  if (!providerType) {
+    const failed = await prisma.snoozedThread.updateMany({
+      where: {
+        executionToken,
+        id: snoozedThread.id,
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+      data: {
+        executionToken: null,
+        status: SnoozedThreadStatus.FAILED,
+      },
+    });
+    return failed.count === 1
+      ? { status: "failed", reason: "missing-provider" }
+      : { status: "skipped" };
   }
 
   try {

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -132,7 +132,7 @@ The Docker Compose setup includes a `cron` container that handles these schedule
 
 | Task | Interval | Endpoint | Description |
 |------|----------|----------|-------------|
-| **Scheduled actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed/scheduled actions when QStash is not configured |
+| **Scheduled mail actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed actions and restores snoozed threads when QStash is not configured |
 | **Automation jobs** | Every 15 minutes | `/api/cron/automation-jobs` | Processes due automation jobs |
 | **Email digests** | Every 30 minutes | `/api/resend/digest/all` | Sends due email digests |
 | **Email watch renewal** | Every 6 hours | `/api/watch/all` | Renews Gmail/Outlook push notification subscriptions |

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -132,7 +132,7 @@ The Docker Compose setup includes a `cron` container that handles these schedule
 
 | Task | Interval | Endpoint | Description |
 |------|----------|----------|-------------|
-| **Scheduled mail actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed actions and restores snoozed threads when QStash is not configured |
+| **Scheduled mail actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed actions when QStash is not configured, and restores snoozed threads |
 | **Automation jobs** | Every 15 minutes | `/api/cron/automation-jobs` | Processes due automation jobs |
 | **Email digests** | Every 30 minutes | `/api/resend/digest/all` | Sends due email digests |
 | **Email watch renewal** | Every 6 hours | `/api/watch/all` | Renews Gmail/Outlook push notification subscriptions |


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260815-195233_pr-3278_fa54e00c01f3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stack 3/9. Previous: #3279. Next: #3282.

- restore due threads through QStash or the scheduled-mail cron fallback
- retry stale/failed execution safely with token fencing
- add the internal execution endpoint and self-hosting documentation

Validation: 9 executor and due-processing tests pass.