### PR TITLE
Mail: scope sidebar keyboard shortcut

### DIFF
--- a/apps/web/components/SideNavWithTopNav.tsx
+++ b/apps/web/components/SideNavWithTopNav.tsx
@@ -83,6 +83,7 @@ export function SideNavWithTopNav({
     <SidebarProvider
       defaultOpen={defaultOpen ? ["left-sidebar"] : []}
       sidebarNames={["left-sidebar", "chat-sidebar"]}
+      keyboardShortcutName="left-sidebar"
     >
       {/* Mail supplies its own sidebar and trigger for this shared state, so
           the global navigation and its mobile header would be duplicates. */}

--- a/apps/web/components/ui/sidebar.test.tsx
+++ b/apps/web/components/ui/sidebar.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SidebarProvider, useSidebar } from "./sidebar";
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+afterEach(cleanup);
+
+describe("SidebarProvider", () => {
+  it("toggles only the sidebar assigned to the keyboard shortcut", () => {
+    render(
+      <SidebarProvider
+        defaultOpen="all"
+        sidebarNames={["left-sidebar", "chat-sidebar"]}
+        keyboardShortcutName="left-sidebar"
+      >
+        <SidebarState />
+      </SidebarProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+
+    expect(screen.getByRole("status").textContent).toBe("chat-sidebar");
+  });
+});
+
+function SidebarState() {
+  const { state } = useSidebar();
+
+  return <output>{state.join(",")}</output>;
+}

--- a/apps/web/components/ui/sidebar.test.tsx
+++ b/apps/web/components/ui/sidebar.test.tsx
@@ -11,7 +11,7 @@ vi.mock("@/hooks/use-mobile", () => ({
 afterEach(cleanup);
 
 describe("SidebarProvider", () => {
-  it("toggles only the sidebar assigned to the keyboard shortcut", () => {
+  it("toggles only the assigned sidebar across repeated shortcuts", () => {
     render(
       <SidebarProvider
         defaultOpen="all"
@@ -25,6 +25,12 @@ describe("SidebarProvider", () => {
     fireEvent.keyDown(window, { key: "b", metaKey: true });
 
     expect(screen.getByRole("status").textContent).toBe("chat-sidebar");
+
+    fireEvent.keyDown(window, { key: "b", metaKey: true });
+
+    expect(screen.getByRole("status").textContent).toBe(
+      "chat-sidebar,left-sidebar",
+    );
   });
 });
 

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -53,6 +53,7 @@ const SidebarProvider = React.forwardRef<
   React.ComponentProps<"div"> & {
     defaultOpen?: "all" | string[];
     sidebarNames?: string[];
+    keyboardShortcutName?: string;
     open?: string[];
     onOpenChange?: (open: string[]) => void;
   }
@@ -61,6 +62,7 @@ const SidebarProvider = React.forwardRef<
     {
       defaultOpen = "all",
       sidebarNames = [],
+      keyboardShortcutName,
       open: openProp,
       onOpenChange: setOpenProp,
       className,
@@ -130,16 +132,17 @@ const SidebarProvider = React.forwardRef<
       const handleKeyDown = (event: KeyboardEvent) => {
         if (
           event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-          (event.metaKey || event.ctrlKey)
+          (event.metaKey || event.ctrlKey) &&
+          keyboardShortcutName
         ) {
           event.preventDefault();
-          toggleSidebar(sidebarNames);
+          toggleSidebar([keyboardShortcutName]);
         }
       };
 
       window.addEventListener("keydown", handleKeyDown);
       return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [toggleSidebar, sidebarNames]);
+    }, [keyboardShortcutName, toggleSidebar]);
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-091826_pr-3295_ccdb8e53ed2f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Limit the shared sidebar keyboard shortcut to the configured primary panel.

- Preserve independent secondary panel state
- Add regression coverage for multi-sidebar layouts
- Validate related keyboard shortcut behavior

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->