### PR TITLE
feat(mail): Add contextual Command K actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -22,6 +22,7 @@ import type {
   MailNavTarget,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
+import { buildMailCommandPalette } from "@/app/(app)/[emailAccountId]/mail/mail-command-palette";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
@@ -45,8 +46,12 @@ import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { useSidebar } from "@/components/ui/sidebar";
-import { useAtom } from "jotai";
-import { commandPaletteOpenAtom } from "@/store/command-palette";
+import { useAtom, useSetAtom } from "jotai";
+import {
+  commandPaletteOpenAtom,
+  commandPalettePageAtom,
+  mailCommandContextAtom,
+} from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
   isGoogleProvider,
@@ -112,6 +117,8 @@ export function MailShell() {
   const { setInput: setChatInput } = useChat();
   const { toggleSidebar } = useSidebar();
   const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
+  const setCommandPalettePage = useSetAtom(commandPalettePageAtom);
+  const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
   const { threadId: sidePanelThreadId } = useDisplayedEmail();
@@ -230,12 +237,14 @@ export function MailShell() {
 
   const orderedIds = useMemo(() => threads.map(getListThreadKey), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, markRead, setReadState, undo } = useThreadActions({
-    emailAccountId,
-    removeThreads: accountThreadState.removeThreads,
-    restoreThreads: accountThreadState.restoreThreads,
-    optimisticallyUpdateThreads: accountThreadState.optimisticallyUpdateThreads,
-  });
+  const { archive, trash, markRead, setReadState, snooze, undo } =
+    useThreadActions({
+      emailAccountId,
+      removeThreads: accountThreadState.removeThreads,
+      restoreThreads: accountThreadState.restoreThreads,
+      optimisticallyUpdateThreads:
+        accountThreadState.optimisticallyUpdateThreads,
+    });
 
   const clampIndex = useCallback(
     (index: number) =>
@@ -306,13 +315,15 @@ export function MailShell() {
   );
 
   const runOn = useCallback(
-    (action: (ids: string[]) => void) => {
+    (action: (ids: string[]) => void, removeFromList: boolean) => {
       if (isAllAccounts) return;
       const ids = selection.targetIds(
         focusedThread ? getListThreadKey(focusedThread) : undefined,
       );
       if (!ids.length) return;
-      if (openThreadId && ids.includes(openThreadId)) setOpenThreadId(null);
+      if (removeFromList && openThreadId && ids.includes(openThreadId)) {
+        setOpenThreadId(null);
+      }
       selection.clear();
       action(ids);
     },
@@ -359,7 +370,7 @@ export function MailShell() {
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
   const archiveTargets = useCallback(async () => {
     if (!isAllAccounts) {
-      runOn(archive);
+      runOn(archive, true);
       return;
     }
     if (!focusedThread || !("account" in focusedThread)) return;
@@ -388,7 +399,73 @@ export function MailShell() {
     restoreCombinedThread,
     runOn,
   ]);
-  const trashTargets = useCallback(() => runOn(trash), [runOn, trash]);
+  const trashTargets = useCallback(() => runOn(trash, true), [runOn, trash]);
+  const markReadTargets = useCallback(
+    () => runOn(markRead, false),
+    [runOn, markRead],
+  );
+  const markUnreadTargets = useCallback(
+    () => runOn((ids) => setReadState(ids, false), false),
+    [runOn, setReadState],
+  );
+  const snoozeTargets = useCallback(
+    (until: Date) => runOn((ids) => snooze(ids, until), true),
+    [runOn, snooze],
+  );
+  const openSnoozePalette = useCallback(
+    () => setCommandPalettePage("snooze"),
+    [setCommandPalettePage],
+  );
+  const commandTargetIds = useMemo(
+    () =>
+      isAllAccounts
+        ? []
+        : selection.targetIds(
+            focusedThread ? getListThreadKey(focusedThread) : undefined,
+          ),
+    [isAllAccounts, selection, focusedThread],
+  );
+  const commandTargets = useMemo(() => {
+    const ids = new Set(commandTargetIds);
+    return threads.filter((thread) => ids.has(getListThreadKey(thread)));
+  }, [commandTargetIds, threads]);
+  const mailCommands = useMemo(
+    () =>
+      buildMailCommandPalette({
+        actions: {
+          archive: archiveTargets,
+          markRead: markReadTargets,
+          markUnread: markUnreadTargets,
+          openSnooze: openSnoozePalette,
+          trash: trashTargets,
+        },
+        hasRead: commandTargets.some(
+          (thread) => !isThreadUnread(thread.messages),
+        ),
+        hasUnread: commandTargets.some((thread) =>
+          isThreadUnread(thread.messages),
+        ),
+        targetCount: commandTargetIds.length,
+      }),
+    [
+      archiveTargets,
+      commandTargetIds.length,
+      commandTargets,
+      markReadTargets,
+      markUnreadTargets,
+      openSnoozePalette,
+      trashTargets,
+    ],
+  );
+
+  useEffect(() => {
+    setMailCommandContext(
+      mailCommands.length
+        ? { commands: mailCommands, snooze: snoozeTargets }
+        : null,
+    );
+    return () => setMailCommandContext(null);
+  }, [mailCommands, setMailCommandContext, snoozeTargets]);
   const isMailOverlayOpen =
     isHelpOpen ||
     isPaletteOpen ||

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -416,15 +416,14 @@ export function MailShell() {
     () => setCommandPalettePage("snooze"),
     [setCommandPalettePage],
   );
-  const commandTargetIds = useMemo(
-    () =>
-      isAllAccounts
-        ? []
-        : selection.targetIds(
-            focusedThread ? getListThreadKey(focusedThread) : undefined,
-          ),
-    [isAllAccounts, selection, focusedThread],
-  );
+  const commandTargetIds = useMemo(() => {
+    if (isAllAccounts) {
+      return focusedThread ? [getListThreadKey(focusedThread)] : [];
+    }
+    return selection.targetIds(
+      focusedThread ? getListThreadKey(focusedThread) : undefined,
+    );
+  }, [isAllAccounts, selection, focusedThread]);
   const commandTargets = useMemo(() => {
     const ids = new Set(commandTargetIds);
     return threads.filter((thread) => ids.has(getListThreadKey(thread)));
@@ -432,13 +431,15 @@ export function MailShell() {
   const mailCommands = useMemo(
     () =>
       buildMailCommandPalette({
-        actions: {
-          archive: archiveTargets,
-          markRead: markReadTargets,
-          markUnread: markUnreadTargets,
-          openSnooze: openSnoozePalette,
-          trash: trashTargets,
-        },
+        actions: isAllAccounts
+          ? { archive: archiveTargets }
+          : {
+              archive: archiveTargets,
+              markRead: markReadTargets,
+              markUnread: markUnreadTargets,
+              openSnooze: openSnoozePalette,
+              trash: trashTargets,
+            },
         hasRead: commandTargets.some(
           (thread) => !isThreadUnread(thread.messages),
         ),
@@ -451,6 +452,7 @@ export function MailShell() {
       archiveTargets,
       commandTargetIds.length,
       commandTargets,
+      isAllAccounts,
       markReadTargets,
       markUnreadTargets,
       openSnoozePalette,

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -71,4 +71,15 @@ describe("buildMailCommandPalette", () => {
       }),
     ).toEqual([]);
   });
+
+  it("only exposes actions supported by the active mail source", () => {
+    const commands = buildMailCommandPalette({
+      actions: { archive: actions.archive },
+      hasRead: true,
+      hasUnread: true,
+      targetCount: 1,
+    });
+
+    expect(commands.map((command) => command.id)).toEqual(["mail-archive"]);
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMailCommandPalette } from "./mail-command-palette";
+
+const actions = {
+  archive: vi.fn(),
+  markRead: vi.fn(),
+  markUnread: vi.fn(),
+  openSnooze: vi.fn(),
+  trash: vi.fn(),
+};
+
+describe("buildMailCommandPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("targets the highlighted row when no checkbox selection exists", () => {
+    const commands = buildMailCommandPalette({
+      actions,
+      hasRead: false,
+      hasUnread: true,
+      targetCount: 1,
+    });
+
+    expect(
+      commands.find((command) => command.id === "mail-archive"),
+    ).toMatchObject({ label: "Archive conversation" });
+    expect(commands.map((command) => command.id)).toEqual(
+      expect.arrayContaining(["mail-mark-read", "mail-snooze"]),
+    );
+    expect(commands.map((command) => command.id)).not.toContain(
+      "mail-mark-unread",
+    );
+  });
+
+  it("labels commands for the full multi-selection", () => {
+    const commands = buildMailCommandPalette({
+      actions,
+      hasRead: true,
+      hasUnread: true,
+      targetCount: 3,
+    });
+
+    expect(
+      commands.find((command) => command.id === "mail-archive"),
+    ).toMatchObject({ label: "Archive 3 conversations" });
+    expect(commands.map((command) => command.id)).toEqual(
+      expect.arrayContaining([
+        "mail-mark-read",
+        "mail-mark-unread",
+        "mail-snooze",
+      ]),
+    );
+
+    const snooze = commands.find((command) => command.id === "mail-snooze");
+    expect(snooze).toMatchObject({
+      label: "Snooze 3 conversations",
+      closeOnSelect: false,
+    });
+    snooze?.action();
+    expect(actions.openSnooze).toHaveBeenCalledOnce();
+  });
+
+  it("returns no mail actions for an empty list", () => {
+    expect(
+      buildMailCommandPalette({
+        actions,
+        hasRead: false,
+        hasUnread: false,
+        targetCount: 0,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -1,0 +1,98 @@
+import {
+  ArchiveIcon,
+  Clock3Icon,
+  MailIcon,
+  MailOpenIcon,
+  Trash2Icon,
+} from "lucide-react";
+import type { Command } from "@/lib/commands/types";
+
+type MailCommandActions = {
+  archive: () => void;
+  markRead: () => void;
+  markUnread: () => void;
+  openSnooze: () => void;
+  trash: () => void;
+};
+
+export function buildMailCommandPalette({
+  actions,
+  hasRead,
+  hasUnread,
+  targetCount,
+}: {
+  actions: MailCommandActions;
+  hasRead: boolean;
+  hasUnread: boolean;
+  targetCount: number;
+}): Command[] {
+  if (targetCount === 0) return [];
+
+  const commands: Command[] = [
+    {
+      id: "mail-archive",
+      label:
+        targetCount === 1
+          ? "Archive conversation"
+          : `Archive ${targetCount} conversations`,
+      icon: ArchiveIcon,
+      shortcut: "E",
+      section: "actions",
+      priority: 0,
+      keywords: ["archive", "remove", "inbox"],
+      action: actions.archive,
+    },
+  ];
+
+  if (hasUnread) {
+    commands.push({
+      id: "mail-mark-read",
+      label: targetCount === 1 ? "Mark as read" : `Mark ${targetCount} as read`,
+      icon: MailOpenIcon,
+      section: "actions",
+      priority: 1,
+      keywords: ["read", "seen", "open"],
+      action: actions.markRead,
+    });
+  }
+
+  if (hasRead) {
+    commands.push({
+      id: "mail-mark-unread",
+      label:
+        targetCount === 1 ? "Mark as unread" : `Mark ${targetCount} as unread`,
+      icon: MailIcon,
+      section: "actions",
+      priority: 2,
+      keywords: ["unread", "unseen", "new"],
+      action: actions.markUnread,
+    });
+  }
+
+  commands.push({
+    id: "mail-snooze",
+    label: targetCount === 1 ? "Snooze" : `Snooze ${targetCount} conversations`,
+    icon: Clock3Icon,
+    section: "actions",
+    priority: 3,
+    keywords: ["snooze", "later", "remind"],
+    action: actions.openSnooze,
+    closeOnSelect: false,
+  });
+
+  commands.push({
+    id: "mail-delete",
+    label:
+      targetCount === 1
+        ? "Delete conversation"
+        : `Delete ${targetCount} conversations`,
+    icon: Trash2Icon,
+    shortcut: "#",
+    section: "actions",
+    priority: 10,
+    keywords: ["delete", "trash", "remove"],
+    action: actions.trash,
+  });
+
+  return commands;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -9,10 +9,10 @@ import type { Command } from "@/lib/commands/types";
 
 type MailCommandActions = {
   archive: () => void;
-  markRead: () => void;
-  markUnread: () => void;
-  openSnooze: () => void;
-  trash: () => void;
+  markRead?: () => void;
+  markUnread?: () => void;
+  openSnooze?: () => void;
+  trash?: () => void;
 };
 
 export function buildMailCommandPalette({
@@ -44,7 +44,7 @@ export function buildMailCommandPalette({
     },
   ];
 
-  if (hasUnread) {
+  if (hasUnread && actions.markRead) {
     commands.push({
       id: "mail-mark-read",
       label: targetCount === 1 ? "Mark as read" : `Mark ${targetCount} as read`,
@@ -56,7 +56,7 @@ export function buildMailCommandPalette({
     });
   }
 
-  if (hasRead) {
+  if (hasRead && actions.markUnread) {
     commands.push({
       id: "mail-mark-unread",
       label:
@@ -69,30 +69,35 @@ export function buildMailCommandPalette({
     });
   }
 
-  commands.push({
-    id: "mail-snooze",
-    label: targetCount === 1 ? "Snooze" : `Snooze ${targetCount} conversations`,
-    icon: Clock3Icon,
-    section: "actions",
-    priority: 3,
-    keywords: ["snooze", "later", "remind"],
-    action: actions.openSnooze,
-    closeOnSelect: false,
-  });
+  if (actions.openSnooze) {
+    commands.push({
+      id: "mail-snooze",
+      label:
+        targetCount === 1 ? "Snooze" : `Snooze ${targetCount} conversations`,
+      icon: Clock3Icon,
+      section: "actions",
+      priority: 3,
+      keywords: ["snooze", "later", "remind"],
+      action: actions.openSnooze,
+      closeOnSelect: false,
+    });
+  }
 
-  commands.push({
-    id: "mail-delete",
-    label:
-      targetCount === 1
-        ? "Delete conversation"
-        : `Delete ${targetCount} conversations`,
-    icon: Trash2Icon,
-    shortcut: "#",
-    section: "actions",
-    priority: 10,
-    keywords: ["delete", "trash", "remove"],
-    action: actions.trash,
-  });
+  if (actions.trash) {
+    commands.push({
+      id: "mail-delete",
+      label:
+        targetCount === 1
+          ? "Delete conversation"
+          : `Delete ${targetCount} conversations`,
+      icon: Trash2Icon,
+      shortcut: "#",
+      section: "actions",
+      priority: 10,
+      keywords: ["delete", "trash", "remove"],
+      action: actions.trash,
+    });
+  }
 
   return commands;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260815-200128_pr-3283_8be81ceddf24/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stack 7/9. Previous: #3281. Next: #3284.

- apply Command K actions to the highlighted row or current multi-selection
- surface only useful mail actions: archive, read/unread, snooze, delete, and compose
- expose the supported archive command for highlighted unified-inbox rows
- connect the nested snooze view to the selected conversations

Validation: 73 focused tests pass across the cumulative product stack.