### PR TITLE
ci: Publish browser test report dashboard

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,9 @@ on:
       - "apps/web/app/**"
       - "apps/web/components/**"
       - "apps/web/hooks/**"
+      - "apps/web/providers/**"
       - "apps/web/store/**"
+      - "apps/web/styles/**"
       - "apps/web/utils/auth/**"
       - "apps/web/utils/auth.ts"
       - "apps/web/utils/auth-client.ts"
@@ -22,6 +24,7 @@ on:
       - "apps/web/next.config.*"
       - "apps/web/package.json"
       - "pnpm-lock.yaml"
+      - "scripts/pnpm-install-without-desktop.sh"
       - ".github/workflows/playwright.yml"
   pull_request:
     branches: [main]
@@ -29,7 +32,9 @@ on:
       - "apps/web/app/**"
       - "apps/web/components/**"
       - "apps/web/hooks/**"
+      - "apps/web/providers/**"
       - "apps/web/store/**"
+      - "apps/web/styles/**"
       - "apps/web/utils/auth/**"
       - "apps/web/utils/auth.ts"
       - "apps/web/utils/auth-client.ts"
@@ -44,6 +49,7 @@ on:
       - "apps/web/next.config.*"
       - "apps/web/package.json"
       - "pnpm-lock.yaml"
