### PR TITLE
analytics: Improve pricing funnel attribution

### DIFF
--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -69,8 +69,9 @@ export default function Pricing(props: PricingProps) {
   );
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
 
+  const pricingFrequencyDefaultVariant = usePricingFrequencyDefault();
   const defaultFrequency =
-    usePricingFrequencyDefault() === "annually"
+    pricingFrequencyDefaultVariant === "annually"
       ? frequencies[1]
       : frequencies[0];
   const [chosenFrequency, setFrequency] = useState<
@@ -108,13 +109,21 @@ export default function Pricing(props: PricingProps) {
       hasExistingSubscription,
       showSkipUpgrade: Boolean(props.showSkipUpgrade),
       displayedTiers: displayedTiers.map((tier) => tier.name),
+      frequency: frequency.value,
+      defaultFrequency: defaultFrequency.value,
+      frequencySource: chosenFrequency ? "user_selected" : "default",
+      pricingFrequencyDefaultVariant,
     });
   }, [
+    chosenFrequency,
+    defaultFrequency.value,
     displayedTiers,
+    frequency.value,
     hasExistingSubscription,
     isLoading,
     isLoggedIn,
     posthog,
+    pricingFrequencyDefaultVariant,
     pricingSource,
     props.showSkipUpgrade,
   ]);
