### PR TITLE
Add account-scoped Meetings redirect

### DIFF
--- a/apps/web/app/(redirects)/meetings/page.tsx
+++ b/apps/web/app/(redirects)/meetings/page.tsx
@@ -1,0 +1,9 @@
+import { redirectToEmailAccountPath } from "@/utils/account";
+
+export default async function MeetingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await redirectToEmailAccountPath("/meetings", await searchParams);
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-001942_pr-3288_481afd6bd763/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- add an unscoped `/meetings` route that redirects to the active email account
- preserve query parameters through the account-scoped redirect

## Testing

- `pnpm exec ultracite check apps/web/app/(redirects)/meetings/page.tsx`
- `pnpm test utils/account.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->