### PR TITLE
feat(mail): add collapsible navigation

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -3,6 +3,7 @@
 import { ColumnsIcon, RowsIcon, SearchIcon, SparklesIcon } from "lucide-react";
 import { Kbd } from "@/components/Kbd";
 import { Tooltip } from "@/components/Tooltip";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
@@ -13,6 +14,7 @@ export type ListToolbarProps = {
   onOpenSearch: () => void;
   onToggleLayout: () => void;
   onToggleAssistant: () => void;
+  showSidebarToggle?: boolean;
 };
 
 export function ListToolbar({
@@ -21,11 +23,16 @@ export function ListToolbar({
   onOpenSearch,
   onToggleLayout,
   onToggleAssistant,
+  showSidebarToggle = false,
 }: ListToolbarProps) {
   const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
 
   return (
     <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3">
+      {showSidebarToggle ? (
+        <SidebarTrigger name="left-sidebar" className="hidden lg:inline-flex" />
+      ) : null}
+
       {/* Opens the command palette rather than searching mail — it navigates
           and runs actions, and promising search we don't have would mislead. */}
       <button

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -115,7 +115,7 @@ export function MailShell() {
   const { data: settings, mutate: mutateSettings } = useMailSettings();
   const { onOpen: openCompose } = useComposeModal();
   const { setInput: setChatInput } = useChat();
-  const { toggleSidebar } = useSidebar();
+  const { state: openSidebars, toggleSidebar } = useSidebar();
   const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
   const setCommandPalettePage = useSetAtom(commandPalettePageAtom);
   const setMailCommandContext = useSetAtom(mailCommandContextAtom);
@@ -137,6 +137,7 @@ export function MailShell() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
+  const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   const isAllAccounts = accountScope === "all";
   const accountLayout: MailLayoutMode =
@@ -639,7 +640,7 @@ export function MailShell() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
-        {!isFocusMode && (
+        {!isFocusMode && isMailSidebarOpen && (
           <MailSidebar
             className="hidden lg:flex"
             activeType={
@@ -686,6 +687,7 @@ export function MailShell() {
               onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
+              showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
             />
             {!isScoped && (
@@ -761,6 +763,7 @@ export function MailShell() {
             onDelete={trashTargets}
             onReply={() => setReplyToMessageId(openMessages?.at(-1)?.id)}
             onToggleFocusMode={() => setIsFocusMode((on) => !on)}
+            showSidebarToggle={!isMailSidebarOpen}
             refetch={refetchOpenThread}
             autoOpenReplyForMessageId={replyToMessageId}
             menu={

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -24,6 +24,7 @@ import type { LabelCount } from "@/app/api/labels/counts/route";
 import { Kbd } from "@/components/Kbd";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { GmailLabel } from "@/utils/gmail/label";
@@ -158,14 +159,19 @@ export function MailSidebar({
         className,
       )}
     >
-      <Link
-        href={backToAppHref}
-        className="mb-2.5 flex shrink-0 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <ArrowLeftIcon className="size-3.5 shrink-0" />
-        <span className="flex-1 truncate">Inbox Zero</span>
-        <Kbd>{getShortcutHint("backToApp")}</Kbd>
-      </Link>
+      <div className="mb-2.5 flex shrink-0 items-center gap-1">
+        <Link
+          href={backToAppHref}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeftIcon className="size-3.5 shrink-0" />
+          <span className="flex-1 truncate">Inbox Zero</span>
+        </Link>
+        <SidebarTrigger
+          name="left-sidebar"
+          className="size-6 shrink-0 text-muted-foreground"
+        />
+      </div>
 
       <Button
         variant="gradient"

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -14,6 +14,7 @@ import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { Kbd } from "@/components/Kbd";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 export type ReaderToolbarProps = {
@@ -38,6 +39,7 @@ export type ReaderToolbarProps = {
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
+  showSidebarToggle?: boolean;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
@@ -62,6 +64,7 @@ export function ReaderToolbar({
   onReply,
   onDelete,
   onToggleFocusMode,
+  showSidebarToggle = false,
   menu,
 }: ReaderToolbarProps) {
   const showBackBar = layout === "list" && !isFocusMode;
@@ -71,6 +74,12 @@ export function ReaderToolbar({
     <div>
       {showBackBar ? (
         <div className="-mx-1 sticky top-0 z-10 mb-4 flex items-center gap-3 bg-card px-1 py-2">
+          {showSidebarToggle ? (
+            <SidebarTrigger
+              name="left-sidebar"
+              className="hidden lg:inline-flex"
+            />
+          ) : null}
           <Button onClick={onBack} size="xs-2" variant="outline">
             <ArrowLeftIcon className="mr-1.5 size-3.5" />
             Back

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -38,6 +38,7 @@ export type ThreadReaderProps = {
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
+  showSidebarToggle?: boolean;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
   refetch: () => void;
   /**
@@ -64,6 +65,7 @@ export function ThreadReader({
   onReply,
   onDelete,
   onToggleFocusMode,
+  showSidebarToggle = false,
   refetch,
   autoOpenReplyForMessageId,
   menu,
@@ -109,6 +111,7 @@ export function ThreadReader({
           position={position}
           senderEmail={extractEmailAddress(sender)}
           senderName={extractNameFromEmail(sender)}
+          showSidebarToggle={showSidebarToggle}
           subject={headerMessage.headers.subject}
         />
 

--- a/apps/web/components/SideNavWithTopNav.tsx
+++ b/apps/web/components/SideNavWithTopNav.tsx
@@ -84,9 +84,8 @@ export function SideNavWithTopNav({
       defaultOpen={defaultOpen ? ["left-sidebar"] : []}
       sidebarNames={["left-sidebar", "chat-sidebar"]}
     >
-      {/* Both are suppressed together: the trigger only opens SideNav, so
-          leaving it on the mail route would render a button that opens an
-          empty drawer. */}
+      {/* Mail supplies its own sidebar and trigger for this shared state, so
+          the global navigation and its mobile header would be duplicates. */}
       {!isMailRoute && (
         <>
           <MobileHeader />


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-003920_pr-3289_913eb1b48b50/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a collapsible sidebar to the mail interface using the existing persisted navigation state.

- Replaces the shortcut badge with the shared sidebar control and exposes a reopen control in list and reader layouts.
- Keeps global navigation suppression aligned with the route-specific sidebar.
- Validation: focused Ultracite checks passed for all changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->