### PR TITLE
fix: type command palette keyboard events

### DIFF
--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -195,7 +195,7 @@ function CommandPaletteContent({
       commandProps={{
         // Disable cmdk's built-in filter since we use custom fuzzy search.
         shouldFilter: false,
-        onKeyDown: (event) => {
+        onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
           if (event.key !== "Escape") event.stopPropagation();
         },
       }}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-004944_pr-3291_03ea9f84c254/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix the command palette type-check failure without changing runtime behavior.

- Type the command root keyboard event as a React event for its div element.
- Verify the web app with the CI-aligned build and Biome checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->