### PR TITLE
Mail: Fix reader loading layout

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -296,10 +296,12 @@ export function MailShell() {
     emailAccountId,
     threadIds: isAllAccounts ? [] : orderedIds,
   });
-  const { data: openThreadData, mutate: refetchOpenThread } = useThread(
-    { id: readerThreadId },
-    { includeDrafts: true },
-  );
+  const {
+    data: openThreadData,
+    error: openThreadError,
+    isLoading: isOpenThreadLoading,
+    mutate: refetchOpenThread,
+  } = useThread({ id: readerThreadId }, { includeDrafts: true });
   // Withheld until the deferred id catches up, so a fast J/K can't pair the new
   // thread's header with the previous thread's body.
   const openMessages =
@@ -821,6 +823,13 @@ export function MailShell() {
             key={openThreadId ?? "empty"}
             thread={openThread ?? null}
             threadId={openThreadId}
+            loading={
+              Boolean(openThreadId) &&
+              (readerThreadId !== openThreadId || isOpenThreadLoading)
+            }
+            error={
+              readerThreadId === openThreadId ? openThreadError : undefined
+            }
             messages={openMessages ?? []}
             userEmail={userEmail}
             userLabels={userLabels}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -820,6 +820,7 @@ export function MailShell() {
           <ThreadReader
             key={openThreadId ?? "empty"}
             thread={openThread ?? null}
+            threadId={openThreadId}
             messages={openMessages ?? []}
             userEmail={userEmail}
             userLabels={userLabels}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type ReactNode } from "react";
 import dynamic from "next/dynamic";
-import { MailIcon } from "lucide-react";
+import { Loader2Icon, MailIcon } from "lucide-react";
 import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
 import type {
   ListThread,
@@ -28,8 +28,10 @@ const SenderContextSheet = dynamic(
 );
 
 export type ThreadReaderProps = {
-  /** The row that is open. `null` renders the empty state. */
+  /** The row that is open. It may lag behind the selected thread while loading. */
   thread: ListThread | null;
+  /** The selected thread, including while its row and messages are loading. */
+  threadId: string | null;
   /**
    * The open thread's full messages. The list payload has no bodies, so this
    * arrives from a second fetch; the header renders before it lands.
@@ -62,6 +64,7 @@ export type ThreadReaderProps = {
 
 export function ThreadReader({
   thread,
+  threadId,
   messages,
   userEmail,
   userLabels,
@@ -83,16 +86,25 @@ export function ThreadReader({
   const [senderContextState, setSenderContextState] = useState<
     "unloaded" | "open" | "closed"
   >("unloaded");
-  const headerMessage = thread?.messages.at(-1);
+  const headerMessage = thread?.messages.at(-1) ?? messages.at(-1);
 
-  if (!thread || !headerMessage) {
+  if (!headerMessage) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 px-6 py-16 text-center">
-        <MailIcon className="size-6 text-muted-foreground" />
-        <div className="text-foreground text-sm">Nothing selected</div>
-        <div className="text-muted-foreground text-xs">
-          Pick another view, or head back to the inbox.
-        </div>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+        {threadId ? (
+          <Loader2Icon
+            aria-label="Loading email"
+            className="size-6 animate-spin text-muted-foreground"
+          />
+        ) : (
+          <>
+            <MailIcon className="size-6 text-muted-foreground" />
+            <div className="text-foreground text-sm">Nothing selected</div>
+            <div className="text-muted-foreground text-xs">
+              Pick another view, or head back to the inbox.
+            </div>
+          </>
+        )}
       </div>
     );
   }
@@ -142,7 +154,7 @@ export function ThreadReader({
           {messages.length > 0 ? (
             <EmailThread
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
-              key={thread.id}
+              key={threadId}
               messages={messages}
               refetch={refetch}
               showReplyButton

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, type ComponentProps, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { Loader2Icon, MailIcon } from "lucide-react";
 import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
@@ -11,6 +11,7 @@ import type {
 import { EmailThread } from "@/components/email-list/EmailThread";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
+import { LoadingContent } from "@/components/LoadingContent";
 import type { EmailLabels } from "@/providers/email-label-types";
 import {
   extractEmailAddress,
@@ -32,6 +33,8 @@ export type ThreadReaderProps = {
   thread: ListThread | null;
   /** The selected thread, including while its row and messages are loading. */
   threadId: string | null;
+  loading: boolean;
+  error?: ComponentProps<typeof LoadingContent>["error"];
   /**
    * The open thread's full messages. The list payload has no bodies, so this
    * arrives from a second fetch; the header renders before it lands.
@@ -65,6 +68,8 @@ export type ThreadReaderProps = {
 export function ThreadReader({
   thread,
   threadId,
+  loading,
+  error,
   messages,
   userEmail,
   userLabels,
@@ -91,20 +96,22 @@ export function ThreadReader({
   if (!headerMessage) {
     return (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-2 px-6 py-16 text-center">
-        {threadId ? (
-          <Loader2Icon
-            aria-label="Loading email"
-            className="size-6 animate-spin text-muted-foreground"
-          />
-        ) : (
-          <>
-            <MailIcon className="size-6 text-muted-foreground" />
-            <div className="text-foreground text-sm">Nothing selected</div>
-            <div className="text-muted-foreground text-xs">
-              Pick another view, or head back to the inbox.
-            </div>
-          </>
-        )}
+        <LoadingContent
+          error={error}
+          loading={loading}
+          loadingComponent={
+            <Loader2Icon
+              aria-label="Loading email"
+              className="size-6 animate-spin text-muted-foreground"
+            />
+          }
+        >
+          <MailIcon className="size-6 text-muted-foreground" />
+          <div className="text-foreground text-sm">Nothing selected</div>
+          <div className="text-muted-foreground text-xs">
+            Pick another view, or head back to the inbox.
+          </div>
+        </LoadingContent>
       </div>
     );
   }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -93,7 +93,7 @@ export function ThreadReader({
   >("unloaded");
   const headerMessage = thread?.messages.at(-1) ?? messages.at(-1);
 
-  if (!headerMessage) {
+  if (error || !headerMessage) {
     return (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-2 px-6 py-16 text-center">
         <LoadingContent


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-133245_pr-3310_ba6cf9d8bc83/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Shows loading progress while a selected thread resolves and allows fetched messages to populate the reader before its list row is available.

Ensures loading and empty states expand across the full desktop reader area.

Validation: Ultracite check and 21 focused unit tests passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->