### PR TITLE
test: Include screenshots in browser reports

### DIFF
--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -16,6 +16,7 @@ real-provider tests cannot accidentally reuse emulated authentication state.
 The emulated project runs when browser-facing files change in pull requests or
 on `main`, plus the daily schedule and manual dispatches. Pull requests retain
 the HTML report, screenshots, traces, and videos as GitHub Actions artifacts.
+Intentional checkpoint screenshots are attached to successful HTML reports.
 Runs on `main` also publish a persistent report history to the public
 Playwright dashboard:
 

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -56,7 +56,7 @@ test("Command K acts on highlighted and selected conversations", async ({
   await expect(palette.getByRole("option", { name: "Snooze" })).toBeVisible();
   await expect(palette).not.toContainText("Applies to");
   await testInfo.attach("Command palette for highlighted conversation", {
-    body: await page.screenshot(),
+    body: await palette.screenshot(),
     contentType: "image/png",
   });
 
@@ -75,7 +75,7 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await expect(palette.getByText("Archive conversation")).toHaveCount(0);
   await testInfo.attach("Snooze preset options", {
-    body: await page.screenshot(),
+    body: await palette.screenshot(),
     contentType: "image/png",
   });
 
@@ -93,7 +93,7 @@ test("Command K acts on highlighted and selected conversations", async ({
     0,
   );
   await testInfo.attach("Natural-language snooze option", {
-    body: await page.screenshot(),
+    body: await palette.screenshot(),
     contentType: "image/png",
   });
 

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -55,8 +55,9 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await expect(palette.getByRole("option", { name: "Snooze" })).toBeVisible();
   await expect(palette).not.toContainText("Applies to");
-  await page.screenshot({
-    path: testInfo.outputPath("01-command-palette-highlighted-row.png"),
+  await testInfo.attach("Command palette for highlighted conversation", {
+    body: await page.screenshot(),
+    contentType: "image/png",
   });
 
   await palette.getByRole("option", { name: "Snooze" }).click();
@@ -73,8 +74,9 @@ test("Command K acts on highlighted and selected conversations", async ({
     palette.getByRole("option", { name: "Next week" }),
   ).toBeVisible();
   await expect(palette.getByText("Archive conversation")).toHaveCount(0);
-  await page.screenshot({
-    path: testInfo.outputPath("02-snooze-presets.png"),
+  await testInfo.attach("Snooze preset options", {
+    body: await page.screenshot(),
+    contentType: "image/png",
   });
 
   const snoozeInput = palette.getByPlaceholder(
@@ -90,8 +92,9 @@ test("Command K acts on highlighted and selected conversations", async ({
   await expect(palette.getByRole("option", { name: "In 3 hours" })).toHaveCount(
     0,
   );
-  await page.screenshot({
-    path: testInfo.outputPath("03-snooze-natural-language.png"),
+  await testInfo.attach("Natural-language snooze option", {
+    body: await page.screenshot(),
+    contentType: "image/png",
   });
 
   await page.keyboard.press("Escape");


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-120715_pr-3306_6d806fa052d4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds intentional visual checkpoints to successful browser-test reports.

- attaches named screenshots to the standard HTML report
- retains failure-only automatic capture behavior
- documents successful-run screenshot availability

Validation: lint, formatting, diff checks, and browser-test discovery.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->