### PR TITLE
mail: Improve combined inbox caching and selection

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -94,6 +94,7 @@ import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getEmailTerminology } from "@/utils/terminology";
 import { createSearchParams } from "@/utils/url";
 import { redirectToSafeUrl } from "@/utils/redirect";
+import type { CombinedListThread } from "@/utils/threads/load-combined";
 
 // Always present, never deletable. Everything else is a saved split. They carry
 // a kind so built-ins and saved splits resolve through one mapping.
@@ -420,7 +421,7 @@ export function MailShell() {
         focusedThread ? getListThreadKey(focusedThread) : undefined,
       );
       const targets = threads.filter(
-        (thread) =>
+        (thread): thread is CombinedListThread =>
           "account" in thread && targetKeys.includes(getListThreadKey(thread)),
       );
       if (!targets.length) return;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -43,6 +43,7 @@ import {
 import type { ThreadMessage } from "@/components/email-list/types";
 import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
+import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
@@ -79,6 +80,7 @@ import {
   archiveThreadAction,
   createLabelAction,
   removeThreadLabelAction,
+  trashThreadAction,
 } from "@/utils/actions/mail";
 import {
   mailSplitToThreadsQuery,
@@ -227,13 +229,14 @@ export function MailShell() {
     enabled: !isAllAccounts,
   });
   const combinedThreadState = useCombinedMailThreads({
+    emailAccountId,
     enabled: isAllAccounts,
     isUnread: activeSplitId === "unread",
   });
   const {
     labelsByAccount,
-    removeThread: removeCombinedThread,
-    restoreThread: restoreCombinedThread,
+    removeThreads: removeCombinedThreads,
+    restoreThreads: restoreCombinedThreads,
   } = combinedThreadState;
   const { threads, isLoading, error, hasMore, isLoadingMore, loadMore } =
     isAllAccounts ? combinedThreadState : accountThreadState;
@@ -401,38 +404,80 @@ export function MailShell() {
   );
 
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
+  const runCombinedAction = useCallback(
+    async ({
+      action,
+      successVerb,
+      actionVerb,
+      failureDescription,
+    }: {
+      action: (emailAccountId: string, threadId: string) => Promise<unknown>;
+      successVerb: string;
+      actionVerb: string;
+      failureDescription: string;
+    }) => {
+      const targetKeys = selection.targetIds(
+        focusedThread ? getListThreadKey(focusedThread) : undefined,
+      );
+      const targets = threads.filter(
+        (thread) =>
+          "account" in thread && targetKeys.includes(getListThreadKey(thread)),
+      );
+      if (!targets.length) return;
+
+      const removal = removeCombinedThreads(targetKeys);
+      selection.clear();
+      const { failedThreadKeys, succeededThreadKeys } =
+        await runCombinedThreadAction({ threads: targets, action });
+      restoreCombinedThreads(removal, failedThreadKeys);
+
+      if (succeededThreadKeys.length) {
+        toast.success(
+          summariseCombinedAction(successVerb, succeededThreadKeys.length),
+        );
+      }
+      if (failedThreadKeys.length) {
+        toast.error(
+          failedThreadKeys.length === targets.length
+            ? `There was an error ${failureDescription}`
+            : `Couldn't ${actionVerb} ${failedThreadKeys.length} of ${targets.length} conversations`,
+        );
+      }
+    },
+    [
+      focusedThread,
+      removeCombinedThreads,
+      restoreCombinedThreads,
+      selection,
+      threads,
+    ],
+  );
   const archiveTargets = useCallback(async () => {
     if (!isAllAccounts) {
       runOn(archive, true, true);
       return;
     }
-    if (!focusedThread || !("account" in focusedThread)) return;
-
-    const removal = removeCombinedThread(getListThreadKey(focusedThread));
-    if (!removal) return;
-
-    try {
-      const result = await archiveThreadAction(focusedThread.account.id, {
-        threadId: focusedThread.id,
-      });
-      if (result?.serverError || result?.validationErrors) {
-        throw new Error("Archive action failed");
-      }
-    } catch {
-      restoreCombinedThread(removal);
-      toast.error("There was an error archiving");
+    await runCombinedAction({
+      action: (accountId, threadId) =>
+        archiveThreadAction(accountId, { threadId }),
+      successVerb: "Archived",
+      actionVerb: "archive",
+      failureDescription: "archiving",
+    });
+  }, [archive, isAllAccounts, runCombinedAction, runOn]);
+  const trashTargets = useCallback(async () => {
+    if (!isAllAccounts) {
+      runOn(trash, true);
       return;
     }
-    toast.success("Archived");
-  }, [
-    archive,
-    focusedThread,
-    isAllAccounts,
-    removeCombinedThread,
-    restoreCombinedThread,
-    runOn,
-  ]);
-  const trashTargets = useCallback(() => runOn(trash, true), [runOn, trash]);
+    await runCombinedAction({
+      action: (accountId, threadId) =>
+        trashThreadAction(accountId, { threadId }),
+      successVerb: "Deleted",
+      actionVerb: "delete",
+      failureDescription: "deleting",
+    });
+  }, [isAllAccounts, runCombinedAction, runOn, trash]);
   const markReadTargets = useCallback(
     () => runOn(markRead, false),
     [runOn, markRead],
@@ -445,14 +490,13 @@ export function MailShell() {
     (until: Date) => runOn((ids) => snooze(ids, until), true),
     [runOn, snooze],
   );
-  const commandTargetIds = useMemo(() => {
-    if (isAllAccounts) {
-      return focusedThread ? [getListThreadKey(focusedThread)] : [];
-    }
-    return selection.targetIds(
-      focusedThread ? getListThreadKey(focusedThread) : undefined,
-    );
-  }, [isAllAccounts, selection, focusedThread]);
+  const commandTargetIds = useMemo(
+    () =>
+      selection.targetIds(
+        focusedThread ? getListThreadKey(focusedThread) : undefined,
+      ),
+    [selection, focusedThread],
+  );
   const commandTargets = useMemo(() => {
     const ids = new Set(commandTargetIds);
     return threads.filter((thread) => ids.has(getListThreadKey(thread)));
@@ -460,7 +504,7 @@ export function MailShell() {
   const mailCommandContext = useMemo(
     () => ({
       actions: isAllAccounts
-        ? { archive: archiveTargets }
+        ? { archive: archiveTargets, trash: trashTargets }
         : {
             archive: archiveTargets,
             markRead: markReadTargets,
@@ -519,13 +563,13 @@ export function MailShell() {
         const next = splits[(index + 1) % splits.length];
         if (next) setActiveSplitId(next.id);
       },
-      select: isAllAccounts ? undefined : () => selection.toggle(clampedIndex),
+      select: () => selection.toggle(clampedIndex),
       // The cursor travels with the extension; without that, every repeat
       // re-extends from the same row and the range never grows.
-      extendSelectionDown: isAllAccounts ? undefined : () => extendSelection(1),
-      extendSelectionUp: isAllAccounts ? undefined : () => extendSelection(-1),
+      extendSelectionDown: () => extendSelection(1),
+      extendSelectionUp: () => extendSelection(-1),
       archive: archiveTargets,
-      delete: isAllAccounts ? undefined : trashTargets,
+      delete: trashTargets,
       reply: isAllAccounts
         ? undefined
         : () => {
@@ -759,7 +803,6 @@ export function MailShell() {
                     ? `all-accounts:${activeSplitId}`
                     : JSON.stringify(query)
                 }
-                selectionEnabled={!isAllAccounts}
               />
             </LoadingContent>
           </section>
@@ -819,6 +862,10 @@ export function MailShell() {
       <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
     </div>
   );
+}
+
+function summariseCombinedAction(verb: string, count: number) {
+  return count === 1 ? verb : `${verb} ${count} conversations`;
 }
 
 function getMailCategories({

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -94,7 +94,6 @@ import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getEmailTerminology } from "@/utils/terminology";
 import { createSearchParams } from "@/utils/url";
 import { redirectToSafeUrl } from "@/utils/redirect";
-import type { CombinedListThread } from "@/utils/threads/load-combined";
 
 // Always present, never deletable. Everything else is a saved split. They carry
 // a kind so built-ins and saved splits resolve through one mapping.
@@ -420,10 +419,16 @@ export function MailShell() {
       const targetKeys = selection.targetIds(
         focusedThread ? getListThreadKey(focusedThread) : undefined,
       );
-      const targets = threads.filter(
-        (thread): thread is CombinedListThread =>
-          "account" in thread && targetKeys.includes(getListThreadKey(thread)),
-      );
+      const targets: Array<{ id: string; account: { id: string } }> = [];
+      for (const thread of threads) {
+        if (
+          !("account" in thread) ||
+          !targetKeys.includes(getListThreadKey(thread))
+        ) {
+          continue;
+        }
+        targets.push({ id: thread.id, account: { id: thread.account.id } });
+      }
       if (!targets.length) return;
 
       const removal = removeCombinedThreads(targetKeys);

--- a/apps/web/app/(app)/[emailAccountId]/mail/combined-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/combined-thread-actions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { runCombinedThreadAction } from "./combined-thread-actions";
+
+describe("runCombinedThreadAction", () => {
+  it("routes same-id threads through their owning accounts", async () => {
+    const action = vi.fn().mockResolvedValue({ data: undefined });
+
+    const result = await runCombinedThreadAction({
+      threads: [
+        createThread("account-1", "shared"),
+        createThread("account-2", "shared"),
+      ],
+      action,
+    });
+
+    expect(action.mock.calls).toEqual([
+      ["account-1", "shared"],
+      ["account-2", "shared"],
+    ]);
+    expect(result).toEqual({
+      failedThreadKeys: [],
+      succeededThreadKeys: ["account-1:shared", "account-2:shared"],
+    });
+  });
+
+  it("reports thrown and rejected action results by composite thread key", async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("provider failed"))
+      .mockResolvedValueOnce({ serverError: "action failed" })
+      .mockResolvedValueOnce({ validationErrors: { threadId: ["invalid"] } });
+
+    const result = await runCombinedThreadAction({
+      threads: [
+        createThread("account-1", "one"),
+        createThread("account-2", "two"),
+        createThread("account-3", "three"),
+      ],
+      action,
+    });
+
+    expect(result).toEqual({
+      failedThreadKeys: ["account-1:one", "account-2:two", "account-3:three"],
+      succeededThreadKeys: [],
+    });
+  });
+});
+
+function createThread(accountId: string, threadId: string) {
+  return {
+    id: threadId,
+    account: {
+      id: accountId,
+      email: `${accountId}@example.com`,
+      name: null,
+      image: null,
+    },
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/combined-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/combined-thread-actions.ts
@@ -1,0 +1,50 @@
+import { mapWithConcurrency } from "@/utils/async";
+
+const THREAD_ACTION_CONCURRENCY = 10;
+
+type CombinedActionThread = {
+  id: string;
+  account: { id: string };
+};
+
+export async function runCombinedThreadAction({
+  threads,
+  action,
+}: {
+  threads: CombinedActionThread[];
+  action: (emailAccountId: string, threadId: string) => Promise<unknown>;
+}) {
+  const results = await mapWithConcurrency(
+    threads,
+    THREAD_ACTION_CONCURRENCY,
+    async (thread) => {
+      const threadKey = `${thread.account.id}:${thread.id}`;
+      try {
+        const result = await action(thread.account.id, thread.id);
+        return { failed: isActionError(result), threadKey };
+      } catch {
+        return { failed: true, threadKey };
+      }
+    },
+  );
+
+  return {
+    failedThreadKeys: results
+      .filter((result) => result.failed)
+      .map((result) => result.threadKey),
+    succeededThreadKeys: results
+      .filter((result) => !result.failed)
+      .map((result) => result.threadKey),
+  };
+}
+
+function isActionError(result: unknown) {
+  return (
+    isRecord(result) &&
+    (Boolean(result.serverError) || Boolean(result.validationErrors))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCombinedMailThreads } from "./use-combined-mail-threads";
+
+const cache = vi.hoisted(() => ({
+  read: vi.fn(),
+  remove: vi.fn(),
+  restore: vi.fn(),
+  write: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/thread-lists", () => ({
+  readCachedThreadList: cache.read,
+  removeCachedThreadsFromView: cache.remove,
+  restoreCachedThreadsToView: cache.restore,
+  writeCachedThreadList: cache.write,
+}));
+
+describe("useCombinedMailThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache.remove.mockResolvedValue(undefined);
+    cache.restore.mockResolvedValue(undefined);
+    cache.write.mockResolvedValue(undefined);
+  });
+
+  it("shows a cached first page while all accounts revalidate", async () => {
+    const network = Promise.withResolvers<unknown>();
+    const cachedThread = createThread("account-1", "cached");
+    cache.read.mockResolvedValue({
+      cachedAt: 100,
+      hasMore: true,
+      threads: [
+        {
+          id: "account-1:cached",
+          thread: cachedThread,
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads).toEqual([cachedThread]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasMore).toBe(true);
+    });
+    expect(cache.read).toHaveBeenCalledWith(
+      expect.objectContaining({ emailAccountId: "account-1" }),
+    );
+  });
+
+  it("persists and restores selected rows using their account-scoped keys", async () => {
+    cache.read.mockResolvedValue(undefined);
+    const first = createThread("account-1", "shared");
+    const second = createThread("account-2", "shared");
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            threads: [first, second],
+            labelsByAccount: {},
+            failedAccountIds: [],
+            nextPageToken: null,
+          }),
+        ),
+      },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+    await waitFor(() =>
+      expect(cache.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailAccountId: "account-1",
+          threads: [
+            { id: "account-1:shared", thread: first },
+            { id: "account-2:shared", thread: second },
+          ],
+        }),
+      ),
+    );
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads([
+        "account-1:shared",
+        "account-2:shared",
+      ]);
+    });
+    expect(result.current.threads).toEqual([]);
+    expect(cache.remove).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadIds: ["account-1:shared", "account-2:shared"],
+      }),
+    );
+
+    act(() => {
+      result.current.restoreThreads(removal, ["account-2:shared"]);
+    });
+    expect(result.current.threads).toEqual([second]);
+    expect(cache.restore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entries: [
+          expect.objectContaining({
+            thread: { id: "account-2:shared", thread: second },
+          }),
+        ],
+      }),
+    );
+  });
+});
+
+function createThread(accountId: string, threadId: string) {
+  return {
+    id: threadId,
+    messages: [
+      {
+        id: `${threadId}-message`,
+        threadId,
+        snippet: threadId,
+        subject: threadId,
+        date: "0",
+        internalDate: "0",
+        labelIds: ["INBOX"],
+        headers: { subject: threadId },
+      },
+    ],
+    plan: undefined,
+    plans: [],
+    snippet: threadId,
+    account: {
+      id: accountId,
+      email: `${accountId}@example.com`,
+      name: null,
+      image: null,
+    },
+  };
+}
+
+function createWrapper(fetcher: (key: string) => unknown) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <SWRConfig
+        value={{
+          fetcher,
+          provider: () => new Map(),
+          shouldRetryOnError: false,
+        }}
+      >
+        {children}
+      </SWRConfig>
+    );
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -1,28 +1,70 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWRInfinite from "swr/infinite";
 import type { GetAllThreadsResponse } from "@/app/api/threads/all/route";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { EmailLabels } from "@/providers/email-label-types";
