### PR TITLE
outlook: Avoid retrying ambiguous Graph writes

### DIFF
--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -92,6 +92,7 @@ import {
   extractErrorInfo,
   isRetryableError,
   withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
 } from "@/utils/microsoft/retry";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
 import { getOutlookMailboxSyncPage } from "@/utils/outlook/mailbox-sync";
@@ -598,7 +599,7 @@ export class OutlookProvider implements EmailProvider {
 
     // For threading, use createReply on the replyToMessageId
     if (params.replyToMessageId) {
-      const draft = await withMicrosoftGraphRetry(
+      const draft = await withMicrosoftGraphWriteRetry(
         () =>
           this.client
             .getClient()
@@ -608,7 +609,7 @@ export class OutlookProvider implements EmailProvider {
       );
 
       // Update the draft with our content
-      await withMicrosoftGraphRetry(
+      await withMicrosoftGraphWriteRetry(
         () =>
           this.client
             .getClient()
@@ -626,7 +627,7 @@ export class OutlookProvider implements EmailProvider {
     }
 
     // Otherwise create standalone draft
-    const draft = await withMicrosoftGraphRetry(
+    const draft = await withMicrosoftGraphWriteRetry(
       () =>
         this.client
           .getClient()
@@ -660,7 +661,7 @@ export class OutlookProvider implements EmailProvider {
       body.subject = params.subject;
     }
 
-    await withMicrosoftGraphRetry(
+    await withMicrosoftGraphWriteRetry(
       () => this.client.getClient().api(`/me/messages/${draftId}`).patch(body),
       this.logger,
     );

--- a/apps/web/utils/microsoft/retry.test.ts
+++ b/apps/web/utils/microsoft/retry.test.ts
@@ -5,6 +5,7 @@ import {
   isRetryableError,
   calculateRetryDelay,
   withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
 } from "./retry";
 
 describe("extractErrorInfo", () => {
@@ -49,6 +50,21 @@ describe("extractErrorInfo", () => {
         message: "Rate limited",
       },
       expected: { status: 429, errorMessage: "Rate limited" },
+    },
+    {
+      name: "p-retry wrapped error",
+      error: {
+        error: {
+          statusCode: 429,
+          code: "TooManyRequests",
+          message: "Throttled",
+        },
+      },
+      expected: {
+        status: 429,
+        code: "TooManyRequests",
+        errorMessage: "Throttled",
+      },
     },
   ])("extracts $name", ({ error, expected }) => {
     expect(extractErrorInfo(error)).toMatchObject(expected);
@@ -226,5 +242,38 @@ describe("withMicrosoftGraphRetry", () => {
     ).rejects.toBeDefined();
 
     expect(operation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withMicrosoftGraphWriteRetry", () => {
+  it.each([
+    Object.assign(new Error("Service unavailable"), { statusCode: 503 }),
+    new Error("fetch failed"),
+    Object.assign(new Error("Change key conflict"), { statusCode: 412 }),
+  ])("does not repeat a write after an ambiguous failure", async (error) => {
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      withMicrosoftGraphWriteRetry(operation, createTestLogger()),
+    ).rejects.toBeDefined();
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a write rejected by a rate limit", async () => {
+    const rateLimitError = Object.assign(new Error("Throttled"), {
+      statusCode: 429,
+      response: { headers: { "retry-after": "0" } },
+    });
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValue("ok");
+
+    await expect(
+      withMicrosoftGraphWriteRetry(operation, createTestLogger(), 1),
+    ).resolves.toBe("ok");
+
+    expect(operation).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/utils/microsoft/retry.ts
+++ b/apps/web/utils/microsoft/retry.ts
@@ -27,69 +27,33 @@ export async function withMicrosoftGraphRetry<T>(
   maxRetries = 5,
   maxBlockingDelayMs = MAX_MICROSOFT_GRAPH_BLOCKING_RETRY_DELAY_MS,
 ): Promise<T> {
-  return pRetry(operation, {
-    retries: maxRetries,
-    onFailedAttempt: async (error) => {
-      const errorInfo = extractErrorInfo(error);
-      const { retryable, isRateLimit, isServerError, isConflictError } =
-        isRetryableError(errorInfo);
+  return withMicrosoftGraphRetryPolicy(
+    operation,
+    logger,
+    maxRetries,
+    maxBlockingDelayMs,
+    "all",
+  );
+}
 
-      if (!retryable) {
-        logger.warn("Non-retryable error encountered", {
-          error,
-          status: errorInfo.status,
-          code: errorInfo.code,
-          responseBody: errorInfo.responseBody,
-        });
-        throw error;
-      }
-
-      const retryAfterHeader = getRetryAfterHeaderFromError(error);
-
-      const delayMs = calculateRetryDelay(
-        isRateLimit,
-        isServerError,
-        isConflictError,
-        error.attemptNumber,
-        retryAfterHeader,
-      );
-
-      logger.warn("Microsoft Graph error. Will retry", {
-        delaySeconds: Math.ceil(delayMs / 1000),
-        attemptNumber: error.attemptNumber,
-        maxRetries,
-        maxBlockingDelaySeconds: Math.ceil(maxBlockingDelayMs / 1000),
-        status: errorInfo.status,
-        code: errorInfo.code,
-        isRateLimit,
-        isServerError,
-        isConflictError,
-        isFetchError: isFetchError(errorInfo),
-        retryAfterHeader,
-        responseBody: errorInfo.responseBody,
-      });
-
-      if (delayMs > maxBlockingDelayMs) {
-        logger.warn("Aborting retry due to long backoff in serverless", {
-          delaySeconds: Math.ceil(delayMs / 1000),
-          maxBlockingDelaySeconds: Math.ceil(maxBlockingDelayMs / 1000),
-          attemptNumber: error.attemptNumber,
-          maxRetries,
-          status: errorInfo.status,
-          code: errorInfo.code,
-          isRateLimit,
-          isServerError,
-          isConflictError,
-        });
-        throw error;
-      }
-
-      // Apply the custom delay
-      if (delayMs > 0) {
-        await sleep(delayMs);
-      }
-    },
-  });
+/**
+ * Retries a non-idempotent Microsoft Graph write only when Graph explicitly
+ * rejects it because of throttling. Network, server, and conflict failures are
+ * ambiguous because the write may already have succeeded.
+ */
+export async function withMicrosoftGraphWriteRetry<T>(
+  operation: () => Promise<T>,
+  logger: Logger,
+  maxRetries = 5,
+  maxBlockingDelayMs = MAX_MICROSOFT_GRAPH_BLOCKING_RETRY_DELAY_MS,
+): Promise<T> {
+  return withMicrosoftGraphRetryPolicy(
+    operation,
+    logger,
+    maxRetries,
+    maxBlockingDelayMs,
+    "rate-limit-only",
+  );
 }
 
 /**
@@ -97,21 +61,23 @@ export async function withMicrosoftGraphRetry<T>(
  */
 export function extractErrorInfo(error: unknown): ErrorInfo {
   const err = error as Record<string, unknown>;
+  const nestedError = err?.error as Record<string, unknown> | undefined;
 
   const status =
     (err?.statusCode as number) ??
     (err?.status as number) ??
     ((err?.response as Record<string, unknown>)?.status as number) ??
+    (nestedError?.statusCode as number) ??
+    (nestedError?.status as number) ??
+    ((nestedError?.response as Record<string, unknown>)?.status as number) ??
     undefined;
 
   const code =
-    (err?.code as string) ??
-    ((err?.error as Record<string, unknown>)?.code as string) ??
-    undefined;
+    (err?.code as string) ?? (nestedError?.code as string) ?? undefined;
 
   const primaryMessage =
     (err?.message as string) ??
-    ((err?.error as Record<string, unknown>)?.message as string) ??
+    (nestedError?.message as string) ??
     (err?.body as string) ??
     "";
 
@@ -218,4 +184,79 @@ export function calculateRetryDelay(
 
   // Default exponential backoff for other retryable errors: 1s, 2s, 4s, 8s, 16s
   return Math.min(1000 * 2 ** (attemptNumber - 1), 16_000);
+}
+
+async function withMicrosoftGraphRetryPolicy<T>(
+  operation: () => Promise<T>,
+  logger: Logger,
+  maxRetries: number,
+  maxBlockingDelayMs: number,
+  retryPolicy: "all" | "rate-limit-only",
+): Promise<T> {
+  return pRetry(operation, {
+    retries: maxRetries,
+    onFailedAttempt: async (error) => {
+      const errorInfo = extractErrorInfo(error);
+      const retryableError = isRetryableError(errorInfo);
+      const { isRateLimit, isServerError, isConflictError } = retryableError;
+      const retryable =
+        retryPolicy === "all" ? retryableError.retryable : isRateLimit;
+
+      if (!retryable) {
+        logger.warn("Non-retryable error encountered", {
+          error,
+          status: errorInfo.status,
+          code: errorInfo.code,
+          responseBody: errorInfo.responseBody,
+          retryPolicy,
+        });
+        throw error;
+      }
+
+      const retryAfterHeader = getRetryAfterHeaderFromError(error);
+
+      const delayMs = calculateRetryDelay(
+        isRateLimit,
+        isServerError,
+        isConflictError,
+        error.attemptNumber,
+        retryAfterHeader,
+      );
+
+      logger.warn("Microsoft Graph error. Will retry", {
+        delaySeconds: Math.ceil(delayMs / 1000),
+        attemptNumber: error.attemptNumber,
+        maxRetries,
+        maxBlockingDelaySeconds: Math.ceil(maxBlockingDelayMs / 1000),
+        status: errorInfo.status,
+        code: errorInfo.code,
+        isRateLimit,
+        isServerError,
+        isConflictError,
+        isFetchError: isFetchError(errorInfo),
+        retryAfterHeader,
+        responseBody: errorInfo.responseBody,
+        retryPolicy,
+      });
+
+      if (delayMs > maxBlockingDelayMs) {
+        logger.warn("Aborting retry due to long backoff in serverless", {
+          delaySeconds: Math.ceil(delayMs / 1000),
+          maxBlockingDelaySeconds: Math.ceil(maxBlockingDelayMs / 1000),
+          attemptNumber: error.attemptNumber,
+          maxRetries,
+          status: errorInfo.status,
+          code: errorInfo.code,
+          isRateLimit,
+          isServerError,
+          isConflictError,
+        });
+        throw error;
+      }
+
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
+    },
+  });
 }

--- a/apps/web/utils/outlook/draft.ts
+++ b/apps/web/utils/outlook/draft.ts
@@ -7,7 +7,10 @@ import {
   getCategoryMap,
   getFolderIds,
 } from "@/utils/outlook/message";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import {
+  withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
+} from "@/utils/microsoft/retry";
 
 export async function getDraft({
   client,
@@ -67,7 +70,7 @@ export async function sendDraft({
 
   // Send the draft - this moves it from Drafts to Sent Items
   // The message ID stays the same after sending
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () => client.getClient().api(`/me/messages/${draftId}/send`).post({}),
     logger,
   );
@@ -110,7 +113,7 @@ export async function deleteDraft({
 
     // DELETE moves the draft to Deleted Items folder (not permanently deleted)
     // This is fine - getDraft() treats drafts not in Drafts folder as "deleted"
-    await withMicrosoftGraphRetry(
+    await withMicrosoftGraphWriteRetry(
       () => client.getClient().api(`/me/messages/${draftId}`).delete(),
       logger,
     );

--- a/apps/web/utils/outlook/filter.ts
+++ b/apps/web/utils/outlook/filter.ts
@@ -2,7 +2,7 @@ import type { OutlookClient } from "@/utils/outlook/client";
 import type { MessageRule } from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { isAlreadyExistsError } from "./errors";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import { withMicrosoftGraphWriteRetry } from "@/utils/microsoft/retry";
 import { getLabelById, getOrCreateLabel } from "@/utils/outlook/label";
 
 // Microsoft Graph API doesn't have a direct equivalent to Gmail filters
@@ -37,7 +37,7 @@ export async function createFilter(options: {
       actions,
     };
 
-    const response: MessageRule = await withMicrosoftGraphRetry(
+    const response: MessageRule = await withMicrosoftGraphWriteRetry(
       () =>
         client.getClient().api("/me/mailFolders/inbox/messageRules").post(rule),
       logger,
@@ -80,7 +80,7 @@ export async function createAutoArchiveFilter({
       },
     };
 
-    const response: MessageRule = await withMicrosoftGraphRetry(
+    const response: MessageRule = await withMicrosoftGraphWriteRetry(
       () =>
         client.getClient().api("/me/mailFolders/inbox/messageRules").post(rule),
       logger,
@@ -106,7 +106,7 @@ export async function deleteFilter({
   logger: Logger;
 }) {
   try {
-    await withMicrosoftGraphRetry(
+    await withMicrosoftGraphWriteRetry(
       () =>
         client
           .getClient()
@@ -215,7 +215,7 @@ export async function updateFilter({
       actions,
     };
 
-    const response: MessageRule = await withMicrosoftGraphRetry(
+    const response: MessageRule = await withMicrosoftGraphWriteRetry(
       () =>
         client
           .getClient()

--- a/apps/web/utils/outlook/folders.ts
+++ b/apps/web/utils/outlook/folders.ts
@@ -1,7 +1,10 @@
 import type { MailFolder } from "@microsoft/microsoft-graph-types";
 import type { OutlookClient } from "./client-types";
 import type { Logger } from "@/utils/logger";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import {
+  withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
+} from "@/utils/microsoft/retry";
 
 export type OutlookSystemFolder =
   | "INBOX"
@@ -215,7 +218,7 @@ export async function getOrCreateOutlookFolderIdByName(
   }
 
   try {
-    const response = await withMicrosoftGraphRetry(
+    const response = await withMicrosoftGraphWriteRetry(
       () =>
         client.getClient().api("/me/mailFolders").post({
           displayName: folderName,

--- a/apps/web/utils/outlook/label.ts
+++ b/apps/web/utils/outlook/label.ts
@@ -402,121 +402,81 @@ export async function archiveThread({
     }
   }
 
+  // In Outlook, archiving is moving to a folder
+  // We need to move each message in the thread individually
+  const escapedThreadId = threadId.replace(/'/g, "''");
+  let messages: { value: Array<{ id: string }> };
   try {
-    // In Outlook, archiving is moving to a folder
-    // We need to move each message in the thread individually
-    const escapedThreadId = threadId.replace(/'/g, "''");
-    const messages = await client
+    messages = await client
       .getClient()
       .api("/me/messages")
       .filter(`conversationId eq '${escapedThreadId}'`) // Escape single quotes in threadId for the filter
       .get();
-
-    const archivePromise = runThreadMessageMutation({
-      messageIds: messages.value.map((message: { id: string }) => message.id),
-      threadId,
-      logger,
-      messageHandler: (messageId) =>
-        withMicrosoftGraphWriteRetry(
-          () =>
-            client.getClient().api(`/me/messages/${messageId}/move`).post({
-              destinationId: folderId,
-            }),
-          logger,
-        ),
-      failureMessage: "Failed to move message to folder",
-      continueOnError: true,
-    });
-
-    const publishPromise = publishArchive({
-      ownerEmail,
-      threadId,
-      actionSource,
-      timestamp: Date.now(),
-    });
-
-    const [archiveResult, publishResult] = await Promise.allSettled([
-      archivePromise,
-      publishPromise,
-    ]);
-
-    // Handle publish errors as non-fatal (just log)
-    if (publishResult.status === "rejected") {
-      logger.error("Failed to publish action to move thread to folder", {
-        folderId,
-        threadId,
-        error: publishResult.reason,
-      });
-    }
-
-    // Handle archive errors
-    if (archiveResult.status === "rejected") {
-      const error = archiveResult.reason;
-      if (error.message?.includes("Requested entity was not found")) {
-        logger.warn("Thread not found", { threadId, userEmail: ownerEmail });
-        return { status: 404, message: "Thread not found" };
-      }
-      logger.error("Failed to move thread to folder", {
-        folderId,
-        threadId,
-        error,
-      });
-      throw error;
-    }
-
-    return { status: 200 };
   } catch (error) {
-    // If the filter fails, try a different approach
-    logger.warn("Filter failed, trying alternative approach", {
+    return archiveThreadWithFallback({
+      client,
+      threadId,
+      ownerEmail,
+      actionSource,
+      folderId,
+      logger,
+      filterError: error,
+    });
+  }
+
+  const archivePromise = runThreadMessageMutation({
+    messageIds: messages.value.map((message) => message.id),
+    threadId,
+    logger,
+    messageHandler: (messageId) =>
+      withMicrosoftGraphWriteRetry(
+        () =>
+          client.getClient().api(`/me/messages/${messageId}/move`).post({
+            destinationId: folderId,
+          }),
+        logger,
+      ),
+    failureMessage: "Failed to move message to folder",
+    continueOnError: true,
+  });
+
+  const publishPromise = publishArchive({
+    ownerEmail,
+    threadId,
+    actionSource,
+    timestamp: Date.now(),
+  });
+
+  const [archiveResult, publishResult] = await Promise.allSettled([
+    archivePromise,
+    publishPromise,
+  ]);
+
+  // Handle publish errors as non-fatal (just log)
+  if (publishResult.status === "rejected") {
+    logger.error("Failed to publish action to move thread to folder", {
+      folderId,
+      threadId,
+      error: publishResult.reason,
+    });
+  }
+
+  // Handle archive errors
+  if (archiveResult.status === "rejected") {
+    const error = archiveResult.reason;
+    if (error.message?.includes("Requested entity was not found")) {
+      logger.warn("Thread not found", { threadId, userEmail: ownerEmail });
+      return { status: 404, message: "Thread not found" };
+    }
+    logger.error("Failed to move thread to folder", {
+      folderId,
       threadId,
       error,
     });
-
-    try {
-      await processThreadMessagesFallback({
-        client,
-        threadId,
-        logger,
-        messageHandler: (messageId) =>
-          withMicrosoftGraphWriteRetry(
-            () =>
-              client
-                .getClient()
-                .api(`/me/messages/${messageId}/move`)
-                .post({ destinationId: folderId }),
-            logger,
-          ),
-        noMessagesMessage:
-          "No messages found for conversationId, skipping folder move",
-      });
-
-      // Publish the archive action
-      try {
-        await publishArchive({
-          ownerEmail,
-          threadId,
-          actionSource,
-          timestamp: Date.now(),
-        });
-      } catch (publishError) {
-        logger.error("Failed to publish action to move thread to folder", {
-          folderId,
-          email: ownerEmail,
-          threadId,
-          error: publishError,
-        });
-      }
-
-      return { status: 200 };
-    } catch (directError) {
-      logger.error("Failed to move thread to folder", {
-        folderId,
-        threadId,
-        error: directError,
-      });
-      throw directError;
-    }
+    throw error;
   }
+
+  return { status: 200 };
 }
 
 // Graph pages at 10 messages by default, which would silently leave the rest of
@@ -812,4 +772,71 @@ function assertNoNormalizedInputCollisions(
 
     if (!existingRawName) normalizedMap.set(normalizedName, rawName);
   });
+}
+
+async function archiveThreadWithFallback({
+  client,
+  threadId,
+  ownerEmail,
+  actionSource,
+  folderId,
+  logger,
+  filterError,
+}: {
+  client: OutlookClient;
+  threadId: string;
+  ownerEmail: string;
+  actionSource: TinybirdEmailAction["actionSource"];
+  folderId: string;
+  logger: Logger;
+  filterError: unknown;
+}) {
+  logger.warn("Filter failed, trying alternative approach", {
+    threadId,
+    error: filterError,
+  });
+
+  try {
+    await processThreadMessagesFallback({
+      client,
+      threadId,
+      logger,
+      messageHandler: (messageId) =>
+        withMicrosoftGraphWriteRetry(
+          () =>
+            client
+              .getClient()
+              .api(`/me/messages/${messageId}/move`)
+              .post({ destinationId: folderId }),
+          logger,
+        ),
+      noMessagesMessage:
+        "No messages found for conversationId, skipping folder move",
+    });
+
+    try {
+      await publishArchive({
+        ownerEmail,
+        threadId,
+        actionSource,
+        timestamp: Date.now(),
+      });
+    } catch (publishError) {
+      logger.error("Failed to publish action to move thread to folder", {
+        folderId,
+        email: ownerEmail,
+        threadId,
+        error: publishError,
+      });
+    }
+
+    return { status: 200 };
+  } catch (directError) {
+    logger.error("Failed to move thread to folder", {
+      folderId,
+      threadId,
+      error: directError,
+    });
+    throw directError;
+  }
 }

--- a/apps/web/utils/outlook/label.ts
+++ b/apps/web/utils/outlook/label.ts
@@ -5,6 +5,7 @@ import { WELL_KNOWN_FOLDERS } from "./constants";
 import {
   extractErrorInfo,
   withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
 } from "@/utils/microsoft/retry";
 import {
   processThreadMessagesFallback,
@@ -112,7 +113,7 @@ export async function createLabel({
         ? color
         : OUTLOOK_COLORS[Math.floor(Math.random() * OUTLOOK_COLORS.length)];
 
-    const response: OutlookCategory = await withMicrosoftGraphRetry(
+    const response: OutlookCategory = await withMicrosoftGraphWriteRetry(
       () =>
         client.getClient().api("/me/outlook/masterCategories").post({
           displayName: sanitizedName,
@@ -257,7 +258,7 @@ export async function labelMessage({
   categories: string[];
   logger: Logger;
 }) {
-  return withMicrosoftGraphRetry(
+  return withMicrosoftGraphWriteRetry(
     () =>
       client.getClient().api(`/me/messages/${messageId}`).patch({
         categories,
@@ -346,7 +347,7 @@ export async function removeThreadLabel({
         (cat) => cat !== categoryName,
       );
 
-      await withMicrosoftGraphRetry(
+      await withMicrosoftGraphWriteRetry(
         () =>
           client.getClient().api(`/me/messages/${messageId}`).patch({
             categories: updatedCategories,
@@ -416,7 +417,7 @@ export async function archiveThread({
       threadId,
       logger,
       messageHandler: (messageId) =>
-        withMicrosoftGraphRetry(
+        withMicrosoftGraphWriteRetry(
           () =>
             client.getClient().api(`/me/messages/${messageId}/move`).post({
               destinationId: folderId,
@@ -477,7 +478,7 @@ export async function archiveThread({
         threadId,
         logger,
         messageHandler: (messageId) =>
-          withMicrosoftGraphRetry(
+          withMicrosoftGraphWriteRetry(
             () =>
               client
                 .getClient()
@@ -606,7 +607,7 @@ async function moveThreadFromFolderToInbox({
     threadId,
     logger,
     messageHandler: (messageId) =>
-      withMicrosoftGraphRetry(
+      withMicrosoftGraphWriteRetry(
         () =>
           client
             .getClient()
@@ -686,7 +687,7 @@ export async function markReadThread({
       threadId,
       logger,
       messageHandler: (messageId) =>
-        withMicrosoftGraphRetry(
+        withMicrosoftGraphWriteRetry(
           () =>
             client.getClient().api(`/me/messages/${messageId}`).patch({
               isRead: read,
@@ -708,7 +709,7 @@ export async function markReadThread({
         threadId,
         logger,
         messageHandler: (messageId) =>
-          withMicrosoftGraphRetry(
+          withMicrosoftGraphWriteRetry(
             () =>
               client
                 .getClient()
@@ -741,7 +742,7 @@ export async function markImportantMessage({
   logger: Logger;
 }) {
   // In Outlook, we use the "Important" flag
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -762,7 +763,7 @@ export async function markStarredMessage({
   messageId: string;
   logger: Logger;
 }) {
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -12,7 +12,10 @@ import {
   buildReplyAllRecipients,
   mergeAndDedupeRecipients,
 } from "@/utils/email/reply-all";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import {
+  withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
+} from "@/utils/microsoft/retry";
 import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
 import { uploadResumableChunks } from "@/utils/microsoft/upload-session";
@@ -50,7 +53,7 @@ export async function sendEmailWithHtml(
 
   // For new emails, create draft then send to get the conversationId.
   // sendMail returns 202 with no body, so we use the draft approach instead.
-  const draft: Message = await withMicrosoftGraphRetry(
+  const draft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -78,7 +81,7 @@ export async function sendEmailWithHtml(
     });
   }
 
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () => client.getClient().api(`/me/messages/${draft.id}/send`).post({}),
     logger,
   );
@@ -116,7 +119,7 @@ export async function replyToEmail(
   // Use createReply to create a properly threaded draft
   // Microsoft Graph's sendMail doesn't support setting In-Reply-To/References headers
   // Only createReply/createReplyAll endpoints ensure proper threading
-  const replyDraft: Message = await withMicrosoftGraphRetry(
+  const replyDraft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       client.getClient().api(`/me/messages/${message.id}/createReply`).post({}),
     logger,
@@ -128,7 +131,7 @@ export async function replyToEmail(
   );
 
   // Update the draft with our content
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -158,7 +161,7 @@ export async function replyToEmail(
   }
 
   // Send the draft
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () => client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
     logger,
   );
@@ -217,7 +220,7 @@ export async function forwardEmail(
     conversationIndex: originalMessage.conversationId || "",
   };
 
-  const forwardDraft: Message = await withMicrosoftGraphRetry(
+  const forwardDraft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -231,7 +234,7 @@ export async function forwardEmail(
     forwardDraft.from?.emailAddress?.address,
   );
 
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -253,7 +256,7 @@ export async function forwardEmail(
     logger,
   );
 
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client.getClient().api(`/me/messages/${forwardDraft.id}/send`).post({}),
     logger,
@@ -346,7 +349,7 @@ export async function draftEmail(
 
   // Use createReplyAll endpoint to create a proper reply draft
   // This ensures the draft is linked to the original message as a reply all
-  const replyDraft: Message = await withMicrosoftGraphRetry(
+  const replyDraft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -364,7 +367,7 @@ export async function draftEmail(
     updateRequest.header("If-Match", etag);
   }
 
-  const updatedDraft: Message = await withMicrosoftGraphRetry(
+  const updatedDraft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       updateRequest.patch({
         subject: args.subject || originalEmail.headers.subject,
@@ -391,7 +394,7 @@ export async function draftEmail(
   // Restore the original message's unread status if it was unread before
   // createReplyAll automatically marks the original message as read
   if (wasUnread) {
-    await withMicrosoftGraphRetry(
+    await withMicrosoftGraphWriteRetry(
       () =>
         client
           .getClient()
@@ -422,7 +425,7 @@ async function sendReplyUsingCreateReply(
   // Use createReply to create a properly threaded draft
   // Microsoft Graph's createReply automatically sets In-Reply-To and References headers
   // based on the original message, ensuring proper threading across email providers
-  const replyDraft: Message = await withMicrosoftGraphRetry(
+  const replyDraft: Message = await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -435,7 +438,7 @@ async function sendReplyUsingCreateReply(
   // Note: We cannot set In-Reply-To/References headers via internetMessageHeaders
   // as Microsoft Graph only allows custom headers (starting with x-) there.
   // The createReply endpoint handles standard threading headers automatically.
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()
@@ -467,7 +470,7 @@ async function sendReplyUsingCreateReply(
   }
 
   // Send the draft
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () => client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
     logger,
   );
@@ -550,7 +553,7 @@ async function addAttachmentsToDraft({
     if (!result) continue;
     const { buffer, base64 } = result;
     if (buffer.length <= MAX_GRAPH_ATTACHMENT_SIZE_BYTES) {
-      await withMicrosoftGraphRetry(
+      await withMicrosoftGraphWriteRetry(
         () =>
           client
             .getClient()
@@ -639,7 +642,7 @@ async function uploadAttachmentViaSession({
   content: Buffer;
   logger: Logger;
 }) {
-  const uploadSession = await withMicrosoftGraphRetry(
+  const uploadSession = await withMicrosoftGraphWriteRetry(
     () =>
       client
         .getClient()

--- a/apps/web/utils/outlook/spam.ts
+++ b/apps/web/utils/outlook/spam.ts
@@ -1,5 +1,5 @@
 import type { OutlookClient } from "@/utils/outlook/client";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import { withMicrosoftGraphWriteRetry } from "@/utils/microsoft/retry";
 import {
   processThreadMessagesFallback,
   runThreadMessageMutation,
@@ -27,7 +27,7 @@ export async function markSpam(
       threadId,
       logger,
       messageHandler: (messageId) =>
-        withMicrosoftGraphRetry(
+        withMicrosoftGraphWriteRetry(
           () =>
             client.getClient().api(`/me/messages/${messageId}/move`).post({
               destinationId: "junkemail",
@@ -50,7 +50,7 @@ export async function markSpam(
         threadId,
         logger,
         messageHandler: (messageId) =>
-          withMicrosoftGraphRetry(
+          withMicrosoftGraphWriteRetry(
             () =>
               client
                 .getClient()

--- a/apps/web/utils/outlook/trash.ts
+++ b/apps/web/utils/outlook/trash.ts
@@ -2,7 +2,7 @@ import type { OutlookClient } from "@/utils/outlook/client";
 import { publishDelete, type TinybirdEmailAction } from "@inboxzero/tinybird";
 import type { Logger } from "@/utils/logger";
 import { runWithBoundedConcurrency } from "@/utils/async";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import { withMicrosoftGraphWriteRetry } from "@/utils/microsoft/retry";
 import { processThreadMessagesFallback } from "@/utils/outlook/thread-helpers";
 
 const THREAD_TRASH_CONCURRENCY = 2;
@@ -32,7 +32,7 @@ export async function trashThread(options: {
       concurrency: THREAD_TRASH_CONCURRENCY,
       run: async (messageId) => {
         try {
-          return await withMicrosoftGraphRetry(
+          return await withMicrosoftGraphWriteRetry(
             () =>
               client.getClient().api(`/me/messages/${messageId}/move`).post({
                 destinationId: "deleteditems",
@@ -104,7 +104,7 @@ export async function trashThread(options: {
         threadId,
         logger,
         messageHandler: (messageId) =>
-          withMicrosoftGraphRetry(
+          withMicrosoftGraphWriteRetry(
             () =>
               client
                 .getClient()

--- a/apps/web/utils/outlook/watch.ts
+++ b/apps/web/utils/outlook/watch.ts
@@ -2,7 +2,7 @@ import type { Client } from "@microsoft/microsoft-graph-client";
 import type { Subscription } from "@microsoft/microsoft-graph-types";
 import { addDays } from "date-fns/addDays";
 import { env } from "@/env";
-import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
+import { withMicrosoftGraphWriteRetry } from "@/utils/microsoft/retry";
 import type { Logger } from "@/utils/logger";
 
 export async function watchOutlook(client: Client, logger: Logger) {
@@ -23,7 +23,7 @@ export async function watchOutlook(client: Client, logger: Logger) {
     clientState: env.MICROSOFT_WEBHOOK_CLIENT_STATE,
   };
 
-  const subscription: Subscription = await withMicrosoftGraphRetry(
+  const subscription: Subscription = await withMicrosoftGraphWriteRetry(
     () => client.api("/subscriptions").post(subscriptionPayload),
     logger,
   );
@@ -39,7 +39,7 @@ export async function unwatchOutlook(
   subscriptionId: string,
   logger: Logger,
 ) {
-  await withMicrosoftGraphRetry(
+  await withMicrosoftGraphWriteRetry(
     () => client.api(`/subscriptions/${subscriptionId}`).delete(),
     logger,
   );

--- a/apps/web/utils/retry/get-retry-after-header.test.ts
+++ b/apps/web/utils/retry/get-retry-after-header.test.ts
@@ -39,4 +39,18 @@ describe("getRetryAfterHeaderFromError", () => {
 
     expect(header).toBe("120");
   });
+
+  it("reads retry-after header from p-retry's nested error", () => {
+    const header = getRetryAfterHeaderFromError({
+      error: {
+        response: {
+          headers: {
+            "retry-after": "15",
+          },
+        },
+      },
+    });
+
+    expect(header).toBe("15");
+  });
 });

--- a/apps/web/utils/retry/get-retry-after-header.ts
+++ b/apps/web/utils/retry/get-retry-after-header.ts
@@ -3,9 +3,13 @@ export function getRetryAfterHeaderFromError(
 ): string | undefined {
   const err = toRecord(error);
   const cause = toRecord(err.cause);
+  const nestedError = toRecord(err.error);
 
   const directHeader = getHeaderValue(toRecord(err.response).headers);
   if (directHeader) return directHeader;
+
+  const nestedHeader = getHeaderValue(toRecord(nestedError.response).headers);
+  if (nestedHeader) return nestedHeader;
 
   return getHeaderValue(toRecord(cause.response).headers);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-083116_pr-3293_3b6726d8fd24/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents duplicate or ambiguous Microsoft Graph side effects after network, server, or conflict failures.

- adds a throttling-only retry policy for non-idempotent Graph writes
- migrates direct Graph POST, PATCH, and DELETE operations to the safer policy
- preserves full retries for reads and resumable upload chunks
- adds regression coverage for wrapped Graph errors and retry headers

Validation: 88 focused Microsoft and Outlook tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->