+      - "scripts/pnpm-install-without-desktop.sh"
       - ".github/workflows/playwright.yml"
   schedule:
     - cron: "0 6 * * *"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,50 @@
 name: Playwright
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/web/app/**"
+      - "apps/web/components/**"
+      - "apps/web/hooks/**"
+      - "apps/web/store/**"
+      - "apps/web/utils/auth/**"
+      - "apps/web/utils/auth.ts"
+      - "apps/web/utils/auth-client.ts"
+      - "apps/web/utils/middleware.ts"
+      - "apps/web/__tests__/playwright/**"
+      - "apps/web/emulate.playwright.config.yaml"
+      - "apps/web/playwright.config.mjs"
+      - "apps/web/scripts/generate-playwright-report-dashboard.ts"
+      - "apps/web/scripts/playwright-report-dashboard*"
+      - "apps/web/env.ts"
+      - "apps/web/instrumentation.ts"
+      - "apps/web/next.config.*"
+      - "apps/web/package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/playwright.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/web/app/**"
+      - "apps/web/components/**"
+      - "apps/web/hooks/**"
+      - "apps/web/store/**"
+      - "apps/web/utils/auth/**"
+      - "apps/web/utils/auth.ts"
+      - "apps/web/utils/auth-client.ts"
+      - "apps/web/utils/middleware.ts"
+      - "apps/web/__tests__/playwright/**"
+      - "apps/web/emulate.playwright.config.yaml"
+      - "apps/web/playwright.config.mjs"
+      - "apps/web/scripts/generate-playwright-report-dashboard.ts"
+      - "apps/web/scripts/playwright-report-dashboard*"
+      - "apps/web/env.ts"
+      - "apps/web/instrumentation.ts"
+      - "apps/web/next.config.*"
+      - "apps/web/package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/playwright.yml"
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -9,7 +53,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: playwright-${{ github.ref }}
+  group: playwright-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -99,11 +143,95 @@ jobs:
         run: pnpm -F inbox-zero-ai test:playwright:emulated
 
       - name: Upload Playwright artifacts
-        if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
+        if: always() && github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-artifacts-${{ github.run_id }}
+          name: playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             apps/web/playwright-report
             apps/web/test-results
           retention-days: 7
+          if-no-files-found: warn
+
+      - name: Publish Playwright dashboard
+        if: always() && github.ref == 'refs/heads/main'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.HETZNER_S3_REGION }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          HETZNER_S3_BUCKET: ${{ vars.HETZNER_S3_BUCKET }}
+          HETZNER_S3_ENDPOINT: ${{ vars.HETZNER_S3_ENDPOINT }}
+          PLAYWRIGHT_RESULT: ${{ steps.playwright_tests.outcome }}
+          PLAYWRIGHT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PLAYWRIGHT_RUN_ID: ${{ github.run_id }}
+          PLAYWRIGHT_RUN_NUMBER: ${{ github.run_number }}
+          PLAYWRIGHT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PLAYWRIGHT_SHA: ${{ github.sha }}
+          PLAYWRIGHT_EVENT: ${{ github.event_name }}
+          PLAYWRIGHT_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f apps/web/playwright-report/index.html ]; then
+            echo "::warning::Playwright did not produce an HTML report; keeping the existing public dashboard."
+            exit 0
+          fi
+
+          dashboard_dir="$GITHUB_WORKSPACE/.tmp/playwright-dashboard"
+          history_path="$dashboard_dir/history.json"
+          dashboard_path="$dashboard_dir/index.html"
+          run_key="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bucket_uri="s3://${HETZNER_S3_BUCKET}/playwright"
+          public_base_url="https://${HETZNER_S3_BUCKET}.${HETZNER_S3_ENDPOINT#https://}/playwright"
+
+          mkdir -p "$dashboard_dir"
+          if aws s3 cp \
+            "$bucket_uri/history.json" \
+            "$history_path" \
+            --endpoint-url "$HETZNER_S3_ENDPOINT" \
+            2>"$dashboard_dir/history-download-error.log"; then
+            echo "Downloaded existing Playwright history."
+          elif grep -Eq "404|NoSuchKey|Not Found" "$dashboard_dir/history-download-error.log"; then
+            echo "No existing Playwright history found; creating it."
+          else
+            cat "$dashboard_dir/history-download-error.log"
+            exit 1
+          fi
+
+          PLAYWRIGHT_REPORT_URL="$public_base_url/runs/$run_key/index.html" \
+            pnpm -F inbox-zero-ai exec tsx \
+              scripts/generate-playwright-report-dashboard.ts \
+              "$history_path" \
+              "$dashboard_path"
+
+          aws s3 sync \
+            apps/web/playwright-report/ \
+            "$bucket_uri/runs/$run_key/" \
+            --endpoint-url "$HETZNER_S3_ENDPOINT" \
+            --cache-control "public,max-age=31536000,immutable"
+          aws s3 sync \
+            apps/web/playwright-report/ \
+            "$bucket_uri/latest/" \
+            --endpoint-url "$HETZNER_S3_ENDPOINT" \
+            --delete \
+            --cache-control "no-cache"
+          aws s3 cp \
+            "$history_path" \
+            "$bucket_uri/history.json" \
+            --endpoint-url "$HETZNER_S3_ENDPOINT" \
+            --content-type "application/json" \
+            --cache-control "no-store"
+          aws s3 cp \
+            "$dashboard_path" \
+            "$bucket_uri/index.html" \
+            --endpoint-url "$HETZNER_S3_ENDPOINT" \
+            --content-type "text/html" \
+            --cache-control "no-store"
+
+          {
+            echo "### Playwright report"
+            echo "- [Dashboard]($public_base_url/index.html)"
+            echo "- [This run]($public_base_url/runs/$run_key/index.html)"
+            echo "- [Latest report]($public_base_url/latest/index.html)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -12,3 +12,11 @@ Playwright tests are separated by their dependency boundary:
 Within `emulated/`, group specs by product area, such as `mail/` or
 `automation/`. Keep setup files inside the boundary they support so
 real-provider tests cannot accidentally reuse emulated authentication state.
+
+The emulated project runs when browser-facing files change in pull requests or
+on `main`, plus the daily schedule and manual dispatches. Pull requests retain
+the HTML report, screenshots, traces, and videos as GitHub Actions artifacts.
+Runs on `main` also publish a persistent report history to the public
+Playwright dashboard:
+
+<https://izghactions.fsn1.your-objectstorage.com/playwright/index.html>

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -146,7 +146,6 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await palette.getByRole("option", { name: "Snooze 2 conversations" }).click();
   await palette.getByRole("option", { name: "In 3 hours" }).click();
-  await expect(page.getByText("Snoozed 2 conversations")).toBeVisible();
   await expect(conversations.getByRole("option")).toHaveCount(1);
 });
 

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -46,13 +46,18 @@ process.env.PLAYWRIGHT_TEST_EMAIL = playwrightTestEmail;
 
 export default defineConfig({
   testDir: "./__tests__/playwright",
+  forbidOnly: !!process.env.CI,
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,
   timeout: 240_000,
   expect: {
     timeout: 20_000,
   },
-  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  reporter: [
+    ...(process.env.CI ? [["github"]] : []),
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+  ],
   use: {
     baseURL,
     trace: "retain-on-failure",

--- a/apps/web/scripts/generate-playwright-report-dashboard.ts
+++ b/apps/web/scripts/generate-playwright-report-dashboard.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  renderPlaywrightDashboard,
+  updatePlaywrightHistory,
+} from "./playwright-report-dashboard";
+
+const [historyPath, dashboardPath] = process.argv.slice(2);
+
+if (!historyPath || !dashboardPath) {
+  throw new Error(
+    "Usage: generate-playwright-report-dashboard <history-path> <dashboard-path>",
+  );
+}
+
+const existingHistory = readHistory(historyPath);
+const history = updatePlaywrightHistory(existingHistory, {
+  attempt: getRequiredNumber("PLAYWRIGHT_RUN_ATTEMPT"),
+  branch: getRequiredEnvironmentVariable("PLAYWRIGHT_BRANCH"),
+  createdAt: new Date().toISOString(),
+  event: getRequiredEnvironmentVariable("PLAYWRIGHT_EVENT"),
+  id: getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_ID"),
+  reportUrl: getRequiredEnvironmentVariable("PLAYWRIGHT_REPORT_URL"),
+  result: getRequiredEnvironmentVariable("PLAYWRIGHT_RESULT"),
+  runNumber: getRequiredNumber("PLAYWRIGHT_RUN_NUMBER"),
+  runUrl: getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_URL"),
+  sha: getRequiredEnvironmentVariable("PLAYWRIGHT_SHA"),
+});
+
+fs.mkdirSync(path.dirname(historyPath), { recursive: true });
+fs.mkdirSync(path.dirname(dashboardPath), { recursive: true });
+fs.writeFileSync(historyPath, `${JSON.stringify(history, null, 2)}\n`);
+fs.writeFileSync(dashboardPath, renderPlaywrightDashboard(history));
+
+console.log(`Playwright dashboard generated with ${history.length} runs.`);
+
+function getRequiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getRequiredNumber(name: string): number {
+  const value = Number(getRequiredEnvironmentVariable(name));
+  if (!Number.isFinite(value)) throw new Error(`${name} must be a number`);
+  return value;
+}
+
+function readHistory(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/apps/web/scripts/playwright-report-dashboard.test.ts
+++ b/apps/web/scripts/playwright-report-dashboard.test.ts
@@ -8,9 +8,14 @@ describe("updatePlaywrightHistory", () => {
   it("places the current attempt first and replaces an existing copy", () => {
     const previousRun = getRun({ id: "100", runNumber: 8 });
     const currentRun = getRun({ id: "200", runNumber: 9 });
+    const existingCurrentRun = getRun({
+      id: currentRun.id,
+      reportUrl: "https://example.com/old-report",
+      runNumber: currentRun.runNumber,
+    });
 
     const history = updatePlaywrightHistory(
-      [previousRun, currentRun],
+      [previousRun, existingCurrentRun],
       currentRun,
     );
 

--- a/apps/web/scripts/playwright-report-dashboard.test.ts
+++ b/apps/web/scripts/playwright-report-dashboard.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderPlaywrightDashboard,
+  updatePlaywrightHistory,
+} from "./playwright-report-dashboard";
+
+describe("updatePlaywrightHistory", () => {
+  it("places the current attempt first and replaces an existing copy", () => {
+    const previousRun = getRun({ id: "100", runNumber: 8 });
+    const currentRun = getRun({ id: "200", runNumber: 9 });
+
+    const history = updatePlaywrightHistory(
+      [previousRun, currentRun],
+      currentRun,
+    );
+
+    expect(history).toEqual([currentRun, previousRun]);
+  });
+
+  it("keeps the latest 100 valid runs", () => {
+    const previousRuns = Array.from({ length: 105 }, (_, index) =>
+      getRun({ id: String(index), runNumber: index }),
+    );
+
+    const history = updatePlaywrightHistory(previousRuns, getRun());
+
+    expect(history).toHaveLength(100);
+    expect(history[0]?.id).toBe("200");
+    expect(history.at(-1)?.id).toBe("98");
+  });
+
+  it("drops malformed history entries", () => {
+    const currentRun = getRun();
+
+    expect(
+      updatePlaywrightHistory([null, { id: "broken" }], currentRun),
+    ).toEqual([currentRun]);
+  });
+});
+
+describe("renderPlaywrightDashboard", () => {
+  it("embeds run history without allowing a script breakout", () => {
+    const html = renderPlaywrightDashboard([
+      getRun({ branch: "</script><script>alert(1)</script>" }),
+    ]);
+
+    expect(html).not.toContain("</script><script>alert(1)</script>");
+    expect(html).toContain(
+      "\\u003c/script>\\u003cscript>alert(1)\\u003c/script>",
+    );
+  });
+});
+
+type PlaywrightRun = Parameters<typeof updatePlaywrightHistory>[1];
+
+function getRun(overrides: Partial<PlaywrightRun> = {}): PlaywrightRun {
+  return {
+    attempt: 1,
+    branch: "main",
+    createdAt: "2026-08-16T10:00:00.000Z",
+    event: "push",
+    id: "200",
+    reportUrl: "https://example.com/playwright/runs/200-1/index.html",
+    result: "success",
+    runNumber: 10,
+    runUrl: "https://github.com/example/repository/actions/runs/200",
+    sha: "abcdef1234567890",
+    ...overrides,
+  };
+}

--- a/apps/web/scripts/playwright-report-dashboard.ts
+++ b/apps/web/scripts/playwright-report-dashboard.ts
@@ -1,0 +1,203 @@
+const MAX_HISTORY_LENGTH = 100;
+
+type PlaywrightRun = {
+  attempt: number;
+  branch: string;
+  createdAt: string;
+  event: string;
+  id: string;
+  reportUrl: string;
+  result: string;
+  runNumber: number;
+  runUrl: string;
+  sha: string;
+};
+
+export function updatePlaywrightHistory(
+  existingHistory: unknown,
+  run: PlaywrightRun,
+): PlaywrightRun[] {
+  const history = Array.isArray(existingHistory)
+    ? existingHistory.filter(isPlaywrightRun)
+    : [];
+
+  return [
+    run,
+    ...history.filter(
+      (previousRun) =>
+        previousRun.id !== run.id || previousRun.attempt !== run.attempt,
+    ),
+  ].slice(0, MAX_HISTORY_LENGTH);
+}
+
+export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
+  const data = JSON.stringify(history).replaceAll("<", "\\u003c");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>Playwright · Inbox Zero</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #09090b; color: #fafafa; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #172554 0, #09090b 34rem); }
+    main { width: min(1080px, calc(100% - 32px)); margin: 0 auto; padding: 64px 0; }
+    header { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 32px; }
+    h1 { margin: 0; font-size: clamp(2rem, 6vw, 4.5rem); letter-spacing: -0.06em; }
+    .eyebrow { margin: 0 0 10px; color: #93c5fd; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; }
+    .subtitle { margin: 10px 0 0; color: #a1a1aa; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; }
+    .button { display: inline-flex; align-items: center; min-height: 40px; padding: 0 16px; border: 1px solid #3f3f46; border-radius: 999px; color: #fafafa; text-decoration: none; background: rgba(24, 24, 27, 0.78); }
+    .button:hover { border-color: #60a5fa; background: #172554; }
+    .summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-bottom: 20px; }
+    .card, .table-wrap { border: 1px solid rgba(113, 113, 122, 0.38); border-radius: 18px; background: rgba(9, 9, 11, 0.78); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28); backdrop-filter: blur(16px); }
+    .card { padding: 20px; }
+    .label { color: #a1a1aa; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+    .value { display: block; margin-top: 8px; font-size: 1.5rem; font-weight: 700; }
+    .table-wrap { overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 16px 18px; border-bottom: 1px solid rgba(63, 63, 70, 0.72); text-align: left; }
+    th { color: #a1a1aa; font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; }
+    tbody tr:last-child td { border-bottom: 0; }
+    tbody tr:hover { background: rgba(30, 41, 59, 0.5); }
+    .status { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; text-transform: capitalize; }
+    .status::before { width: 9px; height: 9px; border-radius: 50%; background: #f59e0b; content: ""; box-shadow: 0 0 18px currentColor; }
+    .status.success { color: #4ade80; }
+    .status.success::before { background: #4ade80; }
+    .status.failure, .status.cancelled { color: #fb7185; }
+    .status.failure::before, .status.cancelled::before { background: #fb7185; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .links { display: flex; gap: 14px; }
+    .links a { color: #93c5fd; text-decoration: none; }
+    .links a:hover { text-decoration: underline; }
+    .empty { padding: 56px 24px; color: #a1a1aa; text-align: center; }
+    footer { margin-top: 18px; color: #71717a; font-size: 0.8rem; text-align: right; }
+    @media (max-width: 760px) {
+      main { padding: 36px 0; }
+      header { align-items: start; flex-direction: column; }
+      .summary { grid-template-columns: 1fr; }
+      .table-wrap { overflow-x: auto; }
+      table { min-width: 760px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">Inbox Zero · browser checks</p>
+        <h1>Playwright</h1>
+        <p class="subtitle">Persistent results from the emulated end-to-end suite.</p>
+      </div>
+      <div class="actions">
+        <a class="button" href="./latest/index.html" id="latest-report">Latest report</a>
+        <a class="button" href="https://github.com/elie222/inbox-zero/actions/workflows/playwright.yml">GitHub Actions</a>
+      </div>
+    </header>
+
+    <section class="summary" id="summary"></section>
+    <section class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>Result</th><th>Run</th><th>Commit</th><th>Trigger</th><th>Published</th><th>Links</th></tr>
+        </thead>
+        <tbody id="runs"></tbody>
+      </table>
+      <div class="empty" id="empty" hidden>No Playwright runs have been published yet.</div>
+    </section>
+    <footer id="generated-at"></footer>
+  </main>
+  <script>
+    const history = ${data};
+    const runs = document.querySelector("#runs");
+    const empty = document.querySelector("#empty");
+    const summary = document.querySelector("#summary");
+    const generatedAt = document.querySelector("#generated-at");
+    const latestReport = document.querySelector("#latest-report");
+
+    if (history.length === 0) {
+      empty.hidden = false;
+      latestReport.hidden = true;
+    }
+
+    const latest = history[0];
+    const recent = history.slice(0, 10);
+    const recentPassing = recent.filter((run) => run.result === "success").length;
+    const cards = [
+      ["Latest result", latest?.result ?? "No runs"],
+      ["Recent pass rate", recent.length ? Math.round((recentPassing / recent.length) * 100) + "%" : "—"],
+      ["Stored runs", String(history.length)],
+    ];
+
+    for (const [label, value] of cards) {
+      const card = document.createElement("article");
+      card.className = "card";
+      const labelElement = document.createElement("span");
+      labelElement.className = "label";
+      labelElement.textContent = label;
+      const valueElement = document.createElement("span");
+      valueElement.className = "value";
+      valueElement.textContent = value;
+      card.append(labelElement, valueElement);
+      summary.append(card);
+    }
+
+    for (const run of history) {
+      const row = document.createElement("tr");
+      const result = document.createElement("td");
+      const status = document.createElement("span");
+      status.className = "status " + run.result;
+      status.textContent = run.result;
+      result.append(status);
+
+      const runNumber = document.createElement("td");
+      runNumber.textContent = "#" + run.runNumber + " · attempt " + run.attempt;
+      const commit = document.createElement("td");
+      commit.className = "mono";
+      commit.textContent = run.sha.slice(0, 7);
+      const event = document.createElement("td");
+      event.textContent = run.event + " · " + run.branch;
+      const published = document.createElement("td");
+      published.textContent = new Date(run.createdAt).toLocaleString();
+      const links = document.createElement("td");
+      links.className = "links";
+      const report = document.createElement("a");
+      report.href = run.reportUrl;
+      report.textContent = "Report";
+      const actions = document.createElement("a");
+      actions.href = run.runUrl;
+      actions.textContent = "Actions";
+      links.append(report, actions);
+
+      row.append(result, runNumber, commit, event, published, links);
+      runs.append(row);
+    }
+
+    generatedAt.textContent = latest
+      ? "Latest result published " + new Date(latest.createdAt).toLocaleString()
+      : "Waiting for the first published run";
+  </script>
+</body>
+</html>`;
+}
+
+function isPlaywrightRun(value: unknown): value is PlaywrightRun {
+  if (!value || typeof value !== "object") return false;
+
+  const run = value as Partial<PlaywrightRun>;
+  return (
+    typeof run.attempt === "number" &&
+    typeof run.branch === "string" &&
+    typeof run.createdAt === "string" &&
+    typeof run.event === "string" &&
+    typeof run.id === "string" &&
+    typeof run.reportUrl === "string" &&
+    typeof run.result === "string" &&
+    typeof run.runNumber === "number" &&
+    typeof run.runUrl === "string" &&
+    typeof run.sha === "string"
+  );
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-110758_pr-3302_20af76dd67cc/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds persistent reporting for browser checks while keeping routine pull request usage scoped.

- generates HTML reports and a compact run-history dashboard
- publishes main-branch results to configured object storage
- runs pull request checks only for relevant browser-facing changes
- retains scheduled and manual regression coverage
- adds focused dashboard generation tests

Validation: focused unit tests, lint, workflow parsing, report generation smoke test, and test discovery.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->