### PR TITLE
desktop: Detect Mac arch from the binary, not the folder name

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -93,24 +93,32 @@ jobs:
             codesign -dv --verbose=2 "$1"
             xcrun stapler validate "$1"
           }
+          mark_arch() {
+            local binary archs
+            binary="$(printf '%s\n' "$1/Contents/MacOS/"*)"
+            archs="$(lipo -archs "$binary")"
+            echo "Architectures in $1: $archs"
+            case " $archs " in
+              *" arm64 "*) has_arm=1 ;;
+            esac
+            case " $archs " in
+              *" x86_64 "*) has_x64=1 ;;
+            esac
+          }
           has_arm=0
           has_x64=0
-          if [ -d "release/mac-arm64/Inbox Zero.app" ]; then
-            verify_app "release/mac-arm64/Inbox Zero.app"
-            has_arm=1
-          fi
-          if [ -d "release/mac-x64/Inbox Zero.app" ]; then
-            verify_app "release/mac-x64/Inbox Zero.app"
-            has_x64=1
-          fi
-          if [ -d "release/mac/Inbox Zero.app" ]; then
-            verify_app "release/mac/Inbox Zero.app"
-            if [ "$(uname -m)" = "arm64" ]; then
-              has_arm=1
-            else
-              has_x64=1
+          echo "Mac output dirs:"
+          ls -d release/mac* 2>/dev/null || true
+          for app in \
+            "release/mac/Inbox Zero.app" \
+            "release/mac-arm64/Inbox Zero.app" \
+            "release/mac-x64/Inbox Zero.app"
+          do
+            if [ -d "$app" ]; then
+              verify_app "$app"
+              mark_arch "$app"
             fi
-          fi
+          done
           if [ "$has_arm" -ne 1 ] || [ "$has_x64" -ne 1 ]; then
             echo "Expected both arm64 and x64 app bundles (arm=$has_arm x64=$has_x64)" >&2
             exit 1


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-144937_pr-3315_db54bf3ea122/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- `desktop-v0.1.1` notarized and stapled both Mac apps, then failed the post-build check because electron-builder put Intel in unsuffixed `release/mac` on the arm64 runner.
- Detect arm64/x86_64 from `lipo -archs` on each `.app` instead of assuming folder names match the runner architecture.

## Test plan
- [ ] Desktop Release Mac job stapler-validates both apps and uploads artifacts
- [ ] `desktop-v0.1.2` GitHub Release publishes after Mac + Windows succeed
- [ ] Fresh Mac download opens without the Gatekeeper malware dialog


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->