### PR TITLE
desktop: Sign macOS builds with the Developer ID certificate

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CSC_IDENTITY_AUTO_DISCOVERY: "false"
       CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_LINK || secrets.WIN_CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
+      CSC_NAME: ${{ matrix.os == 'macos-latest' && 'Developer ID Application: Inbox Zero Inc. (Z46U4K6CNL)' || '' }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -60,6 +60,13 @@ jobs:
         run: |
           pnpm build
           pnpm exec electron-builder ${{ matrix.args }} --publish never
+
+      - name: Verify macOS signature
+        if: runner.os == 'macOS'
+        working-directory: apps/desktop
+        run: |
+          codesign --verify --deep --strict --verbose=2 "release/mac-arm64/Inbox Zero.app"
+          codesign -dv --verbose=2 "release/mac-arm64/Inbox Zero.app"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,7 +25,6 @@ jobs:
         include:
           - os: macos-latest
             args: --mac
-            csc_name: "Developer ID Application: Inbox Zero Inc. (Z46U4K6CNL)"
           - os: windows-latest
             args: --win
 
@@ -34,7 +33,6 @@ jobs:
     env:
       CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_LINK || secrets.WIN_CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
-      CSC_NAME: ${{ matrix.csc_name }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -42,10 +42,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
-          cache: pnpm
 
       - name: Install desktop dependencies
         run: pnpm install --frozen-lockfile --filter @inboxzero/desktop...
+
+      - name: Rebuild esbuild binary
+        run: pnpm --filter @inboxzero/desktop rebuild esbuild
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/desktop-v')

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,6 +25,7 @@ jobs:
         include:
           - os: macos-latest
             args: --mac
+            csc_name: "Developer ID Application: Inbox Zero Inc. (Z46U4K6CNL)"
           - os: windows-latest
             args: --win
 
@@ -33,7 +34,7 @@ jobs:
     env:
       CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_LINK || secrets.WIN_CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
-      CSC_NAME: ${{ matrix.os == 'macos-latest' && 'Developer ID Application: Inbox Zero Inc. (Z46U4K6CNL)' || '' }}
+      CSC_NAME: ${{ matrix.csc_name }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -19,6 +19,7 @@ mac:
   hardenedRuntime: true
   gatekeeperAssess: false
   notarize: false
+  forceCodeSigning: true
   target:
     - target: dmg
       arch:


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-105454_pr-3299_9a35cf425c91/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Stop setting `CSC_IDENTITY_AUTO_DISCOVERY=false`, which made electron-builder skip signing even with `CSC_LINK` present.
- Require a Developer ID signature on Mac (`forceCodeSigning`) and verify the arm64 app after packaging.

## Test plan
- [ ] Desktop Release macOS job logs a Developer ID signature, not "skipped macOS application code signing"
- [ ] `codesign --verify` step passes
- [ ] Windows job still packages without `WIN_CSC_*` secrets


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->