@@ -179,7 +188,16 @@ export default function Pricing(props: PricingProps) {
 
         <PricingFrequencyToggle
           frequency={frequency}
-          setFrequency={setFrequency}
+          setFrequency={(nextFrequency) => {
+            posthog.capture("pricing_frequency_changed", {
+              source: pricingSource,
+              previousFrequency: frequency.value,
+              frequency: nextFrequency.value,
+              defaultFrequency: defaultFrequency.value,
+              pricingFrequencyDefaultVariant,
+            });
+            setFrequency(nextFrequency);
+          }}
         >
           <div className="ml-1">
             <DiscountBadge>Save up to 20%</DiscountBadge>
@@ -200,6 +218,9 @@ export default function Pricing(props: PricingProps) {
               tier={tier}
               userPremiumTier={userPremiumTier}
               frequency={frequency}
+              defaultFrequency={defaultFrequency}
+              frequencySource={chosenFrequency ? "user_selected" : "default"}
+              pricingFrequencyDefaultVariant={pricingFrequencyDefaultVariant}
               stripeSubscriptionId={premium?.stripeSubscriptionId}
               stripeSubscriptionStatus={premium?.stripeSubscriptionStatus}
               hasActiveAppleManagedSubscription={
@@ -221,6 +242,9 @@ function PriceTier({
   tier,
   userPremiumTier,
   frequency,
+  defaultFrequency,
+  frequencySource,
+  pricingFrequencyDefaultVariant,
   stripeSubscriptionId,
   stripeSubscriptionStatus,
   hasActiveAppleManagedSubscription,
@@ -232,6 +256,9 @@ function PriceTier({
   tier: Tier;
   userPremiumTier: PremiumTier | null;
   frequency: Frequency;
+  defaultFrequency: Frequency;
+  frequencySource: "default" | "user_selected";
+  pricingFrequencyDefaultVariant: string;
   stripeSubscriptionId: string | null | undefined;
   stripeSubscriptionStatus: string | null | undefined;
   hasActiveAppleManagedSubscription: boolean;
@@ -331,6 +358,9 @@ function PriceTier({
             tier: tier.name,
             billingTier: upgradeToTier ?? null,
             frequency: frequency.value,
+            defaultFrequency: defaultFrequency.value,
+            frequencySource,
+            pricingFrequencyDefaultVariant,
             cta: getCTAText(),
             isCurrentPlan,
             isLoggedIn,

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -9,7 +9,10 @@ import { usePostHog } from "posthog-js/react";
 import { env } from "@/env";
 import { LoadingContent } from "@/components/LoadingContent";
 import { usePremium } from "@/hooks/usePremium";
-import { usePricingFrequencyDefault } from "@/hooks/useFeatureFlags";
+import {
+  usePricingFrequencyDefault,
+  type PricingFrequencyDefault,
+} from "@/hooks/useFeatureFlags";
 import { Button } from "@/components/ui/button";
 import {
   PricingFrequencyToggle,
@@ -100,7 +103,13 @@ export default function Pricing(props: PricingProps) {
   const router = useRouter();
 
   useEffect(() => {
-    if (isLoading || hasTrackedPricingView.current) return;
+    if (
+      isLoading ||
+      pricingFrequencyDefaultVariant === undefined ||
+      hasTrackedPricingView.current
+    ) {
+      return;
+    }
 
     hasTrackedPricingView.current = true;
     posthog.capture("pricing_page_viewed", {
@@ -194,7 +203,8 @@ export default function Pricing(props: PricingProps) {
               previousFrequency: frequency.value,
               frequency: nextFrequency.value,
               defaultFrequency: defaultFrequency.value,
-              pricingFrequencyDefaultVariant,
+              pricingFrequencyDefaultVariant:
+                pricingFrequencyDefaultVariant ?? null,
             });
             setFrequency(nextFrequency);
           }}
@@ -220,7 +230,9 @@ export default function Pricing(props: PricingProps) {
               frequency={frequency}
               defaultFrequency={defaultFrequency}
               frequencySource={chosenFrequency ? "user_selected" : "default"}
-              pricingFrequencyDefaultVariant={pricingFrequencyDefaultVariant}
+              pricingFrequencyDefaultVariant={
+                pricingFrequencyDefaultVariant ?? null
+              }
               stripeSubscriptionId={premium?.stripeSubscriptionId}
               stripeSubscriptionStatus={premium?.stripeSubscriptionStatus}
               hasActiveAppleManagedSubscription={
@@ -258,7 +270,7 @@ function PriceTier({
   frequency: Frequency;
   defaultFrequency: Frequency;
   frequencySource: "default" | "user_selected";
-  pricingFrequencyDefaultVariant: string;
+  pricingFrequencyDefaultVariant: PricingFrequencyDefault | null;
   stripeSubscriptionId: string | null | undefined;
   stripeSubscriptionStatus: string | null | undefined;
   hasActiveAppleManagedSubscription: boolean;

--- a/apps/web/app/api/stripe/success/route.test.ts
+++ b/apps/web/app/api/stripe/success/route.test.ts
@@ -83,7 +83,6 @@ describe("stripe success route", () => {
 
     expect(trackStripeCheckoutCompletedMock).toHaveBeenCalledWith(
       "user@example.com",
-      "checkout-session-id",
       {
         source: "success_redirect",
       },

--- a/apps/web/app/api/stripe/success/route.test.ts
+++ b/apps/web/app/api/stripe/success/route.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
-const { afterMock, redirectMock, syncStripeDataToDbMock } = vi.hoisted(() => ({
+const {
+  afterMock,
+  redirectMock,
+  syncStripeDataToDbMock,
+  trackStripeCheckoutCompletedMock,
+} = vi.hoisted(() => ({
   afterMock: vi.fn(),
   redirectMock: vi.fn(),
   syncStripeDataToDbMock: vi.fn(),
+  trackStripeCheckoutCompletedMock: vi.fn(),
 }));
 
 vi.mock("next/server", async (importActual) => ({
@@ -41,7 +47,7 @@ vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
 }));
 
 vi.mock("@/utils/posthog", () => ({
-  trackStripeCheckoutCompleted: vi.fn(),
+  trackStripeCheckoutCompleted: trackStripeCheckoutCompletedMock,
 }));
 
 import { GET } from "./route";
@@ -69,6 +75,18 @@ describe("stripe success route", () => {
     });
     expect(redirectMock).toHaveBeenCalledWith(
       "/setup?conversion_event=trial_started&conversion_event_id=checkout-session-id",
+    );
+
+    const trackCheckoutCompleted = afterMock.mock.calls[0]?.[0];
+    expect(trackCheckoutCompleted).toEqual(expect.any(Function));
+    await trackCheckoutCompleted();
+
+    expect(trackStripeCheckoutCompletedMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "checkout-session-id",
+      {
+        source: "success_redirect",
+      },
     );
   });
 });

--- a/apps/web/app/api/stripe/success/route.ts
+++ b/apps/web/app/api/stripe/success/route.ts
@@ -24,19 +24,21 @@ export const GET = withAuth("stripe/success", async (request) => {
 
   if (!user?.premium?.stripeCustomerId) redirect("/premium");
 
+  const stripeCheckoutSessionId = new URL(request.url).searchParams.get(
+    "session_id",
+  );
+
   after(async () => {
     if (!user?.email) return;
-    trackStripeCheckoutCompleted(user.email, { source: "success_redirect" });
+    trackStripeCheckoutCompleted(user.email, stripeCheckoutSessionId, {
+      source: "success_redirect",
+    });
   });
 
   await syncStripeDataToDb({
     customerId: user.premium.stripeCustomerId,
     logger,
   });
-
-  const stripeCheckoutSessionId = new URL(request.url).searchParams.get(
-    "session_id",
-  );
 
   redirect(
     buildRedirectUrl("/setup", {

--- a/apps/web/app/api/stripe/success/route.ts
+++ b/apps/web/app/api/stripe/success/route.ts
@@ -30,7 +30,7 @@ export const GET = withAuth("stripe/success", async (request) => {
 
   after(async () => {
     if (!user?.email) return;
-    trackStripeCheckoutCompleted(user.email, stripeCheckoutSessionId, {
+    await trackStripeCheckoutCompleted(user.email, {
       source: "success_redirect",
     });
   });

--- a/apps/web/app/api/stripe/webhook/controller.ts
+++ b/apps/web/app/api/stripe/webhook/controller.ts
@@ -17,6 +17,7 @@ import {
 } from "@/utils/analytics/server-conversion-events";
 import { sendFacebookConversionEvent } from "@/utils/fb";
 import {
+  getCheckoutSessionIdHash,
   trackBillingTrialStarted,
   trackStripeEvent,
   trackSubscriptionTrialStarted,
@@ -298,10 +299,18 @@ async function trackFacebookBillingConversion({
 }
 
 async function trackEvent(email: string | undefined, event: Stripe.Event) {
+  const checkoutSessionIdHash =
+    event.type === "checkout.session.completed"
+      ? getCheckoutSessionIdHash(
+          (event.data.object as Stripe.Checkout.Session).id,
+        )
+      : undefined;
+
   return trackStripeEvent(email ?? "Unknown", {
     ...event.data.object,
     id: event.id,
     type: event.type,
+    ...(checkoutSessionIdHash && { checkoutSessionIdHash }),
     object: event.data.object, // for legacy
   });
 }

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockEnqueueStripeInvoiceEmail,
   mockSyncAiGenerationOverageForUpcomingInvoice,
   mockTrackStripeEvent,
+  mockGetCheckoutSessionIdHash,
   mockTrackBillingTrialStarted,
   mockTrackTrialStarted,
   mockTrackSubscriptionTrialStarted,
@@ -26,6 +27,9 @@ const {
   mockEnqueueStripeInvoiceEmail: vi.fn(),
   mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
   mockTrackStripeEvent: vi.fn(),
+  mockGetCheckoutSessionIdHash: vi.fn(
+    (checkoutSessionId: string) => `hashed:${checkoutSessionId}`,
+  ),
   mockTrackBillingTrialStarted: vi.fn(),
   mockTrackTrialStarted: vi.fn(),
   mockTrackSubscriptionTrialStarted: vi.fn(),
@@ -78,6 +82,7 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("@/utils/posthog", () => ({
+  getCheckoutSessionIdHash: mockGetCheckoutSessionIdHash,
   trackBillingTrialStarted: mockTrackBillingTrialStarted,
   trackStripeEvent: mockTrackStripeEvent,
   trackSubscriptionTrialStarted: mockTrackSubscriptionTrialStarted,
@@ -185,6 +190,20 @@ describe("processEvent", () => {
       event: expect.objectContaining({ type: "invoice.paid" }),
       logger,
     });
+  });
+
+  it("adds a private correlation key for a verified checkout completion", async () => {
+    await processEvent(checkoutCompletedEvent(), logger);
+
+    expect(mockTrackStripeEvent).toHaveBeenCalledWith(
+      "Unknown",
+      expect.objectContaining({
+        checkoutSessionIdHash: "hashed:cs_test",
+        id: "evt_checkout_test",
+        type: "checkout.session.completed",
+      }),
+    );
+    expect(mockGetCheckoutSessionIdHash).toHaveBeenCalledWith("cs_test");
   });
 
   it("skips dependent billing syncs after customer sync fails", async () => {
@@ -538,6 +557,26 @@ function invoiceEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
       },
     },
     ...overrides,
+  } as Stripe.Event;
+}
+
+function checkoutCompletedEvent(): Stripe.Event {
+  return {
+    id: "evt_checkout_test",
+    type: "checkout.session.completed",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1_700_000_500,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "cs_test",
+        customer: "cus_test",
+        status: "complete",
+      },
+    },
   } as Stripe.Event;
 }
 

--- a/apps/web/components/new-landing/sections/Pricing.tsx
+++ b/apps/web/components/new-landing/sections/Pricing.tsx
@@ -115,7 +115,8 @@ export function Pricing() {
               previousFrequency: frequency,
               frequency: nextFrequency,
               defaultFrequency,
-              pricingFrequencyDefaultVariant,
+              pricingFrequencyDefaultVariant:
+                pricingFrequencyDefaultVariant ?? null,
             });
             setFrequency(nextFrequency);
           }}
@@ -146,7 +147,9 @@ export function Pricing() {
                 frequency={frequency}
                 defaultFrequency={defaultFrequency}
                 frequencySource={chosenFrequency ? "user_selected" : "default"}
-                pricingFrequencyDefaultVariant={pricingFrequencyDefaultVariant}
+                pricingFrequencyDefaultVariant={
+                  pricingFrequencyDefaultVariant ?? null
+                }
                 posthog={posthog}
               />
             </CardWrapper>
@@ -181,7 +184,8 @@ export function Pricing() {
                       frequencySource: chosenFrequency
                         ? "user_selected"
                         : "default",
-                      pricingFrequencyDefaultVariant,
+                      pricingFrequencyDefaultVariant:
+                        pricingFrequencyDefaultVariant ?? null,
                     })
                   }
                 >
@@ -202,7 +206,7 @@ interface PricingCardProps {
   frequency: PricingFrequency;
   frequencySource: "default" | "user_selected";
   posthog: PostHog;
-  pricingFrequencyDefaultVariant: string;
+  pricingFrequencyDefaultVariant: string | null;
   tier: PricingTier;
   tierIndex: number;
 }

--- a/apps/web/components/new-landing/sections/Pricing.tsx
+++ b/apps/web/components/new-landing/sections/Pricing.tsx
@@ -86,12 +86,16 @@ const pricingTiers: PricingTier[] = [
   },
 ];
 
-const frequencies = ["annually", "monthly"];
+const frequencies = ["annually", "monthly"] as const;
+type PricingFrequency = (typeof frequencies)[number];
 
 export function Pricing() {
+  const pricingFrequencyDefaultVariant = usePricingFrequencyDefault();
   const defaultFrequency =
-    usePricingFrequencyDefault() === "annually" ? "annually" : "monthly";
-  const [chosenFrequency, setFrequency] = useState<string | null>(null);
+    pricingFrequencyDefaultVariant === "annually" ? "annually" : "monthly";
+  const [chosenFrequency, setFrequency] = useState<PricingFrequency | null>(
+    null,
+  );
   const frequency = chosenFrequency ?? defaultFrequency;
   const posthog = usePostHog();
 
@@ -105,7 +109,16 @@ export function Pricing() {
       >
         <RadioGroup
           value={frequency}
-          onChange={setFrequency}
+          onChange={(nextFrequency: PricingFrequency) => {
+            posthog.capture("pricing_frequency_changed", {
+              source: "landing_page",
+              previousFrequency: frequency,
+              frequency: nextFrequency,
+              defaultFrequency,
+              pricingFrequencyDefaultVariant,
+            });
+            setFrequency(nextFrequency);
+          }}
           className="w-fit rounded-full p-1.5 text-xs font-semibold leading-5 ring-1 ring-inset ring-gray-200 mb-6 shadow-[0_0_7px_0_rgba(0,0,0,0.0.07)]"
         >
           <Label className="sr-only">Payment frequency</Label>
@@ -130,7 +143,10 @@ export function Pricing() {
               <PricingCard
                 tier={tier}
                 tierIndex={index}
-                isAnnual={frequency === "annually"}
+                frequency={frequency}
+                defaultFrequency={defaultFrequency}
+                frequencySource={chosenFrequency ? "user_selected" : "default"}
+                pricingFrequencyDefaultVariant={pricingFrequencyDefaultVariant}
                 posthog={posthog}
               />
             </CardWrapper>
@@ -157,11 +173,16 @@ export function Pricing() {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={() =>
-                    landingPageAnalytics.pricingCtaClicked(
-                      posthog,
-                      "Enterprise",
-                      "Speak to sales",
-                    )
+                    landingPageAnalytics.pricingCtaClicked(posthog, {
+                      tier: "Enterprise",
+                      cta: "Speak to sales",
+                      frequency,
+                      defaultFrequency,
+                      frequencySource: chosenFrequency
+                        ? "user_selected"
+                        : "default",
+                      pricingFrequencyDefaultVariant,
+                    })
                   }
                 >
                   <Chat />
@@ -177,14 +198,26 @@ export function Pricing() {
 }
 
 interface PricingCardProps {
-  isAnnual: boolean;
+  defaultFrequency: PricingFrequency;
+  frequency: PricingFrequency;
+  frequencySource: "default" | "user_selected";
   posthog: PostHog;
+  pricingFrequencyDefaultVariant: string;
   tier: PricingTier;
   tierIndex: number;
 }
 
-function PricingCard({ tier, tierIndex, isAnnual, posthog }: PricingCardProps) {
+function PricingCard({
+  tier,
+  tierIndex,
+  frequency,
+  defaultFrequency,
+  frequencySource,
+  pricingFrequencyDefaultVariant,
+  posthog,
+}: PricingCardProps) {
   const { name, description, features } = tier;
+  const isAnnual = frequency === "annually";
   const price = isAnnual ? tier.price.annually : tier.price.monthly;
   const isFirstTier = !tierIndex;
 
@@ -226,11 +259,14 @@ function PricingCard({ tier, tierIndex, isAnnual, posthog }: PricingCardProps) {
               href={tier.button.href}
               target={tier.button.target}
               onClick={() =>
-                landingPageAnalytics.pricingCtaClicked(
-                  posthog,
-                  tier.name,
-                  tier.button.content,
-                )
+                landingPageAnalytics.pricingCtaClicked(posthog, {
+                  tier: tier.name,
+                  cta: tier.button.content,
+                  frequency,
+                  defaultFrequency,
+                  frequencySource,
+                  pricingFrequencyDefaultVariant,
+                })
               }
             >
               {tier.button.icon}

--- a/apps/web/ee/billing/stripe/posthog-events.test.ts
+++ b/apps/web/ee/billing/stripe/posthog-events.test.ts
@@ -1,6 +1,12 @@
 import type Stripe from "stripe";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getStripeTrialStartedProperties } from "./posthog-events";
+
+vi.mock("@/app/(app)/premium/config", () => ({
+  getStripeSubscriptionTier: vi.fn(({ priceId }: { priceId: string }) =>
+    priceId === "price_annual" ? "STARTER_ANNUALLY" : null,
+  ),
+}));
 
 describe("getStripeTrialStartedProperties", () => {
   it("returns properties for created trialing subscriptions", () => {
@@ -11,6 +17,14 @@ describe("getStripeTrialStartedProperties", () => {
           id: "sub_trial",
           status: "trialing",
           trial_end: 1_700_000_000,
+          items: {
+            data: [
+              {
+                price: { id: "price_annual" },
+                quantity: 2,
+              },
+            ],
+          },
         },
       },
     });
@@ -22,6 +36,9 @@ describe("getStripeTrialStartedProperties", () => {
       subscriptionId: "sub_trial",
       subscriptionStatus: "trialing",
       trialEnd: "2023-11-14T22:13:20.000Z",
+      tier: "STARTER_ANNUALLY",
+      frequency: "annually",
+      quantity: 2,
     });
   });
 

--- a/apps/web/ee/billing/stripe/posthog-events.ts
+++ b/apps/web/ee/billing/stripe/posthog-events.ts
@@ -1,4 +1,6 @@
 import type Stripe from "stripe";
+import { getStripeSubscriptionTier } from "@/app/(app)/premium/config";
+import type { PremiumTier } from "@/generated/prisma/enums";
 
 export function getStripeTrialStartedProperties(
   event: Stripe.Event,
@@ -6,6 +8,11 @@ export function getStripeTrialStartedProperties(
   const subscription = getTrialStartingSubscription(event);
 
   if (!subscription) return null;
+
+  const subscriptionItem = subscription.items?.data[0];
+  const price = subscriptionItem?.price;
+  const priceId = typeof price === "string" ? price : price?.id;
+  const tier = priceId ? getStripeSubscriptionTier({ priceId }) : null;
 
   return {
     billingProvider: "stripe",
@@ -17,6 +24,9 @@ export function getStripeTrialStartedProperties(
       typeof subscription.trial_end === "number"
         ? new Date(subscription.trial_end * 1000).toISOString()
         : null,
+    tier,
+    frequency: getBillingFrequency(tier),
+    quantity: subscriptionItem?.quantity ?? null,
   };
 }
 
@@ -50,5 +60,11 @@ function getTrialStartingSubscription(
     }
   }
 
+  return null;
+}
+
+function getBillingFrequency(tier: PremiumTier | null) {
+  if (tier?.endsWith("_ANNUALLY")) return "annually";
+  if (tier?.endsWith("_MONTHLY")) return "monthly";
   return null;
 }

--- a/apps/web/hooks/useAnalytics.ts
+++ b/apps/web/hooks/useAnalytics.ts
@@ -105,7 +105,7 @@ export const landingPageAnalytics = {
       frequency: "monthly" | "annually";
       defaultFrequency: "monthly" | "annually";
       frequencySource: "default" | "user_selected";
-      pricingFrequencyDefaultVariant: string;
+      pricingFrequencyDefaultVariant: string | null;
     },
   ) => {
     posthog?.capture?.("Clicked Pricing CTA", properties);

--- a/apps/web/hooks/useAnalytics.ts
+++ b/apps/web/hooks/useAnalytics.ts
@@ -97,8 +97,18 @@ export const landingPageAnalytics = {
   signUpClicked: (posthog: PostHog, position?: string) => {
     posthog?.capture?.("Clicked Sign Up", position ? { position } : undefined);
   },
-  pricingCtaClicked: (posthog: PostHog, tier: string, cta: string) => {
-    posthog?.capture?.("Clicked Pricing CTA", { tier, cta });
+  pricingCtaClicked: (
+    posthog: PostHog,
+    properties: {
+      tier: string;
+      cta: string;
+      frequency: "monthly" | "annually";
+      defaultFrequency: "monthly" | "annually";
+      frequencySource: "default" | "user_selected";
+      pricingFrequencyDefaultVariant: string;
+    },
+  ) => {
+    posthog?.capture?.("Clicked Pricing CTA", properties);
   },
   appDownloadClicked: (posthog: PostHog, platform: "ios" | "android") => {
     posthog?.capture?.("Clicked App Download", { platform });

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -75,14 +75,14 @@ export function usePricingVariant() {
   );
 }
 
-export type PricingFrequencyDefault = "control" | "annually";
+export type PricingFrequencyDefault = "control" | "monthly" | "annually";
 
-export function usePricingFrequencyDefault() {
-  return (
-    (useFeatureFlagVariantKey(
-      "pricing-frequency-default",
-    ) as PricingFrequencyDefault) || "control"
-  );
+export function usePricingFrequencyDefault():
+  | PricingFrequencyDefault
+  | undefined {
+  return useFeatureFlagVariantKey("pricing-frequency-default") as
+    | PricingFrequencyDefault
+    | undefined;
 }
 
 export type TestimonialsVariant = "control" | "senja-widget";

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -40,15 +40,14 @@ vi.mock("@/utils/prisma");
 import {
   FIRST_TIME_EVENTS,
   deletePosthogUser,
+  getCheckoutSessionIdHash,
   posthogCaptureEvent,
   trackFirstTimeEvent,
   trackProductFeedback,
-  trackStripeCheckoutCompleted,
   trackStripeCheckoutCreated,
   trackUserDeleted,
   trackUserDeletionRequested,
 } from "./posthog";
-import { hash } from "@/utils/hash";
 import { redis } from "@/utils/redis";
 
 describe("trackFirstTimeEvent", () => {
@@ -306,24 +305,8 @@ describe("trackStripeCheckoutCreated", () => {
       distinctId: "user@example.com",
       event: "Stripe checkout created",
       properties: {
-        checkoutSessionIdHash: hash("cs_test"),
+        checkoutSessionIdHash: getCheckoutSessionIdHash("cs_test"),
         tier: "BASIC_MONTHLY",
-      },
-      sendFeatureFlags: undefined,
-    });
-  });
-
-  it("uses the same private correlation key for checkout completion", async () => {
-    await trackStripeCheckoutCompleted("user@example.com", "cs_test", {
-      source: "success_redirect",
-    });
-
-    expect(captureMock).toHaveBeenCalledWith({
-      distinctId: "user@example.com",
-      event: "Stripe checkout completed",
-      properties: {
-        checkoutSessionIdHash: hash("cs_test"),
-        source: "success_redirect",
       },
       sendFeatureFlags: undefined,
     });

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -8,6 +8,7 @@ const mockEnv = vi.hoisted(() => ({
   POSTHOG_PROJECT_ID: "project-1",
   POSTHOG_FEEDBACK_SURVEY_ID: "survey-1" as string | undefined,
   POSTHOG_FEEDBACK_SURVEY_QUESTION_ID: "question-1" as string | undefined,
+  EMAIL_ENCRYPT_SALT: "test-encryption-salt",
   NODE_ENV: "test",
 }));
 
@@ -42,10 +43,12 @@ import {
   posthogCaptureEvent,
   trackFirstTimeEvent,
   trackProductFeedback,
+  trackStripeCheckoutCompleted,
   trackStripeCheckoutCreated,
   trackUserDeleted,
   trackUserDeletionRequested,
 } from "./posthog";
+import { hash } from "@/utils/hash";
 import { redis } from "@/utils/redis";
 
 describe("trackFirstTimeEvent", () => {
@@ -299,6 +302,31 @@ describe("trackStripeCheckoutCreated", () => {
       { nx: true, ex: 172_800 },
     );
     expect(captureMock).toHaveBeenCalledTimes(1);
+    expect(captureMock).toHaveBeenCalledWith({
+      distinctId: "user@example.com",
+      event: "Stripe checkout created",
+      properties: {
+        checkoutSessionIdHash: hash("cs_test"),
+        tier: "BASIC_MONTHLY",
+      },
+      sendFeatureFlags: undefined,
+    });
+  });
+
+  it("uses the same private correlation key for checkout completion", async () => {
+    await trackStripeCheckoutCompleted("user@example.com", "cs_test", {
+      source: "success_redirect",
+    });
+
+    expect(captureMock).toHaveBeenCalledWith({
+      distinctId: "user@example.com",
+      event: "Stripe checkout completed",
+      properties: {
+        checkoutSessionIdHash: hash("cs_test"),
+        source: "success_redirect",
+      },
+      sendFeatureFlags: undefined,
+    });
   });
 
   it("captures when Redis is unavailable", async () => {

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -199,7 +199,7 @@ export async function trackStripeCheckoutCreated(
 ) {
   const checkoutProperties = {
     ...properties,
-    checkoutSessionIdHash: hash(checkoutSessionId),
+    checkoutSessionIdHash: getCheckoutSessionIdHash(checkoutSessionId),
   };
   const dedupeKey = `posthog:stripe-checkout-created:${checkoutSessionId}`;
   let firstCapture: string | null;
@@ -240,13 +240,13 @@ export async function trackStripeCheckoutCreated(
 
 export async function trackStripeCheckoutCompleted(
   email: string,
-  checkoutSessionId: string | null,
   properties?: Properties,
 ) {
-  return posthogCaptureEvent(email, "Stripe checkout completed", {
-    ...properties,
-    checkoutSessionIdHash: checkoutSessionId ? hash(checkoutSessionId) : null,
-  });
+  return posthogCaptureEvent(email, "Stripe checkout completed", properties);
+}
+
+export function getCheckoutSessionIdHash(checkoutSessionId: string) {
+  return hash(checkoutSessionId);
 }
 
 export async function trackError({

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -245,7 +245,7 @@ export async function trackStripeCheckoutCompleted(
 ) {
   return posthogCaptureEvent(email, "Stripe checkout completed", {
     ...properties,
-    checkoutSessionIdHash: hash(checkoutSessionId),
+    checkoutSessionIdHash: checkoutSessionId ? hash(checkoutSessionId) : null,
   });
 }
 

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -197,6 +197,10 @@ export async function trackStripeCheckoutCreated(
   checkoutSessionId: string,
   properties?: Properties,
 ) {
+  const checkoutProperties = {
+    ...properties,
+    checkoutSessionIdHash: hash(checkoutSessionId),
+  };
   const dedupeKey = `posthog:stripe-checkout-created:${checkoutSessionId}`;
   let firstCapture: string | null;
 
@@ -209,7 +213,11 @@ export async function trackStripeCheckoutCreated(
     logger.error("Error deduplicating Stripe checkout creation event", {
       error,
     });
-    return posthogCaptureEvent(email, "Stripe checkout created", properties);
+    return posthogCaptureEvent(
+      email,
+      "Stripe checkout created",
+      checkoutProperties,
+    );
   }
 
   if (!firstCapture) return;
@@ -217,7 +225,7 @@ export async function trackStripeCheckoutCreated(
   const captured = await posthogCaptureEvent(
     email,
     "Stripe checkout created",
-    properties,
+    checkoutProperties,
   );
   if (captured) return;
 
@@ -232,9 +240,13 @@ export async function trackStripeCheckoutCreated(
 
 export async function trackStripeCheckoutCompleted(
   email: string,
+  checkoutSessionId: string | null,
   properties?: Properties,
 ) {
-  return posthogCaptureEvent(email, "Stripe checkout completed", properties);
+  return posthogCaptureEvent(email, "Stripe checkout completed", {
+    ...properties,
+    checkoutSessionIdHash: hash(checkoutSessionId),
+  });
 }
 
 export async function trackError({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-135324_pr-3311_da40e7c13d0b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improve pricing funnel analytics so billing-frequency changes can be evaluated end to end.

- capture the default and displayed cadence, selection source, flag variant, and cadence changes on pricing surfaces
- attach plan context to trial starts and correlate checkout milestones with a privacy-preserving HMAC key
- cover Stripe analytics payloads and success-redirect tracking with focused tests

Validation:
- `pnpm test utils/posthog.test.ts app/api/stripe/success/route.test.ts ee/billing/stripe/posthog-events.test.ts`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->