### PR TITLE
refactor(ui): Simplify command palette rows

### DIFF
--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -198,14 +198,7 @@ function CommandPalette() {
                         {command.icon && (
                           <command.icon className="mr-2 h-4 w-4" />
                         )}
-                        <div className="flex flex-1 flex-col">
-                          <span>{command.label}</span>
-                          {command.description && (
-                            <span className="text-xs text-muted-foreground">
-                              {command.description}
-                            </span>
-                          )}
-                        </div>
+                        <span className="flex-1">{command.label}</span>
                         {command.shortcut && (
                           <CommandShortcut>{command.shortcut}</CommandShortcut>
                         )}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260815-192604_pr-3282_e05095963996/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stacked on `feat/mail-snooze-restoration`.

Render Command K choices as a single concise title line, matching the requested Superhuman-style presentation and removing description noise.

This PR changes one component and has no runtime data-path changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->