### PR TITLE
feat(mail): Support bulk thread actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -692,7 +692,7 @@ export function MailShell() {
                 isUnread={isOpenThreadUnread}
                 onToggleRead={() => {
                   if (openThreadId)
-                    setReadState(openThreadId, isOpenThreadUnread);
+                    setReadState([openThreadId], isOpenThreadUnread);
                 }}
                 open={isMenuOpen}
                 onOpenChange={setIsMenuOpen}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -16,6 +16,7 @@ const notifications = vi.hoisted(() => ({
   success: vi.fn(),
 }));
 const markReadThreadAction = vi.hoisted(() => vi.fn());
+const snoozeThreadsAction = vi.hoisted(() => vi.fn());
 
 vi.mock("@/store/archive-queue", () => ({
   archiveEmails: queue.archive,
@@ -28,12 +29,16 @@ vi.mock("@/utils/actions/mail", () => ({
   unarchiveThreadAction: vi.fn(),
   untrashThreadAction: vi.fn(),
 }));
+vi.mock("@/utils/actions/snooze", () => ({ snoozeThreadsAction }));
 vi.mock("sonner", () => ({ toast: notifications }));
 
 describe("useThreadActions read state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markReadThreadAction.mockResolvedValue({});
+    snoozeThreadsAction.mockResolvedValue({
+      data: { failedThreadIds: [], succeededThreadIds: ["thread"] },
+    });
   });
 
   it("marks an unread row locally before queueing the provider update", () => {
@@ -146,7 +151,7 @@ describe("useThreadActions read state", () => {
       }),
     );
 
-    await act(() => result.current.setReadState("thread", false));
+    await act(() => result.current.setReadState(["thread"], false));
 
     expect(markReadThreadAction).toHaveBeenCalledWith("account", {
       threadId: "thread",
@@ -171,11 +176,41 @@ describe("useThreadActions read state", () => {
       }),
     );
 
-    await act(() => result.current.setReadState("thread", true));
+    await act(() => result.current.setReadState(["thread"], true));
 
     expect(transaction.rollback).toHaveBeenCalledWith(["thread"]);
     expect(transaction.commit).not.toHaveBeenCalled();
     expect(notifications.error).toHaveBeenCalledWith("Couldn't mark as read");
+  });
+
+  it("restores only rows that failed to snooze", async () => {
+    const removal = { entries: new Map(), viewIdentity: "view" };
+    const removeThreads = vi.fn(() => removal);
+    const restoreThreads = vi.fn();
+    snoozeThreadsAction.mockResolvedValue({
+      data: {
+        failedThreadIds: ["thread-two"],
+        succeededThreadIds: ["thread-one"],
+      },
+    });
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads,
+        restoreThreads,
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+    const until = new Date("2026-08-16T09:00:00.000Z");
+
+    await act(() => result.current.snooze(["thread-one", "thread-two"], until));
+
+    expect(removeThreads).toHaveBeenCalledWith(["thread-one", "thread-two"]);
+    expect(snoozeThreadsAction).toHaveBeenCalledWith("account", {
+      threadIds: ["thread-one", "thread-two"],
+      snoozedUntil: until,
+    });
+    expect(restoreThreads).toHaveBeenCalledWith(removal, ["thread-two"]);
   });
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -212,6 +212,41 @@ describe("useThreadActions read state", () => {
     });
     expect(restoreThreads).toHaveBeenCalledWith(removal, ["thread-two"]);
   });
+
+  it("chunks snooze actions at the server validation limit", async () => {
+    const threadIds = Array.from(
+      { length: 101 },
+      (_, index) => `thread-${index}`,
+    );
+    snoozeThreadsAction.mockImplementation(
+      async (_emailAccountId, input: { threadIds: string[] }) => ({
+        data: {
+          failedThreadIds: [],
+          succeededThreadIds: input.threadIds,
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads: vi.fn(() => ({
+          entries: new Map(),
+          viewIdentity: "view",
+        })),
+        restoreThreads: vi.fn(),
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+
+    await act(() =>
+      result.current.snooze(threadIds, new Date("2026-08-16T09:00:00.000Z")),
+    );
+
+    expect(snoozeThreadsAction).toHaveBeenCalledTimes(2);
+    expect(
+      snoozeThreadsAction.mock.calls.map((call) => call[1].threadIds),
+    ).toEqual([threadIds.slice(0, 100), threadIds.slice(100)]);
+  });
 });
 
 function createThread(labelIds: string[]): ListThread {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef } from "react";
+import { format } from "date-fns";
 import { toast } from "sonner";
 import {
   archiveEmails,
@@ -20,6 +21,10 @@ import type {
   ThreadRemoval,
 } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
+import { snoozeThreadsAction } from "@/utils/actions/snooze";
+import { mapWithConcurrency } from "@/utils/async";
+
+const THREAD_ACTION_CONCURRENCY = 10;
 
 type UndoableAction = "archive" | "delete";
 
@@ -69,11 +74,13 @@ export function useThreadActions({
       const reverse =
         batch.type === "archive" ? unarchiveThreadAction : untrashThreadAction;
 
-      const reversed = await Promise.all(
-        notCancelled.map(async (threadId) => {
+      const reversed = await mapWithConcurrency(
+        notCancelled,
+        THREAD_ACTION_CONCURRENCY,
+        async (threadId) => {
           const result = await reverse(emailAccountId, { threadId });
           return { threadId, ok: !result?.serverError };
-        }),
+        },
       );
 
       // A thread the provider refused to unarchive is still archived, so
@@ -167,28 +174,83 @@ export function useThreadActions({
   );
 
   const setReadState = useCallback(
-    async (threadId: string, read: boolean) => {
-      const update = optimisticallyUpdateThreads([threadId], (thread) =>
+    async (threadIds: string[], read: boolean) => {
+      const update = optimisticallyUpdateThreads(threadIds, (thread) =>
         withThreadReadState(thread, read),
       );
       if (!update.threadIds.length) return;
 
-      try {
-        const result = await markReadThreadAction(emailAccountId, {
-          threadId,
-          read,
-        });
-        if (result?.serverError) throw new Error(result.serverError);
-      } catch {
-        update.rollback([threadId]);
-        toast.error(read ? "Couldn't mark as read" : "Couldn't mark as unread");
+      const results = await mapWithConcurrency(
+        update.threadIds,
+        THREAD_ACTION_CONCURRENCY,
+        async (threadId) => {
+          try {
+            const result = await markReadThreadAction(emailAccountId, {
+              threadId,
+              read,
+            });
+            return { failed: Boolean(result?.serverError), threadId };
+          } catch {
+            return { failed: true, threadId };
+          }
+        },
+      );
+      const failedThreadIds = results
+        .filter((result) => result.failed)
+        .map(({ threadId }) => threadId);
+
+      for (const threadId of update.threadIds) {
+        if (!failedThreadIds.includes(threadId)) update.commit(threadId);
+      }
+      update.rollback(failedThreadIds);
+
+      if (failedThreadIds.length) {
+        toast.error(
+          failedThreadIds.length === update.threadIds.length
+            ? `Couldn't mark as ${read ? "read" : "unread"}`
+            : `Couldn't mark ${failedThreadIds.length} of ${update.threadIds.length} as ${read ? "read" : "unread"}`,
+        );
         return;
       }
 
-      update.commit(threadId);
-      toast.success(read ? "Marked as read" : "Marked as unread");
+      toast.success(
+        update.threadIds.length === 1
+          ? `Marked as ${read ? "read" : "unread"}`
+          : `Marked ${update.threadIds.length} as ${read ? "read" : "unread"}`,
+      );
     },
     [emailAccountId, optimisticallyUpdateThreads],
+  );
+
+  const snooze = useCallback(
+    async (threadIds: string[], snoozedUntil: Date) => {
+      if (!threadIds.length) return;
+      const removal = removeThreads(threadIds);
+      const result = await snoozeThreadsAction(emailAccountId, {
+        threadIds,
+        snoozedUntil,
+      }).catch(() => null);
+      const failedThreadIds = result?.data?.failedThreadIds ?? threadIds;
+      const succeededThreadIds = result?.data?.succeededThreadIds ?? [];
+
+      restoreThreads(removal, failedThreadIds);
+
+      if (succeededThreadIds.length) {
+        toast.success(
+          succeededThreadIds.length === 1
+            ? `Snoozed until ${format(snoozedUntil, "EEE, MMM d 'at' p")}`
+            : `Snoozed ${succeededThreadIds.length} conversations`,
+        );
+      }
+      if (failedThreadIds.length) {
+        toast.error(
+          failedThreadIds.length === 1
+            ? "Couldn't snooze conversation"
+            : `Couldn't snooze ${failedThreadIds.length} conversations`,
+        );
+      }
+    },
+    [emailAccountId, removeThreads, restoreThreads],
   );
 
   return {
@@ -196,6 +258,7 @@ export function useThreadActions({
     trash: useCallback((ids: string[]) => run("delete", ids), [run]),
     markRead,
     setReadState,
+    snooze,
     undo,
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef } from "react";
 import { format } from "date-fns";
+import chunk from "lodash/chunk";
 import { toast } from "sonner";
 import {
   archiveEmails,
@@ -25,6 +26,8 @@ import { snoozeThreadsAction } from "@/utils/actions/snooze";
 import { mapWithConcurrency } from "@/utils/async";
 
 const THREAD_ACTION_CONCURRENCY = 10;
+const SNOOZE_ACTION_BATCH_CONCURRENCY = 2;
+const SNOOZE_ACTION_BATCH_SIZE = 100;
 
 type UndoableAction = "archive" | "delete";
 
@@ -226,12 +229,28 @@ export function useThreadActions({
     async (threadIds: string[], snoozedUntil: Date) => {
       if (!threadIds.length) return;
       const removal = removeThreads(threadIds);
-      const result = await snoozeThreadsAction(emailAccountId, {
-        threadIds,
-        snoozedUntil,
-      }).catch(() => null);
-      const failedThreadIds = result?.data?.failedThreadIds ?? threadIds;
-      const succeededThreadIds = result?.data?.succeededThreadIds ?? [];
+      const results = await mapWithConcurrency(
+        chunk(threadIds, SNOOZE_ACTION_BATCH_SIZE),
+        SNOOZE_ACTION_BATCH_CONCURRENCY,
+        async (batch) => {
+          const result = await snoozeThreadsAction(emailAccountId, {
+            threadIds: batch,
+            snoozedUntil,
+          }).catch(() => null);
+          return (
+            result?.data ?? {
+              failedThreadIds: batch,
+              succeededThreadIds: [],
+            }
+          );
+        },
+      );
+      const failedThreadIds = results.flatMap(
+        (result) => result.failedThreadIds,
+      );
+      const succeededThreadIds = results.flatMap(
+        (result) => result.succeededThreadIds,
+      );
 
       restoreThreads(removal, failedThreadIds);
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -110,6 +110,19 @@ describe("useThreadSelection", () => {
     expect(result.current.targetIds(undefined)).toEqual([]);
   });
 
+  it("drops selections that are no longer in the current mail view", () => {
+    const { result, rerender } = renderHook(
+      ({ ids }) => useThreadSelection(ids),
+      { initialProps: { ids: ["a", "b", "c"] } },
+    );
+
+    act(() => result.current.toggle(1));
+    rerender({ ids: ["c", "d"] });
+
+    expect(result.current.selectedCount).toBe(0);
+    expect(result.current.targetIds("c")).toEqual(["c"]);
+  });
+
   it("ignores a toggle for an index outside the list", () => {
     const { result } = setup();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -123,6 +123,19 @@ describe("useThreadSelection", () => {
     expect(result.current.targetIds("c")).toEqual(["c"]);
   });
 
+  it("resets positional range state when rows reorder", () => {
+    const { result, rerender } = renderHook(
+      ({ ids }) => useThreadSelection(ids),
+      { initialProps: { ids: ["a", "b", "c"] } },
+    );
+
+    act(() => result.current.toggle(0));
+    rerender({ ids: ["c", "b", "a"] });
+    act(() => result.current.selectRangeTo(1));
+
+    expect([...result.current.selectedIds].sort()).toEqual(["a", "b"]);
+  });
+
   it("ignores a toggle for an index outside the list", () => {
     const { result } = setup();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -31,11 +31,11 @@ export function useThreadSelection(orderedIds: string[]) {
 
   useEffect(() => {
     const visibleIds = new Set(orderedIds);
+    resetAnchor();
+    lastToggledIndex.current = null;
     setSelectedIds((current) => {
       if ([...current].every((id) => visibleIds.has(id))) return current;
 
-      resetAnchor();
-      lastToggledIndex.current = null;
       return new Set([...current].filter((id) => visibleIds.has(id)));
     });
   }, [orderedIds, resetAnchor]);

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Row selection for the mail list.
@@ -28,6 +28,17 @@ export function useThreadSelection(orderedIds: string[]) {
     lastToggledIndex.current = null;
     setSelectedIds((current) => (current.size ? new Set() : current));
   }, [resetAnchor]);
+
+  useEffect(() => {
+    const visibleIds = new Set(orderedIds);
+    setSelectedIds((current) => {
+      if ([...current].every((id) => visibleIds.has(id))) return current;
+
+      resetAnchor();
+      lastToggledIndex.current = null;
+      return new Set([...current].filter((id) => visibleIds.has(id)));
+    });
+  }, [orderedIds, resetAnchor]);
 
   const toggle = useCallback(
     (index: number) => {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260815-193444_pr-3281_8752cd9c5e26/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stacked on `feat/command-palette-snooze-view`.

- support bulk read/unread and snooze mutations
- bound provider mutations with shared concurrency control
- preserve successful optimistic updates while rolling back failures
- prune selections when rows leave the active list

Validation: 17 thread-action and selection tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->