+import { createThreadListCacheKey } from "@/utils/email-cache/keys";
+import {
+  readCachedThreadList,
+  removeCachedThreadsFromView,
+  restoreCachedThreadsToView,
+  writeCachedThreadList,
+} from "@/utils/email-cache/thread-lists";
 import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
+import {
+  EMAIL_CACHE_MEASURES,
+  finishEmailCacheMeasure,
+  startEmailCacheMeasure,
+} from "@/utils/email-cache/telemetry";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 import { createSearchParams } from "@/utils/url";
 
-type CombinedThreadRemoval = {
+type CombinedThread = GetAllThreadsResponse["threads"][number];
+
+type CachedCombinedThread = {
+  id: string;
+  thread: CombinedThread;
+};
+
+type RemovedCombinedThread = {
   thread: GetAllThreadsResponse["threads"][number];
   pageIndex: number;
   index: number;
   threadOrder: readonly string[];
 };
 
+type CombinedThreadRemoval = {
+  viewIdentity: string;
+  entries: Map<string, RemovedCombinedThread>;
+};
+
+type PersistentCombinedView = {
+  identity: string;
+  cachedAt: number;
+  hasMore: boolean;
+  threads: CombinedThread[];
+};
+
 export function useCombinedMailThreads({
+  emailAccountId,
   enabled,
   isUnread,
 }: {
+  emailAccountId: string;
   enabled: boolean;
   isUnread: boolean;
 }) {
+  const viewKey = useMemo(
+    () =>
+      createThreadListCacheKey({
+        scope: "combined",
+        isUnread: isUnread || undefined,
+      }),
+    [isUnread],
+  );
+  const viewIdentity = `${emailAccountId}:${viewKey}`;
   const getKey = useCallback(
     (pageIndex: number, previousPageData: GetAllThreadsResponse | null) => {
       if (!enabled || (previousPageData && !previousPageData.nextPageToken)) {
@@ -43,18 +85,57 @@ export function useCombinedMailThreads({
       revalidateFirstPage: false,
       revalidateOnFocus: false,
     });
+  const [persistent, setPersistent] = useState<PersistentCombinedView>();
+  const remoteIdentity = useRef<string | undefined>(undefined);
   const loadMoreLock = useRef(false);
 
+  remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const startedAt = startEmailCacheMeasure();
+
+    readCachedThreadList<CachedCombinedThread>({
+      emailAccountId,
+      viewKey,
+    }).then((cached) => {
+      finishEmailCacheMeasure(EMAIL_CACHE_MEASURES.listHydration, startedAt);
+      if (cancelled || !cached || remoteIdentity.current === viewIdentity) {
+        return;
+      }
+      setPersistent({
+        identity: viewIdentity,
+        cachedAt: cached.cachedAt,
+        hasMore: cached.hasMore,
+        threads: cached.threads.map((entry) => entry.thread),
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [emailAccountId, enabled, viewIdentity, viewKey]);
+
+  const remoteThreads = useMemo(
+    () => data?.flatMap((page) => page.threads),
+    [data],
+  );
+  const persistentThreads =
+    persistent?.identity === viewIdentity ? persistent.threads : undefined;
+  const sourceThreads = remoteThreads ?? persistentThreads;
   const threads = useMemo(() => {
     const byKey = new Map<string, GetAllThreadsResponse["threads"][number]>();
-    for (const thread of data?.flatMap((page) => page.threads) ?? []) {
-      byKey.set(`${thread.account.id}:${thread.id}`, thread);
+    for (const thread of sourceThreads ?? []) {
+      byKey.set(getListThreadKey(thread), thread);
     }
     return [...byKey.values()].sort(
       (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
     );
-  }, [data]);
-  const hasMore = Boolean(data?.at(-1)?.nextPageToken);
+  }, [sourceThreads]);
+  const hasMore = data
+    ? Boolean(data.at(-1)?.nextPageToken)
+    : persistent?.identity === viewIdentity && persistent.hasMore;
   const isLoadingMore = size > 1 && !data?.[size - 1];
   const labelsByAccount = useMemo(() => {
     const merged: Record<string, EmailLabels> = {};
@@ -66,75 +147,134 @@ export function useCombinedMailThreads({
     return merged;
   }, [data]);
 
-  const removeThread = useCallback(
-    (threadKey: string): CombinedThreadRemoval | undefined => {
-      for (const [pageIndex, page] of (data ?? []).entries()) {
-        const index = page.threads.findIndex(
-          (thread) => getListThreadKey(thread) === threadKey,
-        );
-        const thread = page.threads[index];
-        if (!thread) continue;
-        const threadOrder = page.threads.map(getListThreadKey);
+  useEffect(() => {
+    if (!enabled) return;
+    const firstPage = data?.[0];
+    if (!firstPage) return;
+    writeCachedThreadList({
+      emailAccountId,
+      viewKey,
+      threads: firstPage.threads.map(toCachedCombinedThread),
+      hasMore: Boolean(firstPage.nextPageToken),
+    }).catch(() => {});
+  }, [data, emailAccountId, enabled, viewKey]);
 
-        mutate(
-          (pages) =>
-            pages?.map((currentPage) => ({
-              ...currentPage,
-              threads: currentPage.threads.filter(
-                (item) => getListThreadKey(item) !== threadKey,
-              ),
-            })),
-          { populateCache: true, revalidate: false },
-        ).catch(() => {});
-        return { thread, pageIndex, index, threadOrder };
+  const removeThreads = useCallback(
+    (threadKeys: string[]): CombinedThreadRemoval => {
+      const entries = new Map<string, RemovedCombinedThread>();
+      if (!threadKeys.length) return { viewIdentity, entries };
+      const targets = new Set(threadKeys);
+
+      if (data) {
+        for (const [pageIndex, page] of data.entries()) {
+          const threadOrder = page.threads.map(getListThreadKey);
+          for (const [index, thread] of page.threads.entries()) {
+            const threadKey = getListThreadKey(thread);
+            if (targets.has(threadKey)) {
+              entries.set(threadKey, {
+                thread,
+                pageIndex,
+                index,
+                threadOrder,
+              });
+            }
+          }
+        }
+      } else {
+        const threadOrder = (persistentThreads ?? []).map(getListThreadKey);
+        for (const [index, thread] of (persistentThreads ?? []).entries()) {
+          const threadKey = getListThreadKey(thread);
+          if (targets.has(threadKey)) {
+            entries.set(threadKey, {
+              thread,
+              pageIndex: 0,
+              index,
+              threadOrder,
+            });
+          }
+        }
       }
+
+      const removedKeys = [...entries.keys()];
+      if (!removedKeys.length) return { viewIdentity, entries };
+      const removed = new Set(removedKeys);
+
+      setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? {
+              ...current,
+              threads: current.threads.filter(
+                (thread) => !removed.has(getListThreadKey(thread)),
+              ),
+            }
+          : current,
+      );
+      mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            threads: page.threads.filter(
+              (thread) => !removed.has(getListThreadKey(thread)),
+            ),
+          })),
+        { populateCache: true, revalidate: false },
+      ).catch(() => {});
+      removeCachedThreadsFromView({
+        emailAccountId,
+        viewKey,
+        threadIds: removedKeys,
+      }).catch(() => {});
+
+      return { viewIdentity, entries };
     },
-    [data, mutate],
+    [data, emailAccountId, mutate, persistentThreads, viewIdentity, viewKey],
   );
 
-  const restoreThread = useCallback(
-    (removal: CombinedThreadRemoval) => {
+  const restoreThreads = useCallback(
+    (removal: CombinedThreadRemoval, threadKeys: string[]) => {
+      if (removal.viewIdentity !== viewIdentity) return;
+      const restoring = threadKeys
+        .map((threadKey) => removal.entries.get(threadKey))
+        .filter((entry): entry is RemovedCombinedThread => entry !== undefined);
+      if (!restoring.length) return;
+
+      for (const entry of restoring) {
+        removal.entries.delete(getListThreadKey(entry.thread));
+      }
+      setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? {
+              ...current,
+              threads: insertRestoredThreads(current.threads, restoring),
+            }
+          : current,
+      );
       mutate(
         (pages) =>
           pages?.map((page, pageIndex) => {
-            if (pageIndex !== removal.pageIndex) return page;
-            if (
-              page.threads.some(
-                (thread) =>
-                  getListThreadKey(thread) === getListThreadKey(removal.thread),
-              )
-            ) {
-              return page;
-            }
-
-            const threadsByKey = new Map(
-              [...page.threads, removal.thread].map((thread) => [
-                getListThreadKey(thread),
-                thread,
-              ]),
-            );
-            const threadKeys = restoreThreadOrder(
-              page.threads.map(getListThreadKey),
-              [
-                {
-                  threadId: getListThreadKey(removal.thread),
-                  index: removal.index,
-                  threadOrder: removal.threadOrder,
-                },
-              ],
+            const pageEntries = restoring.filter(
+              (entry) => entry.pageIndex === pageIndex,
             );
             return {
               ...page,
-              threads: threadKeys.flatMap((key) => {
-                const thread = threadsByKey.get(key);
-                return thread ? [thread] : [];
-              }),
+              threads: insertRestoredThreads(page.threads, pageEntries),
             };
           }),
         { populateCache: true, revalidate: false },
       ).catch(() => {});
+      restoreCachedThreadsToView({
+        emailAccountId,
+        viewKey,
+        entries: restoring
+          .filter((entry) => entry.pageIndex === 0)
+          .map(({ thread, index, threadOrder }) => ({
+            thread: toCachedCombinedThread(thread),
+            index,
+            threadOrder,
+          })),
+      }).catch(() => {});
     },
-    [mutate],
+    [emailAccountId, mutate, viewIdentity, viewKey],
   );
 
   useEffect(() => {
@@ -149,16 +289,16 @@ export function useCombinedMailThreads({
 
   return {
     threads,
-    isLoading: isLoading && !threads.length,
-    error: threads.length ? undefined : error,
-    hasMore,
+    isLoading: isLoading && !sourceThreads,
+    error: sourceThreads ? undefined : error,
+    hasMore: Boolean(hasMore),
     isLoadingMore,
     failedAccountIds: [
       ...new Set(data?.flatMap((page) => page.failedAccountIds) ?? []),
     ],
     labelsByAccount,
-    removeThread,
-    restoreThread,
+    removeThreads,
+    restoreThreads,
     loadMore: useCallback(() => {
       if (loadMoreLock.current || !hasMore) return;
       loadMoreLock.current = true;
@@ -167,4 +307,31 @@ export function useCombinedMailThreads({
       });
     }, [hasMore, setSize]),
   };
+}
+
+function toCachedCombinedThread(thread: CombinedThread): CachedCombinedThread {
+  return { id: getListThreadKey(thread), thread };
+}
+
+function insertRestoredThreads(
+  threads: CombinedThread[],
+  restoring: RemovedCombinedThread[],
+) {
+  if (!restoring.length) return threads;
+  const threadsByKey = new Map(
+    [...threads, ...restoring.map((entry) => entry.thread)].map((thread) => [
+      getListThreadKey(thread),
+      thread,
+    ]),
+  );
+  return restoreThreadOrder(
+    threads.map(getListThreadKey),
+    restoring.map(({ thread, index, threadOrder }) => ({
+      threadId: getListThreadKey(thread),
+      index,
+      threadOrder,
+    })),
+  )
+    .map((threadKey) => threadsByKey.get(threadKey))
+    .filter((thread): thread is CombinedThread => thread !== undefined);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-105005_pr-3300_aed262ef04a8/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Aligns combined inbox behavior with account-scoped mail views.

- Hydrates and persists the combined thread list through the existing browser cache.
- Supports keyboard and mouse multi-selection with account-aware archive and delete actions.
- Adds regression coverage for cached hydration, composite thread keys, and action failure handling.