### PR TITLE
fix(mail): keep reader navigation and archive actions in sync

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -33,6 +33,10 @@ import type {
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
 import {
+  getActiveThreadIndex,
+  getNextThreadIdAfterRemoval,
+} from "@/app/(app)/[emailAccountId]/mail/thread-list-behavior";
+import {
   getListThreadKey,
   type MailLayoutMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
@@ -251,11 +255,16 @@ export function MailShell() {
       Math.min(Math.max(0, index), Math.max(0, threads.length - 1)),
     [threads.length],
   );
-  const clampedIndex = clampIndex(focusedIndex);
+  const clampedIndex = getActiveThreadIndex({
+    threadIds: orderedIds,
+    focusedIndex,
+    openThreadId,
+  });
   const focusedThread = threads[clampedIndex];
-  const openThread = isAllAccounts
-    ? undefined
-    : threads.find((thread) => thread.id === openThreadId);
+  const openThread =
+    !isAllAccounts && openThreadId === focusedThread?.id
+      ? focusedThread
+      : undefined;
   const resolvedOpenThreadId = openThread?.id;
   const readAttemptedForOpenThread = useRef<string | null>(null);
 
@@ -315,19 +324,38 @@ export function MailShell() {
   );
 
   const runOn = useCallback(
-    (action: (ids: string[]) => void, removeFromList: boolean) => {
+    (
+      action: (ids: string[]) => void,
+      removeFromList: boolean,
+      autoAdvanceReader = false,
+    ) => {
       if (isAllAccounts) return;
       const ids = selection.targetIds(
         focusedThread ? getListThreadKey(focusedThread) : undefined,
       );
       if (!ids.length) return;
       if (removeFromList && openThreadId && ids.includes(openThreadId)) {
-        setOpenThreadId(null);
+        setOpenThreadId(
+          autoAdvanceReader
+            ? getNextThreadIdAfterRemoval({
+                threadIds: orderedIds,
+                currentThreadId: openThreadId,
+                removedThreadIds: ids,
+              })
+            : null,
+        );
       }
       selection.clear();
       action(ids);
     },
-    [isAllAccounts, selection, focusedThread, openThreadId, setOpenThreadId],
+    [
+      focusedThread,
+      isAllAccounts,
+      openThreadId,
+      orderedIds,
+      selection,
+      setOpenThreadId,
+    ],
   );
 
   const openAt = useCallback(
@@ -350,12 +378,12 @@ export function MailShell() {
     (delta: number) => {
       const next = clampIndex(clampedIndex + delta);
       setFocusedIndex(next);
-      // In split view the reader tracks the cursor; in list view it doesn't,
-      // so J/K browses the list without yanking you out of what you're reading.
-      if (layout === "split" && threads[next])
+      // Once a reader is open, navigation keeps its content and position in
+      // step. A closed list view still lets J/K move the row cursor alone.
+      if ((layout === "split" || openThreadId) && threads[next])
         setOpenThreadId(threads[next].id);
     },
-    [clampIndex, clampedIndex, threads, layout, setOpenThreadId],
+    [clampIndex, clampedIndex, threads, layout, openThreadId, setOpenThreadId],
   );
 
   const extendSelection = useCallback(
@@ -370,7 +398,7 @@ export function MailShell() {
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
   const archiveTargets = useCallback(async () => {
     if (!isAllAccounts) {
-      runOn(archive, true);
+      runOn(archive, true, true);
       return;
     }
     if (!focusedThread || !("account" in focusedThread)) return;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -34,7 +34,8 @@ import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
 import {
   getActiveThreadIndex,
-  getNextThreadIdAfterRemoval,
+  getNextThreadAfterRemoval,
+  getThreadActionTargetIds,
 } from "@/app/(app)/[emailAccountId]/mail/thread-list-behavior";
 import {
   getListThreadKey,
@@ -330,20 +331,26 @@ export function MailShell() {
       autoAdvanceReader = false,
     ) => {
       if (isAllAccounts) return;
-      const ids = selection.targetIds(
-        focusedThread ? getListThreadKey(focusedThread) : undefined,
-      );
+      const ids = getThreadActionTargetIds({
+        openThreadId,
+        activeThreadId: focusedThread
+          ? getListThreadKey(focusedThread)
+          : undefined,
+        selectedThreadIds: [...selection.selectedIds],
+      });
       if (!ids.length) return;
       if (removeFromList && openThreadId && ids.includes(openThreadId)) {
-        setOpenThreadId(
-          autoAdvanceReader
-            ? getNextThreadIdAfterRemoval({
-                threadIds: orderedIds,
-                currentThreadId: openThreadId,
-                removedThreadIds: ids,
-              })
-            : null,
-        );
+        if (autoAdvanceReader) {
+          const nextThread = getNextThreadAfterRemoval({
+            threadIds: orderedIds,
+            currentThreadId: openThreadId,
+            removedThreadIds: ids,
+          });
+          setFocusedIndex(nextThread?.index ?? 0);
+          setOpenThreadId(nextThread?.id ?? null);
+        } else {
+          setOpenThreadId(null);
+        }
       }
       selection.clear();
       action(ids);

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   getActiveThreadIndex,
-  getNextThreadIdAfterRemoval,
+  getNextThreadAfterRemoval,
+  getThreadActionTargetIds,
   scrollElementIntoContainer,
   shouldPrefetchMoreThreads,
   THREAD_PREFETCH_REMAINING,
@@ -27,42 +28,84 @@ describe("getActiveThreadIndex", () => {
       }),
     ).toBe(1);
   });
+
+  it("does not select an unrelated row when the open reader is missing", () => {
+    expect(
+      getActiveThreadIndex({
+        threadIds: ["one", "two", "three"],
+        focusedIndex: 1,
+        openThreadId: "missing",
+      }),
+    ).toBe(-1);
+  });
 });
 
-describe("getNextThreadIdAfterRemoval", () => {
+describe("getThreadActionTargetIds", () => {
+  it("targets an open reader that is missing from the current list", () => {
+    expect(
+      getThreadActionTargetIds({
+        openThreadId: "missing",
+        activeThreadId: undefined,
+        selectedThreadIds: ["one"],
+      }),
+    ).toEqual(["missing"]);
+  });
+
+  it("preserves an explicit selection when the open reader is in the list", () => {
+    expect(
+      getThreadActionTargetIds({
+        openThreadId: "two",
+        activeThreadId: "two",
+        selectedThreadIds: ["one", "two"],
+      }),
+    ).toEqual(["one", "two"]);
+  });
+});
+
+describe("getNextThreadAfterRemoval", () => {
   it("advances to the next surviving thread", () => {
     expect(
-      getNextThreadIdAfterRemoval({
+      getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three"],
         currentThreadId: "two",
         removedThreadIds: ["two"],
       }),
-    ).toBe("three");
+    ).toEqual({ id: "three", index: 1 });
   });
 
   it("skips other threads removed by the same action", () => {
     expect(
-      getNextThreadIdAfterRemoval({
+      getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three", "four"],
         currentThreadId: "two",
         removedThreadIds: ["two", "three"],
       }),
-    ).toBe("four");
+    ).toEqual({ id: "four", index: 1 });
+  });
+
+  it("accounts for earlier threads removed by the same action", () => {
+    expect(
+      getNextThreadAfterRemoval({
+        threadIds: ["one", "two", "three", "four"],
+        currentThreadId: "three",
+        removedThreadIds: ["one", "three"],
+      }),
+    ).toEqual({ id: "four", index: 1 });
   });
 
   it("falls back to the previous surviving thread at the end", () => {
     expect(
-      getNextThreadIdAfterRemoval({
+      getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three"],
         currentThreadId: "three",
         removedThreadIds: ["two", "three"],
       }),
-    ).toBe("one");
+    ).toEqual({ id: "one", index: 0 });
   });
 
   it("closes the reader when every thread is removed", () => {
     expect(
-      getNextThreadIdAfterRemoval({
+      getNextThreadAfterRemoval({
         threadIds: ["one", "two"],
         currentThreadId: "one",
         removedThreadIds: ["one", "two"],

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -1,9 +1,75 @@
 import { describe, expect, it } from "vitest";
 import {
+  getActiveThreadIndex,
+  getNextThreadIdAfterRemoval,
   scrollElementIntoContainer,
   shouldPrefetchMoreThreads,
   THREAD_PREFETCH_REMAINING,
 } from "./thread-list-behavior";
+
+describe("getActiveThreadIndex", () => {
+  it("uses the open reader instead of a stale row cursor", () => {
+    expect(
+      getActiveThreadIndex({
+        threadIds: ["one", "two", "three"],
+        focusedIndex: 0,
+        openThreadId: "three",
+      }),
+    ).toBe(2);
+  });
+
+  it("uses the row cursor when the reader is closed", () => {
+    expect(
+      getActiveThreadIndex({
+        threadIds: ["one", "two", "three"],
+        focusedIndex: 1,
+        openThreadId: null,
+      }),
+    ).toBe(1);
+  });
+});
+
+describe("getNextThreadIdAfterRemoval", () => {
+  it("advances to the next surviving thread", () => {
+    expect(
+      getNextThreadIdAfterRemoval({
+        threadIds: ["one", "two", "three"],
+        currentThreadId: "two",
+        removedThreadIds: ["two"],
+      }),
+    ).toBe("three");
+  });
+
+  it("skips other threads removed by the same action", () => {
+    expect(
+      getNextThreadIdAfterRemoval({
+        threadIds: ["one", "two", "three", "four"],
+        currentThreadId: "two",
+        removedThreadIds: ["two", "three"],
+      }),
+    ).toBe("four");
+  });
+
+  it("falls back to the previous surviving thread at the end", () => {
+    expect(
+      getNextThreadIdAfterRemoval({
+        threadIds: ["one", "two", "three"],
+        currentThreadId: "three",
+        removedThreadIds: ["two", "three"],
+      }),
+    ).toBe("one");
+  });
+
+  it("closes the reader when every thread is removed", () => {
+    expect(
+      getNextThreadIdAfterRemoval({
+        threadIds: ["one", "two"],
+        currentThreadId: "one",
+        removedThreadIds: ["one", "two"],
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("shouldPrefetchMoreThreads", () => {
   it("does not prefetch when there is no next page", () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -2,6 +2,49 @@ export const THREAD_PREFETCH_REMAINING = 8;
 export const THREAD_SCROLL_PADDING_PX = 8;
 export const THREAD_LOAD_MORE_ROOT_MARGIN = "400px 0px";
 
+export function getActiveThreadIndex({
+  threadIds,
+  focusedIndex,
+  openThreadId,
+}: {
+  threadIds: string[];
+  focusedIndex: number;
+  openThreadId: string | null;
+}): number {
+  const clampedFocusedIndex = Math.min(
+    Math.max(0, focusedIndex),
+    Math.max(0, threadIds.length - 1),
+  );
+  if (!openThreadId) return clampedFocusedIndex;
+
+  const openThreadIndex = threadIds.indexOf(openThreadId);
+  return openThreadIndex >= 0 ? openThreadIndex : clampedFocusedIndex;
+}
+
+export function getNextThreadIdAfterRemoval({
+  threadIds,
+  currentThreadId,
+  removedThreadIds,
+}: {
+  threadIds: string[];
+  currentThreadId: string;
+  removedThreadIds: string[];
+}): string | null {
+  const currentIndex = threadIds.indexOf(currentThreadId);
+  if (currentIndex < 0) return null;
+
+  const removed = new Set(removedThreadIds);
+  for (let index = currentIndex + 1; index < threadIds.length; index++) {
+    const threadId = threadIds[index];
+    if (threadId && !removed.has(threadId)) return threadId;
+  }
+  for (let index = currentIndex - 1; index >= 0; index--) {
+    const threadId = threadIds[index];
+    if (threadId && !removed.has(threadId)) return threadId;
+  }
+  return null;
+}
+
 export function shouldPrefetchMoreThreads({
   hasMore,
   isLoadingMore,

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -18,10 +18,24 @@ export function getActiveThreadIndex({
   if (!openThreadId) return clampedFocusedIndex;
 
   const openThreadIndex = threadIds.indexOf(openThreadId);
-  return openThreadIndex >= 0 ? openThreadIndex : clampedFocusedIndex;
+  return openThreadIndex;
 }
 
-export function getNextThreadIdAfterRemoval({
+export function getThreadActionTargetIds({
+  openThreadId,
+  activeThreadId,
+  selectedThreadIds,
+}: {
+  openThreadId: string | null;
+  activeThreadId: string | undefined;
+  selectedThreadIds: string[];
+}): string[] {
+  if (openThreadId && !activeThreadId) return [openThreadId];
+  if (selectedThreadIds.length) return selectedThreadIds;
+  return activeThreadId ? [activeThreadId] : [];
+}
+
+export function getNextThreadAfterRemoval({
   threadIds,
   currentThreadId,
   removedThreadIds,
@@ -29,20 +43,37 @@ export function getNextThreadIdAfterRemoval({
   threadIds: string[];
   currentThreadId: string;
   removedThreadIds: string[];
-}): string | null {
+}): { id: string; index: number } | null {
   const currentIndex = threadIds.indexOf(currentThreadId);
   if (currentIndex < 0) return null;
 
   const removed = new Set(removedThreadIds);
+  let nextThreadId: string | undefined;
   for (let index = currentIndex + 1; index < threadIds.length; index++) {
     const threadId = threadIds[index];
-    if (threadId && !removed.has(threadId)) return threadId;
+    if (threadId && !removed.has(threadId)) {
+      nextThreadId = threadId;
+      break;
+    }
   }
-  for (let index = currentIndex - 1; index >= 0; index--) {
-    const threadId = threadIds[index];
-    if (threadId && !removed.has(threadId)) return threadId;
+  if (!nextThreadId) {
+    for (let index = currentIndex - 1; index >= 0; index--) {
+      const threadId = threadIds[index];
+      if (threadId && !removed.has(threadId)) {
+        nextThreadId = threadId;
+        break;
+      }
+    }
   }
-  return null;
+  if (!nextThreadId) return null;
+
+  const remainingThreadIds = threadIds.filter(
+    (threadId) => !removed.has(threadId),
+  );
+  return {
+    id: nextThreadId,
+    index: remainingThreadIds.indexOf(nextThreadId),
+  };
 }
 
 export function shouldPrefetchMoreThreads({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-004456_pr-3290_41c3d5d8afc3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Keep keyboard navigation synchronized with the open reader and its position.
- Advance the reader to the next available conversation after archive.
- Cover navigation and removal edge cases with focused unit tests.

## Validation
- `pnpm test app/(app)/[emailAccountId]/mail`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->