### PR TITLE
desktop: Notarize Mac builds so Gatekeeper will open them

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,6 +33,9 @@ jobs:
     env:
       CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_LINK || secrets.WIN_CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
+      APPLE_API_KEY_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_KEY_ID || '' }}
+      APPLE_API_ISSUER: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_ISSUER || '' }}
+      APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -56,6 +59,14 @@ jobs:
           VERSION="${GITHUB_REF_NAME#desktop-v}"
           pnpm --filter @inboxzero/desktop exec npm version "$VERSION" --no-git-tag-version --allow-same-version
 
+      - name: Write App Store Connect API key
+        if: runner.os == 'macOS'
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          printf '%s\n' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
+
       - name: Build and package
         working-directory: apps/desktop
         run: |
@@ -72,12 +83,13 @@ jobs:
             test -f release/latest.yml
           fi
 
-      - name: Verify macOS signature
+      - name: Verify macOS signature and notarization
         if: runner.os == 'macOS'
         working-directory: apps/desktop
         run: |
           codesign --verify --deep --strict --verbose=2 "release/mac-arm64/Inbox Zero.app"
           codesign -dv --verbose=2 "release/mac-arm64/Inbox Zero.app"
+          xcrun stapler validate "release/mac-arm64/Inbox Zero.app"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -87,24 +87,32 @@ jobs:
         if: runner.os == 'macOS'
         working-directory: apps/desktop
         run: |
-          shopt -s nullglob
-          apps=(
-            "release/mac/Inbox Zero.app"
-            "release/mac-arm64/Inbox Zero.app"
-            "release/mac-x64/Inbox Zero.app"
-          )
-          found=0
-          for app in "${apps[@]}"; do
-            if [ -d "$app" ]; then
-              echo "Verifying $app"
-              codesign --verify --deep --strict --verbose=2 "$app"
-              codesign -dv --verbose=2 "$app"
-              xcrun stapler validate "$app"
-              found=$((found + 1))
+          verify_app() {
+            echo "Verifying $1"
+            codesign --verify --deep --strict --verbose=2 "$1"
+            codesign -dv --verbose=2 "$1"
+            xcrun stapler validate "$1"
+          }
+          has_arm=0
+          has_x64=0
+          if [ -d "release/mac-arm64/Inbox Zero.app" ]; then
+            verify_app "release/mac-arm64/Inbox Zero.app"
+            has_arm=1
+          fi
+          if [ -d "release/mac-x64/Inbox Zero.app" ]; then
+            verify_app "release/mac-x64/Inbox Zero.app"
+            has_x64=1
+          fi
+          if [ -d "release/mac/Inbox Zero.app" ]; then
+            verify_app "release/mac/Inbox Zero.app"
+            if [ "$(uname -m)" = "arm64" ]; then
+              has_arm=1
+            else
+              has_x64=1
             fi
-          done
-          if [ "$found" -lt 2 ]; then
-            echo "Expected arm64 and x64 app bundles, found $found" >&2
+          fi
+          if [ "$has_arm" -ne 1 ] || [ "$has_x64" -ne 1 ]; then
+            echo "Expected both arm64 and x64 app bundles (arm=$has_arm x64=$has_x64)" >&2
             exit 1
           fi
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -87,9 +87,26 @@ jobs:
         if: runner.os == 'macOS'
         working-directory: apps/desktop
         run: |
-          codesign --verify --deep --strict --verbose=2 "release/mac-arm64/Inbox Zero.app"
-          codesign -dv --verbose=2 "release/mac-arm64/Inbox Zero.app"
-          xcrun stapler validate "release/mac-arm64/Inbox Zero.app"
+          shopt -s nullglob
+          apps=(
+            "release/mac/Inbox Zero.app"
+            "release/mac-arm64/Inbox Zero.app"
+            "release/mac-x64/Inbox Zero.app"
+          )
+          found=0
+          for app in "${apps[@]}"; do
+            if [ -d "$app" ]; then
+              echo "Verifying $app"
+              codesign --verify --deep --strict --verbose=2 "$app"
+              codesign -dv --verbose=2 "$app"
+              xcrun stapler validate "$app"
+              found=$((found + 1))
+            fi
+          done
+          if [ "$found" -lt 2 ]; then
+            echo "Expected arm64 and x64 app bundles, found $found" >&2
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -18,8 +18,10 @@ mac:
   category: public.app-category.productivity
   hardenedRuntime: true
   gatekeeperAssess: false
-  notarize: false
+  notarize: true
   forceCodeSigning: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
   target:
     - target: dmg
       arch:


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-143125_pr-3314_977178943ff6/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Turns on Mac notarization and stapling in the desktop release workflow using App Store Connect API key secrets (Mac job only).
- Adds Electron Hardened Runtime entitlements required for notarization.

## Test plan
- [ ] Desktop Release Mac job notarizes and `stapler validate` succeeds
- [ ] Fresh download of the new `desktop-v*` DMG opens without the Gatekeeper malware dialog
- [ ] Windows job still does not receive Mac signing/notarization secrets


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->