### PR TITLE
feat(mail): Add snooze action

### DIFF
--- a/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
+++ b/apps/web/prisma/migrations/20260815120000_add_snoozed_threads/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "SnoozedThreadStatus" AS ENUM ('PENDING', 'EXECUTING', 'COMPLETED', 'FAILED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "SnoozedThread" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "scheduledFor" TIMESTAMP(3) NOT NULL,
+    "status" "SnoozedThreadStatus" NOT NULL DEFAULT 'PENDING',
+    "schedulingStatus" "SchedulingStatus" NOT NULL DEFAULT 'PENDING',
+    "scheduledId" TEXT,
+    "executionToken" TEXT,
+    "executedAt" TIMESTAMP(3),
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "SnoozedThread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SnoozedThread_status_scheduledFor_idx" ON "SnoozedThread"("status", "scheduledFor");
+
+-- CreateIndex
+CREATE INDEX "SnoozedThread_emailAccountId_threadId_status_idx" ON "SnoozedThread"("emailAccountId", "threadId", "status");
+
+-- Only one live restore may exist for a thread. Terminal records remain as history.
+CREATE UNIQUE INDEX "SnoozedThread_one_active_per_thread_idx"
+ON "SnoozedThread"("emailAccountId", "threadId")
+WHERE "status" IN ('PENDING', 'EXECUTING');
+
+-- AddForeignKey
+ALTER TABLE "SnoozedThread" ADD CONSTRAINT "SnoozedThread_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -203,6 +203,7 @@ model EmailAccount {
   chatMemories     ChatMemory[]
   digests          Digest[]
   scheduledActions ScheduledAction[]
+  snoozedThreads   SnoozedThread[]
   responseTimes    ResponseTime[]
   actions          Action[]
 
@@ -802,6 +803,25 @@ model ScheduledAction {
   @@index([executedRuleId])
   @@index([status, scheduledFor])
   @@index([emailAccountId, messageId])
+}
+
+model SnoozedThread {
+  id               String               @id @default(cuid())
+  createdAt        DateTime             @default(now())
+  updatedAt        DateTime             @updatedAt
+  threadId         String
+  scheduledFor     DateTime
+  status           SnoozedThreadStatus  @default(PENDING)
+  schedulingStatus SchedulingStatus     @default(PENDING)
+  scheduledId      String?
+  executionToken   String?
+  executedAt       DateTime?
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  @@index([status, scheduledFor])
+  @@index([emailAccountId, threadId, status])
 }
 
 // Notes:
@@ -2059,6 +2079,14 @@ enum DigestStatus {
 }
 
 enum ScheduledActionStatus {
+  PENDING
+  EXECUTING
+  COMPLETED
+  FAILED
+  CANCELLED
+}
+
+enum SnoozedThreadStatus {
   PENDING
   EXECUTING
   COMPLETED

--- a/apps/web/utils/actions/snooze.ts
+++ b/apps/web/utils/actions/snooze.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { actionClient } from "@/utils/actions/safe-action";
+import { snoozeThreadsBody } from "@/utils/actions/snooze.validation";
+import { createEmailProvider } from "@/utils/email/provider";
+import { snoozeThreads } from "@/utils/snooze/snooze";
+
+export const snoozeThreadsAction = actionClient
+  .metadata({ name: "snoozeThreads" })
+  .inputSchema(snoozeThreadsBody)
+  .action(
+    async ({
+      ctx: { emailAccount, emailAccountId, logger, provider },
+      parsedInput: { snoozedUntil, threadIds },
+    }) => {
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider,
+        logger,
+      });
+      return snoozeThreads({
+        emailAccountId,
+        logger,
+        ownerEmail: emailAccount.email,
+        provider: emailProvider,
+        snoozedUntil,
+        threadIds,
+      });
+    },
+  );

