### PR TITLE
test: Capture screenshots only for changed browser tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -116,6 +116,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Find changed Playwright tests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          changed_tests_path="$RUNNER_TEMP/changed-playwright-tests.txt"
+          : > "$changed_tests_path"
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]] &&
+            [[ -n "$BASE_SHA" ]] &&
+            [[ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$GITHUB_SHA" -- \
+              apps/web/__tests__/playwright | \
+              sed -n -E '/\.(spec|setup)\.[cm]?[jt]sx?$/ { s#^apps/web/##; p; }' \
+                > "$changed_tests_path"
+          fi
+
+          {
+            echo "PLAYWRIGHT_CHANGED_TEST_FILES<<EOF"
+            cat "$changed_tests_path"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -16,7 +16,8 @@ real-provider tests cannot accidentally reuse emulated authentication state.
 The emulated project runs when browser-facing files change in pull requests or
 on `main`, plus the daily schedule and manual dispatches. Pull requests retain
 the HTML report, screenshots, traces, and videos as GitHub Actions artifacts.
-Intentional checkpoint screenshots are attached to successful HTML reports.
+Intentional checkpoint screenshots are attached when their test file changed
+in a pull request or push. Every test still captures a screenshot on failure.
 Runs on `main` also publish a persistent report history to the public
 Playwright dashboard:
 

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -1,9 +1,11 @@
+import path from "node:path";
 import {
   expect,
   test,
   type APIRequestContext,
   type Locator,
   type Page,
+  type TestInfo,
 } from "@playwright/test";
 import { Client } from "pg";
 
@@ -55,10 +57,11 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await expect(palette.getByRole("option", { name: "Snooze" })).toBeVisible();
   await expect(palette).not.toContainText("Applies to");
-  await testInfo.attach("Command palette for highlighted conversation", {
-    body: await palette.screenshot(),
-    contentType: "image/png",
-  });
+  await attachScreenshotForChangedTest(
+    testInfo,
+    palette,
+    "Command palette for highlighted conversation",
+  );
 
   await palette.getByRole("option", { name: "Snooze" }).click();
   await expect(
@@ -74,10 +77,11 @@ test("Command K acts on highlighted and selected conversations", async ({
     palette.getByRole("option", { name: "Next week" }),
   ).toBeVisible();
   await expect(palette.getByText("Archive conversation")).toHaveCount(0);
-  await testInfo.attach("Snooze preset options", {
-    body: await palette.screenshot(),
-    contentType: "image/png",
-  });
+  await attachScreenshotForChangedTest(
+    testInfo,
+    palette,
+    "Snooze preset options",
+  );
 
   const snoozeInput = palette.getByPlaceholder(
     "When should it return? Try Friday at 3pm",
@@ -92,10 +96,11 @@ test("Command K acts on highlighted and selected conversations", async ({
   await expect(palette.getByRole("option", { name: "In 3 hours" })).toHaveCount(
     0,
   );
-  await testInfo.attach("Natural-language snooze option", {
-    body: await palette.screenshot(),
-    contentType: "image/png",
-  });
+  await attachScreenshotForChangedTest(
+    testInfo,
+    palette,
+    "Natural-language snooze option",
+  );
 
   await page.keyboard.press("Escape");
   await expect(palette).toBeVisible();
@@ -185,6 +190,30 @@ async function ensureReadState(
   await expect(palette).toBeHidden();
   await page.keyboard.press("Escape");
   await expect(selectionCount).toBeHidden();
+}
+
+async function attachScreenshotForChangedTest(
+  testInfo: TestInfo,
+  locator: Locator,
+  name: string,
+) {
+  const testFile = path
+    .relative(process.cwd(), testInfo.file)
+    .split(path.sep)
+    .join("/");
+  const changedTestFiles = new Set(
+    (process.env.PLAYWRIGHT_CHANGED_TEST_FILES ?? "")
+      .split("\n")
+      .map((file) => file.trim())
+      .filter(Boolean),
+  );
+
+  if (!changedTestFiles.has(testFile)) return;
+
+  await testInfo.attach(name, {
+    body: await locator.screenshot(),
+    contentType: "image/png",
+  });
 }
 
 async function restoreActiveSnoozes(


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-123007_pr-3308_7beb9bf31faf/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Captures intentional browser-test checkpoints only when their spec changed while preserving failure screenshots for all tests.

- detects changed Playwright specs in CI
- gates named report attachments per test file
- documents the behavior and validates lint, workflow parsing, and test discovery

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->