### PR TITLE
mail: Add snooze keyboard shortcut

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -53,7 +53,7 @@ test("Command K acts on highlighted and selected conversations", async ({
   await expect(
     palette.getByRole("option", { name: "Mark as read" }),
   ).toBeVisible();
-  await expect(palette.getByRole("option", { name: "Snooze" })).toBeVisible();
+  await expect(palette.getByRole("option", { name: "Snooze H" })).toBeVisible();
   await expect(palette).not.toContainText("Applies to");
   await testInfo.attach("Command palette for highlighted conversation", {
     body: await palette.screenshot(),
@@ -100,6 +100,16 @@ test("Command K acts on highlighted and selected conversations", async ({
   await page.keyboard.press("Escape");
   await expect(palette).toBeVisible();
   await expect(palette.getByRole("option", { name: "Snooze" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(palette).toBeHidden();
+
+  await page.keyboard.press("KeyH");
+  await expect(palette).toBeVisible();
+  await expect(
+    palette.getByPlaceholder("When should it return? Try Friday at 3pm"),
+  ).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(palette.getByRole("option", { name: "Snooze H" })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(palette).toBeHidden();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -55,6 +55,7 @@ describe("buildMailCommandPalette", () => {
     const snooze = commands.find((command) => command.id === "mail-snooze");
     expect(snooze).toMatchObject({
       label: "Snooze 3 conversations",
+      shortcut: "H",
       closeOnSelect: false,
     });
     snooze?.action();

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -6,6 +6,7 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import type { Command } from "@/lib/commands/types";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 type MailCommandActions = {
   archive: () => void;
@@ -75,6 +76,7 @@ export function buildMailCommandPalette({
       label:
         targetCount === 1 ? "Snooze" : `Snooze ${targetCount} conversations`,
       icon: Clock3Icon,
+      shortcut: getShortcutHint("snooze"),
       section: "actions",
       priority: 3,
       keywords: ["snooze", "later", "remind"],

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -105,6 +105,13 @@ function CommandPaletteContent({
           showEmail(null);
         }
       : undefined,
+    snooze: mailCommandContext?.actions.snooze
+      ? () => {
+          setSearch("");
+          setPage("snooze");
+          setOpen(true);
+        }
+      : undefined,
     // While the palette is open, Escape belongs to the dialog.
     backToList: open || !threadId ? undefined : () => showEmail(null),
   };

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -153,6 +153,13 @@ const SHORTCUT_DEFINITIONS = [
     },
   },
   {
+    id: "snooze",
+    keys: ["h"],
+    scope: "mail",
+    group: "Triage",
+    label: "Snooze",
+  },
+  {
     // `#` sits behind shift on US layouts and in front of it on others.
     id: "delete",
     keys: ["shift+#", "#", "backspace"],

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -14,11 +14,14 @@ afterEach(cleanup);
 describe("useShortcuts", () => {
   it("runs the handler for a mail shortcut while the mail scope is active", () => {
     const archive = vi.fn();
-    renderShortcuts({ archive });
+    const snooze = vi.fn();
+    renderShortcuts({ archive, snooze });
 
     press({ key: "e", code: "KeyE" });
+    press({ key: "h", code: "KeyH" });
 
     expect(archive).toHaveBeenCalledOnce();
+    expect(snooze).toHaveBeenCalledOnce();
   });
 
   it("leaves mail shortcuts inert outside the mail scope", () => {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-123148_pr-3309_474f900e3ec4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a keyboard shortcut for opening the snooze-time command flow.

- registers H as a mail triage shortcut and shows it in shortcut surfaces
- opens the existing snooze picker directly for the active conversation selection
- adds focused unit and emulated browser coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->