### PR TITLE
mail: Hide Gmail system categories from thread rows

### DIFF
--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -58,6 +58,25 @@ describe("getEmailMessageCellLabels", () => {
 });
 
 describe("getEmailThreadLabels", () => {
+  it("hides Gmail system categories while keeping user labels", () => {
+    const categoryIds = [
+      "CATEGORY_PERSONAL",
+      "CATEGORY_SOCIAL",
+      "CATEGORY_PROMOTIONS",
+      "CATEGORY_FORUMS",
+      "CATEGORY_UPDATES",
+    ];
+    const labels = getEmailThreadLabels({
+      messages: [{ labelIds: ["label-calendar", ...categoryIds] }],
+      userLabels: Object.fromEntries([
+        ["label-calendar", { id: "label-calendar", name: "Calendar" }],
+        ...categoryIds.map((id) => [id, { id, name: id }]),
+      ]),
+    });
+
+    expect(labels).toEqual([{ id: "label-calendar", name: "Calendar" }]);
+  });
+
   it("keeps a thread label when the newest message is a draft without it", () => {
     const labels = getEmailThreadLabels({
       messages: [

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -6,20 +6,16 @@ import {
 import { isDefined } from "@/utils/types";
 import { getRuleLabel } from "@/utils/rule/consts";
 import { SystemType } from "@/generated/prisma/enums";
-import { GmailLabel } from "@/utils/gmail/label";
+import { GMAIL_SYSTEM_LABELS, GmailLabel } from "@/utils/gmail/label";
 import { OutlookLabel } from "@/utils/outlook/constants";
 
 export type EmailMessageCellLabel = Pick<EmailLabel, "id" | "name" | "color">;
 
 const TO_REPLY_LABEL = getRuleLabel(SystemType.TO_REPLY);
 const AWAITING_REPLY_LABEL = getRuleLabel(SystemType.AWAITING_REPLY);
-const GMAIL_CATEGORY_LABELS = new Set([
-  GmailLabel.PERSONAL,
-  GmailLabel.SOCIAL,
-  GmailLabel.PROMOTIONS,
-  GmailLabel.FORUMS,
-  GmailLabel.UPDATES,
-]);
+const GMAIL_CATEGORY_LABELS = new Set(
+  GMAIL_SYSTEM_LABELS.filter((label) => label.startsWith("CATEGORY_")),
+);
 
 export function getEmailMessageCellLabels({
   labelIds,

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -13,6 +13,13 @@ export type EmailMessageCellLabel = Pick<EmailLabel, "id" | "name" | "color">;
 
 const TO_REPLY_LABEL = getRuleLabel(SystemType.TO_REPLY);
 const AWAITING_REPLY_LABEL = getRuleLabel(SystemType.AWAITING_REPLY);
+const GMAIL_CATEGORY_LABELS = new Set([
+  GmailLabel.PERSONAL,
+  GmailLabel.SOCIAL,
+  GmailLabel.PROMOTIONS,
+  GmailLabel.FORUMS,
+  GmailLabel.UPDATES,
+]);
 
 export function getEmailMessageCellLabels({
   labelIds,
@@ -73,7 +80,7 @@ export function getEmailThreadLabels({
     ...new Set(
       [...messages].reverse().flatMap((message) => message.labelIds ?? []),
     ),
-  ];
+  ].filter((labelId) => !GMAIL_CATEGORY_LABELS.has(labelId));
 
   return getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-114113_pr-3305_c207e714278b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keep user-created labels visible in mail thread rows while suppressing Gmail system category labels.

- Filters all five Gmail category identifiers before selecting visible thread labels
- Adds regression coverage for preserving ordinary labels
- Validated with the focused unit test and repository lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->