### PR TITLE
test: Expand mail client browser coverage

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -38,14 +38,25 @@ test("Command K acts on highlighted and selected conversations", async ({
 
   await page.goto(`/${emailAccountId}/mail`);
   const conversations = page.getByRole("listbox", { name: "Conversations" });
+  const options = conversations.getByRole("option");
+  let initialConversationCount = 0;
   await expect
-    .poll(() => conversations.getByRole("option").count(), {
-      timeout: 60_000,
-    })
+    .poll(
+      async () => {
+        const firstCount = await options.count();
+        await page.waitForTimeout(250);
+        const secondCount = await options.count();
+        await page.waitForTimeout(250);
+        const thirdCount = await options.count();
+        initialConversationCount =
+          firstCount === secondCount && secondCount === thirdCount
+            ? thirdCount
+            : 0;
+        return initialConversationCount;
+      },
+      { timeout: 60_000 },
+    )
     .toBeGreaterThanOrEqual(3);
-  const initialConversationCount = await conversations
-    .getByRole("option")
-    .count();
   await ensureReadState(page, conversations, "Alice Example", false);
   await ensureReadState(page, conversations, "Bob Example", true);
 
@@ -151,9 +162,7 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await palette.getByRole("option", { name: "Snooze 2 conversations" }).click();
   await palette.getByRole("option", { name: "In 3 hours" }).click();
-  await expect(conversations.getByRole("option")).toHaveCount(
-    initialConversationCount - 2,
-  );
+  await expect(options).toHaveCount(initialConversationCount - 2);
 });
 
 async function ensureReadState(

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -38,9 +38,14 @@ test("Command K acts on highlighted and selected conversations", async ({
 
   await page.goto(`/${emailAccountId}/mail`);
   const conversations = page.getByRole("listbox", { name: "Conversations" });
-  await expect(conversations.getByRole("option")).toHaveCount(3, {
-    timeout: 60_000,
-  });
+  await expect
+    .poll(() => conversations.getByRole("option").count(), {
+      timeout: 60_000,
+    })
+    .toBeGreaterThanOrEqual(3);
+  const initialConversationCount = await conversations
+    .getByRole("option")
+    .count();
   await ensureReadState(page, conversations, "Alice Example", false);
   await ensureReadState(page, conversations, "Bob Example", true);
 
@@ -146,7 +151,9 @@ test("Command K acts on highlighted and selected conversations", async ({
   ).toBeVisible();
   await palette.getByRole("option", { name: "Snooze 2 conversations" }).click();
   await palette.getByRole("option", { name: "In 3 hours" }).click();
-  await expect(conversations.getByRole("option")).toHaveCount(1);
+  await expect(conversations.getByRole("option")).toHaveCount(
+    initialConversationCount - 2,
+  );
 });
 
 async function ensureReadState(

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("composes, sends, and reads a new message from Sent", async ({ page }) => {
+  const { conversations } = await openMail(page);
+
+  await page.getByRole("button", { name: /^Compose/ }).click();
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  await dialog
+    .getByRole("textbox", { name: "To" })
+    .fill("recipient@example.com");
+  await dialog.getByPlaceholder("Subject").fill("Playwright Composed Message");
+  const composeEditor = dialog.locator("[contenteditable='true']");
+  await composeEditor.pressSequentially("A composed message body.");
+  await expect(composeEditor).toContainText("A composed message body.");
+  await dialog.getByRole("button", { name: /^Send/ }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: /^Sent/ }).click();
+  const sentConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Playwright Composed Message",
+  );
+  await expect(sentConversation).toBeVisible();
+  await sentConversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Playwright Composed Message" }),
+  ).toBeVisible();
+  await expect(page.getByText("recipient@example.com").first()).toBeVisible();
+});
+
+test("replies inside an existing conversation", async ({ page }) => {
+  const { conversations } = await openMail(page);
+  const replyConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Reply Workflow Message",
+  );
+  await replyConversation.click();
+  await expect(
+    page.getByText("Please reply to this seeded conversation."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /^Reply R$/ }).click();
+  const replyEditor = page.locator("[contenteditable='true']");
+  await expect(replyEditor).toBeVisible();
+  await replyEditor.pressSequentially("A reply sent through the mail reader.");
+  await expect(replyEditor).toContainText(
+    "A reply sent through the mail reader.",
+  );
+  await page.getByRole("button", { name: /^Send/ }).click();
+
+  await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
+  await expect(page.getByText("Me", { exact: true })).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -1,15 +1,18 @@
 import { expect, test } from "@playwright/test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
-test("composes, sends, and reads a new message from Sent", async ({ page }) => {
+test("composes, sends, and reads a new message from Sent", async ({
+  page,
+}, testInfo) => {
   const { conversations } = await openMail(page);
+  const subject = `Playwright Composed Message ${testInfo.retry}`;
 
   await page.getByRole("button", { name: /^Compose/ }).click();
   const dialog = page.getByRole("dialog", { name: "New Message" });
   await dialog
     .getByRole("textbox", { name: "To" })
     .fill("recipient@example.com");
-  await dialog.getByPlaceholder("Subject").fill("Playwright Composed Message");
+  await dialog.getByPlaceholder("Subject").fill(subject);
   const composeEditor = dialog.locator("[contenteditable='true']");
   await composeEditor.pressSequentially("A composed message body.");
   await expect(composeEditor).toContainText("A composed message body.");
@@ -22,17 +25,15 @@ test("composes, sends, and reads a new message from Sent", async ({ page }) => {
   const sentConversation = conversationWithSubject(
     page,
     conversations,
-    "Playwright Composed Message",
+    subject,
   );
   await expect(sentConversation).toBeVisible();
   await sentConversation.click();
-  await expect(
-    page.getByRole("heading", { name: "Playwright Composed Message" }),
-  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: subject })).toBeVisible();
   await expect(page.getByText("recipient@example.com").first()).toBeVisible();
 });
 
-test("replies inside an existing conversation", async ({ page }) => {
+test("replies inside an existing conversation", async ({ page }, testInfo) => {
   const { conversations } = await openMail(page);
   const replyConversation = conversationWithSubject(
     page,
@@ -43,16 +44,17 @@ test("replies inside an existing conversation", async ({ page }) => {
   await expect(
     page.getByText("Please reply to this seeded conversation."),
   ).toBeVisible();
+  const sentByMe = page.getByText("Me", { exact: true });
+  const initialSentByMeCount = await sentByMe.count();
 
   await page.getByRole("button", { name: /^Reply R$/ }).click();
   const replyEditor = page.locator("[contenteditable='true']");
   await expect(replyEditor).toBeVisible();
-  await replyEditor.pressSequentially("A reply sent through the mail reader.");
-  await expect(replyEditor).toContainText(
-    "A reply sent through the mail reader.",
-  );
+  const replyBody = `A reply sent through the mail reader. ${testInfo.retry}`;
+  await replyEditor.pressSequentially(replyBody);
+  await expect(replyEditor).toContainText(replyBody);
   await page.getByRole("button", { name: /^Send/ }).click();
 
   await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
-  await expect(page.getByText("Me", { exact: true })).toBeVisible();
+  await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("switches between list, split, and focused reading layouts", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+
+  await page.getByRole("button", { name: "Switch list or split view" }).click();
+  await expect(
+    page.getByText("Nothing selected", { exact: true }),
+  ).toBeVisible();
+  await expect(conversations).toBeVisible();
+
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Project Label Message",
+  ).click();
+  await expect(
+    page.getByRole("heading", { name: "Project Label Message" }),
+  ).toBeVisible();
+  await expect(conversations).toBeVisible();
+
+  await page.getByRole("button", { name: /^Focus mode/ }).click();
+  await expect(conversations).toBeHidden();
+  await expect(
+    page.getByRole("button", { name: /^Exit focus mode/ }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /^Exit focus mode/ }).click();
+  await expect(conversations).toBeVisible();
+  await page.getByRole("button", { name: "Switch list or split view" }).click();
+  await page.getByRole("button", { name: /^Back/ }).click();
+  await expect(conversations).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -5,11 +5,11 @@ test("switches between list, split, and focused reading layouts", async ({
   page,
 }) => {
   const { conversations } = await openMail(page);
+  const emptyReader = page.getByText("Nothing selected", { exact: true });
+  await expect(emptyReader).toBeHidden();
 
   await page.getByRole("button", { name: "Switch list or split view" }).click();
-  await expect(
-    page.getByText("Nothing selected", { exact: true }),
-  ).toBeVisible();
+  await expect(emptyReader).toBeVisible();
   await expect(conversations).toBeVisible();
 
   await conversationWithSubject(

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -1,0 +1,32 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export async function openMail(page: Page) {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.goto(`/${emailAccountId}/mail`);
+
+  const conversations = page.getByRole("listbox", { name: "Conversations" });
+  await expect(conversations).toBeVisible({ timeout: 60_000 });
+
+  return { conversations, emailAccountId };
+}
+
+export function conversationWithSubject(
+  page: Page,
+  conversations: Locator,
+  subject: string,
+) {
+  return conversations
+    .getByRole("option")
+    .filter({ has: page.getByText(subject, { exact: true }) });
+}
+
+async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -98,13 +98,18 @@ test("navigates drafts and sent mail from the sidebar", async ({ page }) => {
   await expect(draft).toHaveCount(0);
 });
 
-test("creates a label and shows every keyboard workflow", async ({ page }) => {
+test("creates a label and shows every keyboard workflow", async ({
+  page,
+}, testInfo) => {
   await openMail(page);
+  const labelName = `Daily QA ${testInfo.retry}`;
 
   await page.getByRole("button", { name: "Create label" }).click();
-  await page.getByRole("textbox", { name: "New label name" }).fill("Daily QA");
+  await page.getByRole("textbox", { name: "New label name" }).fill(labelName);
   await page.getByRole("button", { name: "Add", exact: true }).click();
-  await expect(page.getByRole("link", { name: /^Daily QA/ })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: labelName, exact: true }),
+  ).toBeVisible();
 
   await page.getByRole("button", { name: /^Keyboard shortcuts/ }).click();
   const dialog = page.getByRole("dialog", { name: "Keyboard shortcuts" });

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("opens a complete conversation and updates its read state", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+  const readerConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Navigation Message",
+  );
+  await expect(readerConversation).toBeVisible();
+
+  await readerConversation.click();
+
+  await expect(
+    page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("First message in the reader conversation."),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "A second message proves the complete conversation is rendered.",
+    ),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/thread-id=thr_playwright_reader/);
+
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  const markUnread = page.getByRole("menuitem", { name: "Mark as unread" });
+  await expect(markUnread).toBeVisible();
+  await markUnread.click();
+  await expect(
+    page.getByText("Marked as unread", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  const markRead = page.getByRole("menuitem", { name: "Mark as read" });
+  await expect(markRead).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(markRead).toBeHidden();
+  await expect(
+    page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/thread-id=thr_playwright_reader/);
+
+  await page.getByRole("button", { name: /^Back/ }).click();
+  await expect(conversations).toBeVisible();
+  await expect(readerConversation).toBeVisible();
+  await expect(page).not.toHaveURL(/thread-id=/);
+});
+
+test("filters the mail list by state, category, and label", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+
+  await page.getByRole("button", { name: "Unread", exact: true }).click();
+  await expect(
+    conversationWithSubject(page, conversations, "Keyboard Navigation Message"),
+  ).toBeVisible();
+  await expect(
+    conversationWithSubject(page, conversations, "Read Command Message"),
+  ).toHaveCount(0);
+
+  await page.getByRole("link", { name: /^Promotions/ }).click();
+  await expect(
+    conversationWithSubject(page, conversations, "Promotion Category Message"),
+  ).toBeVisible();
+  await expect(conversations.getByRole("option")).toHaveCount(1);
+  await expect(page).toHaveURL(/type=CATEGORY_PROMOTIONS/);
+
+  await page.getByRole("link", { name: /^Project Alpha/ }).click();
+  await expect(
+    conversationWithSubject(page, conversations, "Project Label Message"),
+  ).toBeVisible();
+  await expect(conversations.getByRole("option")).toHaveCount(1);
+  await expect(page).toHaveURL(/labelId=Label_project/);
+});
+
+test("navigates drafts and sent mail from the sidebar", async ({ page }) => {
+  const { conversations } = await openMail(page);
+
+  await page.getByRole("link", { name: /^Drafts/ }).click();
+  const draft = conversationWithSubject(
+    page,
+    conversations,
+    "Seeded Draft Message",
+  );
+  await expect(draft).toBeVisible();
+  await expect(draft.getByText("Draft", { exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: /^Sent/ }).click();
+  await expect(
+    conversationWithSubject(page, conversations, "Seeded Sent Message"),
+  ).toBeVisible();
+  await expect(draft).toHaveCount(0);
+});
+
+test("creates a label and shows every keyboard workflow", async ({ page }) => {
+  await openMail(page);
+
+  await page.getByRole("button", { name: "Create label" }).click();
+  await page.getByRole("textbox", { name: "New label name" }).fill("Daily QA");
+  await page.getByRole("button", { name: "Add", exact: true }).click();
+  await expect(page.getByRole("link", { name: /^Daily QA/ })).toBeVisible();
+
+  await page.getByRole("button", { name: /^Keyboard shortcuts/ }).click();
+  const dialog = page.getByRole("dialog", { name: "Keyboard shortcuts" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Next message", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("Archive", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("New message", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("Send reply", { exact: true })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("archives a selected conversation and restores it with undo", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+  const archiveConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Archive Action Message",
+  );
+
+  await archiveConversation
+    .getByRole("checkbox", { name: "Select conversation from Erin Example" })
+    .click();
+  await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: /^Archive E$/ }).click();
+
+  await expect(archiveConversation).toHaveCount(0);
+  const notifications = page.getByRole("region", {
+    name: "Notifications alt+T",
+  });
+  await expect(
+    notifications.getByText("Archived", { exact: true }),
+  ).toBeVisible();
+  await notifications.getByRole("button", { name: /^Undo/ }).click();
+  await expect(archiveConversation).toBeVisible();
+});
+
+test("deletes an open conversation and returns to the list", async ({
+  page,
+}) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const deletedConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Delete Action Message",
+  );
+  await deletedConversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Delete Action Message" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /^Delete \(/ }).click();
+
+  await expect(conversations).toBeVisible();
+  await expect(deletedConversation).toHaveCount(0);
+  await expect(page.getByText("Deleted", { exact: true })).toBeVisible();
+
+  const restoreResponse = await page.request.post(
+    "/api/threads/thr_playwright_delete/untrash",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(restoreResponse.ok()).toBeTruthy();
+});
+
+test("selects ranges and opens conversations with the keyboard", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+  const options = conversations.getByRole("option");
+  await expect(options.first()).toBeVisible();
+
+  await page.keyboard.press("x");
+  await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
+  await page.keyboard.press("Shift+j");
+  await expect(page.getByText("2 selected", { exact: true })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByText("2 selected", { exact: true })).toBeHidden();
+
+  await page.keyboard.press("j");
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("button", { name: /^Back/ })).toBeVisible();
+  await expect(page).toHaveURL(/thread-id=/);
+  await page.keyboard.press("Escape");
+  await expect(conversations).toBeVisible();
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -544,10 +544,7 @@ export function MailShell() {
     );
     return () => setMailCommandContext(null);
   }, [mailCommandContext, setMailCommandContext]);
-  const isMailOverlayOpen =
-    isHelpOpen ||
-    isPaletteOpen ||
-    (isMenuOpen && Boolean(openThread?.plans.length));
+  const isMailOverlayOpen = isHelpOpen || isPaletteOpen || isMenuOpen;
 
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -545,7 +545,7 @@ export function MailShell() {
     return () => setMailCommandContext(null);
   }, [mailCommandContext, setMailCommandContext]);
   const isMailOverlayOpen =
-    isHelpOpen || isPaletteOpen || (isMenuOpen && Boolean(openThread));
+    isHelpOpen || isPaletteOpen || (isMenuOpen && Boolean(openThreadId));
 
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -544,7 +544,8 @@ export function MailShell() {
     );
     return () => setMailCommandContext(null);
   }, [mailCommandContext, setMailCommandContext]);
-  const isMailOverlayOpen = isHelpOpen || isPaletteOpen || isMenuOpen;
+  const isMailOverlayOpen =
+    isHelpOpen || isPaletteOpen || (isMenuOpen && Boolean(openThread));
 
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -83,6 +83,7 @@ export function ThreadActionsMenu({
         <DropdownMenuContent
           align="end"
           className="w-[min(24rem,calc(100vw-1rem))]"
+          onEscapeKeyDown={(event) => event.stopPropagation()}
         >
           {plans.map((plan) => (
             <RuleAttribution

--- a/apps/web/components/editor/Tiptap.tsx
+++ b/apps/web/components/editor/Tiptap.tsx
@@ -39,6 +39,7 @@ export const Tiptap = forwardRef<
   ref,
 ) {
   const editor = useEditor({
+    immediatelyRender: false,
     extensions: [
       StarterKit.configure({
         // Configure lists to preserve formatting

--- a/apps/web/emulate.playwright.config.yaml
+++ b/apps/web/emulate.playwright.config.yaml
@@ -8,6 +8,12 @@ google:
       name: Inbox Zero Smoke
       redirect_uris:
         - __PLAYWRIGHT_TEST_REDIRECT_URI__
+  labels:
+    - id: Label_project
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      name: Project Alpha
+      color_background: "#d7e6fc"
+      color_text: "#10253f"
   messages:
     - id: msg_playwright_1
       thread_id: thr_playwright_1
@@ -41,6 +47,112 @@ google:
         - INBOX
         - UNREAD
       internal_date: "1735812000000"
+    - id: msg_playwright_reader_1
+      thread_id: thr_playwright_reader
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Dana Example <dana@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Reader Navigation Message
+      body_text: First message in the reader conversation.
+      label_ids:
+        - INBOX
+        - UNREAD
+      internal_date: "1735725600000"
+    - id: msg_playwright_reader_2
+      thread_id: thr_playwright_reader
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: __PLAYWRIGHT_TEST_EMAIL__
+      to: Dana Example <dana@example.com>
+      subject: "Re: Reader Navigation Message"
+      body_text: A second message proves the complete conversation is rendered.
+      label_ids:
+        - INBOX
+        - SENT
+      internal_date: "1735729200000"
+    - id: msg_playwright_archive
+      thread_id: thr_playwright_archive
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Erin Example <erin@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Archive Action Message
+      body_text: This conversation is reserved for archive and undo coverage.
+      label_ids:
+        - INBOX
+      internal_date: "1735642800000"
+    - id: msg_playwright_delete
+      thread_id: thr_playwright_delete
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Frank Example <frank@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Delete Action Message
+      body_text: This conversation is reserved for delete coverage.
+      label_ids:
+        - INBOX
+      internal_date: "1735556400000"
+    - id: msg_playwright_keyboard
+      thread_id: thr_playwright_keyboard
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Grace Example <grace@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Keyboard Navigation Message
+      body_text: This conversation is reserved for keyboard navigation coverage.
+      label_ids:
+        - INBOX
+        - UNREAD
+      internal_date: "1735470000000"
+    - id: msg_playwright_label
+      thread_id: thr_playwright_label
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Harper Example <harper@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Project Label Message
+      body_text: This conversation is visible in the seeded project label.
+      label_ids:
+        - INBOX
+        - Label_project
+      internal_date: "1735383600000"
+    - id: msg_playwright_promotion
+      thread_id: thr_playwright_promotion
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Offers Example <offers@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Promotion Category Message
+      body_text: This conversation is visible in the promotions category.
+      label_ids:
+        - INBOX
+        - CATEGORY_PROMOTIONS
+      internal_date: "1735297200000"
+    - id: msg_playwright_draft
+      thread_id: thr_playwright_draft
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: __PLAYWRIGHT_TEST_EMAIL__
+      to: Jordan Example <jordan@example.com>
+      subject: Seeded Draft Message
+      body_text: This unsent draft is visible in the Drafts view.
+      label_ids:
+        - DRAFT
+      internal_date: "1735210800000"
+    - id: msg_playwright_sent
+      thread_id: thr_playwright_sent
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: __PLAYWRIGHT_TEST_EMAIL__
+      to: Kai Example <kai@example.com>
+      subject: Seeded Sent Message
+      body_text: This sent conversation is visible in the Sent view.
+      label_ids:
+        - SENT
+      internal_date: "1735124400000"
+    - id: msg_playwright_reply
+      thread_id: thr_playwright_reply
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Leslie Example <leslie@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Reply Workflow Message
+      body_text: Please reply to this seeded conversation.
+      label_ids:
+        - INBOX
+        - UNREAD
+      internal_date: "1735038000000"
   calendars:
     - id: primary
       user_email: __PLAYWRIGHT_TEST_EMAIL__

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -48,6 +48,8 @@ export default defineConfig({
   testDir: "./__tests__/playwright",
   forbidOnly: !!process.env.CI,
   fullyParallel: false,
+  // Every browser test shares one seeded provider and one authenticated account.
+  workers: 1,
   retries: process.env.CI ? 1 : 0,
   timeout: 240_000,
   expect: {
@@ -129,6 +131,7 @@ export default defineConfig({
         NEXT_PUBLIC_POSTHOG_API_HOST: "",
         NEXT_PUBLIC_DUB_REFER_DOMAIN: "",
         NEXT_PUBLIC_IS_RESEND_CONFIGURED: "",
+        NEXT_PUBLIC_CONTACTS_ENABLED: "false",
         PLAYWRIGHT_TEST_EMAIL: playwrightTestEmail,
       },
     },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-142028_pr-3313_8a7c0262337f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Expands emulator-backed Playwright coverage for core mail client workflows and enriches the seeded provider fixtures. It also hardens editor hydration and Escape handling surfaced by the new scenarios, while serializing tests that share one mutable mailbox.

Validation: `pnpm -F inbox-zero-ai test:playwright:emulated` (12 passed) and targeted Biome checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->