### PR TITLE
fix(mail): show active account address in switcher

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -34,6 +34,8 @@ export function MailAccountSwitcher({
   const activeLabel = isAllAccounts
     ? "All accounts"
     : emailAccount?.name || emailAccount?.email || "Choose account";
+  const activeEmail =
+    !isAllAccounts && emailAccount?.name ? emailAccount.email : null;
   let activeIcon: ReactNode = null;
   if (isAllAccounts) {
     activeIcon = <AllAccountsIcon />;
@@ -66,8 +68,15 @@ export function MailAccountSwitcher({
             )}
           >
             {activeIcon}
-            <span className="min-w-0 flex-1 truncate font-medium text-sm">
-              {activeLabel}
+            <span className="min-w-0 flex-1 leading-tight">
+              <span className="block truncate font-medium text-sm">
+                {activeLabel}
+              </span>
+              {activeEmail ? (
+                <span className="block truncate text-muted-foreground text-xs">
+                  {activeEmail}
+                </span>
+              ) : null}
             </span>
             <ChevronsUpDownIcon className="size-4 text-muted-foreground" />
           </button>


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-002836_pr-3287_f7e26624279c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Shows the active email address beneath the display name in the mail account switcher.

- Preserves single-line states for all-accounts and address-only labels
- Adds truncation and muted styling consistent with existing account selectors
- Validated with Ultracite and git diff checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->