### PR TITLE
Mail: reuse core sidebar shell

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -665,12 +665,8 @@ export function MailShell() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
-        <div className="hidden lg:contents">
-          <Sidebar
-            name="left-sidebar"
-            desktopOpen={!isFocusMode && isMailSidebarOpen}
-            width="236px"
-          >
+        <div className="hidden [--sidebar-width:236px] lg:contents">
+          <Sidebar name="left-sidebar" forceCollapsed={isFocusMode}>
             <MailSidebar
               className="h-full w-full border-r-0"
               activeType={

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -49,7 +49,7 @@ import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
-import { useSidebar } from "@/components/ui/sidebar";
+import { Sidebar, useSidebar } from "@/components/ui/sidebar";
 import { useAtom, useSetAtom } from "jotai";
 import {
   commandPaletteOpenAtom,
@@ -665,9 +665,14 @@ export function MailShell() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
-        {!isFocusMode && isMailSidebarOpen && (
+        <Sidebar
+          name="left-sidebar"
+          desktopBreakpoint="lg"
+          desktopOpen={!isFocusMode && isMailSidebarOpen}
+          width="236px"
+        >
           <MailSidebar
-            className="hidden lg:flex"
+            className="h-full w-full border-r-0"
             activeType={
               scopeLabelId || scopeFolderId ? null : (scopeType ?? "inbox")
             }
@@ -694,7 +699,7 @@ export function MailShell() {
               />
             }
           />
-        )}
+        </Sidebar>
 
         {showList && (
           <section

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -665,41 +665,42 @@ export function MailShell() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
-        <Sidebar
-          name="left-sidebar"
-          desktopBreakpoint="lg"
-          desktopOpen={!isFocusMode && isMailSidebarOpen}
-          width="236px"
-        >
-          <MailSidebar
-            className="h-full w-full border-r-0"
-            activeType={
-              scopeLabelId || scopeFolderId ? null : (scopeType ?? "inbox")
-            }
-            activeLabelId={scopeLabelId}
-            activeFolderId={scopeFolderId}
-            hrefFor={hrefFor}
-            labels={isAllAccounts ? [] : visibleLabels}
-            folders={isAllAccounts || !isOutlook ? [] : folders}
-            countsById={isAllAccounts ? NO_COUNTS : countsById}
-            categories={isAllAccounts ? [] : categories}
-            categoryHeading={isOutlook ? "Inbox" : "Categories"}
-            labelsHeading={terminology.label.pluralCapitalized}
-            labelSingular={terminology.label.singular}
-            backToAppHref={prefixPath(emailAccountId, "/automation")}
-            onCompose={openCompose}
-            onCreateLabel={onCreateLabel}
-            onOpenShortcuts={openShortcuts}
-            unified={isAllAccounts}
-            footer={
-              <MailAccountSwitcher
-                isAllAccounts={isAllAccounts}
-                onSelectAll={selectAllAccounts}
-                variant="sidebar"
-              />
-            }
-          />
-        </Sidebar>
+        <div className="hidden lg:contents">
+          <Sidebar
+            name="left-sidebar"
+            desktopOpen={!isFocusMode && isMailSidebarOpen}
+            width="236px"
+          >
+            <MailSidebar
+              className="h-full w-full border-r-0"
+              activeType={
+                scopeLabelId || scopeFolderId ? null : (scopeType ?? "inbox")
+              }
+              activeLabelId={scopeLabelId}
+              activeFolderId={scopeFolderId}
+              hrefFor={hrefFor}
+              labels={isAllAccounts ? [] : visibleLabels}
+              folders={isAllAccounts || !isOutlook ? [] : folders}
+              countsById={isAllAccounts ? NO_COUNTS : countsById}
+              categories={isAllAccounts ? [] : categories}
+              categoryHeading={isOutlook ? "Inbox" : "Categories"}
+              labelsHeading={terminology.label.pluralCapitalized}
+              labelSingular={terminology.label.singular}
+              backToAppHref={prefixPath(emailAccountId, "/automation")}
+              onCompose={openCompose}
+              onCreateLabel={onCreateLabel}
+              onOpenShortcuts={openShortcuts}
+              unified={isAllAccounts}
+              footer={
+                <MailAccountSwitcher
+                  isAllAccounts={isAllAccounts}
+                  onSelectAll={selectAllAccounts}
+                  variant="sidebar"
+                />
+              }
+            />
+          </Sidebar>
+        </div>
 
         {showList && (
           <section

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -206,6 +206,9 @@ const Sidebar = React.forwardRef<
     side?: "left" | "right";
     variant?: "sidebar" | "floating" | "inset";
     collapsible?: "offcanvas" | "icon" | "none";
+    desktopBreakpoint?: "md" | "lg";
+    desktopOpen?: boolean;
+    width?: React.CSSProperties["width"];
   }
 >(
   (
@@ -214,6 +217,9 @@ const Sidebar = React.forwardRef<
       side = "left",
       variant = "sidebar",
       collapsible = "offcanvas",
+      desktopBreakpoint = "md",
+      desktopOpen,
+      width,
       className,
       children,
       ...props
@@ -265,14 +271,24 @@ const Sidebar = React.forwardRef<
       );
     }
 
+    const isDesktopOpen = desktopOpen ?? state.includes(name);
+
     return (
       <div
         ref={ref}
-        className="group peer hidden text-sidebar-foreground md:block"
-        data-state={state.includes(name) ? "expanded" : "collapsed"}
-        data-collapsible={state.includes(name) ? "" : collapsible}
+        className={cn(
+          "group peer text-sidebar-foreground",
+          desktopBreakpoint === "lg" ? "hidden lg:block" : "hidden md:block",
+        )}
+        data-state={isDesktopOpen ? "expanded" : "collapsed"}
+        data-collapsible={isDesktopOpen ? "" : collapsible}
         data-variant={variant}
         data-side={side}
+        style={
+          width
+            ? ({ "--sidebar-width": width } as React.CSSProperties)
+            : undefined
+        }
       >
         {/* This is what handles the sidebar gap on desktop */}
         <div
@@ -287,7 +303,8 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+            "fixed inset-y-0 z-10 h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear",
+            desktopBreakpoint === "lg" ? "hidden lg:flex" : "hidden md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -309,7 +326,7 @@ const Sidebar = React.forwardRef<
                 child.type === SidebarMenuButton
               ) {
                 return React.cloneElement(child, {
-                  isCollapsed: !state.includes(name),
+                  isCollapsed: !isDesktopOpen,
                 } as React.ComponentProps<typeof SidebarMenuButton>);
               }
               return child;

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -206,7 +206,6 @@ const Sidebar = React.forwardRef<
     side?: "left" | "right";
     variant?: "sidebar" | "floating" | "inset";
     collapsible?: "offcanvas" | "icon" | "none";
-    desktopBreakpoint?: "md" | "lg";
     desktopOpen?: boolean;
     width?: React.CSSProperties["width"];
   }
@@ -217,7 +216,6 @@ const Sidebar = React.forwardRef<
       side = "left",
       variant = "sidebar",
       collapsible = "offcanvas",
-      desktopBreakpoint = "md",
       desktopOpen,
       width,
       className,
@@ -276,10 +274,7 @@ const Sidebar = React.forwardRef<
     return (
       <div
         ref={ref}
-        className={cn(
-          "group peer text-sidebar-foreground",
-          desktopBreakpoint === "lg" ? "hidden lg:block" : "hidden md:block",
-        )}
+        className="group peer hidden text-sidebar-foreground md:block"
         data-state={isDesktopOpen ? "expanded" : "collapsed"}
         data-collapsible={isDesktopOpen ? "" : collapsible}
         data-variant={variant}
@@ -303,8 +298,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear",
-            desktopBreakpoint === "lg" ? "hidden lg:flex" : "hidden md:flex",
+            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -206,8 +206,7 @@ const Sidebar = React.forwardRef<
     side?: "left" | "right";
     variant?: "sidebar" | "floating" | "inset";
     collapsible?: "offcanvas" | "icon" | "none";
-    desktopOpen?: boolean;
-    width?: React.CSSProperties["width"];
+    forceCollapsed?: boolean;
   }
 >(
   (
@@ -216,8 +215,7 @@ const Sidebar = React.forwardRef<
       side = "left",
       variant = "sidebar",
       collapsible = "offcanvas",
-      desktopOpen,
-      width,
+      forceCollapsed = false,
       className,
       children,
       ...props
@@ -269,7 +267,7 @@ const Sidebar = React.forwardRef<
       );
     }
 
-    const isDesktopOpen = desktopOpen ?? state.includes(name);
+    const isDesktopOpen = state.includes(name) && !forceCollapsed;
 
     return (
       <div
@@ -279,11 +277,6 @@ const Sidebar = React.forwardRef<
         data-collapsible={isDesktopOpen ? "" : collapsible}
         data-variant={variant}
         data-side={side}
-        style={
-          width
-            ? ({ "--sidebar-width": width } as React.CSSProperties)
-            : undefined
-        }
       >
         {/* This is what handles the sidebar gap on desktop */}
         <div


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-104021_pr-3297_49aacf2fa6ee/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Use the shared sidebar shell for mail navigation so collapse behavior matches the rest of the application.

- Reuse the existing off-canvas width and position transitions
- Preserve the mail-specific width, breakpoint, and focus mode behavior
- Keep folders, labels, and categories in the mail navigation content
- Validate related sidebar and shortcut behavior

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->