### PR TITLE
mail: Fix rotated image proxy URL signatures

### DIFF
--- a/apps/web/utils/email/image-proxy.server.test.ts
+++ b/apps/web/utils/email/image-proxy.server.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validateAssetProxySignature } from "@inboxzero/image-proxy/proxy-url";
 import { createTestLogger } from "@/__tests__/helpers";
 
 describe("rewriteHtmlForImageProxy", () => {
@@ -58,6 +59,34 @@ describe("rewriteHtmlForImageProxy", () => {
     expect(result.remoteAssetsProxied).toBe(true);
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  it("signs with the first secret when rotation secrets are configured", async () => {
+    const currentSecret = "a".repeat(20);
+    const previousSecret = "b".repeat(20);
+    const { rewriteHtmlForImageProxy } = await loadModule({
+      IMAGE_PROXY_SIGNING_SECRET: `${currentSecret}, ${previousSecret}`,
+      NEXT_PUBLIC_IMAGE_PROXY_BASE_URL: "https://proxy.example.com/image",
+    });
+
+    const result = await rewriteHtmlForImageProxy(
+      '<img src="https://cdn.example.com/photo.png" />',
+      createTestLogger(),
+    );
+    const src = result.html
+      .match(/src="([^"]+)"/)?.[1]
+      .replaceAll("&amp;", "&");
+    const proxyUrl = new URL(src!);
+
+    await expect(
+      validateAssetProxySignature({
+        assetUrl: proxyUrl.searchParams.get("u")!,
+        expiresAt: Number.parseInt(proxyUrl.searchParams.get("e")!, 10),
+        signature: proxyUrl.searchParams.get("s")!,
+        signingSecret: currentSecret,
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("rewrites remote assets through the app proxy route when enabled", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { rewriteHtmlForImageProxy } = await loadModule({

--- a/apps/web/utils/email/image-proxy.server.ts
+++ b/apps/web/utils/email/image-proxy.server.ts
@@ -30,7 +30,10 @@ function getImageProxyConfig(logger: Logger) {
     externalProxyBaseUrl: env.NEXT_PUBLIC_IMAGE_PROXY_BASE_URL,
     useAppRoute,
   });
-  const signingSecret = env.IMAGE_PROXY_SIGNING_SECRET;
+  const signingSecret = env.IMAGE_PROXY_SIGNING_SECRET?.split(
+    ",",
+    1,
+  )[0]?.trim();
 
   if (!proxyBaseUrl) return null;
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-091655_pr-3296_57b75bd89ec5/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Use the active image-proxy signing key when a rotation list is configured, so generated image URLs validate against the proxy.

- Select and trim the first configured signing key for new URLs
- Add regression coverage and validate the related HTML rewriting tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->