### PR TITLE
command palette: Simplify mail context state

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -22,7 +22,6 @@ import type {
   MailNavTarget,
 } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
-import { buildMailCommandPalette } from "@/app/(app)/[emailAccountId]/mail/mail-command-palette";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
@@ -49,7 +48,6 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useAtom, useSetAtom } from "jotai";
 import {
   commandPaletteOpenAtom,
-  commandPalettePageAtom,
   mailCommandContextAtom,
 } from "@/store/command-palette";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -117,7 +115,6 @@ export function MailShell() {
   const { setInput: setChatInput } = useChat();
   const { toggleSidebar } = useSidebar();
   const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
-  const setCommandPalettePage = useSetAtom(commandPalettePageAtom);
   const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
@@ -412,10 +409,6 @@ export function MailShell() {
     (until: Date) => runOn((ids) => snooze(ids, until), true),
     [runOn, snooze],
   );
-  const openSnoozePalette = useCallback(
-    () => setCommandPalettePage("snooze"),
-    [setCommandPalettePage],
-  );
   const commandTargetIds = useMemo(() => {
     if (isAllAccounts) {
       return focusedThread ? [getListThreadKey(focusedThread)] : [];
@@ -428,26 +421,25 @@ export function MailShell() {
     const ids = new Set(commandTargetIds);
     return threads.filter((thread) => ids.has(getListThreadKey(thread)));
   }, [commandTargetIds, threads]);
-  const mailCommands = useMemo(
-    () =>
-      buildMailCommandPalette({
-        actions: isAllAccounts
-          ? { archive: archiveTargets }
-          : {
-              archive: archiveTargets,
-              markRead: markReadTargets,
-              markUnread: markUnreadTargets,
-              openSnooze: openSnoozePalette,
-              trash: trashTargets,
-            },
-        hasRead: commandTargets.some(
-          (thread) => !isThreadUnread(thread.messages),
-        ),
-        hasUnread: commandTargets.some((thread) =>
-          isThreadUnread(thread.messages),
-        ),
-        targetCount: commandTargetIds.length,
-      }),
+  const mailCommandContext = useMemo(
+    () => ({
+      actions: isAllAccounts
+        ? { archive: archiveTargets }
+        : {
+            archive: archiveTargets,
+            markRead: markReadTargets,
+            markUnread: markUnreadTargets,
+            snooze: snoozeTargets,
+            trash: trashTargets,
+          },
+      hasRead: commandTargets.some(
+        (thread) => !isThreadUnread(thread.messages),
+      ),
+      hasUnread: commandTargets.some((thread) =>
+        isThreadUnread(thread.messages),
+      ),
+      targetCount: commandTargetIds.length,
+    }),
     [
       archiveTargets,
       commandTargetIds.length,
@@ -455,19 +447,17 @@ export function MailShell() {
       isAllAccounts,
       markReadTargets,
       markUnreadTargets,
-      openSnoozePalette,
+      snoozeTargets,
       trashTargets,
     ],
   );
 
   useEffect(() => {
     setMailCommandContext(
-      mailCommands.length
-        ? { commands: mailCommands, snooze: snoozeTargets }
-        : null,
+      mailCommandContext.targetCount ? mailCommandContext : null,
     );
     return () => setMailCommandContext(null);
-  }, [mailCommands, setMailCommandContext, snoozeTargets]);
+  }, [mailCommandContext, setMailCommandContext]);
   const isMailOverlayOpen =
     isHelpOpen ||
     isPaletteOpen ||

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { ArrowLeftIcon, Loader2Icon } from "lucide-react";
 import { useAtom, useAtomValue } from "jotai";
+import { buildMailCommandPalette } from "@/app/(app)/[emailAccountId]/mail/mail-command-palette";
 import { buildSnoozeCommandPalette } from "@/app/(app)/[emailAccountId]/mail/snooze-command-palette";
 import {
   CommandDialog,
@@ -17,9 +18,9 @@ import {
 import { useComposeModal } from "@/providers/ComposeModalProvider";
 import {
   commandPaletteOpenAtom,
-  commandPalettePageAtom,
   mailCommandContextAtom,
 } from "@/store/command-palette";
+import type { MailCommandContext } from "@/store/command-palette";
 import { archiveEmails } from "@/store/archive-queue";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -64,161 +65,122 @@ export function CommandK() {
 }
 
 function CommandPalette() {
-  const [open, setOpen] = useAtom(commandPaletteOpenAtom);
-  const [page, setPage] = useAtom(commandPalettePageAtom);
-  const [search, setSearch] = React.useState("");
-  const inputRef = React.useRef<HTMLInputElement>(null);
   const mailCommandContext = useAtomValue(mailCommandContextAtom);
+  const displayedEmail = useDisplayedEmail();
+  const activeMailContext = displayedEmail.threadId ? null : mailCommandContext;
+
+  return (
+    <CommandPaletteContent
+      key={activeMailContext ? "mail" : "default"}
+      displayedEmail={displayedEmail}
+      mailCommandContext={activeMailContext}
+    />
+  );
+}
+
+function CommandPaletteContent({
+  displayedEmail,
+  mailCommandContext,
+}: {
+  displayedEmail: ReturnType<typeof useDisplayedEmail>;
+  mailCommandContext: MailCommandContext | null;
+}) {
+  const [open, setOpen] = useAtom(commandPaletteOpenAtom);
+  const [page, setPage] = React.useState<"root" | "snooze">("root");
+  const [search, setSearch] = React.useState("");
 
   const { emailAccountId } = useAccount();
-  const { threadId, showEmail } = useDisplayedEmail();
+  const { threadId, showEmail } = displayedEmail;
   const { onOpen: onOpenComposeModal } = useComposeModal();
-  const activeMailContext = threadId ? null : mailCommandContext;
   const { commands, isLoading } = useCommandPaletteCommands({
-    enabled: !activeMailContext,
+    enabled: !mailCommandContext,
   });
 
-  const onArchive = React.useCallback(() => {
-    if (threadId) {
-      archiveEmails({ threadIds: [threadId], emailAccountId });
-      showEmail(null);
-    }
-  }, [threadId, showEmail, emailAccountId]);
-
-  const shortcutHandlers = React.useMemo<ShortcutHandlers>(
-    () => ({
-      commandPalette: () => setOpen((prev) => !prev),
-      compose: onOpenComposeModal,
-      archive: threadId ? onArchive : undefined,
-      // While the palette is open, Escape belongs to the dialog.
-      backToList: open || !threadId ? undefined : () => showEmail(null),
-    }),
-    [threadId, open, onArchive, onOpenComposeModal, showEmail, setOpen],
-  );
+  const shortcutHandlers: ShortcutHandlers = {
+    commandPalette: () => setOpen((wasOpen) => !wasOpen),
+    compose: onOpenComposeModal,
+    archive: threadId
+      ? () => {
+          archiveEmails({ threadIds: [threadId], emailAccountId });
+          showEmail(null);
+        }
+      : undefined,
+    // While the palette is open, Escape belongs to the dialog.
+    backToList: open || !threadId ? undefined : () => showEmail(null),
+  };
 
   useShortcuts(shortcutHandlers);
 
-  // the registry decides which shortcuts surface as palette entries
-  const shortcutCommands = React.useMemo<Command[]>(
-    () => buildShortcutPaletteCommands(shortcutHandlers),
-    [shortcutHandlers],
-  );
+  const shortcutCommands = buildShortcutPaletteCommands(shortcutHandlers);
+  const mailCommands = mailCommandContext
+    ? buildMailCommandPalette({
+        actions: {
+          archive: mailCommandContext.actions.archive,
+          markRead: mailCommandContext.actions.markRead,
+          markUnread: mailCommandContext.actions.markUnread,
+          openSnooze: mailCommandContext.actions.snooze
+            ? () => setPage("snooze")
+            : undefined,
+          trash: mailCommandContext.actions.trash,
+        },
+        hasRead: mailCommandContext.hasRead,
+        hasUnread: mailCommandContext.hasUnread,
+        targetCount: mailCommandContext.targetCount,
+      })
+    : [];
 
-  const snoozeCommands = React.useMemo(() => {
-    if (page !== "snooze" || !activeMailContext) return [];
-
-    return buildSnoozeCommandPalette({
-      onSnooze: activeMailContext.snooze,
+  let allCommands: Command[];
+  if (page === "snooze" && mailCommandContext?.actions.snooze) {
+    const snoozeCommands = buildSnoozeCommandPalette({
+      onSnooze: mailCommandContext.actions.snooze,
       query: search,
     });
-  }, [activeMailContext, page, search]);
-
-  const actionCommands = React.useMemo(() => {
-    if (page === "snooze" && activeMailContext) {
-      if (search.trim()) return snoozeCommands;
-
-      return [
-        {
-          id: "mail-snooze-back",
-          label: "Back to commands",
-          icon: ArrowLeftIcon,
-          section: "actions" as const,
-          priority: -1,
-          closeOnSelect: false,
-          action: () => setPage("root"),
-        },
-        ...snoozeCommands,
-      ];
-    }
-
-    return activeMailContext
+    allCommands = search.trim()
+      ? snoozeCommands
+      : [
+          {
+            id: "mail-snooze-back",
+            label: "Back to commands",
+            icon: ArrowLeftIcon,
+            section: "actions",
+            priority: -1,
+            closeOnSelect: false,
+            action: () => setPage("root"),
+          },
+          ...snoozeCommands,
+        ];
+  } else {
+    const actionCommands = mailCommandContext
       ? [
-          ...activeMailContext.commands,
+          ...mailCommands,
           ...shortcutCommands.filter((command) => command.id === "compose"),
         ]
       : shortcutCommands;
-  }, [
-    activeMailContext,
-    page,
-    search,
-    setPage,
-    shortcutCommands,
-    snoozeCommands,
-  ]);
+    allCommands = [...actionCommands, ...commands];
+  }
 
-  const allCommands = React.useMemo(
-    () =>
-      page === "snooze" ? actionCommands : [...actionCommands, ...commands],
-    [actionCommands, commands, page],
-  );
+  const filteredCommands =
+    page === "snooze" || !search.trim()
+      ? allCommands
+      : fuzzySearch(search, allCommands);
+  const groupedCommands = groupCommands(filteredCommands);
 
-  const filteredCommands = React.useMemo(() => {
-    if (page === "snooze" || !search.trim()) {
-      return allCommands;
+  const executeCommand = (command: Command) => {
+    setSearch("");
+    if (command.closeOnSelect !== false) {
+      setOpen(false);
+      setPage("root");
     }
-    return fuzzySearch(search, allCommands);
-  }, [allCommands, page, search]);
+    command.action();
+  };
 
-  const groupedCommands = React.useMemo(() => {
-    const groups: Record<CommandSection, Command[]> = {
-      actions: [],
-      navigation: [],
-      rules: [],
-      accounts: [],
-      settings: [],
-    };
-
-    for (const command of filteredCommands) {
-      groups[command.section].push(command);
-    }
-
-    return groups;
-  }, [filteredCommands]);
-
-  const executeCommand = React.useCallback(
-    (command: Command) => {
-      setSearch("");
-      if (command.closeOnSelect !== false) {
-        setOpen(false);
-        setPage("root");
-      }
-      command.action();
-    },
-    [setOpen, setPage],
-  );
-
-  const handleOpenChange = React.useCallback(
-    (isOpen: boolean) => {
-      setOpen(isOpen);
-      if (!isOpen) {
-        setPage("root");
-        setSearch("");
-      }
-    },
-    [setOpen, setPage],
-  );
-
-  React.useEffect(() => {
-    if (page === "snooze" && !activeMailContext) {
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
       setPage("root");
       setSearch("");
     }
-  }, [activeMailContext, page, setPage]);
-
-  React.useEffect(() => {
-    if (open && page === "snooze") inputRef.current?.focus();
-  }, [open, page]);
-
-  const commandProps = React.useMemo(
-    () => ({
-      // disable cmdk's built-in filter since we use custom fuzzy search
-      shouldFilter: false,
-      onKeyDown: (e: React.KeyboardEvent) => {
-        if (e.key !== "Escape") e.stopPropagation();
-      },
-    }),
-    [],
-  );
+  };
 
   return (
     <CommandDialog
@@ -230,10 +192,17 @@ function CommandPalette() {
         setPage("root");
         setSearch("");
       }}
-      commandProps={commandProps}
+      commandProps={{
+        // Disable cmdk's built-in filter since we use custom fuzzy search.
+        shouldFilter: false,
+        onKeyDown: (event) => {
+          if (event.key !== "Escape") event.stopPropagation();
+        },
+      }}
     >
       <CommandInput
-        ref={inputRef}
+        key={page}
+        autoFocus
         placeholder={
           page === "snooze"
             ? "When should it return? Try Friday at 3pm"
@@ -318,4 +287,18 @@ function CommandPalette() {
       </div>
     </CommandDialog>
   );
+}
+
+function groupCommands(commands: Command[]) {
+  const groups: Record<CommandSection, Command[]> = {
+    actions: [],
+    navigation: [],
+    rules: [],
+    accounts: [],
+    settings: [],
+  };
+
+  for (const command of commands) groups[command.section].push(command);
+
+  return groups;
 }

--- a/apps/web/hooks/useCommandPaletteCommands.ts
+++ b/apps/web/hooks/useCommandPaletteCommands.ts
@@ -10,7 +10,6 @@ import {
   ScrollTextIcon,
   UsersIcon,
   ShieldCheckIcon,
-  type LucideIcon,
   CalendarIcon,
   FileTextIcon,
   BrushIcon,
@@ -29,21 +28,26 @@ import {
 } from "@/hooks/useFeatureFlags";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 
-interface NavigationItem {
-  href: string;
-  icon: LucideIcon;
-  keywords?: string[];
-  name: string;
-}
-
-function useNavigationItems(): NavigationItem[] {
+export function useCommandPaletteCommands({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) {
+  const router = useRouter();
   const { emailAccountId, provider } = useAccount();
+  const { data: rulesData, isLoading: rulesLoading } = useRules(
+    undefined,
+    enabled,
+  );
+  const { data: user, isLoading: userLoading } = useUser(enabled);
   const showCleaner = useCleanerEnabled();
   const showMeetingBriefs = useMeetingBriefsEnabled();
   const showIntegrations = useIntegrationsEnabled();
 
-  return useMemo(
-    () => [
+  const commands = useMemo<Command[]>(() => {
+    if (!enabled) return [];
+
+    const navigationItems = [
       {
         name: "Assistant",
         href: prefixPath(emailAccountId, "/automation"),
@@ -104,47 +108,20 @@ function useNavigationItems(): NavigationItem[] {
         icon: ShieldCheckIcon,
         keywords: ["block", "cold", "spam", "filter"],
       },
-    ],
-    [
-      emailAccountId,
-      provider,
-      showCleaner,
-      showMeetingBriefs,
-      showIntegrations,
-    ],
-  );
-}
-
-export function useCommandPaletteCommands({
-  enabled = true,
-}: {
-  enabled?: boolean;
-} = {}) {
-  const router = useRouter();
-  const { emailAccountId } = useAccount();
-  const { data: rulesData, isLoading: rulesLoading } = useRules(
-    undefined,
-    enabled,
-  );
-  const { data: user, isLoading: userLoading } = useUser(enabled);
-  const navigationItems = useNavigationItems();
-
-  const navigationCommands = useMemo<Command[]>(
-    () =>
-      navigationItems.map((item, index) => ({
+    ];
+    const navigationCommands: Command[] = navigationItems.map(
+      (item, index) => ({
         id: `nav-${item.name.toLowerCase().replace(/\s+/g, "-")}`,
         label: `Go to ${item.name}`,
         icon: item.icon,
-        section: "navigation" as const,
+        section: "navigation",
         priority: index + 10,
-        keywords: [item.name.toLowerCase(), ...(item.keywords || [])],
+        keywords: [item.name.toLowerCase(), ...item.keywords],
         action: () => router.push(item.href),
-      })),
-    [navigationItems, router],
-  );
+      }),
+    );
 
-  const settingsCommands = useMemo<Command[]>(
-    () => [
+    const settingsCommands: Command[] = [
       {
         id: "settings-general",
         label: "Settings",
@@ -196,14 +173,9 @@ export function useCommandPaletteCommands({
         keywords: ["accounts", "email", "switch"],
         action: () => router.push("/accounts"),
       },
-    ],
-    [router, emailAccountId],
-  );
+    ];
 
-  const ruleCommands = useMemo<Command[]>(() => {
-    if (!rulesData) return [];
-
-    return rulesData.map((rule, index) => ({
+    const ruleCommands: Command[] = (rulesData ?? []).map((rule, index) => ({
       id: `rule-${rule.id}`,
       label: rule.name,
       description: rule.instructions || "View rule",
@@ -214,12 +186,8 @@ export function useCommandPaletteCommands({
       action: () =>
         router.push(prefixPath(emailAccountId, `/assistant/rule/${rule.id}`)),
     }));
-  }, [rulesData, router, emailAccountId]);
 
-  const accountCommands = useMemo<Command[]>(() => {
-    if (!user?.emailAccounts) return [];
-
-    return user.emailAccounts
+    const accountCommands: Command[] = (user?.emailAccounts ?? [])
       .filter((account) => account.id !== emailAccountId)
       .map((account, index) => ({
         id: `account-${account.id}`,
@@ -231,29 +199,27 @@ export function useCommandPaletteCommands({
         keywords: ["switch", "account", account.email?.toLowerCase() || ""],
         action: () => router.push(prefixPath(account.id, "/automation")),
       }));
-  }, [user?.emailAccounts, router, emailAccountId]);
 
-  const allCommands = useMemo(
-    () =>
-      enabled
-        ? [
-            ...navigationCommands,
-            ...settingsCommands,
-            ...ruleCommands,
-            ...accountCommands,
-          ]
-        : [],
-    [
-      enabled,
-      navigationCommands,
-      settingsCommands,
-      ruleCommands,
-      accountCommands,
-    ],
-  );
+    return [
+      ...navigationCommands,
+      ...settingsCommands,
+      ...ruleCommands,
+      ...accountCommands,
+    ];
+  }, [
+    emailAccountId,
+    enabled,
+    provider,
+    router,
+    rulesData,
+    showCleaner,
+    showIntegrations,
+    showMeetingBriefs,
+    user?.emailAccounts,
+  ]);
 
   return {
-    commands: allCommands,
+    commands,
     isLoading: enabled && (rulesLoading || userLoading),
   };
 }

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
-import type { Command } from "@/lib/commands/types";
 
 /**
  * Open state for the command palette. It lives outside CommandK so surfaces
@@ -8,17 +7,21 @@ import type { Command } from "@/lib/commands/types";
  */
 export const commandPaletteOpenAtom = atom(false);
 
-type CommandPalettePage = "root" | "snooze";
-
-export const commandPalettePageAtom = atom<CommandPalettePage>("root");
-
-type MailCommandContext = {
-  commands: Command[];
-  snooze: (until: Date) => void;
+export type MailCommandContext = {
+  actions: {
+    archive: () => void;
+    markRead?: () => void;
+    markUnread?: () => void;
+    snooze?: (until: Date) => void;
+    trash?: () => void;
+  };
+  hasRead: boolean;
+  hasUnread: boolean;
+  targetCount: number;
 };
 
 /**
- * Commands owned by the active mail list. Keeping the callbacks here lets the
- * app-wide palette act on list state without duplicating selection state.
+ * The active mail list owns its selection state and actions. This bridge lets
+ * the app-wide palette consume them without duplicating that state.
  */
 export const mailCommandContextAtom = atom<MailCommandContext | null>(null);


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260815-232741_pr-3286_45745bff525e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keeps the Command-K mail and snooze behavior while reducing state synchronization and hook indirection. Stacked on #3277.\n\n- make the snooze subpage local to Command-K and remove its global page atom\n- pass raw mail actions and target state through the cross-layout bridge\n- remove unnecessary Command-K memo/callback/effect layers and consolidate dynamic command construction\n- preserve description-backed fuzzy search and verify the focused command, snooze, shortcut, action, and selection suites

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->