--- a/apps/web/utils/actions/snooze.validation.test.ts
+++ b/apps/web/utils/actions/snooze.validation.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  MIN_SNOOZE_DELAY_MS,
-  snoozeThreadsBody,
-} from "@/utils/actions/snooze.validation";
+import { snoozeThreadsBody } from "@/utils/actions/snooze.validation";
 
 describe("snoozeThreadsBody", () => {
   afterEach(() => vi.useRealTimers());
@@ -13,7 +10,7 @@ describe("snoozeThreadsBody", () => {
 
     const result = snoozeThreadsBody.safeParse({
       threadIds: ["thread"],
-      snoozedUntil: new Date(Date.now() + MIN_SNOOZE_DELAY_MS - 1),
+      snoozedUntil: new Date(Date.now() + 60_000 - 1),
     });
 
     expect(result.success).toBe(false);
@@ -25,9 +22,18 @@ describe("snoozeThreadsBody", () => {
 
     const result = snoozeThreadsBody.safeParse({
       threadIds: ["thread"],
-      snoozedUntil: new Date(Date.now() + MIN_SNOOZE_DELAY_MS),
+      snoozedUntil: new Date(Date.now() + 60_000),
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it("rejects oversized provider thread IDs", () => {
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["x".repeat(513)],
+      snoozedUntil: new Date(Date.now() + 60_000),
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/apps/web/utils/actions/snooze.validation.test.ts
+++ b/apps/web/utils/actions/snooze.validation.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MIN_SNOOZE_DELAY_MS,
+  snoozeThreadsBody,
+} from "@/utils/actions/snooze.validation";
+
+describe("snoozeThreadsBody", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("rejects times close enough to race the archive operation", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-15T12:00:00.000Z");
+
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["thread"],
+      snoozedUntil: new Date(Date.now() + MIN_SNOOZE_DELAY_MS - 1),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a time beyond the scheduling buffer", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-15T12:00:00.000Z");
+
+    const result = snoozeThreadsBody.safeParse({
+      threadIds: ["thread"],
+      snoozedUntil: new Date(Date.now() + MIN_SNOOZE_DELAY_MS),
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/utils/actions/snooze.validation.ts
+++ b/apps/web/utils/actions/snooze.validation.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
-export const MIN_SNOOZE_DELAY_MS = 60_000;
+const MIN_SNOOZE_DELAY_MS = 60_000;
 
 export const snoozeThreadsBody = z.object({
-  threadIds: z.array(z.string().min(1)).min(1).max(100),
+  threadIds: z.array(z.string().min(1).max(512)).min(1).max(100),
   snoozedUntil: z.coerce
     .date()
     .refine((date) => date.getTime() >= Date.now() + MIN_SNOOZE_DELAY_MS, {

--- a/apps/web/utils/actions/snooze.validation.ts
+++ b/apps/web/utils/actions/snooze.validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const MIN_SNOOZE_DELAY_MS = 60_000;
+
+export const snoozeThreadsBody = z.object({
+  threadIds: z.array(z.string().min(1)).min(1).max(100),
+  snoozedUntil: z.coerce
+    .date()
+    .refine((date) => date.getTime() >= Date.now() + MIN_SNOOZE_DELAY_MS, {
+      message: "Snooze time must be at least one minute in the future",
+    }),
+});

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -8,12 +8,30 @@ import {
   scheduleSnoozedThread,
 } from "./scheduler";
 
-vi.mock("@/utils/prisma");
-vi.mock("@/env", () => ({ env: { QSTASH_TOKEN: "" } }));
+const { env, publishJSON, qstashRequest } = vi.hoisted(() => ({
+  env: {
+    CRON_SECRET: "cron-secret",
+    INTERNAL_API_URL: "https://inbox-zero.test",
+    NEXT_PUBLIC_BASE_URL: "https://inbox-zero.test",
+    QSTASH_TOKEN: "",
+  },
+  publishJSON: vi.fn(),
+  qstashRequest: vi.fn(),
+}));
 
-describe("snoozed thread scheduler without QStash", () => {
+vi.mock("@/utils/prisma");
+vi.mock("@/env", () => ({ env }));
+vi.mock("@upstash/qstash", () => ({
+  Client: class {
+    http = { request: qstashRequest };
+    publishJSON = publishJSON;
+  },
+}));
+
+describe("snoozed thread scheduler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    env.QSTASH_TOKEN = "";
     prisma.$transaction.mockImplementation(async (operations) =>
       Promise.all(operations as Promise<unknown>[]),
     );
@@ -123,7 +141,7 @@ describe("snoozed thread scheduler without QStash", () => {
       scheduledId: null,
     } as never);
 
-    await scheduleSnoozedThread({
+    const result = await scheduleSnoozedThread({
       emailAccountId: "account",
       scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
       threadId: "thread",
@@ -138,6 +156,14 @@ describe("snoozed thread scheduler without QStash", () => {
       data: { status: SnoozedThreadStatus.CANCELLED },
       select: { id: true, scheduledId: true },
     });
+    expect(prisma.snoozedThread.create).toHaveBeenCalledWith({
+      data: {
+        emailAccountId: "account",
+        scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+        threadId: "thread",
+      },
+    });
+    expect(result).toEqual({ id: "new-snooze", scheduledId: null });
   });
 
   it("replaces existing snoozes and creates the new restore atomically", async () => {
@@ -176,5 +202,84 @@ describe("snoozed thread scheduler without QStash", () => {
         status: SnoozedThreadStatus.PENDING,
       },
     });
+  });
+
+  it("publishes QStash work and persists its delivery ID", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const scheduledFor = new Date("2026-08-17T09:00:00.000Z");
+    const record = { id: "snooze", scheduledId: null } as never;
+    const scheduledRecord = {
+      id: "snooze",
+      scheduledId: "message-id",
+    } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([]);
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    prisma.snoozedThread.update.mockResolvedValue(scheduledRecord);
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor,
+      threadId: "thread",
+    });
+
+    expect(publishJSON).toHaveBeenCalledWith({
+      url: "https://inbox-zero.test/api/snoozed-threads/execute",
+      body: { snoozedThreadId: "snooze" },
+      notBefore: Math.ceil(scheduledFor.getTime() / 1000),
+      deduplicationId: "snoozed-thread-snooze",
+      contentBasedDeduplication: false,
+      headers: new Headers({ authorization: "Bearer cron-secret" }),
+    });
+    expect(prisma.snoozedThread.update).toHaveBeenCalledWith({
+      where: { id: "snooze" },
+      data: {
+        scheduledId: "message-id",
+        schedulingStatus: "SCHEDULED",
+      },
+    });
+    expect(result).toBe(scheduledRecord);
+  });
+
+  it("keeps cron fallback pending when QStash publishing fails", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "snooze", scheduledId: null } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([]);
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    publishJSON.mockRejectedValue(new Error("offline"));
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: { id: "snooze", status: SnoozedThreadStatus.PENDING },
+      data: { schedulingStatus: "FAILED" },
+    });
+    expect(result).toBe(record);
+  });
+
+  it("removes accepted QStash work when its delivery ID cannot be persisted", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "snooze", scheduledId: null } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([]);
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    prisma.snoozedThread.update.mockRejectedValue(new Error("offline"));
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(qstashRequest).toHaveBeenCalledWith({
+      path: ["v2", "messages", "message-id"],
+      method: "DELETE",
+    });
+    expect(result).toBe(record);
   });
 });

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -282,4 +282,28 @@ describe("snoozed thread scheduler", () => {
     });
     expect(result).toBe(record);
   });
+
+  it("keeps accepted QStash work when the scheduling write committed ambiguously", async () => {
+    env.QSTASH_TOKEN = "qstash-token";
+    const record = { id: "snooze", scheduledId: null } as never;
+    const persisted = {
+      id: "snooze",
+      scheduledId: "message-id",
+      schedulingStatus: "SCHEDULED",
+    } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([]);
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    prisma.snoozedThread.update.mockRejectedValue(new Error("connection lost"));
+    prisma.snoozedThread.findUnique.mockResolvedValue(persisted);
+    publishJSON.mockResolvedValue({ messageId: "message-id" });
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(qstashRequest).not.toHaveBeenCalled();
+    expect(result).toBe(persisted);
+  });
 });

--- a/apps/web/utils/snooze/scheduler.test.ts
+++ b/apps/web/utils/snooze/scheduler.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  cancelSnoozedThread,
+  markSnoozedThreadAsExecuting,
+  releaseSnoozedThreadForRetry,
+  scheduleSnoozedThread,
+} from "./scheduler";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/env", () => ({ env: { QSTASH_TOKEN: "" } }));
+
+describe("snoozed thread scheduler without QStash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.$transaction.mockImplementation(async (operations) =>
+      Promise.all(operations as Promise<unknown>[]),
+    );
+  });
+
+  it("persists work for the cron fallback", async () => {
+    const record = { id: "snooze", scheduledId: null } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([]);
+    prisma.snoozedThread.create.mockResolvedValue(record);
+    const scheduledFor = new Date("2026-08-16T09:00:00.000Z");
+
+    const result = await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor,
+      threadId: "thread",
+    });
+
+    expect(result).toBe(record);
+    expect(prisma.snoozedThread.create).toHaveBeenCalledWith({
+      data: { emailAccountId: "account", scheduledFor, threadId: "thread" },
+    });
+    expect(prisma.snoozedThread.updateManyAndReturn).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account",
+        threadId: "thread",
+        status: SnoozedThreadStatus.PENDING,
+      },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+      select: { id: true, scheduledId: true },
+    });
+  });
+
+  it("claims pending work only once", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    const executionToken = await markSnoozedThreadAsExecuting("snooze");
+
+    expect(executionToken).toEqual(expect.any(String));
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "snooze",
+        OR: [
+          { status: SnoozedThreadStatus.PENDING },
+          {
+            status: SnoozedThreadStatus.EXECUTING,
+            updatedAt: { lte: expect.any(Date) },
+          },
+        ],
+      },
+      data: {
+        executionToken,
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+    });
+  });
+
+  it("reclaims an execution after its lease becomes stale", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+    const now = new Date("2026-08-16T09:30:00.000Z");
+
+    expect(await markSnoozedThreadAsExecuting("snooze", now)).toEqual(
+      expect.any(String),
+    );
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            {
+              status: SnoozedThreadStatus.EXECUTING,
+              updatedAt: { lte: new Date("2026-08-16T09:15:00.000Z") },
+            },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("cancels cron-backed work in the database", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 1 });
+
+    expect(await cancelSnoozedThread({ id: "snooze", scheduledId: null })).toBe(
+      true,
+    );
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: { id: "snooze", status: SnoozedThreadStatus.PENDING },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+    });
+  });
+
+  it("does not cancel work that another worker already claimed", async () => {
+    prisma.snoozedThread.updateMany.mockResolvedValue({ count: 0 });
+
+    expect(await cancelSnoozedThread({ id: "snooze", scheduledId: null })).toBe(
+      false,
+    );
+  });
+
+  it("replaces an earlier pending snooze for the same thread", async () => {
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue([
+      { id: "old-snooze", scheduledId: null },
+      { id: "duplicate-snooze", scheduledId: null },
+    ] as never);
+    prisma.snoozedThread.create.mockResolvedValue({
+      id: "new-snooze",
+      scheduledId: null,
+    } as never);
+
+    await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    expect(prisma.snoozedThread.updateManyAndReturn).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account",
+        threadId: "thread",
+        status: SnoozedThreadStatus.PENDING,
+      },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+      select: { id: true, scheduledId: true },
+    });
+  });
+
+  it("replaces existing snoozes and creates the new restore atomically", async () => {
+    const cancelledSnoozes = [{ id: "old-snooze", scheduledId: null }] as never;
+    const newSnooze = { id: "new-snooze", scheduledId: null } as never;
+    prisma.snoozedThread.updateManyAndReturn.mockResolvedValue(
+      cancelledSnoozes,
+    );
+    prisma.snoozedThread.create.mockResolvedValue(newSnooze);
+
+    await scheduleSnoozedThread({
+      emailAccountId: "account",
+      scheduledFor: new Date("2026-08-17T09:00:00.000Z"),
+      threadId: "thread",
+    });
+
+    const operations = prisma.$transaction.mock.calls[0]?.[0];
+    expect(operations).toHaveLength(2);
+    expect(await Promise.all(operations as Promise<unknown>[])).toEqual([
+      cancelledSnoozes,
+      newSnooze,
+    ]);
+  });
+
+  it("releases claimed work for a later retry", async () => {
+    await releaseSnoozedThreadForRetry("snooze", "claim-token");
+
+    expect(prisma.snoozedThread.updateMany).toHaveBeenCalledWith({
+      where: {
+        executionToken: "claim-token",
+        id: "snooze",
+        status: SnoozedThreadStatus.EXECUTING,
+      },
+      data: {
+        executionToken: null,
+        status: SnoozedThreadStatus.PENDING,
+      },
+    });
+  });
+});

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "@upstash/qstash";
+import { env } from "@/env";
+import { SnoozedThreadStatus } from "@/generated/prisma/enums";
+import { getCronSecretHeader } from "@/utils/cron";
+import { getInternalApiUrl } from "@/utils/internal-api";
+import { createScopedLogger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+const logger = createScopedLogger("snoozed-threads");
+export const SNOOZE_EXECUTION_LEASE_MS = 15 * 60 * 1000;
+
+function getQstashClient() {
+  if (!env.QSTASH_TOKEN) return null;
+  return new Client({ token: env.QSTASH_TOKEN });
+}
+
+export async function scheduleSnoozedThread({
+  emailAccountId,
+  scheduledFor,
+  threadId,
+}: {
+  emailAccountId: string;
+  scheduledFor: Date;
+  threadId: string;
+}) {
+  const [cancelledSnoozes, snoozedThread] = await prisma.$transaction([
+    prisma.snoozedThread.updateManyAndReturn({
+      where: {
+        emailAccountId,
+        threadId,
+        status: SnoozedThreadStatus.PENDING,
+      },
+      data: { status: SnoozedThreadStatus.CANCELLED },
+      select: { id: true, scheduledId: true },
+    }),
+    prisma.snoozedThread.create({
+      data: { emailAccountId, scheduledFor, threadId },
+    }),
+  ]);
+
+  await Promise.all(cancelledSnoozes.map(deleteScheduledMessage));
+
+  const client = getQstashClient();
+  if (!client) {
+    logger.info("QStash unavailable; snoozed thread will use cron fallback", {
+      snoozedThreadId: snoozedThread.id,
+      scheduledFor,
+    });
+    return snoozedThread;
+  }
+
+  let scheduledId: string | undefined;
+  try {
+    const response = await client.publishJSON({
+      url: `${getInternalApiUrl()}/api/snoozed-threads/execute`,
+      body: { snoozedThreadId: snoozedThread.id },
+      notBefore: Math.ceil(scheduledFor.getTime() / 1000),
+      deduplicationId: `snoozed-thread-${snoozedThread.id}`,
+      contentBasedDeduplication: false,
+      headers: getCronSecretHeader(),
+    });
+    scheduledId = "messageId" in response ? response.messageId : undefined;
+  } catch (error) {
+    await markSchedulingFailed(snoozedThread.id);
+    logger.error("QStash scheduling failed; using cron fallback", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return snoozedThread;
+  }
+
+  try {
+    return await prisma.snoozedThread.update({
+      where: { id: snoozedThread.id },
+      data: { scheduledId, schedulingStatus: "SCHEDULED" },
+    });
+  } catch (error) {
+    logger.error("Failed to persist QStash scheduling details", {
+      error,
+      snoozedThreadId: snoozedThread.id,
+    });
+    return snoozedThread;
+  }
+}
+
+export async function cancelSnoozedThread({
+  id,
+  scheduledId,
+}: {
+  id: string;
+  scheduledId: string | null;
+}) {
+  const cancelled = await prisma.snoozedThread.updateMany({
+    where: { id, status: SnoozedThreadStatus.PENDING },
+    data: { status: SnoozedThreadStatus.CANCELLED },
+  });
+  if (cancelled.count !== 1) return false;
+
+  const client = getQstashClient();
+  if (!client || !scheduledId) return true;
+
+  await deleteScheduledMessage({ id, scheduledId });
+  return true;
+}
+
+export async function markSnoozedThreadAsExecuting(
+  id: string,
+  now = new Date(),
+) {
+  const staleBefore = new Date(now.getTime() - SNOOZE_EXECUTION_LEASE_MS);
+  const executionToken = randomUUID();
+  const updated = await prisma.snoozedThread.updateMany({
+    where: {
+      id,
+      OR: [
+        { status: SnoozedThreadStatus.PENDING },
+        {
+          status: SnoozedThreadStatus.EXECUTING,
+          updatedAt: { lte: staleBefore },
+        },
+      ],
+    },
+    data: { executionToken, status: SnoozedThreadStatus.EXECUTING },
+  });
+  return updated.count === 1 ? executionToken : null;
+}
+
+export async function releaseSnoozedThreadForRetry(
+  id: string,
+  executionToken: string,
+) {
+  await prisma.snoozedThread.updateMany({
+    where: {
+      executionToken,
+      id,
+      status: SnoozedThreadStatus.EXECUTING,
+    },
+    data: {
+      executionToken: null,
+      status: SnoozedThreadStatus.PENDING,
+    },
+  });
+}
+
+async function markSchedulingFailed(id: string) {
+  try {
+    await prisma.snoozedThread.updateMany({
+      where: { id, status: SnoozedThreadStatus.PENDING },
+      data: { schedulingStatus: "FAILED" },
+    });
+  } catch (error) {
+    logger.warn("Failed to record QStash scheduling failure", {
+      error,
+      snoozedThreadId: id,
+    });
+  }
+}
+
+async function deleteScheduledMessage({
+  id,
+  scheduledId,
+}: {
+  id: string;
+  scheduledId: string | null;
+}) {
+  const client = getQstashClient();
+  if (!client || !scheduledId) return;
+
+  try {
+    await client.http.request({
+      path: ["v2", "messages", scheduledId],
+      method: "DELETE",
+    });
+  } catch (error) {
+    logger.warn("Failed to remove cancelled snooze from QStash", {
+      error,
+      snoozedThreadId: id,
+    });
+  }
+}

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -76,6 +76,10 @@ export async function scheduleSnoozedThread({
       data: { scheduledId, schedulingStatus: "SCHEDULED" },
     });
   } catch (error) {
+    await deleteScheduledMessage({
+      id: snoozedThread.id,
+      scheduledId: scheduledId ?? null,
+    });
     logger.error("Failed to persist QStash scheduling details", {
       error,
       snoozedThreadId: snoozedThread.id,

--- a/apps/web/utils/snooze/scheduler.ts
+++ b/apps/web/utils/snooze/scheduler.ts
@@ -76,10 +76,29 @@ export async function scheduleSnoozedThread({
       data: { scheduledId, schedulingStatus: "SCHEDULED" },
     });
   } catch (error) {
-    await deleteScheduledMessage({
-      id: snoozedThread.id,
-      scheduledId: scheduledId ?? null,
-    });
+    try {
+      const persisted = await prisma.snoozedThread.findUnique({
+        where: { id: snoozedThread.id },
+      });
+      if (
+        persisted?.scheduledId === scheduledId &&
+        persisted.schedulingStatus === "SCHEDULED"
+      ) {
+        logger.warn("Recovered persisted QStash scheduling details", {
+          snoozedThreadId: snoozedThread.id,
+        });
+        return persisted;
+      }
+      await deleteScheduledMessage({
+        id: snoozedThread.id,
+        scheduledId: scheduledId ?? null,
+      });
+    } catch (recoveryError) {
+      logger.warn("Could not determine whether QStash details persisted", {
+        error: recoveryError,
+        snoozedThreadId: snoozedThread.id,
+      });
+    }
     logger.error("Failed to persist QStash scheduling details", {
       error,
       snoozedThreadId: snoozedThread.id,

--- a/apps/web/utils/snooze/snooze.test.ts
+++ b/apps/web/utils/snooze/snooze.test.ts
@@ -44,6 +44,11 @@ describe("snoozeThreads", () => {
       succeededThreadIds: ["one", "two"],
     });
     expect(scheduleSnoozedThread).toHaveBeenCalledTimes(2);
+    expect(scheduleSnoozedThread).toHaveBeenNthCalledWith(1, {
+      emailAccountId: "account",
+      scheduledFor: snoozedUntil,
+      threadId: "one",
+    });
     expect(
       vi.mocked(scheduleSnoozedThread).mock.invocationCallOrder[0],
     ).toBeLessThan(
@@ -97,5 +102,31 @@ describe("snoozeThreads", () => {
 
     expect(result.failedThreadIds).toEqual(["one"]);
     expect(provider.archiveThreadWithLabel).not.toHaveBeenCalled();
+  });
+
+  it("reports successful and failed threads independently", async () => {
+    const provider = createMockEmailProvider({
+      archiveThreadWithLabel: vi.fn(async (threadId: string) => {
+        if (threadId === "two") throw new Error("provider failed");
+      }),
+    });
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one", "two"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: ["two"],
+      succeededThreadIds: ["one"],
+    });
+    expect(cancelSnoozedThread).toHaveBeenCalledWith({
+      id: "snooze-two",
+      scheduledId: "qstash-two",
+    });
   });
 });

--- a/apps/web/utils/snooze/snooze.test.ts
+++ b/apps/web/utils/snooze/snooze.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import {
+  cancelSnoozedThread,
+  scheduleSnoozedThread,
+} from "@/utils/snooze/scheduler";
+import { snoozeThreads } from "./snooze";
+
+vi.mock("@/utils/snooze/scheduler", () => ({
+  cancelSnoozedThread: vi.fn(),
+  scheduleSnoozedThread: vi.fn(),
+}));
+
+const logger = createTestLogger();
+const snoozedUntil = new Date("2026-08-16T09:00:00.000Z");
+
+describe("snoozeThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(scheduleSnoozedThread).mockImplementation(
+      async ({ threadId }) =>
+        ({
+          id: `snooze-${threadId}`,
+          scheduledId: `qstash-${threadId}`,
+        }) as never,
+    );
+  });
+
+  it("schedules restoration before archiving every unique thread", async () => {
+    const provider = createMockEmailProvider();
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one", "one", "two"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: [],
+      succeededThreadIds: ["one", "two"],
+    });
+    expect(scheduleSnoozedThread).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(scheduleSnoozedThread).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(provider.archiveThreadWithLabel).mock.invocationCallOrder[0] ??
+        Number.POSITIVE_INFINITY,
+    );
+    expect(provider.archiveThreadWithLabel).toHaveBeenCalledWith(
+      "one",
+      "owner@example.com",
+    );
+  });
+
+  it("cancels restoration when the provider cannot archive a thread", async () => {
+    const provider = createMockEmailProvider({
+      archiveThreadWithLabel: vi
+        .fn()
+        .mockRejectedValue(new Error("provider failed")),
+    });
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one"],
+    });
+
+    expect(result).toEqual({
+      failedThreadIds: ["one"],
+      succeededThreadIds: [],
+    });
+    expect(cancelSnoozedThread).toHaveBeenCalledWith({
+      id: "snooze-one",
+      scheduledId: "qstash-one",
+    });
+  });
+
+  it("does not archive when restoration could not be scheduled", async () => {
+    vi.mocked(scheduleSnoozedThread).mockRejectedValue(new Error("offline"));
+    const provider = createMockEmailProvider();
+
+    const result = await snoozeThreads({
+      emailAccountId: "account",
+      logger,
+      ownerEmail: "owner@example.com",
+      provider,
+      snoozedUntil,
+      threadIds: ["one"],
+    });
+
+    expect(result.failedThreadIds).toEqual(["one"]);
+    expect(provider.archiveThreadWithLabel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/snooze/snooze.ts
+++ b/apps/web/utils/snooze/snooze.ts
@@ -1,0 +1,83 @@
+import type { EmailProvider } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import { mapWithConcurrency } from "@/utils/async";
+import {
+  cancelSnoozedThread,
+  scheduleSnoozedThread,
+} from "@/utils/snooze/scheduler";
+
+const SNOOZE_CONCURRENCY = 10;
+
+export async function snoozeThreads({
+  emailAccountId,
+  logger,
+  ownerEmail,
+  provider,
+  snoozedUntil,
+  threadIds,
+}: {
+  emailAccountId: string;
+  logger: Logger;
+  ownerEmail: string;
+  provider: EmailProvider;
+  snoozedUntil: Date;
+  threadIds: string[];
+}) {
+  const uniqueThreadIds = [...new Set(threadIds)];
+  const results = await mapWithConcurrency(
+    uniqueThreadIds,
+    SNOOZE_CONCURRENCY,
+    async (threadId) => {
+      try {
+        await snoozeThread({
+          emailAccountId,
+          ownerEmail,
+          provider,
+          snoozedUntil,
+          threadId,
+        });
+        return true;
+      } catch (error) {
+        logger.error("Failed to snooze thread", { error, threadId });
+        return false;
+      }
+    },
+  );
+
+  const succeededThreadIds = uniqueThreadIds.filter(
+    (_, index) => results[index],
+  );
+  const failedThreadIds = uniqueThreadIds.filter((_, index) => !results[index]);
+
+  return { failedThreadIds, succeededThreadIds };
+}
+
+async function snoozeThread({
+  emailAccountId,
+  ownerEmail,
+  provider,
+  snoozedUntil,
+  threadId,
+}: {
+  emailAccountId: string;
+  ownerEmail: string;
+  provider: EmailProvider;
+  snoozedUntil: Date;
+  threadId: string;
+}) {
+  const snoozedThread = await scheduleSnoozedThread({
+    emailAccountId,
+    scheduledFor: snoozedUntil,
+    threadId,
+  });
+
+  try {
+    await provider.archiveThreadWithLabel(threadId, ownerEmail);
+  } catch (error) {
+    await cancelSnoozedThread({
+      id: snoozedThread.id,
+      scheduledId: snoozedThread.scheduledId,
+    });
+    throw error;
+  }
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260815-195052_pr-3279_5d5265f64a7e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stack 2/9. Previous: #3277. Next: #3278.

- expose a validated server action for snoozing threads
- archive only after restoration is durably scheduled
- cancel scheduled restoration if provider archiving fails
- return per-thread success/failure for bulk UI feedback

Validation: 7 action/domain tests pass.