### PR TITLE
mail: Download attachments with account context

### DIFF
--- a/apps/web/components/email-list/EmailAttachments.tsx
+++ b/apps/web/components/email-list/EmailAttachments.tsx
@@ -1,10 +1,51 @@
+"use client";
+
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
 import { DownloadIcon } from "lucide-react";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { CardBasic } from "@/components/ui/card";
+import { toastError } from "@/components/Toast";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { fetchAttachment } from "@/utils/attachments/download";
 
 export function EmailAttachments({ message }: { message: ThreadMessage }) {
+  const { emailAccountId } = useAccount();
+  const [downloadingAttachmentId, setDownloadingAttachmentId] = useState<
+    string | null
+  >(null);
+
+  const downloadAttachment = async ({
+    attachmentId,
+    filename,
+    url,
+  }: {
+    attachmentId: string;
+    filename: string;
+    url: string;
+  }) => {
+    setDownloadingAttachmentId(attachmentId);
+
+    try {
+      const blob = await fetchAttachment({ url, emailAccountId });
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      try {
+        link.click();
+      } finally {
+        link.remove();
+        URL.revokeObjectURL(objectUrl);
+      }
+    } catch {
+      toastError({ description: "Failed to download attachment" });
+    } finally {
+      setDownloadingAttachmentId(null);
+    }
+  };
+
   return (
     <div className="mt-4 grid grid-cols-2 gap-2 xl:grid-cols-3">
       {message.attachments?.map((attachment) => {
@@ -18,17 +59,27 @@ export function EmailAttachments({ message }: { message: ThreadMessage }) {
         const url = `/api/messages/attachment?${searchParams.toString()}`;
 
         return (
-          <CardBasic key={attachment.filename} className="p-4">
+          <CardBasic key={attachment.attachmentId} className="p-4">
             <div className="text-muted-foreground">{attachment.filename}</div>
             <div className="mt-4 flex items-center justify-between">
               <div className="text-muted-foreground">
                 {mimeTypeToString(attachment.mimeType)}
               </div>
-              <Button variant="outline" size="sm" asChild>
-                <Link href={url} target="_blank">
-                  <DownloadIcon className="mr-2 h-4 w-4" />
-                  Download
-                </Link>
+              <Button
+                variant="outline"
+                size="sm"
+                type="button"
+                disabled={downloadingAttachmentId === attachment.attachmentId}
+                onClick={() =>
+                  downloadAttachment({
+                    attachmentId: attachment.attachmentId,
+                    filename: attachment.filename,
+                    url,
+                  })
+                }
+              >
+                <DownloadIcon className="mr-2 h-4 w-4" />
+                Download
               </Button>
             </div>
           </CardBasic>

--- a/apps/web/components/email-list/EmailAttachments.tsx
+++ b/apps/web/components/email-list/EmailAttachments.tsx
@@ -11,20 +11,16 @@ import { fetchAttachment } from "@/utils/attachments/download";
 
 export function EmailAttachments({ message }: { message: ThreadMessage }) {
   const { emailAccountId } = useAccount();
-  const [downloadingAttachmentId, setDownloadingAttachmentId] = useState<
-    string | null
-  >(null);
+  const [isDownloading, setIsDownloading] = useState(false);
 
   const downloadAttachment = async ({
-    attachmentId,
     filename,
     url,
   }: {
-    attachmentId: string;
     filename: string;
     url: string;
   }) => {
-    setDownloadingAttachmentId(attachmentId);
+    setIsDownloading(true);
 
     try {
       const blob = await fetchAttachment({ url, emailAccountId });
@@ -42,7 +38,7 @@ export function EmailAttachments({ message }: { message: ThreadMessage }) {
     } catch {
       toastError({ description: "Failed to download attachment" });
     } finally {
-      setDownloadingAttachmentId(null);
+      setIsDownloading(false);
     }
   };
 
@@ -69,10 +65,9 @@ export function EmailAttachments({ message }: { message: ThreadMessage }) {
                 variant="outline"
                 size="sm"
                 type="button"
-                disabled={downloadingAttachmentId === attachment.attachmentId}
+                disabled={!emailAccountId || isDownloading}
                 onClick={() =>
                   downloadAttachment({
-                    attachmentId: attachment.attachmentId,
                     filename: attachment.filename,
                     url,
                   })

--- a/apps/web/utils/attachments/download.test.ts
+++ b/apps/web/utils/attachments/download.test.ts
@@ -40,4 +40,15 @@ describe("fetchAttachment", () => {
       }),
     ).rejects.toThrow("Failed to download attachment");
   });
+
+  it("rejects before fetching when the email account is unavailable", async () => {
+    await expect(
+      fetchAttachment({
+        url: "/api/messages/attachment?messageId=message-id",
+        emailAccountId: "",
+      }),
+    ).rejects.toThrow("Email account ID is required");
+
+    expect(fetchWithAccount).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/utils/attachments/download.test.ts
+++ b/apps/web/utils/attachments/download.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithAccount } from "@/utils/fetch";
+import { fetchAttachment } from "./download";
+
+vi.mock("@/utils/fetch", () => ({ fetchWithAccount: vi.fn() }));
+
+describe("fetchAttachment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the attachment with the selected email account", async () => {
+    const blob = new Blob(["attachment"]);
+    vi.mocked(fetchWithAccount).mockResolvedValue(
+      new Response(blob, { status: 200 }),
+    );
+
+    await expect(
+      fetchAttachment({
+        url: "/api/messages/attachment?messageId=message-id",
+        emailAccountId: "account-id",
+      }),
+    ).resolves.toEqual(blob);
+
+    expect(fetchWithAccount).toHaveBeenCalledWith({
+      url: "/api/messages/attachment?messageId=message-id",
+      emailAccountId: "account-id",
+    });
+  });
+
+  it("rejects an unsuccessful attachment response", async () => {
+    vi.mocked(fetchWithAccount).mockResolvedValue(
+      new Response(null, { status: 403 }),
+    );
+
+    await expect(
+      fetchAttachment({
+        url: "/api/messages/attachment?messageId=message-id",
+        emailAccountId: "account-id",
+      }),
+    ).rejects.toThrow("Failed to download attachment");
+  });
+});

--- a/apps/web/utils/attachments/download.ts
+++ b/apps/web/utils/attachments/download.ts
@@ -7,6 +7,10 @@ export async function fetchAttachment({
   url: string;
   emailAccountId: string;
 }): Promise<Blob> {
+  if (!emailAccountId) {
+    throw new Error("Email account ID is required");
+  }
+
   const response = await fetchWithAccount({ url, emailAccountId });
 
   if (!response.ok) {

--- a/apps/web/utils/attachments/download.ts
+++ b/apps/web/utils/attachments/download.ts
@@ -1,0 +1,17 @@
+import { fetchWithAccount } from "@/utils/fetch";
+
+export async function fetchAttachment({
+  url,
+  emailAccountId,
+}: {
+  url: string;
+  emailAccountId: string;
+}): Promise<Blob> {
+  const response = await fetchWithAccount({ url, emailAccountId });
+
+  if (!response.ok) {
+    throw new Error("Failed to download attachment");
+  }
+
+  return response.blob();
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-083250_pr-3294_e4da67c49837/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes attachment downloads that previously navigated to the provider route without the required email-account header.

- fetches attachment data with the selected email account context
- creates a browser download from the returned blob
- reports failed downloads and prevents duplicate clicks while a download is active
- adds focused regression coverage for account-scoped fetches and error responses

Validation: focused attachment download tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->