### PR TITLE
feat(mail): Add Command K snooze view

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSnoozeCommandPalette,
+  getSnoozePresets,
+  parseSnoozeDate,
+} from "./snooze-command-palette";
+
+describe("buildSnoozeCommandPalette", () => {
+  it("offers useful future presets with next week landing on Monday morning", () => {
+    const presets = getSnoozePresets(new Date(2026, 7, 15, 10));
+
+    expect(presets.map(({ id }) => id)).toEqual([
+      "three-hours",
+      "tomorrow",
+      "next-week",
+    ]);
+    expect(presets[0]?.until).toEqual(new Date(2026, 7, 15, 13));
+    expect(presets[1]?.until).toEqual(new Date(2026, 7, 16, 9));
+    expect(presets[2]?.until).toEqual(new Date(2026, 7, 17, 9));
+  });
+
+  it("turns natural language into one actionable result", () => {
+    const onSnooze = vi.fn();
+    const commands = buildSnoozeCommandPalette({
+      now: new Date(2026, 7, 15, 10),
+      onSnooze,
+      query: "tomorrow at 3pm",
+    });
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]?.label).toContain("Sun, Aug 16 at 3:00 PM");
+    commands[0]?.action();
+    expect(onSnooze).toHaveBeenCalledWith(new Date(2026, 7, 16, 15));
+  });
+
+  it("defaults date-only input to 9am", () => {
+    expect(parseSnoozeDate("next Friday", new Date(2026, 7, 15, 10))).toEqual(
+      new Date(2026, 7, 21, 9),
+    );
+  });
+
+  it("does not offer invalid or past dates", () => {
+    const now = new Date(2026, 7, 15, 10);
+
+    expect(parseSnoozeDate("not a date", now)).toBeNull();
+    expect(parseSnoozeDate("yesterday", now)).toBeNull();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/snooze-command-palette.ts
@@ -1,0 +1,79 @@
+import { format } from "date-fns";
+import { Clock3Icon } from "lucide-react";
+import * as chrono from "chrono-node";
+import type { Command } from "@/lib/commands/types";
+
+export function buildSnoozeCommandPalette({
+  now = new Date(),
+  onSnooze,
+  query,
+}: {
+  now?: Date;
+  onSnooze: (until: Date) => void;
+  query: string;
+}): Command[] {
+  const naturalLanguageDate = parseSnoozeDate(query, now);
+  if (query.trim()) {
+    if (!naturalLanguageDate) return [];
+
+    return [
+      {
+        id: "mail-snooze-natural-language",
+        label: `Snooze until ${format(naturalLanguageDate, "EEE, MMM d 'at' p")}`,
+        icon: Clock3Icon,
+        section: "actions",
+        priority: 0,
+        keywords: [query],
+        action: () => onSnooze(naturalLanguageDate),
+      },
+    ];
+  }
+
+  return getSnoozePresets(now).map((preset, index) => ({
+    id: `mail-snooze-${preset.id}`,
+    label: preset.label,
+    icon: Clock3Icon,
+    section: "actions",
+    priority: index,
+    keywords: ["snooze", "later", "remind", preset.id],
+    action: () => onSnooze(preset.until),
+  }));
+}
+
+export function parseSnoozeDate(input: string, now = new Date()) {
+  const result = chrono.casual.parse(input.trim(), now, {
+    forwardDate: true,
+  })[0];
+  if (!result) return null;
+
+  const date = result.start.date();
+  if (!result.start.isCertain("hour")) date.setHours(9, 0, 0, 0);
+  if (date <= now) return null;
+
+  return date;
+}
+
+export function getSnoozePresets(now: Date) {
+  const tomorrowMorning = new Date(now);
+  tomorrowMorning.setDate(tomorrowMorning.getDate() + 1);
+  tomorrowMorning.setHours(9, 0, 0, 0);
+
+  const nextWeek = new Date(now);
+  const daysUntilMonday = (8 - nextWeek.getDay()) % 7 || 7;
+  nextWeek.setDate(nextWeek.getDate() + daysUntilMonday);
+  nextWeek.setHours(9, 0, 0, 0);
+
+  return [
+    {
+      id: "three-hours",
+      label: "In 3 hours",
+      until: new Date(now.getTime() + 3 * 60 * 60 * 1000),
+    },
+    {
+      id: "tomorrow",
+      label: "Tomorrow morning",
+      until: tomorrowMorning,
+    },
+    { id: "next-week", label: "Next week", until: nextWeek },
+  ];
+}

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { Loader2Icon } from "lucide-react";
-import { useAtom } from "jotai";
+import { ArrowLeftIcon, Loader2Icon } from "lucide-react";
+import { useAtom, useAtomValue } from "jotai";
+import { buildSnoozeCommandPalette } from "@/app/(app)/[emailAccountId]/mail/snooze-command-palette";
 import {
   CommandDialog,
   CommandEmpty,
@@ -14,7 +15,11 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
-import { commandPaletteOpenAtom } from "@/store/command-palette";
+import {
+  commandPaletteOpenAtom,
+  commandPalettePageAtom,
+  mailCommandContextAtom,
+} from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -60,12 +65,18 @@ export function CommandK() {
 
 function CommandPalette() {
   const [open, setOpen] = useAtom(commandPaletteOpenAtom);
+  const [page, setPage] = useAtom(commandPalettePageAtom);
   const [search, setSearch] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const mailCommandContext = useAtomValue(mailCommandContextAtom);
 
   const { emailAccountId } = useAccount();
   const { threadId, showEmail } = useDisplayedEmail();
   const { onOpen: onOpenComposeModal } = useComposeModal();
-  const { commands, isLoading } = useCommandPaletteCommands();
+  const activeMailContext = threadId ? null : mailCommandContext;
+  const { commands, isLoading } = useCommandPaletteCommands({
+    enabled: !activeMailContext,
+  });
 
   const onArchive = React.useCallback(() => {
     if (threadId) {
@@ -88,26 +99,66 @@ function CommandPalette() {
   useShortcuts(shortcutHandlers);
 
   // the registry decides which shortcuts surface as palette entries
-  const actionCommands = React.useMemo<Command[]>(
+  const shortcutCommands = React.useMemo<Command[]>(
     () => buildShortcutPaletteCommands(shortcutHandlers),
     [shortcutHandlers],
   );
 
-  // combine action commands with dynamic commands
+  const snoozeCommands = React.useMemo(() => {
+    if (page !== "snooze" || !activeMailContext) return [];
+
+    return buildSnoozeCommandPalette({
+      onSnooze: activeMailContext.snooze,
+      query: search,
+    });
+  }, [activeMailContext, page, search]);
+
+  const actionCommands = React.useMemo(() => {
+    if (page === "snooze" && activeMailContext) {
+      if (search.trim()) return snoozeCommands;
+
+      return [
+        {
+          id: "mail-snooze-back",
+          label: "Back to commands",
+          icon: ArrowLeftIcon,
+          section: "actions" as const,
+          priority: -1,
+          closeOnSelect: false,
+          action: () => setPage("root"),
+        },
+        ...snoozeCommands,
+      ];
+    }
+
+    return activeMailContext
+      ? [
+          ...activeMailContext.commands,
+          ...shortcutCommands.filter((command) => command.id === "compose"),
+        ]
+      : shortcutCommands;
+  }, [
+    activeMailContext,
+    page,
+    search,
+    setPage,
+    shortcutCommands,
+    snoozeCommands,
+  ]);
+
   const allCommands = React.useMemo(
-    () => [...actionCommands, ...commands],
-    [actionCommands, commands],
+    () =>
+      page === "snooze" ? actionCommands : [...actionCommands, ...commands],
+    [actionCommands, commands, page],
   );
 
-  // filter commands with fuzzy search
   const filteredCommands = React.useMemo(() => {
-    if (!search.trim()) {
+    if (page === "snooze" || !search.trim()) {
       return allCommands;
     }
     return fuzzySearch(search, allCommands);
-  }, [allCommands, search]);
+  }, [allCommands, page, search]);
 
-  // group commands by section
   const groupedCommands = React.useMemo(() => {
     const groups: Record<CommandSection, Command[]> = {
       actions: [],
@@ -124,36 +175,56 @@ function CommandPalette() {
     return groups;
   }, [filteredCommands]);
 
-  // execute command
   const executeCommand = React.useCallback(
     (command: Command) => {
-      setOpen(false);
       setSearch("");
+      if (command.closeOnSelect !== false) {
+        setOpen(false);
+        setPage("root");
+      }
       command.action();
     },
-    [setOpen],
+    [setOpen, setPage],
   );
 
-  // memoized handlers to avoid re-renders
   const handleOpenChange = React.useCallback(
     (isOpen: boolean) => {
       setOpen(isOpen);
-      if (!isOpen) setSearch("");
+      if (!isOpen) {
+        setPage("root");
+        setSearch("");
+      }
     },
-    [setOpen],
+    [setOpen, setPage],
   );
+
+  React.useEffect(() => {
+    if (page === "snooze" && !activeMailContext) {
+      setPage("root");
+      setSearch("");
+    }
+  }, [activeMailContext, page, setPage]);
+
+  React.useEffect(() => {
+    if (open && page === "snooze") inputRef.current?.focus();
+  }, [open, page]);
 
   const commandProps = React.useMemo(
     () => ({
       // disable cmdk's built-in filter since we use custom fuzzy search
       shouldFilter: false,
       onKeyDown: (e: React.KeyboardEvent) => {
-        if (e.key !== "Escape") {
+        if (e.key === "Escape" && page === "snooze") {
+          e.preventDefault();
           e.stopPropagation();
+          setPage("root");
+          setSearch("");
+          return;
         }
+        if (e.key !== "Escape") e.stopPropagation();
       },
     }),
-    [],
+    [page, setPage],
   );
 
   return (
@@ -163,7 +234,12 @@ function CommandPalette() {
       commandProps={commandProps}
     >
       <CommandInput
-        placeholder="Type a command or search..."
+        ref={inputRef}
+        placeholder={
+          page === "snooze"
+            ? "When should it return? Try Friday at 3pm"
+            : "Type a command or search..."
+        }
         value={search}
         onValueChange={setSearch}
       />
@@ -174,7 +250,11 @@ function CommandPalette() {
           </div>
         ) : (
           <>
-            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandEmpty>
+              {page === "snooze"
+                ? "Try a date like tomorrow at 3pm."
+                : "No results found."}
+            </CommandEmpty>
             {SECTION_ORDER.map((section, index) => {
               const sectionCommands = groupedCommands[section];
               if (sectionCommands.length === 0) return null;
@@ -188,7 +268,13 @@ function CommandPalette() {
               return (
                 <React.Fragment key={section}>
                   {showSeparator && <CommandSeparator />}
-                  <CommandGroup heading={SECTION_LABELS[section]}>
+                  <CommandGroup
+                    heading={
+                      page === "snooze" && section === "actions"
+                        ? "Snooze until"
+                        : SECTION_LABELS[section]
+                    }
+                  >
                     {sectionCommands.map((command) => (
                       <CommandItem
                         key={command.id}
@@ -228,7 +314,7 @@ function CommandPalette() {
           <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
             esc
           </kbd>
-          close
+          {page === "snooze" ? "back" : "close"}
         </span>
       </div>
     </CommandDialog>

--- a/apps/web/hooks/useCommandPaletteCommands.ts
+++ b/apps/web/hooks/useCommandPaletteCommands.ts
@@ -115,11 +115,18 @@ function useNavigationItems(): NavigationItem[] {
   );
 }
 
-export function useCommandPaletteCommands() {
+export function useCommandPaletteCommands({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) {
   const router = useRouter();
   const { emailAccountId } = useAccount();
-  const { data: rulesData, isLoading: rulesLoading } = useRules();
-  const { data: user, isLoading: userLoading } = useUser();
+  const { data: rulesData, isLoading: rulesLoading } = useRules(
+    undefined,
+    enabled,
+  );
+  const { data: user, isLoading: userLoading } = useUser(enabled);
   const navigationItems = useNavigationItems();
 
   const navigationCommands = useMemo<Command[]>(
@@ -227,21 +234,26 @@ export function useCommandPaletteCommands() {
   }, [user?.emailAccounts, router, emailAccountId]);
 
   const allCommands = useMemo(
-    () => [
-      ...navigationCommands,
-      ...settingsCommands,
-      ...ruleCommands,
-      ...accountCommands,
+    () =>
+      enabled
+        ? [
+            ...navigationCommands,
+            ...settingsCommands,
+            ...ruleCommands,
+            ...accountCommands,
+          ]
+        : [],
+    [
+      enabled,
+      navigationCommands,
+      settingsCommands,
+      ruleCommands,
+      accountCommands,
     ],
-    [navigationCommands, settingsCommands, ruleCommands, accountCommands],
   );
 
   return {
     commands: allCommands,
-    isLoading: rulesLoading || userLoading,
-    navigationCommands,
-    settingsCommands,
-    ruleCommands,
-    accountCommands,
+    isLoading: enabled && (rulesLoading || userLoading),
   };
 }

--- a/apps/web/hooks/useRules.tsx
+++ b/apps/web/hooks/useRules.tsx
@@ -2,10 +2,10 @@ import useSWR from "swr";
 import type { RulesResponse } from "@/app/api/user/rules/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
-export function useRules(emailAccountId?: string) {
+export function useRules(emailAccountId?: string, enabled = true) {
   const { emailAccountId: contextId } = useAccount();
   const id = emailAccountId ?? contextId;
   return useSWR<RulesResponse, { error: string }>(
-    id ? ["/api/user/rules", id] : null,
+    enabled && id ? ["/api/user/rules", id] : null,
   );
 }

--- a/apps/web/hooks/useUser.ts
+++ b/apps/web/hooks/useUser.ts
@@ -2,8 +2,10 @@ import useSWR from "swr";
 import type { UserResponse } from "@/app/api/user/me/route";
 import { processSWRResponse } from "@/utils/swr";
 
-export function useUser() {
-  const swrResult = useSWR<UserResponse | { error: string }>("/api/user/me");
+export function useUser(enabled = true) {
+  const swrResult = useSWR<UserResponse | { error: string }>(
+    enabled ? "/api/user/me" : null,
+  );
   const processed = processSWRResponse<UserResponse>(swrResult);
 
   // Treat 401 as "not authenticated" — return null data without error

--- a/apps/web/lib/commands/types.ts
+++ b/apps/web/lib/commands/types.ts
@@ -9,6 +9,7 @@ export type CommandSection =
 
 export interface Command {
   action: () => void | Promise<void>;
+  closeOnSelect?: boolean;
   description?: string;
   icon?: LucideIcon;
   id: string;

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -194,9 +194,9 @@ describe("buildShortcutPaletteCommands", () => {
   });
 
   it("leaves shortcuts without palette metadata out", () => {
-    const commands = buildShortcutPaletteCommands({ compose: vi.fn() });
+    const commands = buildShortcutPaletteCommands({ reply: vi.fn() });
 
-    expect(commands.map((command) => command.id)).not.toContain("compose");
+    expect(commands.map((command) => command.id)).not.toContain("reply");
   });
 });
 

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -1,4 +1,4 @@
-import { ArchiveIcon, type LucideIcon } from "lucide-react";
+import { ArchiveIcon, PenLineIcon, type LucideIcon } from "lucide-react";
 import type { Command, CommandSection } from "@/lib/commands/types";
 import { createClientLogger } from "@/utils/logger-client";
 
@@ -217,6 +217,13 @@ const SHORTCUT_DEFINITIONS = [
     scope: "global",
     group: "Assistant & rules",
     label: "New message",
+    palette: {
+      section: "actions",
+      description: "Compose a new email",
+      keywords: ["compose", "write", "email"],
+      priority: 20,
+      icon: PenLineIcon,
+    },
   },
   {
     id: "send",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -136,6 +136,7 @@
     "capital-case": "2.0.0",
     "chat": "4.28.1",
     "cheerio": "1.2.0",
+    "chrono-node": "2.10.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import type { Command } from "@/lib/commands/types";
 
 /**
  * Open state for the command palette. It lives outside CommandK so surfaces
@@ -6,3 +7,18 @@ import { atom } from "jotai";
  * faking a ⌘K keystroke.
  */
 export const commandPaletteOpenAtom = atom(false);
+
+type CommandPalettePage = "root" | "snooze";
+
+export const commandPalettePageAtom = atom<CommandPalettePage>("root");
+
+type MailCommandContext = {
+  commands: Command[];
+  snooze: (until: Date) => void;
+};
+
+/**
+ * Commands owned by the active mail list. Keeping the callbacks here lets the
+ * app-wide palette act on list state without duplicating selection state.
+ */
+export const mailCommandContextAtom = atom<MailCommandContext | null>(null);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
+      chrono-node:
+        specifier: 2.10.1
+        version: 2.10.1
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -7222,6 +7225,10 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chrono-node@2.10.1:
+    resolution: {integrity: sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
@@ -19535,6 +19542,8 @@ snapshots:
   chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
+
+  chrono-node@2.10.1: {}
 
   citty@0.2.2: {}
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260815-193900_pr-3280_1b500484da3b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stacked on `feat/command-palette-single-line`.

- add nested Command K pages with Escape/back behavior
- present preset snooze times in a dedicated view
- parse natural-language dates with chrono-node
- avoid loading irrelevant global commands while mail context owns the palette

Validation: 25 parser and shortcut-registry tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->