### PR TITLE
test: Add emulator coverage for sidebar flows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -98,6 +98,7 @@ jobs:
 
     env:
       NODE_ENV: development
+      NODE_OPTIONS: --max_old_space_size=6144
       NEXT_PUBLIC_BASE_URL: http://localhost:3000
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       AUTH_SECRET: secret
@@ -116,14 +117,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Find changed Playwright tests
+      - name: Find changed Playwright files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           set -euo pipefail
 
-          changed_tests_path="$RUNNER_TEMP/changed-playwright-tests.txt"
-          : > "$changed_tests_path"
+          changed_files_path="$RUNNER_TEMP/changed-playwright-files.txt"
+          : > "$changed_files_path"
 
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]] &&
             [[ -n "$BASE_SHA" ]] &&
@@ -131,13 +132,13 @@ jobs:
             git fetch --no-tags --depth=1 origin "$BASE_SHA"
             git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$GITHUB_SHA" -- \
               apps/web/__tests__/playwright | \
-              sed -n -E '/\.(spec|setup)\.[cm]?[jt]sx?$/ { s#^apps/web/##; p; }' \
-                > "$changed_tests_path"
+              sed 's#^apps/web/##' \
+                > "$changed_files_path"
           fi
 
           {
             echo "PLAYWRIGHT_CHANGED_TEST_FILES<<EOF"
-            cat "$changed_tests_path"
+            cat "$changed_files_path"
             echo "EOF"
           } >> "$GITHUB_ENV"
 
@@ -181,6 +182,7 @@ jobs:
           path: |
             apps/web/playwright-report
             apps/web/test-results
+          compression-level: 1
           retention-days: 7
           if-no-files-found: warn
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,7 +65,7 @@ concurrency:
 jobs:
   playwright:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,7 +65,7 @@ concurrency:
 jobs:
   playwright:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -13,6 +13,11 @@ Within `emulated/`, group specs by product area, such as `mail/` or
 `automation/`. Keep setup files inside the boundary they support so
 real-provider tests cannot accidentally reuse emulated authentication state.
 
+The package-level emulated command runs each product area with a fresh Next and
+emulator process, then merges their reports. This prevents the development
+server's compiled route graph from exhausting its heap during the full suite.
+Run a spec directly with Playwright when iterating on one flow.
+
 The emulated project runs when browser-facing files change in pull requests or
 on `main`, plus the daily schedule and manual dispatches. Pull requests retain
 the HTML report, screenshots, traces, and videos as GitHub Actions artifacts.

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import {
+  openAttachments,
+  resetAttachmentTestState,
+  setupAttachmentTestState,
+} from "./attachment-test-helpers";
+
+test.beforeEach(async () => {
+  await setupAttachmentTestState();
+});
+
+test.afterEach(async () => {
+  await resetAttachmentTestState();
+});
+
+test("uses Drive folders to complete auto-file attachment setup", async ({
+  page,
+}) => {
+  await openAttachments(page);
+
+  await expect(
+    page.getByRole("heading", { name: "Let's set up auto-filing" }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText("Google Drive", { exact: true })).toBeVisible();
+  await expect(page.getByText("Smoke Docs", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+
+  const createdFolderName = `Playwright Receipts ${process.env.PLAYWRIGHT_RUN_ID}`;
+  await page.getByRole("button", { name: "Add folder" }).click();
+  const createFolderDialog = page.getByRole("dialog", {
+    name: "Create folder",
+  });
+  await createFolderDialog.getByLabel("Folder name").fill(createdFolderName);
+  await createFolderDialog
+    .getByRole("button", { name: "Create folder" })
+    .click();
+  await expect(page.getByText("Folder created!", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.getByText(createdFolderName, { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+
+  const smokeDocsCheckbox = page.locator("#folder-drv_root_child");
+  await smokeDocsCheckbox.click();
+  await expect(smokeDocsCheckbox).toBeChecked();
+
+  await page
+    .locator('textarea[name="filingPrompt"]')
+    .fill("File receipts and invoices in Smoke Docs.");
+  const previewButton = page.getByRole("button", {
+    name: "Preview with my recent emails",
+  });
+  await expect(previewButton).toBeEnabled({ timeout: 60_000 });
+  await previewButton.click();
+
+  await expect(
+    page.getByText(
+      "We couldn't find recent emails with attachments to preview.",
+      { exact: true },
+    ),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.getByRole("button", { name: "Start auto-filing anyway" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Auto-file attachments" }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText("Google Drive", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Allowed folders", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Smoke Docs", { exact: true })).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
@@ -16,6 +16,7 @@ test.afterEach(async () => {
 test("uses Drive folders to complete auto-file attachment setup", async ({
   page,
 }, testInfo) => {
+  test.setTimeout(360_000);
   await openAttachments(page);
 
   await expect(
@@ -55,12 +56,7 @@ test("uses Drive folders to complete auto-file attachment setup", async ({
   await expect(previewButton).toBeEnabled({ timeout: 60_000 });
   await previewButton.click();
 
-  await expect(
-    page.getByText(
-      "We couldn't find recent emails with attachments to preview.",
-      { exact: true },
-    ),
-  ).toBeVisible({ timeout: 60_000 });
+  await expectEmptyPreview(page);
   await page.getByRole("button", { name: "Start auto-filing anyway" }).click();
 
   await expect(
@@ -72,3 +68,22 @@ test("uses Drive folders to complete auto-file attachment setup", async ({
   ).toBeVisible();
   await expect(page.getByText("Smoke Docs", { exact: true })).toBeVisible();
 });
+
+async function expectEmptyPreview(page: Parameters<typeof openAttachments>[0]) {
+  const emptyPreview = page.getByText(
+    "We couldn't find recent emails with attachments to preview.",
+    { exact: true },
+  );
+
+  try {
+    await expect(emptyPreview).toBeVisible({ timeout: 90_000 });
+  } catch {
+    await openAttachments(page);
+    const previewButton = page.getByRole("button", {
+      name: "Preview with my recent emails",
+    });
+    await expect(previewButton).toBeEnabled({ timeout: 120_000 });
+    await previewButton.click();
+    await expect(emptyPreview).toBeVisible({ timeout: 120_000 });
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-onboarding.spec.ts
@@ -15,7 +15,7 @@ test.afterEach(async () => {
 
 test("uses Drive folders to complete auto-file attachment setup", async ({
   page,
-}) => {
+}, testInfo) => {
   await openAttachments(page);
 
   await expect(
@@ -26,7 +26,7 @@ test("uses Drive folders to complete auto-file attachment setup", async ({
     timeout: 60_000,
   });
 
-  const createdFolderName = `Playwright Receipts ${process.env.PLAYWRIGHT_RUN_ID}`;
+  const createdFolderName = `Playwright Receipts ${process.env.PLAYWRIGHT_RUN_ID}-${testInfo.retry}`;
   await page.getByRole("button", { name: "Add folder" }).click();
   const createFolderDialog = page.getByRole("dialog", {
     name: "Create folder",

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
@@ -1,0 +1,84 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const PLAYWRIGHT_TEST_EMAIL =
+  process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
+
+export async function openAttachments(page: Page) {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.goto(`/${emailAccountId}/drive`);
+  return { emailAccountId };
+}
+
+export async function setupAttachmentTestState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await resetAttachmentState(client);
+    const result = await client.query(
+      `INSERT INTO "DriveConnection" (
+         id, "createdAt", "updatedAt", provider, email,
+         "accessToken", "refreshToken", "expiresAt", "isConnected",
+         "emailAccountId"
+       )
+       SELECT
+         ea.id || '-playwright-drive',
+         CURRENT_TIMESTAMP,
+         CURRENT_TIMESTAMP,
+         'google',
+         ea.email,
+         account.access_token,
+         account.refresh_token,
+         account.expires_at,
+         true,
+         ea.id
+       FROM "EmailAccount" ea
+       INNER JOIN "Account" account ON account.id = ea."accountId"
+       WHERE ea.email = $1
+       RETURNING id`,
+      [PLAYWRIGHT_TEST_EMAIL],
+    );
+    if (result.rowCount !== 1) {
+      throw new Error("Could not seed the Playwright Drive connection");
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+export async function resetAttachmentTestState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await resetAttachmentState(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+async function resetAttachmentState(client: Client) {
+  await client.query(
+    `DELETE FROM "DriveConnection"
+     WHERE "emailAccountId" = (
+       SELECT id FROM "EmailAccount" WHERE email = $1
+     )`,
+    [PLAYWRIGHT_TEST_EMAIL],
+  );
+  await client.query(
+    `UPDATE "EmailAccount"
+     SET "filingEnabled" = false, "filingPrompt" = NULL
+     WHERE email = $1`,
+    [PLAYWRIGHT_TEST_EMAIL],
+  );
+}

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
@@ -1,12 +1,31 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
 
 export async function openAttachments(page: Page) {
-  const emailAccountId = await getEmailAccountId(page);
-  await page.goto(`/${emailAccountId}/drive`);
+  let emailAccountId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        try {
+          emailAccountId = await getEmailAccountId(page);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toBe(true);
+  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+
+  await navigateUntilReady(
+    page,
+    `/${emailAccountId}/drive`,
+    page.getByRole("heading", { name: "Let's set up auto-filing" }),
+  );
 }
 
 export async function setupAttachmentTestState() {
@@ -80,4 +99,16 @@ async function resetAttachmentState(client: Client) {
      WHERE email = $1`,
     [PLAYWRIGHT_TEST_EMAIL],
   );
+}
+
+async function navigateUntilReady(page: Page, url: string, ready: Locator) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(url, { timeout: 60_000, waitUntil: "domcontentloaded" });
+      await expect(ready).toBeVisible({ timeout: 60_000 });
+      return;
+    } catch (error) {
+      if (attempt === 1) throw error;
+    }
+  }
 }

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
@@ -7,7 +7,6 @@ const PLAYWRIGHT_TEST_EMAIL =
 export async function openAttachments(page: Page) {
   const emailAccountId = await getEmailAccountId(page);
   await page.goto(`/${emailAccountId}/drive`);
-  return { emailAccountId };
 }
 
 export async function setupAttachmentTestState() {

--- a/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
@@ -1,0 +1,249 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+export const HISTORY_RULE_ID = "playwright-automation-history-rule";
+export const HISTORY_RULE_NAME = "Playwright history archive";
+export const HISTORY_EXECUTED_RULE_ID =
+  "playwright-automation-history-execution";
+export const KNOWLEDGE_TITLE = "Playwright product context";
+export const UPDATED_KNOWLEDGE_TITLE = "Playwright customer context";
+
+export type AutomationSettingsCleanup = Awaited<
+  ReturnType<typeof seedAutomationSettings>
+> & {
+  emailAccountId: string;
+};
+
+export async function getAutomationEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+export async function markAutomationOnboardingViewed(page: Page) {
+  await page.goto("/");
+  await page.context().addCookies([
+    {
+      name: "viewed_assistant_onboarding",
+      value: "true",
+      url: new URL(page.url()).origin,
+    },
+  ]);
+}
+
+export function getAutomationSettingsCard(page: Page, name: string) {
+  return page
+    .getByRole("heading", { name, exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'group/card')][1]");
+}
+
+export async function seedAutomationHistory(emailAccountId: string) {
+  await withClient(async (client) => {
+    await deleteAutomationHistory(client);
+    await client.query(
+      `INSERT INTO "Rule"
+         (id, name, enabled, automate, "runOnThreads", instructions,
+          "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, $2, true, true, false, $3, $4,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        HISTORY_RULE_ID,
+        HISTORY_RULE_NAME,
+        "Archive routine project updates",
+        emailAccountId,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "ExecutedRule"
+         (id, "threadId", "messageId", status, automated, reason, "ruleId",
+          "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, 'thr_playwright_1', 'msg_playwright_1', 'APPLIED', false,
+               $2, $3, $4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        HISTORY_EXECUTED_RULE_ID,
+        "The message is a routine project update.",
+        HISTORY_RULE_ID,
+        emailAccountId,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "ExecutedAction"
+         (id, type, "executionStatus", "executedAt", "executedRuleId",
+          "createdAt", "updatedAt")
+       VALUES ($1, 'ARCHIVE', 'SUCCEEDED', CURRENT_TIMESTAMP, $2,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [`${HISTORY_EXECUTED_RULE_ID}-archive`, HISTORY_EXECUTED_RULE_ID],
+    );
+  });
+}
+
+export async function cleanupAutomationHistory() {
+  await withClient(deleteAutomationHistory);
+}
+
+export async function seedAutomationSettings(emailAccountId: string) {
+  return withClient(async (client) => {
+    const existingRule = await client.query<{ id: string }>(
+      `SELECT id FROM "Rule"
+       WHERE "emailAccountId" = $1 AND "systemType" = 'TO_REPLY'`,
+      [emailAccountId],
+    );
+    const createdToReplyRule = existingRule.rowCount === 0;
+    const toReplyRuleId =
+      existingRule.rows[0]?.id ??
+      `playwright-automation-to-reply-${emailAccountId}`;
+
+    if (createdToReplyRule) {
+      await client.query(
+        `INSERT INTO "Rule"
+           (id, name, enabled, automate, "runOnThreads", instructions,
+            "systemType", "emailAccountId", "createdAt", "updatedAt")
+         VALUES ($1, 'To Reply', true, true, false,
+                 'Emails that need a response', 'TO_REPLY', $2,
+                 CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        [toReplyRuleId, emailAccountId],
+      );
+    } else {
+      await client.query(
+        `UPDATE "Rule" SET enabled = true, "updatedAt" = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [toReplyRuleId],
+      );
+    }
+
+    await client.query(
+      `DELETE FROM "Action" WHERE "ruleId" = $1 AND type = 'DRAFT_EMAIL'`,
+      [toReplyRuleId],
+    );
+    await client.query(
+      `DELETE FROM "Knowledge"
+       WHERE "emailAccountId" = $1 AND title IN ($2, $3)`,
+      [emailAccountId, KNOWLEDGE_TITLE, UPDATED_KNOWLEDGE_TITLE],
+    );
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET about = NULL,
+           "writingStyle" = NULL,
+           signature = NULL,
+           "includeReferralSignature" = false,
+           "multiRuleSelectionEnabled" = false,
+           "sensitiveDataPolicy" = NULL,
+           "draftReplyConfidence" = 'ALL_EMAILS',
+           "allowHiddenAiDraftLinks" = false,
+           "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+
+    return { createdToReplyRule, toReplyRuleId };
+  });
+}
+
+export async function cleanupAutomationSettings({
+  createdToReplyRule,
+  emailAccountId,
+  toReplyRuleId,
+}: {
+  createdToReplyRule: boolean;
+  emailAccountId: string;
+  toReplyRuleId: string;
+}) {
+  await withClient(async (client) => {
+    await client.query(
+      `DELETE FROM "Knowledge"
+       WHERE "emailAccountId" = $1 AND title IN ($2, $3)`,
+      [emailAccountId, KNOWLEDGE_TITLE, UPDATED_KNOWLEDGE_TITLE],
+    );
+    if (createdToReplyRule) {
+      await client.query(`DELETE FROM "Rule" WHERE id = $1`, [toReplyRuleId]);
+    } else {
+      await client.query(
+        `DELETE FROM "Action" WHERE "ruleId" = $1 AND type = 'DRAFT_EMAIL'`,
+        [toReplyRuleId],
+      );
+    }
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET about = NULL,
+           "writingStyle" = NULL,
+           signature = NULL,
+           "includeReferralSignature" = false,
+           "multiRuleSelectionEnabled" = false,
+           "sensitiveDataPolicy" = NULL,
+           "draftReplyConfidence" = 'ALL_EMAILS',
+           "allowHiddenAiDraftLinks" = false,
+           "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+  });
+}
+
+export async function getAutomationSettingsState(emailAccountId: string) {
+  return withClient(async (client) => {
+    const accountResult = await client.query<{
+      about: string | null;
+      allowHiddenAiDraftLinks: boolean;
+      draftReplyConfidence: string;
+      includeReferralSignature: boolean;
+      multiRuleSelectionEnabled: boolean;
+      sensitiveDataPolicy: string | null;
+    }>(
+      `SELECT about,
+              "allowHiddenAiDraftLinks",
+              "draftReplyConfidence"::text,
+              "includeReferralSignature",
+              "multiRuleSelectionEnabled",
+              "sensitiveDataPolicy"
+       FROM "EmailAccount" WHERE id = $1`,
+      [emailAccountId],
+    );
+    const draftActions = await client.query<{ type: string }>(
+      `SELECT a.type::text
+       FROM "Action" a
+       JOIN "Rule" r ON r.id = a."ruleId"
+       WHERE r."emailAccountId" = $1 AND r."systemType" = 'TO_REPLY'
+       ORDER BY a.type::text`,
+      [emailAccountId],
+    );
+
+    return {
+      ...accountResult.rows[0],
+      draftActionTypes: draftActions.rows.map((row) => row.type),
+    };
+  });
+}
+
+export async function getKnowledgeState(emailAccountId: string) {
+  return withClient(async (client) => {
+    const result = await client.query<{ content: string; title: string }>(
+      `SELECT title, content FROM "Knowledge"
+       WHERE "emailAccountId" = $1 AND title IN ($2, $3)
+       LIMIT 1`,
+      [emailAccountId, KNOWLEDGE_TITLE, UPDATED_KNOWLEDGE_TITLE],
+    );
+    return result.rows[0];
+  });
+}
+
+async function deleteAutomationHistory(client: Client) {
+  await client.query(`DELETE FROM "ExecutedRule" WHERE id = $1`, [
+    HISTORY_EXECUTED_RULE_ID,
+  ]);
+  await client.query(`DELETE FROM "Rule" WHERE id = $1`, [HISTORY_RULE_ID]);
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const HISTORY_RULE_ID = "playwright-automation-history-rule";
@@ -7,6 +7,44 @@ export const HISTORY_EXECUTED_RULE_ID =
   "playwright-automation-history-execution";
 export const KNOWLEDGE_TITLE = "Playwright product context";
 export const UPDATED_KNOWLEDGE_TITLE = "Playwright customer context";
+const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
+
+type AutomationAccountSettings = {
+  about: string | null;
+  allowHiddenAiDraftLinks: boolean;
+  draftReplyConfidence: string;
+  includeReferralSignature: boolean;
+  multiRuleSelectionEnabled: boolean;
+  sensitiveDataPolicy: string | null;
+  signature: string | null;
+  writingStyle: string | null;
+};
+
+type DraftActionSnapshot = {
+  bcc: string | null;
+  cc: string | null;
+  content: string | null;
+  createdAt: Date;
+  delayInMinutes: number | null;
+  emailAccountId: string;
+  folderId: string | null;
+  folderName: string | null;
+  id: string;
+  integrationArgs: unknown;
+  integrationName: string | null;
+  integrationToolName: string | null;
+  label: string | null;
+  labelId: string | null;
+  messagingChannelEmailAccountId: string | null;
+  messagingChannelId: string | null;
+  ruleId: string;
+  staticAttachments: unknown;
+  subject: string | null;
+  to: string | null;
+  type: string;
+  updatedAt: Date;
+  url: string | null;
+};
 
 export type AutomationSettingsCleanup = Awaited<
   ReturnType<typeof seedAutomationSettings>
@@ -15,14 +53,7 @@ export type AutomationSettingsCleanup = Awaited<
 };
 
 export async function getAutomationEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
+  return getEmailAccountIdWithRetry(page);
 }
 
 export async function markAutomationOnboardingViewed(page: Page) {
@@ -40,6 +71,28 @@ export function getAutomationSettingsCard(page: Page, name: string) {
   return page
     .getByRole("heading", { name, exact: true })
     .locator("xpath=ancestor::div[contains(@class, 'group/card')][1]");
+}
+
+export async function expectVisibleAfterTransientFetch(
+  page: Page,
+  locator: Locator,
+) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await expect(locator).toBeVisible({ timeout: 60_000 });
+      return;
+    } catch (error) {
+      const hasTransientFetchError = await page
+        .getByText("Failed to fetch")
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      if (!hasTransientFetchError || attempt === 2) throw error;
+
+      await page.reload({ waitUntil: "domcontentloaded" });
+    }
+  }
 }
 
 export async function seedAutomationHistory(emailAccountId: string) {
@@ -88,12 +141,30 @@ export async function cleanupAutomationHistory() {
 
 export async function seedAutomationSettings(emailAccountId: string) {
   return withClient(async (client) => {
-    const existingRule = await client.query<{ id: string }>(
-      `SELECT id FROM "Rule"
+    const accountResult = await client.query<AutomationAccountSettings>(
+      `SELECT about,
+              "allowHiddenAiDraftLinks",
+              "draftReplyConfidence"::text,
+              "includeReferralSignature",
+              "multiRuleSelectionEnabled",
+              "sensitiveDataPolicy",
+              signature,
+              "writingStyle"
+       FROM "EmailAccount" WHERE id = $1`,
+      [emailAccountId],
+    );
+    const previousAccountSettings = accountResult.rows[0];
+    if (!previousAccountSettings) {
+      throw new Error("The Playwright email account was not found");
+    }
+
+    const existingRule = await client.query<{ enabled: boolean; id: string }>(
+      `SELECT id, enabled FROM "Rule"
        WHERE "emailAccountId" = $1 AND "systemType" = 'TO_REPLY'`,
       [emailAccountId],
     );
     const createdToReplyRule = existingRule.rowCount === 0;
+    const previousToReplyRuleEnabled = existingRule.rows[0]?.enabled ?? null;
     const toReplyRuleId =
       existingRule.rows[0]?.id ??
       `playwright-automation-to-reply-${emailAccountId}`;
@@ -116,6 +187,18 @@ export async function seedAutomationSettings(emailAccountId: string) {
       );
     }
 
+    const previousDraftActions = await client.query<DraftActionSnapshot>(
+      `SELECT id, "createdAt", "updatedAt", type::text, "ruleId",
+              "emailAccountId", "messagingChannelId",
+              "messagingChannelEmailAccountId", label, "labelId", subject,
+              content, "to", cc, bcc, url, "folderName", "folderId",
+              "delayInMinutes", "staticAttachments", "integrationName",
+              "integrationToolName", "integrationArgs"
+       FROM "Action"
+       WHERE "ruleId" = $1 AND type = 'DRAFT_EMAIL'
+       ORDER BY id`,
+      [toReplyRuleId],
+    );
     await client.query(
       `DELETE FROM "Action" WHERE "ruleId" = $1 AND type = 'DRAFT_EMAIL'`,
       [toReplyRuleId],
@@ -140,17 +223,29 @@ export async function seedAutomationSettings(emailAccountId: string) {
       [emailAccountId],
     );
 
-    return { createdToReplyRule, toReplyRuleId };
+    return {
+      createdToReplyRule,
+      previousAccountSettings,
+      previousDraftActions: previousDraftActions.rows,
+      previousToReplyRuleEnabled,
+      toReplyRuleId,
+    };
   });
 }
 
 export async function cleanupAutomationSettings({
   createdToReplyRule,
   emailAccountId,
+  previousAccountSettings,
+  previousDraftActions,
+  previousToReplyRuleEnabled,
   toReplyRuleId,
 }: {
   createdToReplyRule: boolean;
   emailAccountId: string;
+  previousAccountSettings: AutomationAccountSettings;
+  previousDraftActions: DraftActionSnapshot[];
+  previousToReplyRuleEnabled: boolean | null;
   toReplyRuleId: string;
 }) {
   await withClient(async (client) => {
@@ -166,20 +261,40 @@ export async function cleanupAutomationSettings({
         `DELETE FROM "Action" WHERE "ruleId" = $1 AND type = 'DRAFT_EMAIL'`,
         [toReplyRuleId],
       );
+      for (const action of previousDraftActions) {
+        await restoreDraftAction(client, action);
+      }
+      if (previousToReplyRuleEnabled !== null) {
+        await client.query(
+          `UPDATE "Rule" SET enabled = $2, "updatedAt" = CURRENT_TIMESTAMP
+           WHERE id = $1 AND "emailAccountId" = $3`,
+          [toReplyRuleId, previousToReplyRuleEnabled, emailAccountId],
+        );
+      }
     }
     await client.query(
       `UPDATE "EmailAccount"
-       SET about = NULL,
-           "writingStyle" = NULL,
-           signature = NULL,
-           "includeReferralSignature" = false,
-           "multiRuleSelectionEnabled" = false,
-           "sensitiveDataPolicy" = NULL,
-           "draftReplyConfidence" = 'ALL_EMAILS',
-           "allowHiddenAiDraftLinks" = false,
+       SET about = $2,
+           "writingStyle" = $3,
+           signature = $4,
+           "includeReferralSignature" = $5,
+           "multiRuleSelectionEnabled" = $6,
+           "sensitiveDataPolicy" = $7,
+           "draftReplyConfidence" = $8::"DraftReplyConfidence",
+           "allowHiddenAiDraftLinks" = $9,
            "updatedAt" = CURRENT_TIMESTAMP
        WHERE id = $1`,
-      [emailAccountId],
+      [
+        emailAccountId,
+        previousAccountSettings.about,
+        previousAccountSettings.writingStyle,
+        previousAccountSettings.signature,
+        previousAccountSettings.includeReferralSignature,
+        previousAccountSettings.multiRuleSelectionEnabled,
+        previousAccountSettings.sensitiveDataPolicy,
+        previousAccountSettings.draftReplyConfidence,
+        previousAccountSettings.allowHiddenAiDraftLinks,
+      ],
     );
   });
 }
@@ -224,6 +339,7 @@ export async function getKnowledgeState(emailAccountId: string) {
     const result = await client.query<{ content: string; title: string }>(
       `SELECT title, content FROM "Knowledge"
        WHERE "emailAccountId" = $1 AND title IN ($2, $3)
+       ORDER BY "updatedAt" DESC
        LIMIT 1`,
       [emailAccountId, KNOWLEDGE_TITLE, UPDATED_KNOWLEDGE_TITLE],
     );
@@ -238,6 +354,78 @@ async function deleteAutomationHistory(client: Client) {
   await client.query(`DELETE FROM "Rule" WHERE id = $1`, [HISTORY_RULE_ID]);
 }
 
+async function restoreDraftAction(client: Client, action: DraftActionSnapshot) {
+  await client.query(
+    `INSERT INTO "Action" (
+       id, "createdAt", "updatedAt", type, "ruleId", "emailAccountId",
+       "messagingChannelId", "messagingChannelEmailAccountId", label,
+       "labelId", subject, content, "to", cc, bcc, url, "folderName",
+       "folderId", "delayInMinutes", "staticAttachments", "integrationName",
+       "integrationToolName", "integrationArgs"
+     )
+     VALUES (
+       $1, $2, $3, $4::"ActionType", $5, $6, $7, $8, $9, $10, $11, $12,
+       $13, $14, $15, $16, $17, $18, $19, $20::jsonb, $21, $22, $23::jsonb
+     )`,
+    [
+      action.id,
+      action.createdAt,
+      action.updatedAt,
+      action.type,
+      action.ruleId,
+      action.emailAccountId,
+      action.messagingChannelId,
+      action.messagingChannelEmailAccountId,
+      action.label,
+      action.labelId,
+      action.subject,
+      action.content,
+      action.to,
+      action.cc,
+      action.bcc,
+      action.url,
+      action.folderName,
+      action.folderId,
+      action.delayInMinutes,
+      stringifyJson(action.staticAttachments),
+      action.integrationName,
+      action.integrationToolName,
+      stringifyJson(action.integrationArgs),
+    ],
+  );
+}
+
+async function getEmailAccountIdWithRetry(page: Page) {
+  let lastError: unknown;
+  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await page.request.get("/api/user/email-accounts");
+      if (response.ok()) {
+        const { emailAccounts } = (await response.json()) as {
+          emailAccounts: { id: string }[];
+        };
+        const emailAccountId = emailAccounts[0]?.id;
+        if (emailAccountId) return emailAccountId;
+        lastError = new Error("The setup project created no account");
+      } else {
+        lastError = new Error(
+          `Email accounts request failed with ${response.status()}`,
+        );
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await page.waitForTimeout(1000);
+  }
+
+  throw new Error(
+    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
+  );
+}
+
 async function withClient<T>(callback: (client: Client) => Promise<T>) {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   await client.connect();
@@ -246,4 +434,12 @@ async function withClient<T>(callback: (client: Client) => Promise<T>) {
   } finally {
     await client.end();
   }
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stringifyJson(value: unknown) {
+  return value === null || value === undefined ? null : JSON.stringify(value);
 }

--- a/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
@@ -1,50 +1,22 @@
-import { expect, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const RULE_NAME = "Playwright receipts";
 export const UPDATED_RULE_NAME = "Playwright vendor receipts";
 
-export async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
-}
-
-export async function markAssistantOnboardingViewed(page: Page) {
-  await page.goto("/");
-  await page.context().addCookies([
-    {
-      name: "viewed_assistant_onboarding",
-      value: "true",
-      url: new URL(page.url()).origin,
-    },
-  ]);
-}
-
 export async function cleanupTestRules(emailAccountId?: string) {
   if (!emailAccountId) return;
-  const client = new Client({ connectionString: process.env.DATABASE_URL });
-  await client.connect();
-  try {
+
+  await withClient(async (client) => {
     await client.query(
       `DELETE FROM "Rule"
        WHERE "emailAccountId" = $1 AND name IN ($2, $3)`,
       [emailAccountId, RULE_NAME, UPDATED_RULE_NAME],
     );
-  } finally {
-    await client.end();
-  }
+  });
 }
 
 export async function getRuleState(emailAccountId: string) {
-  const client = new Client({ connectionString: process.env.DATABASE_URL });
-  await client.connect();
-  try {
+  return withClient(async (client) => {
     const result = await client.query<{
       enabled: boolean;
       instructions: string | null;
@@ -60,6 +32,14 @@ export async function getRuleState(emailAccountId: string) {
       [emailAccountId, RULE_NAME, UPDATED_RULE_NAME],
     );
     return result.rows[0];
+  });
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
   } finally {
     await client.end();
   }

--- a/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
@@ -54,7 +54,9 @@ export async function getRuleState(emailAccountId: string) {
       `SELECT r.name, r.enabled, r.instructions, a.type::text
        FROM "Rule" r
        JOIN "Action" a ON a."ruleId" = r.id
-       WHERE r."emailAccountId" = $1 AND r.name IN ($2, $3)`,
+       WHERE r."emailAccountId" = $1 AND r.name IN ($2, $3)
+       ORDER BY a.id
+       LIMIT 1`,
       [emailAccountId, RULE_NAME, UPDATED_RULE_NAME],
     );
     return result.rows[0];

--- a/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-test-helpers.ts
@@ -1,0 +1,64 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+export const RULE_NAME = "Playwright receipts";
+export const UPDATED_RULE_NAME = "Playwright vendor receipts";
+
+export async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+export async function markAssistantOnboardingViewed(page: Page) {
+  await page.goto("/");
+  await page.context().addCookies([
+    {
+      name: "viewed_assistant_onboarding",
+      value: "true",
+      url: new URL(page.url()).origin,
+    },
+  ]);
+}
+
+export async function cleanupTestRules(emailAccountId?: string) {
+  if (!emailAccountId) return;
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `DELETE FROM "Rule"
+       WHERE "emailAccountId" = $1 AND name IN ($2, $3)`,
+      [emailAccountId, RULE_NAME, UPDATED_RULE_NAME],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+export async function getRuleState(emailAccountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    const result = await client.query<{
+      enabled: boolean;
+      instructions: string | null;
+      name: string;
+      type: string;
+    }>(
+      `SELECT r.name, r.enabled, r.instructions, a.type::text
+       FROM "Rule" r
+       JOIN "Action" a ON a."ruleId" = r.id
+       WHERE r."emailAccountId" = $1 AND r.name IN ($2, $3)`,
+      [emailAccountId, RULE_NAME, UPDATED_RULE_NAME],
+    );
+    return result.rows[0];
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanupAutomationHistory,
+  getAutomationEmailAccountId,
+  HISTORY_RULE_ID,
+  HISTORY_RULE_NAME,
+  markAutomationOnboardingViewed,
+  seedAutomationHistory,
+} from "./automation-tabs-test-helpers";
+
+test.afterEach(async () => {
+  await cleanupAutomationHistory();
+});
+
+test("shows persisted execution history and preserves rule filters", async ({
+  page,
+}) => {
+  const emailAccountId = await getAutomationEmailAccountId(page);
+  await seedAutomationHistory(emailAccountId);
+  await markAutomationOnboardingViewed(page);
+
+  const historyResponse = await page.request.get(
+    "/api/user/executed-rules/history?page=1&ruleId=all",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(historyResponse.ok()).toBeTruthy();
+  const historyData = (await historyResponse.json()) as {
+    results: Array<{ messageId: string }>;
+  };
+  expect(historyData.results).toContainEqual(
+    expect.objectContaining({ messageId: "msg_playwright_1" }),
+  );
+
+  await page.goto(`/${emailAccountId}/automation?tab=history`);
+  await expect(
+    page.getByRole("button", { name: "History", exact: true }),
+  ).toHaveAttribute("data-selected", "true");
+  await expect(page.getByText(HISTORY_RULE_NAME, { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(
+    page.getByText("Applied manually", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "All rules" }).click();
+  await page.getByRole("menuitem", { name: HISTORY_RULE_NAME }).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("ruleId") === HISTORY_RULE_ID,
+  );
+  await page.reload();
+  await expect(
+    page.getByRole("button", { name: HISTORY_RULE_NAME }),
+  ).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(
+    page.getByText("Applied manually", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: HISTORY_RULE_NAME }).click();
+  await page.getByRole("menuitem", { name: "No match" }).click();
+  await expect(page.getByText("No history", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(
+    page.getByText("No emails have been processed for this rule.", {
+      exact: true,
+    }),
+  ).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   cleanupAutomationHistory,
+  expectVisibleAfterTransientFetch,
   getAutomationEmailAccountId,
   HISTORY_RULE_ID,
   HISTORY_RULE_NAME,
@@ -19,25 +20,36 @@ test("shows persisted execution history and preserves rule filters", async ({
   await seedAutomationHistory(emailAccountId);
   await markAutomationOnboardingViewed(page);
 
-  const historyResponse = await page.request.get(
-    "/api/user/executed-rules/history?page=1&ruleId=all",
-    { headers: { "X-Email-Account-ID": emailAccountId } },
-  );
-  expect(historyResponse.ok()).toBeTruthy();
-  const historyData = (await historyResponse.json()) as {
-    results: Array<{ messageId: string }>;
-  };
-  expect(historyData.results).toContainEqual(
-    expect.objectContaining({ messageId: "msg_playwright_1" }),
-  );
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get(
+            "/api/user/executed-rules/history?page=1&ruleId=all",
+            { headers: { "X-Email-Account-ID": emailAccountId } },
+          );
+          if (!response.ok()) return [];
+
+          const historyData = (await response.json()) as {
+            results: Array<{ messageId: string }>;
+          };
+          return historyData.results.map((result) => result.messageId);
+        } catch {
+          return [];
+        }
+      },
+      { timeout: 60_000 },
+    )
+    .toContain("msg_playwright_1");
 
   await page.goto(`/${emailAccountId}/automation?tab=history`);
   await expect(
     page.getByRole("button", { name: "History", exact: true }),
   ).toHaveAttribute("data-selected", "true");
-  await expect(page.getByText(HISTORY_RULE_NAME, { exact: true })).toBeVisible({
-    timeout: 60_000,
-  });
+  await expectVisibleAfterTransientFetch(
+    page,
+    page.getByText(HISTORY_RULE_NAME, { exact: true }),
+  );
   await expect(
     page.getByText("Applied manually", { exact: true }),
   ).toBeVisible();
@@ -48,11 +60,10 @@ test("shows persisted execution history and preserves rule filters", async ({
     (url) => url.searchParams.get("ruleId") === HISTORY_RULE_ID,
   );
   await page.reload();
-  await expect(
+  await expectVisibleAfterTransientFetch(
+    page,
     page.getByRole("button", { name: HISTORY_RULE_NAME }),
-  ).toBeVisible({
-    timeout: 60_000,
-  });
+  );
   await expect(
     page.getByText("Applied manually", { exact: true }),
   ).toBeVisible();

--- a/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
@@ -80,7 +80,7 @@ test("creates, edits, toggles, and deletes a manual automation rule", async ({
     "unchecked",
   );
   await expect
-    .poll(() => getRuleState(emailAccountId))
+    .poll(() => getRuleState(emailAccountId), { timeout: 60_000 })
     .toMatchObject({
       enabled: false,
       name: UPDATED_RULE_NAME,
@@ -91,5 +91,7 @@ test("creates, edits, toggles, and deletes a manual automation rule", async ({
   await page.getByRole("menuitem", { name: "Delete" }).click();
   await expect(page.getByText("Rule deleted", { exact: true })).toBeVisible();
   await expect(updatedRuleRow).toHaveCount(0);
-  await expect.poll(() => getRuleState(emailAccountId)).toBeUndefined();
+  await expect
+    .poll(() => getRuleState(emailAccountId), { timeout: 60_000 })
+    .toBeUndefined();
 });

--- a/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
 import {
   cleanupTestRules,
-  getEmailAccountId,
   getRuleState,
-  markAssistantOnboardingViewed,
   RULE_NAME,
   UPDATED_RULE_NAME,
 } from "./automation-test-helpers";
+import {
+  getAutomationEmailAccountId,
+  markAutomationOnboardingViewed,
+} from "./automation-tabs-test-helpers";
 
 let emailAccountIdForCleanup: string | undefined;
 
@@ -18,10 +20,10 @@ test.afterEach(async () => {
 test("creates, edits, toggles, and deletes a manual automation rule", async ({
   page,
 }) => {
-  const emailAccountId = await getEmailAccountId(page);
+  const emailAccountId = await getAutomationEmailAccountId(page);
   emailAccountIdForCleanup = emailAccountId;
   await cleanupTestRules(emailAccountId);
-  await markAssistantOnboardingViewed(page);
+  await markAutomationOnboardingViewed(page);
 
   await page.goto(`/${emailAccountId}/automation`);
   await expect(

--- a/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
@@ -6,9 +6,12 @@ import {
   UPDATED_RULE_NAME,
 } from "./automation-test-helpers";
 import {
+  expectVisibleAfterTransientFetch,
   getAutomationEmailAccountId,
   markAutomationOnboardingViewed,
 } from "./automation-tabs-test-helpers";
+
+const SERVER_ACTION_TIMEOUT_MS = 120_000;
 
 let emailAccountIdForCleanup: string | undefined;
 
@@ -20,15 +23,17 @@ test.afterEach(async () => {
 test("creates, edits, toggles, and deletes a manual automation rule", async ({
   page,
 }) => {
+  test.setTimeout(360_000);
   const emailAccountId = await getAutomationEmailAccountId(page);
   emailAccountIdForCleanup = emailAccountId;
   await cleanupTestRules(emailAccountId);
   await markAutomationOnboardingViewed(page);
 
   await page.goto(`/${emailAccountId}/automation`);
-  await expect(
+  await expectVisibleAfterTransientFetch(
+    page,
     page.getByRole("heading", { name: "AI Assistant", exact: true }),
-  ).toBeVisible();
+  );
 
   await page.getByRole("button", { name: "Add Rule" }).click();
   await page.getByRole("button", { name: "Add rule manually" }).click();
@@ -48,7 +53,9 @@ test("creates, edits, toggles, and deletes a manual automation rule", async ({
   await expect(createButton).toBeEnabled();
   await createButton.click();
   await expect
-    .poll(() => getRuleState(emailAccountId), { timeout: 60_000 })
+    .poll(() => getRuleState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
     .toMatchObject({
       enabled: true,
       instructions: "Receipts and invoices from software vendors",

--- a/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanupTestRules,
+  getEmailAccountId,
+  getRuleState,
+  markAssistantOnboardingViewed,
+  RULE_NAME,
+  UPDATED_RULE_NAME,
+} from "./automation-test-helpers";
+
+let emailAccountIdForCleanup: string | undefined;
+
+test.afterEach(async () => {
+  await cleanupTestRules(emailAccountIdForCleanup);
+  emailAccountIdForCleanup = undefined;
+});
+
+test("creates, edits, toggles, and deletes a manual automation rule", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  emailAccountIdForCleanup = emailAccountId;
+  await cleanupTestRules(emailAccountId);
+  await markAssistantOnboardingViewed(page);
+
+  await page.goto(`/${emailAccountId}/automation`);
+  await expect(
+    page.getByRole("heading", { name: "AI Assistant", exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Add Rule" }).click();
+  await page.getByRole("button", { name: "Add rule manually" }).click();
+
+  const createDialog = page.getByRole("dialog", { name: "Create Rule" });
+  await createDialog
+    .getByPlaceholder(
+      "e.g. Newsletters, regular content from publications, blogs, or services I've subscribed to",
+    )
+    .fill("Receipts and invoices from software vendors");
+  await createDialog.getByRole("combobox").first().click();
+  await page.getByRole("option", { name: "Archive" }).click();
+  await createDialog
+    .getByRole("textbox", { name: "Rule name" })
+    .fill(RULE_NAME);
+  const createButton = createDialog.getByRole("button", { name: "Create" });
+  await expect(createButton).toBeEnabled();
+  await createButton.click();
+  await expect
+    .poll(() => getRuleState(emailAccountId), { timeout: 60_000 })
+    .toMatchObject({
+      enabled: true,
+      instructions: "Receipts and invoices from software vendors",
+      name: RULE_NAME,
+      type: "ARCHIVE",
+    });
+  await page.reload();
+
+  const ruleRow = page.getByRole("row").filter({ hasText: RULE_NAME });
+  await expect(ruleRow).toBeVisible({ timeout: 60_000 });
+
+  await ruleRow.getByRole("button", { name: "Toggle menu" }).click();
+  await page.getByRole("menuitem", { name: "Edit manually" }).click();
+  const editDialog = page.getByRole("dialog", { name: "Edit Rule" });
+  await editDialog
+    .getByRole("textbox", { name: "Rule name" })
+    .fill(UPDATED_RULE_NAME);
+  await editDialog.getByRole("button", { name: "Save" }).click();
+  await expect
+    .poll(() => getRuleState(emailAccountId), { timeout: 60_000 })
+    .toMatchObject({ name: UPDATED_RULE_NAME });
+  await page.reload();
+
+  const updatedRuleRow = page
+    .getByRole("row")
+    .filter({ hasText: UPDATED_RULE_NAME });
+  await expect(updatedRuleRow).toBeVisible({ timeout: 60_000 });
+  await updatedRuleRow.getByRole("switch").click();
+  await expect(updatedRuleRow.getByRole("switch")).toHaveAttribute(
+    "data-state",
+    "unchecked",
+  );
+  await expect
+    .poll(() => getRuleState(emailAccountId))
+    .toMatchObject({
+      enabled: false,
+      name: UPDATED_RULE_NAME,
+    });
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await updatedRuleRow.getByRole("button", { name: "Toggle menu" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await expect(page.getByText("Rule deleted", { exact: true })).toBeVisible();
+  await expect(updatedRuleRow).toHaveCount(0);
+  await expect.poll(() => getRuleState(emailAccountId)).toBeUndefined();
+});

--- a/apps/web/__tests__/playwright/emulated/automation/settings-controls.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/settings-controls.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test";
+import {
+  type AutomationSettingsCleanup,
+  cleanupAutomationSettings,
+  getAutomationEmailAccountId,
+  getAutomationSettingsCard,
+  getAutomationSettingsState,
+  markAutomationOnboardingViewed,
+  seedAutomationSettings,
+} from "./automation-tabs-test-helpers";
+
+let settingsCleanup: AutomationSettingsCleanup | undefined;
+
+test.afterEach(async () => {
+  if (settingsCleanup) await cleanupAutomationSettings(settingsCleanup);
+  settingsCleanup = undefined;
+});
+
+test("persists personalization, drafting, and advanced settings", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+  const emailAccountId = await getAutomationEmailAccountId(page);
+  settingsCleanup = {
+    ...(await seedAutomationSettings(emailAccountId)),
+    emailAccountId,
+  };
+  await markAutomationOnboardingViewed(page);
+
+  await page.goto(`/${emailAccountId}/automation?tab=settings`);
+  await expect(
+    page.getByRole("button", { name: "Settings", exact: true }),
+  ).toHaveAttribute("data-selected", "true");
+
+  for (const heading of [
+    "Auto draft replies",
+    "Draft confidence",
+    "Writing style",
+    "Personal instructions",
+    "Email signature",
+    "Draft knowledge base",
+    "Learned patterns",
+    "Sync to browser extension",
+    "Multi-rule selection",
+    "Include referral signature",
+    "Allow hidden links in AI drafts",
+    "Sensitive data protection",
+  ]) {
+    await expect(page.getByRole("heading", { name: heading })).toBeVisible({
+      timeout: 60_000,
+    });
+  }
+
+  const personalInstructionsItem = getAutomationSettingsCard(
+    page,
+    "Personal instructions",
+  );
+  await personalInstructionsItem.getByRole("button", { name: "Edit" }).click();
+  const personalInstructionsDialog = page.getByRole("dialog", {
+    name: "Personal instructions",
+  });
+  await personalInstructionsDialog
+    .getByRole("textbox")
+    .fill("I lead product. Keep replies concise and surface customer risks.");
+  await personalInstructionsDialog
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({
+      about: "I lead product. Keep replies concise and surface customer risks.",
+    });
+
+  const draftConfidence = page.getByRole("combobox", {
+    name: "Draft confidence",
+  });
+  await draftConfidence.click();
+  await page.getByRole("option", { name: /High confidence/ }).click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({ draftReplyConfidence: "HIGH_CONFIDENCE" });
+
+  const multiRuleItem = getAutomationSettingsCard(page, "Multi-rule selection");
+  await multiRuleItem.getByRole("switch").click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({ multiRuleSelectionEnabled: true });
+
+  const referralItem = getAutomationSettingsCard(
+    page,
+    "Include referral signature",
+  );
+  await referralItem.getByRole("switch").click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({ includeReferralSignature: true });
+
+  const hiddenLinksItem = getAutomationSettingsCard(
+    page,
+    "Allow hidden links in AI drafts",
+  );
+  await hiddenLinksItem.getByRole("switch").click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({ allowHiddenAiDraftLinks: true });
+
+  const sensitiveData = page.getByRole("combobox", {
+    name: "Sensitive data protection",
+  });
+  await sensitiveData.click();
+  await page.getByRole("option", { name: /Block/ }).click();
+  await expect
+    .poll(() => getAutomationSettingsState(emailAccountId), {
+      timeout: 60_000,
+    })
+    .toMatchObject({ sensitiveDataPolicy: "BLOCK" });
+
+  await page.reload();
+  await expect(draftConfidence).toContainText("High confidence", {
+    timeout: 60_000,
+  });
+  await expect(multiRuleItem.getByRole("switch")).toBeChecked();
+  await expect(referralItem.getByRole("switch")).toBeChecked();
+  await expect(hiddenLinksItem.getByRole("switch")).toBeChecked();
+  await expect(sensitiveData).toContainText("Block");
+
+  await personalInstructionsItem.getByRole("button", { name: "Edit" }).click();
+  await expect(personalInstructionsDialog.getByRole("textbox")).toHaveValue(
+    "I lead product. Keep replies concise and surface customer risks.",
+  );
+});

--- a/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   type AutomationSettingsCleanup,
   cleanupAutomationSettings,
+  expectVisibleAfterTransientFetch,
   getAutomationEmailAccountId,
   getAutomationSettingsCard,
   getAutomationSettingsState,
@@ -11,6 +12,8 @@ import {
   seedAutomationSettings,
   UPDATED_KNOWLEDGE_TITLE,
 } from "./automation-tabs-test-helpers";
+
+const SERVER_ACTION_TIMEOUT_MS = 120_000;
 
 let settingsCleanup: AutomationSettingsCleanup | undefined;
 
@@ -30,15 +33,27 @@ test("enables drafting and manages persisted draft knowledge", async ({
   };
   await markAutomationOnboardingViewed(page);
 
-  const knowledgeResponse = await page.request.get("/api/knowledge", {
-    headers: { "X-Email-Account-ID": emailAccountId },
-  });
-  expect(knowledgeResponse.ok()).toBeTruthy();
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get("/api/knowledge", {
+            headers: { "X-Email-Account-ID": emailAccountId },
+          });
+          return response.ok();
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(true);
 
   await page.goto(`/${emailAccountId}/automation?tab=settings`);
   const autoDraftItem = getAutomationSettingsCard(page, "Auto draft replies");
   const autoDraftSwitch = autoDraftItem.getByRole("switch");
-  await expect(autoDraftSwitch).not.toBeChecked({ timeout: 60_000 });
+  await expectVisibleAfterTransientFetch(page, autoDraftSwitch);
+  await expect(autoDraftSwitch).not.toBeChecked();
   await autoDraftSwitch.click();
   await expect
     .poll(
@@ -46,16 +61,18 @@ test("enables drafting and manages persisted draft knowledge", async ({
         const state = await getAutomationSettingsState(emailAccountId);
         return state.draftActionTypes;
       },
-      { timeout: 60_000 },
+      { timeout: SERVER_ACTION_TIMEOUT_MS },
     )
     .toContain("DRAFT_EMAIL");
 
   await page.reload();
-  await expect(autoDraftSwitch).toBeChecked({ timeout: 60_000 });
+  await expectVisibleAfterTransientFetch(page, autoDraftSwitch);
+  await expect(autoDraftSwitch).toBeChecked();
 
   const knowledgeItem = getAutomationSettingsCard(page, "Draft knowledge base");
   const manageKnowledge = knowledgeItem.getByRole("button", { name: "Manage" });
-  await expect(manageKnowledge).toBeEnabled();
+  await expectVisibleAfterTransientFetch(page, manageKnowledge);
+  await expect(manageKnowledge).toBeEnabled({ timeout: 60_000 });
   await manageKnowledge.click();
 
   const knowledgeDialog = page.getByRole("dialog", {
@@ -73,7 +90,9 @@ test("enables drafting and manages persisted draft knowledge", async ({
     .fill("Customers use the product to reach inbox zero every morning.");
   await addDialog.getByRole("button", { name: "Create" }).click();
   await expect
-    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .poll(() => getKnowledgeState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
     .toEqual({
       content: "Customers use the product to reach inbox zero every morning.",
       title: KNOWLEDGE_TITLE,
@@ -94,7 +113,9 @@ test("enables drafting and manages persisted draft knowledge", async ({
     .fill("Customers use the product to triage important email every morning.");
   await editDialog.getByRole("button", { name: "Update" }).click();
   await expect
-    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .poll(() => getKnowledgeState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
     .toEqual({
       content:
         "Customers use the product to triage important email every morning.",
@@ -111,7 +132,9 @@ test("enables drafting and manages persisted draft knowledge", async ({
   });
   await deleteDialog.getByRole("button", { name: "Delete" }).click();
   await expect
-    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .poll(() => getKnowledgeState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
     .toBeUndefined();
   await expect(updatedRow).toHaveCount(0);
 });

--- a/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test";
+import {
+  type AutomationSettingsCleanup,
+  cleanupAutomationSettings,
+  getAutomationEmailAccountId,
+  getAutomationSettingsCard,
+  getAutomationSettingsState,
+  getKnowledgeState,
+  KNOWLEDGE_TITLE,
+  markAutomationOnboardingViewed,
+  seedAutomationSettings,
+  UPDATED_KNOWLEDGE_TITLE,
+} from "./automation-tabs-test-helpers";
+
+let settingsCleanup: AutomationSettingsCleanup | undefined;
+
+test.afterEach(async () => {
+  if (settingsCleanup) await cleanupAutomationSettings(settingsCleanup);
+  settingsCleanup = undefined;
+});
+
+test("enables drafting and manages persisted draft knowledge", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+  const emailAccountId = await getAutomationEmailAccountId(page);
+  settingsCleanup = {
+    ...(await seedAutomationSettings(emailAccountId)),
+    emailAccountId,
+  };
+  await markAutomationOnboardingViewed(page);
+
+  const knowledgeResponse = await page.request.get("/api/knowledge", {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  expect(knowledgeResponse.ok()).toBeTruthy();
+
+  await page.goto(`/${emailAccountId}/automation?tab=settings`);
+  const autoDraftItem = getAutomationSettingsCard(page, "Auto draft replies");
+  const autoDraftSwitch = autoDraftItem.getByRole("switch");
+  await expect(autoDraftSwitch).not.toBeChecked({ timeout: 60_000 });
+  await autoDraftSwitch.click();
+  await expect
+    .poll(
+      async () => {
+        const state = await getAutomationSettingsState(emailAccountId);
+        return state.draftActionTypes;
+      },
+      { timeout: 60_000 },
+    )
+    .toContain("DRAFT_EMAIL");
+
+  await page.reload();
+  await expect(autoDraftSwitch).toBeChecked({ timeout: 60_000 });
+
+  const knowledgeItem = getAutomationSettingsCard(page, "Draft knowledge base");
+  const manageKnowledge = knowledgeItem.getByRole("button", { name: "Manage" });
+  await expect(manageKnowledge).toBeEnabled();
+  await manageKnowledge.click();
+
+  const knowledgeDialog = page.getByRole("dialog", {
+    name: "Draft knowledge base",
+  });
+  await expect(
+    knowledgeDialog.getByText("No knowledge entries yet", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await knowledgeDialog.getByRole("button", { name: "Add" }).click();
+
+  const addDialog = page.getByRole("dialog", { name: "Add Knowledge" });
+  await addDialog.getByRole("textbox", { name: "Title" }).fill(KNOWLEDGE_TITLE);
+  await addDialog
+    .locator('[contenteditable="true"]')
+    .fill("Customers use the product to reach inbox zero every morning.");
+  await addDialog.getByRole("button", { name: "Create" }).click();
+  await expect
+    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .toEqual({
+      content: "Customers use the product to reach inbox zero every morning.",
+      title: KNOWLEDGE_TITLE,
+    });
+
+  const knowledgeRow = knowledgeDialog
+    .getByRole("row")
+    .filter({ hasText: KNOWLEDGE_TITLE });
+  await expect(knowledgeRow).toBeVisible({ timeout: 60_000 });
+  await knowledgeRow.getByRole("button", { name: "Edit" }).click();
+
+  const editDialog = page.getByRole("dialog", { name: "Edit Knowledge" });
+  await editDialog
+    .getByRole("textbox", { name: "Title" })
+    .fill(UPDATED_KNOWLEDGE_TITLE);
+  await editDialog
+    .locator('[contenteditable="true"]')
+    .fill("Customers use the product to triage important email every morning.");
+  await editDialog.getByRole("button", { name: "Update" }).click();
+  await expect
+    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .toEqual({
+      content:
+        "Customers use the product to triage important email every morning.",
+      title: UPDATED_KNOWLEDGE_TITLE,
+    });
+
+  const updatedRow = knowledgeDialog
+    .getByRole("row")
+    .filter({ hasText: UPDATED_KNOWLEDGE_TITLE });
+  await expect(updatedRow).toBeVisible({ timeout: 60_000 });
+  await updatedRow.getByRole("button").last().click();
+  const deleteDialog = page.getByRole("alertdialog", {
+    name: "Delete Knowledge Base Entry",
+  });
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect
+    .poll(() => getKnowledgeState(emailAccountId), { timeout: 60_000 })
+    .toBeUndefined();
+  await expect(updatedRow).toHaveCount(0);
+});

--- a/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import {
+  getAutomationEmailAccountId,
+  markAutomationOnboardingViewed,
+} from "./automation-tabs-test-helpers";
+
+test("preserves search, custom email, and Apply workspace state", async ({
+  page,
+}) => {
+  const emailAccountId = await getAutomationEmailAccountId(page);
+  await markAutomationOnboardingViewed(page);
+
+  const messagesResponse = await page.request.get("/api/messages", {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  expect(messagesResponse.ok()).toBeTruthy();
+
+  await page.goto(`/${emailAccountId}/automation?tab=test`);
+  await expect(
+    page.getByRole("button", { name: "Test", exact: true }),
+  ).toHaveAttribute("data-selected", "true");
+  const search = page.getByPlaceholder("Search emails...");
+  await search.fill("Playwright Test Message");
+  await search.press("Enter");
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("search") === "Playwright Test Message",
+  );
+  await expect(search).toHaveValue("Playwright Test Message");
+
+  await page.getByRole("button", { name: "Custom" }).click();
+  const customContent = page.getByPlaceholder(
+    "Paste in email content or write your own. e.g. Receipt from Stripe for $49",
+  );
+  await expect(customContent).toBeVisible();
+  await customContent.fill("A custom receipt from the emulator workspace");
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("custom") === "true",
+  );
+
+  await page.getByRole("switch").click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("mode") === "apply",
+  );
+  await expect(page.getByRole("button", { name: "Run on All" })).toBeVisible();
+  await expect(
+    page.getByText("Run your rules on previous emails", { exact: true }),
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole("switch")).toBeChecked();
+  await expect(search).toHaveValue("Playwright Test Message");
+  await expect(page.getByRole("button", { name: "Run on All" })).toBeVisible({
+    timeout: 60_000,
+  });
+  await page.getByRole("switch").click();
+  await expect(page.getByRole("button", { name: "Test All" })).toBeVisible();
+  await expect(customContent).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
@@ -47,7 +47,7 @@ test("changes which Google calendar is used for availability", async ({
     page.getByRole("button", {
       name: "0 of 1 calendars selected for availability",
     }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 60_000 });
 });
 
 test("persists the booking link and scheduling timezone", async ({ page }) => {

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  getCalendarTestState,
   openCalendars,
   PLAYWRIGHT_TEST_EMAIL,
   resetCalendarTestState,
@@ -17,6 +18,7 @@ test.afterEach(async () => {
 test("changes which Google calendar is used for availability", async ({
   page,
 }) => {
+  test.setTimeout(360_000);
   await openCalendars(page);
 
   const calendarSummary = page.getByRole("button", {
@@ -34,23 +36,21 @@ test("changes which Google calendar is used for availability", async ({
   );
   const availabilitySwitch = calendarCard.getByRole("switch");
   await expect(availabilitySwitch).toBeChecked();
-  const toggleResponse = page.waitForResponse(
-    (response) =>
-      response.request().method() === "POST" &&
-      new URL(response.url()).pathname.endsWith("/calendars"),
-  );
   await availabilitySwitch.click();
-  expect((await toggleResponse).ok()).toBeTruthy();
+  await expect
+    .poll(() => getCalendarTestState(), { timeout: 120_000 })
+    .toMatchObject({ calendarEnabled: false });
 
-  await page.reload();
+  await openCalendars(page);
   await expect(
     page.getByRole("button", {
       name: "0 of 1 calendars selected for availability",
     }),
-  ).toBeVisible({ timeout: 60_000 });
+  ).toBeVisible({ timeout: 120_000 });
 });
 
 test("persists the booking link and scheduling timezone", async ({ page }) => {
+  test.setTimeout(360_000);
   await openCalendars(page);
 
   const bookingLinkInput = page.getByPlaceholder("https://cal.com/your-link");
@@ -60,8 +60,11 @@ test("persists the booking link and scheduling timezone", async ({ page }) => {
     .getByRole("button", { name: "Save" })
     .click();
   await expect(
-    page.getByText("Booking link updated!", { exact: true }),
-  ).toBeVisible();
+    page.getByText("Booking link updated!", { exact: true }).last(),
+  ).toBeVisible({ timeout: 120_000 });
+  await expect
+    .poll(() => getCalendarTestState(), { timeout: 120_000 })
+    .toMatchObject({ bookingLink: "https://cal.com/playwright-test" });
 
   const timezoneSelect = page.locator('select[name="timezone"]');
   await timezoneSelect.selectOption("Europe/Paris");
@@ -70,10 +73,18 @@ test("persists the booking link and scheduling timezone", async ({ page }) => {
     .getByRole("button", { name: "Save" })
     .click();
   await expect(
-    page.getByText("Timezone updated!", { exact: true }),
-  ).toBeVisible();
+    page.getByText("Timezone updated!", { exact: true }).last(),
+  ).toBeVisible({ timeout: 120_000 });
+  await expect
+    .poll(() => getCalendarTestState(), { timeout: 120_000 })
+    .toMatchObject({ timezone: "Europe/Paris" });
 
-  await page.reload();
-  await expect(bookingLinkInput).toHaveValue("https://cal.com/playwright-test");
-  await expect(timezoneSelect).toHaveValue("Europe/Paris");
+  await openCalendars(page);
+  await expect(bookingLinkInput).toHaveValue(
+    "https://cal.com/playwright-test",
+    { timeout: 120_000 },
+  );
+  await expect(timezoneSelect).toHaveValue("Europe/Paris", {
+    timeout: 120_000,
+  });
 });

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-core-flows.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import {
+  openCalendars,
+  PLAYWRIGHT_TEST_EMAIL,
+  resetCalendarTestState,
+  setupCalendarTestState,
+} from "./calendar-test-helpers";
+
+test.beforeEach(async () => {
+  await setupCalendarTestState();
+});
+
+test.afterEach(async () => {
+  await resetCalendarTestState();
+});
+
+test("changes which Google calendar is used for availability", async ({
+  page,
+}) => {
+  await openCalendars(page);
+
+  const calendarSummary = page.getByRole("button", {
+    name: "1 of 1 calendars selected for availability",
+  });
+  await expect(calendarSummary).toBeVisible({ timeout: 60_000 });
+  await calendarSummary.click();
+
+  const primaryCalendar = calendarSummary
+    .locator("..")
+    .getByText(PLAYWRIGHT_TEST_EMAIL, { exact: true });
+  await expect(primaryCalendar).toBeVisible();
+  const calendarCard = primaryCalendar.locator(
+    "xpath=ancestor::div[contains(@class, 'group/card')][1]",
+  );
+  const availabilitySwitch = calendarCard.getByRole("switch");
+  await expect(availabilitySwitch).toBeChecked();
+  const toggleResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname.endsWith("/calendars"),
+  );
+  await availabilitySwitch.click();
+  expect((await toggleResponse).ok()).toBeTruthy();
+
+  await page.reload();
+  await expect(
+    page.getByRole("button", {
+      name: "0 of 1 calendars selected for availability",
+    }),
+  ).toBeVisible();
+});
+
+test("persists the booking link and scheduling timezone", async ({ page }) => {
+  await openCalendars(page);
+
+  const bookingLinkInput = page.getByPlaceholder("https://cal.com/your-link");
+  await bookingLinkInput.fill("https://cal.com/playwright-test");
+  await bookingLinkInput
+    .locator("xpath=ancestor::form")
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect(
+    page.getByText("Booking link updated!", { exact: true }),
+  ).toBeVisible();
+
+  const timezoneSelect = page.locator('select[name="timezone"]');
+  await timezoneSelect.selectOption("Europe/Paris");
+  await timezoneSelect
+    .locator("xpath=ancestor::form")
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect(
+    page.getByText("Timezone updated!", { exact: true }),
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(bookingLinkInput).toHaveValue("https://cal.com/playwright-test");
+  await expect(timezoneSelect).toHaveValue("Europe/Paris");
+});

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
@@ -1,15 +1,31 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
 
 export async function openCalendars(page: Page) {
-  const emailAccountId = await getEmailAccountId(page);
-  await page.goto(`/${emailAccountId}/calendars`);
-  await expect(
+  let emailAccountId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        try {
+          emailAccountId = await getEmailAccountId(page);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toBe(true);
+  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+
+  await navigateUntilReady(
+    page,
+    `/${emailAccountId}/calendars`,
     page.getByRole("heading", { name: "Calendars", exact: true }),
-  ).toBeVisible();
+  );
   return { emailAccountId };
 }
 
@@ -85,6 +101,37 @@ export async function resetCalendarTestState() {
   }
 }
 
+export async function getCalendarTestState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    const result = await client.query<{
+      bookingLink: string | null;
+      calendarEnabled: boolean;
+      timezone: string | null;
+    }>(
+      `SELECT
+         ea."calendarBookingLink" AS "bookingLink",
+         ea.timezone,
+         calendar."isEnabled" AS "calendarEnabled"
+       FROM "EmailAccount" ea
+       JOIN "CalendarConnection" connection
+         ON connection."emailAccountId" = ea.id
+       JOIN "Calendar" calendar
+         ON calendar."connectionId" = connection.id
+       WHERE ea.email = $1
+         AND connection.id = ea.id || '-playwright-calendar'
+         AND calendar.id = ea.id || '-playwright-primary-calendar'`,
+      [PLAYWRIGHT_TEST_EMAIL],
+    );
+    const state = result.rows[0];
+    if (!state) throw new Error("The Playwright calendar state was not found");
+    return state;
+  } finally {
+    await client.end();
+  }
+}
+
 async function getEmailAccountId(page: Page) {
   const response = await page.request.get("/api/user/email-accounts");
   expect(response.ok()).toBeTruthy();
@@ -110,4 +157,16 @@ async function resetCalendarState(client: Client) {
      WHERE email = $1`,
     [PLAYWRIGHT_TEST_EMAIL],
   );
+}
+
+async function navigateUntilReady(page: Page, url: string, ready: Locator) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(url, { timeout: 60_000, waitUntil: "domcontentloaded" });
+      await expect(ready).toBeVisible({ timeout: 60_000 });
+      return;
+    } catch (error) {
+      if (attempt === 1) throw error;
+    }
+  }
 }

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
@@ -1,0 +1,113 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+export const PLAYWRIGHT_TEST_EMAIL =
+  process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
+
+export async function openCalendars(page: Page) {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.goto(`/${emailAccountId}/calendars`);
+  await expect(
+    page.getByRole("heading", { name: "Calendars", exact: true }),
+  ).toBeVisible();
+  return { emailAccountId };
+}
+
+export async function setupCalendarTestState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await resetCalendarState(client);
+    const result = await client.query(
+      `WITH target AS (
+         SELECT
+           ea.id AS "emailAccountId",
+           ea.email,
+           account.access_token,
+           account.refresh_token,
+           account.expires_at
+         FROM "EmailAccount" ea
+         INNER JOIN "Account" account ON account.id = ea."accountId"
+         WHERE ea.email = $1
+       ), connection AS (
+         INSERT INTO "CalendarConnection" (
+           id, "createdAt", "updatedAt", provider, email,
+           "accessToken", "refreshToken", "expiresAt", "isConnected",
+           "emailAccountId"
+         )
+         SELECT
+           target."emailAccountId" || '-playwright-calendar',
+           CURRENT_TIMESTAMP,
+           CURRENT_TIMESTAMP,
+           'google',
+           target.email,
+           target.access_token,
+           target.refresh_token,
+           target.expires_at,
+           true,
+           target."emailAccountId"
+         FROM target
+         RETURNING id, "emailAccountId"
+       )
+       INSERT INTO "Calendar" (
+         id, "createdAt", "updatedAt", "calendarId", name, "primary",
+         "isEnabled", timezone, "connectionId"
+       )
+       SELECT
+         connection."emailAccountId" || '-playwright-primary-calendar',
+         CURRENT_TIMESTAMP,
+         CURRENT_TIMESTAMP,
+         'primary',
+         $1,
+         true,
+         true,
+         'UTC',
+         connection.id
+       FROM connection
+       RETURNING id`,
+      [PLAYWRIGHT_TEST_EMAIL],
+    );
+    if (result.rowCount !== 1) {
+      throw new Error("Could not seed the Playwright calendar connection");
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+export async function resetCalendarTestState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await resetCalendarState(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+async function resetCalendarState(client: Client) {
+  await client.query(
+    `DELETE FROM "CalendarConnection"
+     WHERE "emailAccountId" = (
+       SELECT id FROM "EmailAccount" WHERE email = $1
+     )`,
+    [PLAYWRIGHT_TEST_EMAIL],
+  );
+  await client.query(
+    `UPDATE "EmailAccount"
+     SET timezone = NULL, "calendarBookingLink" = NULL
+     WHERE email = $1`,
+    [PLAYWRIGHT_TEST_EMAIL],
+  );
+}

--- a/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
@@ -20,17 +20,27 @@ test("persists rule delivery, feature routing, and channel disconnection", async
   await seedChannel(emailAccountId);
   await markAssistantOnboardingViewed(page);
 
-  const channelsResponse = await page.request.get(
-    "/api/user/messaging-channels",
-    { headers: { "X-Email-Account-ID": emailAccountId } },
-  );
-  expect(channelsResponse.ok()).toBeTruthy();
-  const channelsData = (await channelsResponse.json()) as {
-    channels: Array<{ id: string }>;
-  };
-  expect(channelsData.channels).toContainEqual(
-    expect.objectContaining({ id: CHANNEL_ID }),
-  );
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get(
+            "/api/user/messaging-channels",
+            { headers: { "X-Email-Account-ID": emailAccountId } },
+          );
+          if (!response.ok()) return false;
+
+          const data = (await response.json()) as {
+            channels: Array<{ id: string }>;
+          };
+          return data.channels.some((channel) => channel.id === CHANNEL_ID);
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(true);
 
   await page.goto(`/${emailAccountId}/channels`);
   await expect(page.getByRole("heading", { name: "Channels" })).toBeVisible();
@@ -66,7 +76,7 @@ test("persists rule delivery, feature routing, and channel disconnection", async
       routePurposes: ["MEETING_BRIEFS", "RULE_NOTIFICATIONS"],
     });
 
-  await telegramSection.getByRole("button").first().click();
+  await telegramSection.locator('button[aria-haspopup="menu"]').click();
   await page.getByRole("menuitem", { name: "Disconnect Telegram" }).click();
   await expect(
     page.getByText("Telegram disconnected", { exact: true }),

--- a/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
@@ -58,10 +58,14 @@ test("persists rule delivery, feature routing, and channel disconnection", async
   const ruleItem = page.locator('[data-slot="item"]', {
     hasText: CHANNEL_RULE_NAME,
   });
-  await ruleItem.getByRole("switch").click();
-  await expect(page.getByText("Settings saved", { exact: true })).toBeVisible();
+  const ruleSwitch = ruleItem.getByRole("switch");
+  await expect(ruleSwitch).toBeEnabled({ timeout: 60_000 });
+  await ruleSwitch.click();
+  await expect(page.getByText("Settings saved", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
   await expect
-    .poll(() => getChannelState())
+    .poll(() => getChannelState(emailAccountId), { timeout: 60_000 })
     .toMatchObject({
       actionTypes: ["NOTIFY_MESSAGING_CHANNEL"],
     });
@@ -69,9 +73,11 @@ test("persists rule delivery, feature routing, and channel disconnection", async
   const meetingBriefsItem = page.locator('[data-slot="item"]', {
     hasText: "Meeting briefs",
   });
-  await meetingBriefsItem.getByRole("switch").click();
+  const meetingBriefsSwitch = meetingBriefsItem.getByRole("switch");
+  await expect(meetingBriefsSwitch).toBeEnabled({ timeout: 60_000 });
+  await meetingBriefsSwitch.click();
   await expect
-    .poll(() => getChannelState())
+    .poll(() => getChannelState(emailAccountId), { timeout: 60_000 })
     .toMatchObject({
       routePurposes: ["MEETING_BRIEFS", "RULE_NOTIFICATIONS"],
     });
@@ -80,9 +86,9 @@ test("persists rule delivery, feature routing, and channel disconnection", async
   await page.getByRole("menuitem", { name: "Disconnect Telegram" }).click();
   await expect(
     page.getByText("Telegram disconnected", { exact: true }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 60_000 });
   await expect
-    .poll(() => getChannelState(), { timeout: 60_000 })
+    .poll(() => getChannelState(emailAccountId), { timeout: 60_000 })
     .toEqual({
       actionTypes: ["NOTIFY_MESSAGING_CHANNEL"],
       isConnected: false,

--- a/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import {
+  CHANNEL_ID,
+  CHANNEL_RULE_NAME,
+  cleanupSeededChannel,
+  getChannelState,
+  getEmailAccountId,
+  markAssistantOnboardingViewed,
+  seedChannel,
+} from "./channels-test-helpers";
+
+test.afterEach(async () => {
+  await cleanupSeededChannel();
+});
+
+test("persists rule delivery, feature routing, and channel disconnection", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await seedChannel(emailAccountId);
+  await markAssistantOnboardingViewed(page);
+
+  const channelsResponse = await page.request.get(
+    "/api/user/messaging-channels",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(channelsResponse.ok()).toBeTruthy();
+  const channelsData = (await channelsResponse.json()) as {
+    channels: Array<{ id: string }>;
+  };
+  expect(channelsData.channels).toContainEqual(
+    expect.objectContaining({ id: CHANNEL_ID }),
+  );
+
+  await page.goto(`/${emailAccountId}/channels`);
+  await expect(page.getByRole("heading", { name: "Channels" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Telegram" })).toBeVisible({
+    timeout: 60_000,
+  });
+
+  const telegramSection = page
+    .getByRole("heading", { name: "Telegram" })
+    .locator("..");
+  await expect(
+    telegramSection.getByText("Connected", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  const ruleItem = page.locator('[data-slot="item"]', {
+    hasText: CHANNEL_RULE_NAME,
+  });
+  await ruleItem.getByRole("switch").click();
+  await expect(page.getByText("Settings saved", { exact: true })).toBeVisible();
+  await expect
+    .poll(() => getChannelState())
+    .toMatchObject({
+      actionTypes: ["NOTIFY_MESSAGING_CHANNEL"],
+    });
+
+  const meetingBriefsItem = page.locator('[data-slot="item"]', {
+    hasText: "Meeting briefs",
+  });
+  await meetingBriefsItem.getByRole("switch").click();
+  await expect
+    .poll(() => getChannelState())
+    .toMatchObject({
+      routePurposes: ["MEETING_BRIEFS", "RULE_NOTIFICATIONS"],
+    });
+
+  await telegramSection.getByRole("button").first().click();
+  await page.getByRole("menuitem", { name: "Disconnect Telegram" }).click();
+  await expect(
+    page.getByText("Telegram disconnected", { exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() => getChannelState(), { timeout: 60_000 })
+    .toEqual({
+      actionTypes: ["NOTIFY_MESSAGING_CHANNEL"],
+      isConnected: false,
+      routePurposes: [],
+    });
+  await page.reload();
+  await expect(
+    page.getByText("No channels available.", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+});

--- a/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
@@ -1,0 +1,118 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+export const CHANNEL_ID = "playwright-telegram-channel";
+export const CHANNEL_RULE_ID = "playwright-channel-rule";
+export const CHANNEL_RULE_NAME = "Playwright priority notifications";
+
+export async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+export async function markAssistantOnboardingViewed(page: Page) {
+  await page.goto("/");
+  await page.context().addCookies([
+    {
+      name: "viewed_assistant_onboarding",
+      value: "true",
+      url: new URL(page.url()).origin,
+    },
+  ]);
+}
+
+export async function seedChannel(emailAccountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await deleteSeededState(client);
+    await client.query(
+      `INSERT INTO "Rule"
+         (id, name, enabled, automate, "runOnThreads", "conditionalOperator",
+          instructions, "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, $2, true, true, false, 'AND', $3, $4,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        CHANNEL_RULE_ID,
+        CHANNEL_RULE_NAME,
+        "Messages that need immediate attention",
+        emailAccountId,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "Action"
+         (id, type, "ruleId", "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, 'ARCHIVE', $2, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [`${CHANNEL_RULE_ID}-archive`, CHANNEL_RULE_ID, emailAccountId],
+    );
+    await client.query(
+      `INSERT INTO "MessagingChannel"
+         (id, provider, "isConnected", "teamId", "teamName", "providerUserId",
+          "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, 'TELEGRAM', true, $2, 'Playwright Telegram', $2, $3,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [CHANNEL_ID, "playwright-chat-1001", emailAccountId],
+    );
+    await client.query(
+      `INSERT INTO "MessagingRoute"
+         (id, purpose, "targetType", "targetId", "messagingChannelId",
+          "createdAt", "updatedAt")
+       VALUES ($1, 'RULE_NOTIFICATIONS', 'DIRECT_MESSAGE', $2, $3,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [`${CHANNEL_ID}-notifications`, "playwright-chat-1001", CHANNEL_ID],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+export async function cleanupSeededChannel() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await deleteSeededState(client);
+  } finally {
+    await client.end();
+  }
+}
+
+export async function getChannelState() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    const channelResult = await client.query<{ isConnected: boolean }>(
+      `SELECT "isConnected" FROM "MessagingChannel" WHERE id = $1`,
+      [CHANNEL_ID],
+    );
+    const actionsResult = await client.query<{ type: string }>(
+      `SELECT type::text FROM "Action"
+       WHERE "ruleId" = $1 AND "messagingChannelId" = $2`,
+      [CHANNEL_RULE_ID, CHANNEL_ID],
+    );
+    const routesResult = await client.query<{ purpose: string }>(
+      `SELECT purpose::text FROM "MessagingRoute"
+       WHERE "messagingChannelId" = $1 ORDER BY purpose::text`,
+      [CHANNEL_ID],
+    );
+    return {
+      actionTypes: actionsResult.rows.map((row) => row.type),
+      isConnected: channelResult.rows[0]?.isConnected,
+      routePurposes: routesResult.rows.map((row) => row.purpose),
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+async function deleteSeededState(client: Client) {
+  await client.query(`DELETE FROM "MessagingChannel" WHERE id = $1`, [
+    CHANNEL_ID,
+  ]);
+  await client.query(`DELETE FROM "Rule" WHERE id = $1`, [CHANNEL_RULE_ID]);
+}

--- a/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
@@ -1,19 +1,40 @@
-import { expect, type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const CHANNEL_ID = "playwright-telegram-channel";
 export const CHANNEL_RULE_ID = "playwright-channel-rule";
 export const CHANNEL_RULE_NAME = "Playwright priority notifications";
+const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
 
 export async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
+  let lastError: unknown;
+  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await page.request.get("/api/user/email-accounts");
+      if (response.ok()) {
+        const { emailAccounts } = (await response.json()) as {
+          emailAccounts: { id: string }[];
+        };
+        const emailAccountId = emailAccounts[0]?.id;
+        if (emailAccountId) return emailAccountId;
+        lastError = new Error("The setup project created no account");
+      } else {
+        lastError = new Error(
+          `Email accounts request failed with ${response.status()}`,
+        );
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await page.waitForTimeout(1000);
+  }
+
+  throw new Error(
+    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
+  );
 }
 
 export async function markAssistantOnboardingViewed(page: Page) {
@@ -82,23 +103,31 @@ export async function cleanupSeededChannel() {
   }
 }
 
-export async function getChannelState() {
+export async function getChannelState(emailAccountId: string) {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   await client.connect();
   try {
     const channelResult = await client.query<{ isConnected: boolean }>(
-      `SELECT "isConnected" FROM "MessagingChannel" WHERE id = $1`,
-      [CHANNEL_ID],
+      `SELECT "isConnected" FROM "MessagingChannel"
+       WHERE id = $1 AND "emailAccountId" = $2`,
+      [CHANNEL_ID, emailAccountId],
     );
     const actionsResult = await client.query<{ type: string }>(
       `SELECT type::text FROM "Action"
-       WHERE "ruleId" = $1 AND "messagingChannelId" = $2`,
-      [CHANNEL_RULE_ID, CHANNEL_ID],
+       WHERE "ruleId" = $1
+         AND "emailAccountId" = $2
+         AND "messagingChannelId" = $3
+         AND "messagingChannelEmailAccountId" = $2
+       ORDER BY type::text`,
+      [CHANNEL_RULE_ID, emailAccountId, CHANNEL_ID],
     );
     const routesResult = await client.query<{ purpose: string }>(
-      `SELECT purpose::text FROM "MessagingRoute"
-       WHERE "messagingChannelId" = $1 ORDER BY purpose::text`,
-      [CHANNEL_ID],
+      `SELECT mr.purpose::text
+       FROM "MessagingRoute" mr
+       JOIN "MessagingChannel" mc ON mc.id = mr."messagingChannelId"
+       WHERE mr."messagingChannelId" = $1 AND mc."emailAccountId" = $2
+       ORDER BY mr.purpose::text`,
+      [CHANNEL_ID, emailAccountId],
     );
     return {
       actionTypes: actionsResult.rows.map((row) => row.type),
@@ -115,4 +144,8 @@ async function deleteSeededState(client: Client) {
     CHANNEL_ID,
   ]);
   await client.query(`DELETE FROM "Rule" WHERE id = $1`, [CHANNEL_RULE_ID]);
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
@@ -1,17 +1,38 @@
-import { expect, type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const SEEDED_CHAT_ID = "playwright-manage-chat";
+const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
 
 export async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
+  let lastError: unknown;
+  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await page.request.get("/api/user/email-accounts");
+      if (response.ok()) {
+        const { emailAccounts } = (await response.json()) as {
+          emailAccounts: { id: string }[];
+        };
+        const emailAccountId = emailAccounts[0]?.id;
+        if (emailAccountId) return emailAccountId;
+        lastError = new Error("The setup project created no account");
+      } else {
+        lastError = new Error(
+          `Email accounts request failed with ${response.status()}`,
+        );
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await page.waitForTimeout(1000);
+  }
+
+  throw new Error(
+    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
+  );
 }
 
 export async function markAssistantOnboardingViewed(page: Page) {
@@ -69,6 +90,29 @@ export async function cleanupSeededChat() {
   }
 }
 
+export async function getChatState(emailAccountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    const result = await client.query<{
+      isDeleted: boolean;
+      name: string | null;
+    }>(
+      `SELECT name, "deletedAt" IS NOT NULL AS "isDeleted"
+       FROM "Chat"
+       WHERE id = $1 AND "emailAccountId" = $2`,
+      [SEEDED_CHAT_ID, emailAccountId],
+    );
+    return result.rows[0];
+  } finally {
+    await client.end();
+  }
+}
+
 async function deleteSeededChat(client: Client) {
   await client.query(`DELETE FROM "Chat" WHERE id = $1`, [SEEDED_CHAT_ID]);
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
@@ -1,0 +1,74 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+export const SEEDED_CHAT_ID = "playwright-manage-chat";
+
+export async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+export async function markAssistantOnboardingViewed(page: Page) {
+  await page.goto("/");
+  await page.context().addCookies([
+    {
+      name: "viewed_assistant_onboarding",
+      value: "true",
+      url: new URL(page.url()).origin,
+    },
+  ]);
+}
+
+export async function seedChat(emailAccountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await deleteSeededChat(client);
+    await client.query(
+      `INSERT INTO "Chat" (id, "emailAccountId", name, "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [SEEDED_CHAT_ID, emailAccountId, "Inbox planning"],
+    );
+    await client.query(
+      `INSERT INTO "ChatMessage" (id, "chatId", role, parts, "createdAt", "updatedAt")
+       VALUES ($1, $2, 'user', $3::jsonb, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+              ($4, $2, 'assistant', $5::jsonb, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        `${SEEDED_CHAT_ID}-user`,
+        SEEDED_CHAT_ID,
+        JSON.stringify([
+          { type: "text", text: "Help me make a plan for today's inbox." },
+        ]),
+        `${SEEDED_CHAT_ID}-assistant`,
+        JSON.stringify([
+          {
+            type: "text",
+            text: "Start with unread mail, then review anything awaiting a reply.",
+          },
+        ]),
+      ],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+export async function cleanupSeededChat() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await deleteSeededChat(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function deleteSeededChat(client: Client) {
+  await client.query(`DELETE FROM "Chat" WHERE id = $1`, [SEEDED_CHAT_ID]);
+}

--- a/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
@@ -1,10 +1,13 @@
 import { expect, test } from "@playwright/test";
 import {
   cleanupSeededChat,
+  getChatState,
   getEmailAccountId,
   markAssistantOnboardingViewed,
   seedChat,
 } from "./chat-test-helpers";
+
+const SERVER_ACTION_TIMEOUT_MS = 120_000;
 
 test.afterEach(async () => {
   await cleanupSeededChat();
@@ -41,8 +44,15 @@ test("opens, renames, starts fresh from, and deletes persisted chats", async ({
 
   const renameDialog = page.getByRole("dialog", { name: "Rename chat" });
   await renameDialog.getByRole("textbox").fill("Daily inbox plan");
-  await renameDialog.getByRole("button", { name: "Save" }).click();
-  await expect(page.getByText("Chat renamed.", { exact: true })).toBeVisible();
+  const saveButton = renameDialog.getByRole("button", { name: "Save" });
+  await expect(saveButton).toBeEnabled({ timeout: 60_000 });
+  await saveButton.click();
+  await expect
+    .poll(() => getChatState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
+    .toMatchObject({ isDeleted: false, name: "Daily inbox plan" });
+  await expect(renameDialog).toBeHidden({ timeout: 60_000 });
 
   await page.getByRole("button", { name: "New Chat" }).click();
   await expect(page.getByTestId("chat-input")).toHaveValue("");
@@ -59,8 +69,15 @@ test("opens, renames, starts fresh from, and deletes persisted chats", async ({
 
   const deleteDialog = page.getByRole("alertdialog", { name: "Delete chat?" });
   await expect(deleteDialog).toContainText("Daily inbox plan");
-  await deleteDialog.getByRole("button", { name: "Delete" }).click();
-  await expect(page.getByText("Chat deleted.", { exact: true })).toBeVisible();
+  const deleteButton = deleteDialog.getByRole("button", { name: "Delete" });
+  await expect(deleteButton).toBeEnabled({ timeout: 60_000 });
+  await deleteButton.click();
+  await expect
+    .poll(() => getChatState(emailAccountId), {
+      timeout: SERVER_ACTION_TIMEOUT_MS,
+    })
+    .toMatchObject({ isDeleted: true, name: null });
+  await expect(deleteDialog).toBeHidden({ timeout: 60_000 });
 
   await page.getByRole("button", { name: "Chat History" }).click();
   await expect(

--- a/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanupSeededChat,
+  getEmailAccountId,
+  markAssistantOnboardingViewed,
+  seedChat,
+} from "./chat-test-helpers";
+
+test.afterEach(async () => {
+  await cleanupSeededChat();
+});
+
+test("opens, renames, starts fresh from, and deletes persisted chats", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await seedChat(emailAccountId);
+  await markAssistantOnboardingViewed(page);
+
+  await page.goto(`/${emailAccountId}/assistant`);
+  await expect(page).toHaveURL(new RegExp(`/${emailAccountId}/assistant`));
+  await expect(page.getByTestId("chat-input")).toBeVisible();
+
+  await page.getByRole("button", { name: "Chat History" }).click();
+  await page.getByRole("menuitem", { name: "Inbox planning" }).click();
+  await expect(
+    page.getByText("Help me make a plan for today's inbox."),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Start with unread mail, then review anything awaiting a reply.",
+    ),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Chat History" }).click();
+  const chatRow = page
+    .getByRole("menuitem", { name: "Inbox planning" })
+    .locator("..");
+  await chatRow.getByRole("button", { name: "Chat options" }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+
+  const renameDialog = page.getByRole("dialog", { name: "Rename chat" });
+  await renameDialog.getByRole("textbox").fill("Daily inbox plan");
+  await renameDialog.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("Chat renamed.", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "New Chat" }).click();
+  await expect(page.getByTestId("chat-input")).toHaveValue("");
+  await expect(
+    page.getByRole("button", { name: "Help me handle my inbox today" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Chat History" }).click();
+  const renamedRow = page
+    .getByRole("menuitem", { name: "Daily inbox plan" })
+    .locator("..");
+  await renamedRow.getByRole("button", { name: "Chat options" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  const deleteDialog = page.getByRole("alertdialog", { name: "Delete chat?" });
+  await expect(deleteDialog).toContainText("Daily inbox plan");
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Chat deleted.", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Chat History" }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "No previous chats found" }),
+  ).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/cleanup/analytics.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/analytics.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanUpFixture,
+  type CleanupFixture,
+  openCleanupFeature,
+  prepareCleanupFixture,
+} from "./cleanup-test-helpers";
+
+let fixture: CleanupFixture;
+
+test.beforeEach(async ({ page }) => {
+  fixture = await prepareCleanupFixture(page);
+});
+
+test.afterEach(async () => {
+  await cleanUpFixture(fixture);
+});
+
+test("shows seeded traffic and updates the reporting granularity", async ({
+  page,
+}) => {
+  await openCleanupFeature(page, fixture, "stats");
+  await expect(page.getByRole("heading", { name: "Analytics" })).toBeVisible();
+  const onboardingDialog = page.getByRole("dialog", {
+    name: "Welcome to email analytics",
+  });
+  await expect(onboardingDialog).toBeVisible();
+  await onboardingDialog.getByRole("button", { name: "Get Started" }).click();
+
+  await expect(
+    page.getByText("analytics-sender@example.com", { exact: true }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await expect(
+    page.getByText("analytics-recipient@example.com", { exact: true }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Group by week" }).click();
+  await page.getByRole("menuitemcheckbox", { name: "Day" }).click();
+  await expect(
+    page.getByRole("button", { name: "Group by day" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /Last month/ }).click();
+  await page.getByText("Last week", { exact: true }).click();
+  await expect(page.getByRole("button", { name: /Last week/ })).toBeVisible();
+  await expect(
+    page.getByText("analytics-sender@example.com", { exact: true }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+});

--- a/apps/web/__tests__/playwright/emulated/cleanup/analytics.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/analytics.spec.ts
@@ -6,19 +6,21 @@ import {
   prepareCleanupFixture,
 } from "./cleanup-test-helpers";
 
-let fixture: CleanupFixture;
+let fixture: CleanupFixture | undefined;
 
 test.beforeEach(async ({ page }) => {
+  fixture = undefined;
   fixture = await prepareCleanupFixture(page);
 });
 
 test.afterEach(async () => {
-  await cleanUpFixture(fixture);
+  if (fixture) await cleanUpFixture(fixture);
 });
 
 test("shows seeded traffic and updates the reporting granularity", async ({
   page,
 }) => {
+  if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await openCleanupFeature(page, fixture, "stats");
   await expect(page.getByRole("heading", { name: "Analytics" })).toBeVisible();
   const onboardingDialog = page.getByRole("dialog", {

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-import { openMail } from "../mail/mail-test-helpers";
 import {
   CLEANUP_ARCHIVE_THREAD_ID,
   CLEANUP_KEEP_THREAD_ID,
@@ -26,6 +25,7 @@ test.afterEach(async () => {
 });
 
 test("archives only selected senders from a category", async ({ page }) => {
+  test.setTimeout(360_000);
   if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await openCleanupFeature(page, fixture, "bulk-archive");
   await expect(page.getByRole("heading", { name: "Bulk Archive" })).toBeVisible(
@@ -46,9 +46,13 @@ test("archives only selected senders from a category", async ({ page }) => {
   ).toBeVisible();
 
   await newsletterCard.getByRole("button", { name: "Archive 1 of 2" }).click();
-  await expect(page.getByText("Archived 1!", { exact: true })).toBeVisible();
+  await expect(page.getByText("Archived 1!", { exact: true })).toBeVisible({
+    timeout: 120_000,
+  });
 
-  const { conversations } = await openMail(page);
+  await openCleanupFeature(page, fixture, "mail");
+  const conversations = page.getByRole("listbox", { name: "Conversations" });
+  await expect(conversations).toBeVisible({ timeout: 120_000 });
   await expect(
     conversations.getByText("Cleanup Category Archive Candidate", {
       exact: true,

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -10,9 +10,10 @@ import {
   restoreCleanupThreads,
 } from "./cleanup-test-helpers";
 
-let fixture: CleanupFixture;
+let fixture: CleanupFixture | undefined;
 
 test.beforeEach(async ({ page }) => {
+  fixture = undefined;
   fixture = await prepareCleanupFixture(page);
   await restoreCleanupThreads(page, fixture.emailAccountId, [
     CLEANUP_ARCHIVE_THREAD_ID,
@@ -21,10 +22,11 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.afterEach(async () => {
-  await cleanUpFixture(fixture);
+  if (fixture) await cleanUpFixture(fixture);
 });
 
 test("archives only selected senders from a category", async ({ page }) => {
+  if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await openCleanupFeature(page, fixture, "bulk-archive");
   await expect(page.getByRole("heading", { name: "Bulk Archive" })).toBeVisible(
     { timeout: 60_000 },

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { openMail } from "../mail/mail-test-helpers";
+import {
+  CLEANUP_ARCHIVE_THREAD_ID,
+  CLEANUP_KEEP_THREAD_ID,
+  cleanUpFixture,
+  type CleanupFixture,
+  openCleanupFeature,
+  prepareCleanupFixture,
+  restoreCleanupThreads,
+} from "./cleanup-test-helpers";
+
+let fixture: CleanupFixture;
+
+test.beforeEach(async ({ page }) => {
+  fixture = await prepareCleanupFixture(page);
+  await restoreCleanupThreads(page, fixture.emailAccountId, [
+    CLEANUP_ARCHIVE_THREAD_ID,
+    CLEANUP_KEEP_THREAD_ID,
+  ]);
+});
+
+test.afterEach(async () => {
+  await cleanUpFixture(fixture);
+});
+
+test("archives only selected senders from a category", async ({ page }) => {
+  await openCleanupFeature(page, fixture, "bulk-archive");
+  await expect(page.getByRole("heading", { name: "Bulk Archive" })).toBeVisible(
+    { timeout: 60_000 },
+  );
+
+  const newsletterCard = page
+    .locator('[role="button"]')
+    .filter({ has: page.getByRole("heading", { name: "Newsletter" }) });
+  await newsletterCard.click();
+
+  await expect(
+    page.getByText("2 of 2 selected", { exact: true }),
+  ).toBeVisible();
+  await page.getByRole("checkbox", { name: "Select Cleanup Keep" }).click();
+  await expect(
+    page.getByText("1 of 2 selected", { exact: true }),
+  ).toBeVisible();
+
+  await newsletterCard.getByRole("button", { name: "Archive 1 of 2" }).click();
+  await expect(page.getByText("Archived 1!", { exact: true })).toBeVisible();
+
+  const { conversations } = await openMail(page);
+  await expect(
+    conversations.getByText("Cleanup Category Archive Candidate", {
+      exact: true,
+    }),
+  ).toHaveCount(0);
+  await expect(
+    conversations.getByText("Cleanup Category Keep Candidate", { exact: true }),
+  ).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import {
   CLEANUP_BLOCK_THREAD_ID,
   cleanUpFixture,
@@ -25,14 +25,14 @@ test.afterEach(async () => {
 test("blocks a selected sender and surfaces it in Auto Archive", async ({
   page,
 }) => {
+  test.setTimeout(360_000);
   if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await openCleanupFeature(page, fixture, "bulk-unsubscribe");
   await expect(
     page.getByRole("heading", { name: "Bulk Unsubscriber" }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: /Unhandled/ }).click();
-  await page.getByRole("menuitem", { name: "All" }).click();
+  await selectNewsletterFilter(page, "Unhandled", "All");
 
   const senderRow = page
     .getByRole("row")
@@ -42,10 +42,34 @@ test("blocks a selected sender and surfaces it in Auto Archive", async ({
   await senderRow.getByRole("link", { name: "Block" }).click();
   await expect(
     page.getByText("Sender blocked. Future emails will be archived."),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 120_000 });
 
-  await page.getByRole("button", { name: /All/ }).click();
-  await page.getByRole("menuitem", { name: "Auto Archive" }).click();
-  await expect(senderRow).toBeVisible();
-  await expect(senderRow.getByRole("link", { name: "Block" })).toBeVisible();
+  await selectNewsletterFilter(page, "All", "Auto Archive");
+  await expect(senderRow).toBeVisible({ timeout: 120_000 });
+  await expect(senderRow.getByRole("link", { name: "Block" })).toBeVisible({
+    timeout: 60_000,
+  });
 });
+
+async function selectNewsletterFilter(
+  page: Page,
+  currentFilter: string,
+  nextFilter: string,
+) {
+  const trigger = page.getByRole("button", {
+    name: new RegExp(currentFilter),
+  });
+  const option = page.getByRole("menuitem", { name: nextFilter });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await trigger.click();
+    try {
+      await option.waitFor({ state: "visible", timeout: 10_000 });
+      await option.click();
+      return;
+    } catch (error) {
+      if (attempt === 2) throw error;
+      await page.keyboard.press("Escape");
+    }
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import {
+  CLEANUP_BLOCK_THREAD_ID,
+  cleanUpFixture,
+  type CleanupFixture,
+  openCleanupFeature,
+  prepareCleanupFixture,
+  restoreCleanupThreads,
+} from "./cleanup-test-helpers";
+
+let fixture: CleanupFixture;
+
+test.beforeEach(async ({ page }) => {
+  fixture = await prepareCleanupFixture(page);
+  await restoreCleanupThreads(page, fixture.emailAccountId, [
+    CLEANUP_BLOCK_THREAD_ID,
+  ]);
+});
+
+test.afterEach(async () => {
+  await cleanUpFixture(fixture);
+});
+
+test("blocks a selected sender and surfaces it in Auto Archive", async ({
+  page,
+}) => {
+  await openCleanupFeature(page, fixture, "bulk-unsubscribe");
+  await expect(
+    page.getByRole("heading", { name: "Bulk Unsubscriber" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /Unhandled/ }).click();
+  await page.getByRole("menuitem", { name: "All" }).click();
+
+  const senderRow = page
+    .getByRole("row")
+    .filter({ hasText: "cleanup-block@example.com" });
+  await expect(senderRow).toContainText("Cleanup Weekly", { timeout: 60_000 });
+
+  await senderRow.getByRole("link", { name: "Block" }).click();
+  await expect(
+    page.getByText("Sender blocked. Future emails will be archived."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /All/ }).click();
+  await page.getByRole("menuitem", { name: "Auto Archive" }).click();
+  await expect(senderRow).toBeVisible();
+  await expect(senderRow.getByRole("link", { name: "Block" })).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-unsubscribe.spec.ts
@@ -8,9 +8,10 @@ import {
   restoreCleanupThreads,
 } from "./cleanup-test-helpers";
 
-let fixture: CleanupFixture;
+let fixture: CleanupFixture | undefined;
 
 test.beforeEach(async ({ page }) => {
+  fixture = undefined;
   fixture = await prepareCleanupFixture(page);
   await restoreCleanupThreads(page, fixture.emailAccountId, [
     CLEANUP_BLOCK_THREAD_ID,
@@ -18,12 +19,13 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.afterEach(async () => {
-  await cleanUpFixture(fixture);
+  if (fixture) await cleanUpFixture(fixture);
 });
 
 test("blocks a selected sender and surfaces it in Auto Archive", async ({
   page,
 }) => {
+  if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await openCleanupFeature(page, fixture, "bulk-unsubscribe");
   await expect(
     page.getByRole("heading", { name: "Bulk Unsubscriber" }),

--- a/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
@@ -1,0 +1,299 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const CLEANUP_SENDERS = [
+  "cleanup-block@example.com",
+  "cleanup-archive@example.com",
+  "cleanup-keep@example.com",
+];
+
+const CLEANUP_NEWSLETTERS = [
+  "cleanup-archive@example.com",
+  "cleanup-keep@example.com",
+];
+
+export const CLEANUP_BLOCK_THREAD_ID = "thr_playwright_cleanup_block";
+export const CLEANUP_ARCHIVE_THREAD_ID = "thr_playwright_cleanup_archive";
+export const CLEANUP_KEEP_THREAD_ID = "thr_playwright_cleanup_keep";
+
+export type CleanupFixture = {
+  emailAccountId: string;
+  previousAutoCategorizeSenders: boolean;
+  previousPremiumId: string | null;
+  premiumId: string;
+  categoryIds: string[];
+};
+
+export async function prepareCleanupFixture(
+  page: Page,
+): Promise<CleanupFixture> {
+  const { id: emailAccountId } = await getEmailAccount(page);
+  const client = await connectToDatabase();
+  const runId = process.env.PLAYWRIGHT_RUN_ID ?? "local";
+  const premiumId = `playwright_cleanup_premium_${runId}`;
+
+  try {
+    const accountResult = await client.query<{
+      autoCategorizeSenders: boolean;
+      premiumId: string | null;
+    }>(
+      `SELECT ea."autoCategorizeSenders", u."premiumId"
+       FROM "EmailAccount" ea
+       JOIN "User" u ON u.id = ea."userId"
+       WHERE ea.id = $1`,
+      [emailAccountId],
+    );
+    const account = accountResult.rows[0];
+    if (!account) throw new Error("The Playwright email account was not found");
+
+    await deleteCleanupRows(client, emailAccountId);
+
+    await client.query(
+      `INSERT INTO "Premium" (id, "createdAt", "updatedAt", "pendingInvites", tier)
+       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ARRAY[]::text[], 'PRO_MONTHLY')
+       ON CONFLICT (id) DO UPDATE
+       SET tier = EXCLUDED.tier, "updatedAt" = CURRENT_TIMESTAMP`,
+      [premiumId],
+    );
+    await client.query(
+      `UPDATE "User"
+       SET "premiumId" = $2, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = (SELECT "userId" FROM "EmailAccount" WHERE id = $1)`,
+      [emailAccountId, premiumId],
+    );
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET "autoCategorizeSenders" = true, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+
+    const categoryIds = await seedBulkArchiveData(client, emailAccountId);
+    await seedEmailStats(client, emailAccountId);
+
+    return {
+      emailAccountId,
+      previousAutoCategorizeSenders: account.autoCategorizeSenders,
+      previousPremiumId: account.premiumId,
+      premiumId,
+      categoryIds,
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+export async function cleanUpFixture(fixture: CleanupFixture) {
+  const client = await connectToDatabase();
+
+  try {
+    await deleteCleanupRows(client, fixture.emailAccountId);
+    await client.query(
+      `DELETE FROM "Category"
+       WHERE "emailAccountId" = $1 AND id = ANY($2::text[])`,
+      [fixture.emailAccountId, fixture.categoryIds],
+    );
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET "autoCategorizeSenders" = $2, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [fixture.emailAccountId, fixture.previousAutoCategorizeSenders],
+    );
+    await client.query(
+      `UPDATE "User"
+       SET "premiumId" = $2, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE "premiumId" = $3
+         AND id = (SELECT "userId" FROM "EmailAccount" WHERE id = $1)`,
+      [fixture.emailAccountId, fixture.previousPremiumId, fixture.premiumId],
+    );
+    await client.query(`DELETE FROM "Premium" WHERE id = $1`, [
+      fixture.premiumId,
+    ]);
+  } finally {
+    await client.end();
+  }
+}
+
+export async function restoreCleanupThreads(
+  page: Page,
+  emailAccountId: string,
+  threadIds: string[],
+) {
+  for (const threadId of threadIds) {
+    const response = await page.request.post(
+      `/api/threads/${threadId}/unarchive`,
+      { headers: { "X-Email-Account-ID": emailAccountId } },
+    );
+    expect(response.ok()).toBeTruthy();
+  }
+}
+
+export async function openCleanupFeature(
+  page: Page,
+  fixture: CleanupFixture,
+  expectedPath: string,
+) {
+  await page.goto(`/${fixture.emailAccountId}/${expectedPath}`);
+  await expect(page).toHaveURL(
+    new RegExp(`/${fixture.emailAccountId}/${expectedPath}(?:\\?.*)?$`),
+  );
+}
+
+async function getEmailAccount(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string; email: string }[];
+  };
+  const emailAccount = emailAccounts[0];
+  if (!emailAccount) throw new Error("The setup project created no account");
+  return emailAccount;
+}
+
+async function connectToDatabase() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  return client;
+}
+
+async function deleteCleanupRows(client: Client, emailAccountId: string) {
+  await client.query(
+    `DELETE FROM "EmailMessage"
+     WHERE "emailAccountId" = $1
+       AND (
+         "messageId" LIKE 'playwright_cleanup_%'
+         OR "from" = ANY($2::text[])
+       )`,
+    [emailAccountId, CLEANUP_SENDERS],
+  );
+  await client.query(
+    `DELETE FROM "Newsletter"
+     WHERE "emailAccountId" = $1 AND email = ANY($2::text[])`,
+    [emailAccountId, [...CLEANUP_SENDERS, "analytics-sender@example.com"]],
+  );
+}
+
+async function seedBulkArchiveData(client: Client, emailAccountId: string) {
+  const categoryIds: string[] = [];
+  const ownedCategoryIds: string[] = [];
+
+  for (const [index, name] of ["Newsletter", "Marketing"].entries()) {
+    const id = `playwright_cleanup_category_${index}_${emailAccountId}`;
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO "Category" (id, "createdAt", "updatedAt", name, description, "emailAccountId")
+       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, $3, $4)
+       ON CONFLICT (name, "emailAccountId") DO UPDATE
+       SET description = EXCLUDED.description, "updatedAt" = CURRENT_TIMESTAMP
+       RETURNING id`,
+      [
+        id,
+        name,
+        `${name} messages for Playwright cleanup coverage`,
+        emailAccountId,
+      ],
+    );
+    const categoryId = result.rows[0]?.id;
+    if (!categoryId) throw new Error(`Could not seed ${name} category`);
+    categoryIds.push(categoryId);
+    if (categoryId === id) ownedCategoryIds.push(categoryId);
+  }
+
+  await client.query(
+    `INSERT INTO "Newsletter" (id, "createdAt", "updatedAt", email, name, "emailAccountId", "categoryId")
+     VALUES
+       ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, 'Cleanup Newsletter', $5, $6),
+       ($3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $4, 'Cleanup Keep', $5, $6)
+     ON CONFLICT (email, "emailAccountId") DO UPDATE
+     SET name = EXCLUDED.name, "categoryId" = EXCLUDED."categoryId", "updatedAt" = CURRENT_TIMESTAMP`,
+    [
+      `playwright_cleanup_newsletter_archive_${emailAccountId}`,
+      CLEANUP_NEWSLETTERS[0],
+      `playwright_cleanup_newsletter_keep_${emailAccountId}`,
+      CLEANUP_NEWSLETTERS[1],
+      emailAccountId,
+      categoryIds[0],
+    ],
+  );
+
+  return ownedCategoryIds;
+}
+
+async function seedEmailStats(client: Client, emailAccountId: string) {
+  const rows = [
+    {
+      id: "block-1",
+      threadId: "db_cleanup_block_1",
+      messageId: "playwright_cleanup_block_1",
+      from: "cleanup-block@example.com",
+      fromName: "Cleanup Weekly",
+      to: "playwright-recipient@example.com",
+      read: false,
+      sent: false,
+      inbox: true,
+    },
+    {
+      id: "block-2",
+      threadId: "db_cleanup_block_2",
+      messageId: "playwright_cleanup_block_2",
+      from: "cleanup-block@example.com",
+      fromName: "Cleanup Weekly",
+      to: "playwright-recipient@example.com",
+      read: false,
+      sent: false,
+      inbox: true,
+    },
+    ...[1, 2, 3].map((number) => ({
+      id: `analytics-received-${number}`,
+      threadId: `db_cleanup_analytics_received_${number}`,
+      messageId: `playwright_cleanup_analytics_received_${number}`,
+      from: "analytics-sender@example.com",
+      fromName: "Analytics Sender",
+      to: "playwright-recipient@example.com",
+      read: number !== 3,
+      sent: false,
+      inbox: number !== 2,
+    })),
+    ...[1, 2].map((number) => ({
+      id: `analytics-sent-${number}`,
+      threadId: `db_cleanup_analytics_sent_${number}`,
+      messageId: `playwright_cleanup_analytics_sent_${number}`,
+      from: "playwright-sender@example.com",
+      fromName: "Playwright Sender",
+      to: "analytics-recipient@example.com",
+      read: true,
+      sent: true,
+      inbox: false,
+    })),
+  ];
+
+  for (const row of rows) {
+    await client.query(
+      `INSERT INTO "EmailMessage" (
+         id, "createdAt", "updatedAt", "threadId", "messageId", date,
+         "from", "fromName", "fromDomain", "to", "unsubscribeLink",
+         read, sent, draft, inbox, "emailAccountId"
+       )
+       VALUES (
+         $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, $3,
+         CURRENT_TIMESTAMP - INTERVAL '1 day', $4, $5, $6, $7, NULL,
+         $8, $9, false, $10, $11
+       )
+       ON CONFLICT ("emailAccountId", "threadId", "messageId") DO UPDATE
+       SET date = EXCLUDED.date, read = EXCLUDED.read, sent = EXCLUDED.sent,
+           inbox = EXCLUDED.inbox, "updatedAt" = CURRENT_TIMESTAMP`,
+      [
+        `playwright_cleanup_email_${row.id}_${emailAccountId}`,
+        row.threadId,
+        row.messageId,
+        row.from,
+        row.fromName,
+        row.from.split("@")[1],
+        row.to,
+        row.read,
+        row.sent,
+        row.inbox,
+        emailAccountId,
+      ],
+    );
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 const CLEANUP_SENDERS = [
@@ -120,11 +120,22 @@ export async function restoreCleanupThreads(
   threadIds: string[],
 ) {
   for (const threadId of threadIds) {
-    const response = await page.request.post(
-      `/api/threads/${threadId}/unarchive`,
-      { headers: { "X-Email-Account-ID": emailAccountId } },
-    );
-    expect(response.ok()).toBeTruthy();
+    await expect
+      .poll(
+        async () => {
+          try {
+            const response = await page.request.post(
+              `/api/threads/${threadId}/unarchive`,
+              { headers: { "X-Email-Account-ID": emailAccountId } },
+            );
+            return response.ok();
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 120_000 },
+      )
+      .toBe(true);
   }
 }
 
@@ -133,7 +144,12 @@ export async function openCleanupFeature(
   fixture: CleanupFixture,
   expectedPath: string,
 ) {
-  await page.goto(`/${fixture.emailAccountId}/${expectedPath}`);
+  const url = `/${fixture.emailAccountId}/${expectedPath}`;
+  await navigateUntilReady(
+    page,
+    url,
+    getCleanupFeatureReadyLocator(page, expectedPath),
+  );
   await expect(page).toHaveURL(
     new RegExp(`/${fixture.emailAccountId}/${expectedPath}(?:\\?.*)?$`),
   );
@@ -295,5 +311,32 @@ async function seedEmailStats(client: Client, emailAccountId: string) {
         emailAccountId,
       ],
     );
+  }
+}
+
+function getCleanupFeatureReadyLocator(page: Page, expectedPath: string) {
+  switch (expectedPath) {
+    case "stats":
+      return page.getByRole("heading", { name: "Analytics" });
+    case "bulk-archive":
+      return page.getByRole("heading", { name: "Bulk Archive" });
+    case "bulk-unsubscribe":
+      return page.getByRole("heading", { name: "Bulk Unsubscriber" });
+    case "mail":
+      return page.getByRole("listbox", { name: "Conversations" });
+    default:
+      throw new Error(`Unsupported cleanup path: ${expectedPath}`);
+  }
+}
+
+async function navigateUntilReady(page: Page, url: string, ready: Locator) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(url, { timeout: 60_000, waitUntil: "domcontentloaded" });
+      await expect(ready).toBeVisible({ timeout: 60_000 });
+      return;
+    } catch (error) {
+      if (attempt === 1) throw error;
+    }
   }
 }

--- a/apps/web/__tests__/playwright/emulated/integrations/integration-configuration.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/integrations/integration-configuration.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import {
+  getIntegrationRow,
+  getIntegrationToolCard,
+  openIntegrations,
+  resetIntegrationTestState,
+  setupIntegrationTestState,
+} from "./integration-test-helpers";
+
+test.beforeEach(async () => {
+  await setupIntegrationTestState();
+});
+
+test.afterEach(async () => {
+  await resetIntegrationTestState();
+});
+
+test("persists which read tools are enabled", async ({ page }) => {
+  await openIntegrations(page);
+
+  const notionRow = getIntegrationRow(page, "Notion");
+  await expect(notionRow.getByText("Connected", { exact: false })).toBeVisible({
+    timeout: 60_000,
+  });
+  await notionRow.getByRole("button", { name: "Integration actions" }).click();
+  await page
+    .getByRole("menuitem", { name: "Manage tools (1 of 2 on)" })
+    .click();
+
+  const fetchToolCard = getIntegrationToolCard(page, "notion-fetch");
+  const fetchToolSwitch = fetchToolCard.getByRole("switch");
+  await expect(fetchToolSwitch).toBeChecked();
+  await fetchToolSwitch.click();
+  await expect(page.getByText("Tool updated", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(notionRow.getByText("Connected", { exact: false })).toBeVisible({
+    timeout: 60_000,
+  });
+  await notionRow.getByRole("button", { name: "Integration actions" }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "Manage tools (0 of 2 on)" }),
+  ).toBeVisible();
+});
+
+test("persists pause state and disconnects the integration", async ({
+  page,
+}) => {
+  await openIntegrations(page);
+
+  const notionRow = getIntegrationRow(page, "Notion");
+  await expect(notionRow.getByText("Connected", { exact: false })).toBeVisible({
+    timeout: 60_000,
+  });
+  await notionRow.getByRole("button", { name: "Integration actions" }).click();
+  await page.getByRole("menuitem", { name: "Pause" }).click();
+  await expect(page.getByText("Notion paused", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(notionRow.getByText("Paused", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+  await notionRow.getByRole("button", { name: "Integration actions" }).click();
+  await expect(page.getByRole("menuitem", { name: "Resume" })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await notionRow.getByRole("button", { name: "Integration actions" }).click();
+  await page.getByRole("menuitem", { name: "Disconnect" }).click();
+  await expect(
+    page.getByText("Disconnected successfully", { exact: true }),
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(
+    notionRow.getByRole("button", { name: "Connect", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+});

--- a/apps/web/__tests__/playwright/emulated/integrations/integration-configuration.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/integrations/integration-configuration.spec.ts
@@ -16,6 +16,7 @@ test.afterEach(async () => {
 });
 
 test("persists which read tools are enabled", async ({ page }) => {
+  test.setTimeout(360_000);
   await openIntegrations(page);
 
   const notionRow = getIntegrationRow(page, "Notion");
@@ -31,9 +32,11 @@ test("persists which read tools are enabled", async ({ page }) => {
   const fetchToolSwitch = fetchToolCard.getByRole("switch");
   await expect(fetchToolSwitch).toBeChecked();
   await fetchToolSwitch.click();
-  await expect(page.getByText("Tool updated", { exact: true })).toBeVisible();
+  await expect(page.getByText("Tool updated", { exact: true })).toBeVisible({
+    timeout: 120_000,
+  });
 
-  await page.reload();
+  await openIntegrations(page);
   await expect(notionRow.getByText("Connected", { exact: false })).toBeVisible({
     timeout: 60_000,
   });
@@ -46,6 +49,7 @@ test("persists which read tools are enabled", async ({ page }) => {
 test("persists pause state and disconnects the integration", async ({
   page,
 }) => {
+  test.setTimeout(360_000);
   await openIntegrations(page);
 
   const notionRow = getIntegrationRow(page, "Notion");
@@ -54,9 +58,11 @@ test("persists pause state and disconnects the integration", async ({
   });
   await notionRow.getByRole("button", { name: "Integration actions" }).click();
   await page.getByRole("menuitem", { name: "Pause" }).click();
-  await expect(page.getByText("Notion paused", { exact: true })).toBeVisible();
+  await expect(page.getByText("Notion paused", { exact: true })).toBeVisible({
+    timeout: 120_000,
+  });
 
-  await page.reload();
+  await openIntegrations(page);
   await expect(notionRow.getByText("Paused", { exact: true })).toBeVisible({
     timeout: 60_000,
   });
@@ -69,9 +75,9 @@ test("persists pause state and disconnects the integration", async ({
   await page.getByRole("menuitem", { name: "Disconnect" }).click();
   await expect(
     page.getByText("Disconnected successfully", { exact: true }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 120_000 });
 
-  await page.reload();
+  await openIntegrations(page);
   await expect(
     notionRow.getByRole("button", { name: "Connect", exact: true }),
   ).toBeVisible({ timeout: 60_000 });

--- a/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
 
 const PLAYWRIGHT_TEST_EMAIL =
@@ -6,11 +6,27 @@ const PLAYWRIGHT_TEST_EMAIL =
 const INTEGRATION_ID = "playwright-mcp-notion";
 
 export async function openIntegrations(page: Page) {
-  const emailAccountId = await getEmailAccountId(page);
-  await page.goto(`/${emailAccountId}/integrations`);
-  await expect(
+  let emailAccountId: string | undefined;
+  await expect
+    .poll(
+      async () => {
+        try {
+          emailAccountId = await getEmailAccountId(page);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toBe(true);
+  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+
+  await navigateUntilReady(
+    page,
+    `/${emailAccountId}/integrations`,
     page.getByRole("heading", { name: "Integrations", exact: true }),
-  ).toBeVisible({ timeout: 60_000 });
+  );
 }
 
 export async function setupIntegrationTestState() {
@@ -131,5 +147,17 @@ async function withClient<T>(callback: (client: Client) => Promise<T>) {
     return await callback(client);
   } finally {
     await client.end();
+  }
+}
+
+async function navigateUntilReady(page: Page, url: string, ready: Locator) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(url, { timeout: 60_000, waitUntil: "domcontentloaded" });
+      await expect(ready).toBeVisible({ timeout: 60_000 });
+      return;
+    } catch (error) {
+      if (attempt === 1) throw error;
+    }
   }
 }

--- a/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
@@ -1,0 +1,135 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const PLAYWRIGHT_TEST_EMAIL =
+  process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
+const INTEGRATION_ID = "playwright-mcp-notion";
+
+export async function openIntegrations(page: Page) {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.goto(`/${emailAccountId}/integrations`);
+  await expect(
+    page.getByRole("heading", { name: "Integrations", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+}
+
+export async function setupIntegrationTestState() {
+  await withClient(async (client) => {
+    await resetIntegrationState(client);
+    const result = await client.query(
+      `WITH target AS (
+         SELECT id AS "emailAccountId"
+         FROM "EmailAccount"
+         WHERE email = $1
+       ), integration AS (
+         INSERT INTO "McpIntegration" (id, name, "createdAt", "updatedAt")
+         VALUES ($2, 'notion', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+         ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+         RETURNING id
+       ), connection AS (
+         INSERT INTO "McpConnection" (
+           id, name, "isActive", "integrationId", "emailAccountId",
+           "createdAt", "updatedAt"
+         )
+         SELECT
+           target."emailAccountId" || '-playwright-notion',
+           'Playwright Notion Workspace',
+           true,
+           integration.id,
+           target."emailAccountId",
+           CURRENT_TIMESTAMP,
+           CURRENT_TIMESTAMP
+         FROM target, integration
+         RETURNING id
+       )
+       INSERT INTO "McpTool" (
+         id, name, description, "isEnabled", "isWrite", "connectionId",
+         "createdAt", "updatedAt"
+       )
+       SELECT
+         connection.id || '-fetch',
+         'notion-fetch',
+         'Fetch a Notion page',
+         true,
+         false,
+         connection.id,
+         CURRENT_TIMESTAMP,
+         CURRENT_TIMESTAMP
+       FROM connection
+       UNION ALL
+       SELECT
+         connection.id || '-search',
+         'notion-search',
+         'Search the connected Notion workspace',
+         false,
+         false,
+         connection.id,
+         CURRENT_TIMESTAMP,
+         CURRENT_TIMESTAMP
+       FROM connection
+       RETURNING id`,
+      [PLAYWRIGHT_TEST_EMAIL, INTEGRATION_ID],
+    );
+    if (result.rowCount !== 2) {
+      throw new Error("Could not seed the Playwright MCP integration");
+    }
+  });
+}
+
+export async function resetIntegrationTestState() {
+  await withClient(resetIntegrationState);
+}
+
+export function getIntegrationRow(page: Page, name: string) {
+  return page
+    .getByRole("row")
+    .filter({ has: page.getByText(name, { exact: true }) });
+}
+
+export function getIntegrationToolCard(page: Page, name: string) {
+  return page
+    .getByText(name, { exact: true })
+    .locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+}
+
+async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+async function resetIntegrationState(client: Client) {
+  await client.query(
+    `DELETE FROM "McpConnection"
+     WHERE "emailAccountId" = (
+       SELECT id FROM "EmailAccount" WHERE email = $1
+     )
+     AND "integrationId" = (
+       SELECT id FROM "McpIntegration" WHERE name = 'notion'
+     )`,
+    [PLAYWRIGHT_TEST_EMAIL],
+  );
+  await client.query(
+    `DELETE FROM "McpIntegration"
+     WHERE id = $1
+     AND NOT EXISTS (
+       SELECT 1 FROM "McpConnection" WHERE "integrationId" = $1
+     )`,
+    [INTEGRATION_ID],
+  );
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -157,17 +157,6 @@ test("Command K acts on highlighted and selected conversations", async ({
 
   await palette.getByRole("option", { name: "Mark 2 as read" }).click();
   await expect(palette).toBeHidden();
-  await page.keyboard.press(`${commandModifier}+KeyK`);
-  await expect(palette).toBeVisible();
-  await expect(
-    palette.getByRole("option", { name: "Mark 2 as read" }),
-  ).toHaveCount(0);
-  await expect(
-    palette.getByRole("option", { name: "Mark as unread" }),
-  ).toBeVisible();
-
-  await page.keyboard.press("Escape");
-  await expect(palette).toBeHidden();
   await conversations
     .getByRole("checkbox", { name: "Select conversation from Alice Example" })
     .click();
@@ -175,6 +164,9 @@ test("Command K acts on highlighted and selected conversations", async ({
     .getByRole("checkbox", { name: "Select conversation from Bob Example" })
     .click();
   await page.keyboard.press(`${commandModifier}+KeyK`);
+  await expect(
+    palette.getByRole("option", { name: "Mark 2 as unread" }),
+  ).toBeVisible();
   await expect(
     palette.getByRole("option", { name: "Snooze 2 conversations" }),
   ).toBeVisible();

--- a/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-core-flow.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-core-flow.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanUpMeetingBotFixture,
+  type MeetingBotFixture,
+  openMeetings,
+  prepareMeetingBotFixture,
+} from "./meeting-bot-test-helpers";
+
+let fixture: MeetingBotFixture | undefined;
+
+test.beforeEach(async ({ page }) => {
+  fixture = undefined;
+  fixture = await prepareMeetingBotFixture(page);
+});
+
+test.afterEach(async () => {
+  if (fixture) await cleanUpMeetingBotFixture(fixture);
+});
+
+test("enables the notetaker and persists meeting choices, notes, and settings", async ({
+  page,
+}) => {
+  if (!fixture) throw new Error("The Meeting Bot fixture was not prepared");
+  await openMeetings(page, fixture);
+
+  await expect(
+    page.getByRole("heading", { name: "Never write meeting notes again" }),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.getByRole("button", { name: "Get started" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Which meetings should we join?" }),
+  ).toBeVisible();
+  await page
+    .getByRole("group", { name: "Which meetings to join" })
+    .getByText("Only the ones I turn on myself", { exact: true })
+    .click();
+  await page
+    .getByRole("button", { name: "Start recording my meetings" })
+    .click();
+
+  await expect(
+    page.getByRole("heading", { name: "Meetings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole("heading", { name: "Up next" })).toBeVisible();
+
+  const upcomingToggle = page.getByRole("switch", {
+    name: "Record Product planning with notetaker",
+  });
+  await expect(upcomingToggle).toBeVisible({ timeout: 60_000 });
+  await expect(upcomingToggle).not.toBeChecked();
+  await upcomingToggle.click();
+  await expect(upcomingToggle).toBeChecked();
+
+  await page.getByRole("button", { name: "Recorded product review" }).click();
+  const meetingDialog = page.getByRole("dialog", {
+    name: "Recorded product review",
+  });
+  await expect(meetingDialog).toContainText(
+    "The team finalized the launch plan for onboarding improvements.",
+  );
+  await expect(meetingDialog).toContainText(
+    "Release the onboarding improvements on Friday.",
+  );
+  await expect(meetingDialog).toContainText(
+    "Prepare the customer announcement.",
+  );
+  await expect(meetingDialog).toContainText(
+    "We will ship the onboarding improvements on Friday.",
+  );
+  await expect(meetingDialog).toContainText("Follow-up draft is ready");
+  await meetingDialog.getByRole("button", { name: "Close" }).click();
+
+  await page.getByRole("button", { name: "Settings" }).click();
+  const settingsDialog = page.getByRole("dialog", {
+    name: "Notetaker settings",
+  });
+  const recapToggle = settingsDialog.getByRole("switch", {
+    name: "Email me the notes",
+  });
+  await expect(recapToggle).toBeChecked();
+  await recapToggle.click();
+  await expect(page.getByText("Settings saved", { exact: true })).toBeVisible();
+  await settingsDialog.getByRole("button", { name: "Close" }).click();
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Meetings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(
+    page.getByRole("switch", {
+      name: "Record Product planning with notetaker",
+    }),
+  ).toBeChecked({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Settings" }).click();
+  const persistedSettingsDialog = page.getByRole("dialog", {
+    name: "Notetaker settings",
+  });
+  await expect(
+    persistedSettingsDialog.getByRole("radio", {
+      name: "Only the ones I turn on myself",
+    }),
+  ).toBeChecked();
+  await expect(
+    persistedSettingsDialog.getByRole("switch", {
+      name: "Email me the notes",
+    }),
+  ).not.toBeChecked();
+});

--- a/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
@@ -1,0 +1,327 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const UPCOMING_EVENT_ID = "evt_playwright_meeting_bot";
+const RECORDED_MEETING_ID_PREFIX = "playwright_meeting_bot_recorded";
+const RECORDING_ID_PREFIX = "playwright_meeting_bot_recording";
+const CALENDAR_CONNECTION_ID_PREFIX = "playwright_meeting_bot_calendar";
+
+export type MeetingBotFixture = {
+  emailAccountId: string;
+  previousPremiumId: string | null;
+  previousSettings: {
+    enabled: boolean;
+    joinRule: string;
+    recapEmailEnabled: boolean;
+    followUpDraftEnabled: boolean;
+  };
+  premiumId: string;
+  recordedMeetingId: string;
+  recordingId: string;
+  calendarConnectionId: string;
+};
+
+export async function prepareMeetingBotFixture(
+  page: Page,
+): Promise<MeetingBotFixture> {
+  const { id: emailAccountId } = await getEmailAccount(page);
+  const runId = process.env.PLAYWRIGHT_RUN_ID ?? "local";
+  const premiumId = `playwright_meeting_bot_premium_${runId}`;
+  const recordedMeetingId = `${RECORDED_MEETING_ID_PREFIX}_${emailAccountId}`;
+  const recordingId = `${RECORDING_ID_PREFIX}_${emailAccountId}`;
+  const calendarConnectionId = `${CALENDAR_CONNECTION_ID_PREFIX}_${emailAccountId}`;
+
+  return withClient(async (client) => {
+    const result = await client.query<{
+      accessToken: string | null;
+      email: string;
+      expiresAt: Date | null;
+      followUpDraftEnabled: boolean;
+      joinRule: string;
+      meetingRecorderEnabled: boolean;
+      premiumId: string | null;
+      recapEmailEnabled: boolean;
+      refreshToken: string | null;
+    }>(
+      `SELECT
+         ea.email,
+         ea."meetingRecorderEnabled",
+         ea."meetingRecorderJoinRule"::text AS "joinRule",
+         ea."meetingRecorderRecapEmailEnabled" AS "recapEmailEnabled",
+         ea."meetingRecorderFollowUpDraftEnabled" AS "followUpDraftEnabled",
+         u."premiumId",
+         account.access_token AS "accessToken",
+         account.refresh_token AS "refreshToken",
+         account.expires_at AS "expiresAt"
+       FROM "EmailAccount" ea
+       JOIN "User" u ON u.id = ea."userId"
+       JOIN "Account" account ON account.id = ea."accountId"
+       WHERE ea.id = $1`,
+      [emailAccountId],
+    );
+    const account = result.rows[0];
+    if (!account) throw new Error("The Playwright email account was not found");
+
+    await deleteFixtureRows(client, {
+      emailAccountId,
+      recordedMeetingId,
+      recordingId,
+      calendarConnectionId,
+    });
+
+    await client.query(
+      `INSERT INTO "Premium" (
+         id, "createdAt", "updatedAt", "pendingInvites", tier,
+         "adminGrantTier", "adminGrantExpiresAt"
+       )
+       VALUES (
+         $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ARRAY[]::text[],
+         'PLUS_MONTHLY', 'PLUS_MONTHLY', CURRENT_TIMESTAMP + INTERVAL '1 day'
+       )
+       ON CONFLICT (id) DO UPDATE
+       SET
+         tier = EXCLUDED.tier,
+         "adminGrantTier" = EXCLUDED."adminGrantTier",
+         "adminGrantExpiresAt" = EXCLUDED."adminGrantExpiresAt",
+         "updatedAt" = CURRENT_TIMESTAMP`,
+      [premiumId],
+    );
+    await client.query(
+      `UPDATE "User"
+       SET "premiumId" = $2, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = (SELECT "userId" FROM "EmailAccount" WHERE id = $1)`,
+      [emailAccountId, premiumId],
+    );
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET
+         "meetingRecorderEnabled" = false,
+         "meetingRecorderJoinRule" = 'OFF',
+         "meetingRecorderRecapEmailEnabled" = true,
+         "meetingRecorderFollowUpDraftEnabled" = true,
+         "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+
+    await client.query(
+      `INSERT INTO "CalendarConnection" (
+         id, "createdAt", "updatedAt", provider, email,
+         "accessToken", "refreshToken", "expiresAt", "isConnected",
+         "emailAccountId"
+       )
+       VALUES (
+         $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'google', $2,
+         $3, $4, $5, true, $6
+       )`,
+      [
+        calendarConnectionId,
+        account.email,
+        account.accessToken,
+        account.refreshToken,
+        account.expiresAt,
+        emailAccountId,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "Calendar" (
+         id, "createdAt", "updatedAt", "calendarId", name, "primary",
+         "isEnabled", timezone, "connectionId"
+       )
+       VALUES (
+         $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'primary', $2, true,
+         true, 'UTC', $3
+       )`,
+      [
+        `playwright_meeting_bot_primary_${emailAccountId}`,
+        account.email,
+        calendarConnectionId,
+      ],
+    );
+
+    await seedRecordedMeeting(client, {
+      emailAccountId,
+      recordedMeetingId,
+      recordingId,
+    });
+
+    return {
+      emailAccountId,
+      previousPremiumId: account.premiumId,
+      previousSettings: {
+        enabled: account.meetingRecorderEnabled,
+        joinRule: account.joinRule,
+        recapEmailEnabled: account.recapEmailEnabled,
+        followUpDraftEnabled: account.followUpDraftEnabled,
+      },
+      premiumId,
+      recordedMeetingId,
+      recordingId,
+      calendarConnectionId,
+    };
+  });
+}
+
+export async function cleanUpMeetingBotFixture(fixture: MeetingBotFixture) {
+  await withClient(async (client) => {
+    await deleteFixtureRows(client, fixture);
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET
+         "meetingRecorderEnabled" = $2,
+         "meetingRecorderJoinRule" = $3::"MeetingJoinRule",
+         "meetingRecorderRecapEmailEnabled" = $4,
+         "meetingRecorderFollowUpDraftEnabled" = $5,
+         "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [
+        fixture.emailAccountId,
+        fixture.previousSettings.enabled,
+        fixture.previousSettings.joinRule,
+        fixture.previousSettings.recapEmailEnabled,
+        fixture.previousSettings.followUpDraftEnabled,
+      ],
+    );
+    await client.query(
+      `UPDATE "User"
+       SET "premiumId" = $2, "updatedAt" = CURRENT_TIMESTAMP
+       WHERE "premiumId" = $3
+         AND id = (SELECT "userId" FROM "EmailAccount" WHERE id = $1)`,
+      [fixture.emailAccountId, fixture.previousPremiumId, fixture.premiumId],
+    );
+    await client.query(`DELETE FROM "Premium" WHERE id = $1`, [
+      fixture.premiumId,
+    ]);
+  });
+}
+
+export async function openMeetings(page: Page, fixture: MeetingBotFixture) {
+  await page.goto(`/${fixture.emailAccountId}/meetings`);
+  await expect(page).toHaveURL(
+    new RegExp(`/${fixture.emailAccountId}/meetings(?:\\?.*)?$`),
+  );
+}
+
+async function seedRecordedMeeting(
+  client: Client,
+  fixture: Pick<
+    MeetingBotFixture,
+    "emailAccountId" | "recordedMeetingId" | "recordingId"
+  >,
+) {
+  const transcript = [
+    {
+      speakerName: "Alex",
+      startTime: 0,
+      endTime: 8,
+      text: "We will ship the onboarding improvements on Friday.",
+      isHost: true,
+    },
+    {
+      speakerName: "Jordan",
+      startTime: 9,
+      endTime: 16,
+      text: "I will prepare the customer announcement.",
+      isHost: false,
+    },
+  ];
+  const summary = {
+    overview: "The team finalized the launch plan for onboarding improvements.",
+    keyDecisions: ["Release the onboarding improvements on Friday."],
+    actionItems: [
+      {
+        description: "Prepare the customer announcement.",
+        owner: "Jordan",
+      },
+    ],
+    openQuestions: [],
+    nextSteps: ["Review the release checklist tomorrow."],
+  };
+
+  await client.query(
+    `INSERT INTO "MeetingRecording" (
+       id, "createdAt", "updatedAt", "meetingUrl", "normalizedMeetingUrl",
+       "meetingStartTime", status, transcript, "transcriptFetchedAt"
+     )
+     VALUES (
+       $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+       'https://meet.google.com/recorded-demo',
+       'https://meet.google.com/recorded-demo',
+       CURRENT_TIMESTAMP - INTERVAL '2 hours', 'DONE', $2::jsonb,
+       CURRENT_TIMESTAMP - INTERVAL '1 hour'
+     )`,
+    [fixture.recordingId, JSON.stringify(transcript)],
+  );
+  await client.query(
+    `INSERT INTO "Meeting" (
+       id, "createdAt", "updatedAt", "calendarEventId", "eventTitle",
+       "startTime", "endTime", attendees, "organizerEmail", "joinOverride",
+       "processingStatus", summary, "followUpDraftId", "recapSentAt",
+       "recordingId", "emailAccountId"
+     )
+     VALUES (
+       $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+       'evt_playwright_recorded_meeting', 'Recorded product review',
+       CURRENT_TIMESTAMP - INTERVAL '2 hours',
+       CURRENT_TIMESTAMP - INTERVAL '1 hour',
+       $2::jsonb, 'playwright-host@example.com', true,
+       'COMPLETED', $3::jsonb, 'playwright-follow-up-draft',
+       CURRENT_TIMESTAMP - INTERVAL '45 minutes', $4, $5
+     )`,
+    [
+      fixture.recordedMeetingId,
+      JSON.stringify([
+        { email: "playwright-host@example.com", name: "Alex" },
+        { email: "external-attendee@example.com", name: "Jordan" },
+      ]),
+      JSON.stringify(summary),
+      fixture.recordingId,
+      fixture.emailAccountId,
+    ],
+  );
+}
+
+async function deleteFixtureRows(
+  client: Client,
+  fixture: Pick<
+    MeetingBotFixture,
+    | "emailAccountId"
+    | "recordedMeetingId"
+    | "recordingId"
+    | "calendarConnectionId"
+  >,
+) {
+  await client.query(
+    `DELETE FROM "Meeting"
+     WHERE "emailAccountId" = $1
+       AND (id = $2 OR "calendarEventId" = $3)`,
+    [fixture.emailAccountId, fixture.recordedMeetingId, UPCOMING_EVENT_ID],
+  );
+  await client.query(`DELETE FROM "MeetingRecording" WHERE id = $1`, [
+    fixture.recordingId,
+  ]);
+  await client.query(`DELETE FROM "CalendarConnection" WHERE id = $1`, [
+    fixture.calendarConnectionId,
+  ]);
+}
+
+async function getEmailAccount(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccount = emailAccounts[0];
+  if (!emailAccount) throw new Error("The setup project created no account");
+  return emailAccount;
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/onboarding/control-onboarding.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/onboarding/control-onboarding.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import {
+  getPersistedOnboardingState,
+  openControlOnboarding,
+  resetOnboardingTestState,
+  setupOnboardingTestState,
+} from "./onboarding-test-helpers";
+
+test.beforeEach(async () => {
+  await setupOnboardingTestState();
+});
+
+test.afterEach(async () => {
+  await resetOnboardingTestState();
+});
+
+test("completes account setup and persists onboarding choices", async ({
+  page,
+}) => {
+  await openControlOnboarding(page);
+
+  await page.getByRole("button", { name: "Founder", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "What's the size of your company?" }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page
+    .getByRole("button", { name: "11-100 people", exact: true })
+    .click();
+  await expect(
+    page.getByRole("heading", {
+      name: "How did you hear about Inbox Zero?",
+    }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "GitHub", exact: true }).click();
+  await expect(
+    page.getByRole("heading", {
+      name: "How do you want your inbox organized?",
+    }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(
+    page.getByRole("heading", {
+      name: "Should we draft replies for you?",
+    }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Yes, please", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Custom rules", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Invite your team", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.getByRole("button", { name: "Skip", exact: true }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Labels are ready", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+
+  await expect(page).toHaveURL(/\/welcome-upgrade(?:\?.*)?$/, {
+    timeout: 60_000,
+  });
+  await expect(
+    page.getByRole("heading", { name: "Start your 7-day FREE trial" }),
+  ).toBeVisible();
+
+  await expect
+    .poll(getPersistedOnboardingState, { timeout: 30_000 })
+    .toMatchObject({
+      completed: true,
+      draftRepliesEnabled: true,
+      role: "Founder",
+      surveyCompanySize: 50,
+      surveyRole: "Founder",
+      surveySource: "github",
+    });
+  expect(
+    (await getPersistedOnboardingState())?.systemRuleCount,
+  ).toBeGreaterThan(0);
+});

--- a/apps/web/__tests__/playwright/emulated/onboarding/onboarding-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/onboarding/onboarding-test-helpers.ts
@@ -1,0 +1,171 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const PLAYWRIGHT_TEST_EMAIL =
+  process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
+
+type PreviousOnboardingState = {
+  completedOnboardingAt: Date | null;
+  emailAccountId: string;
+  onboardingAnswers: unknown;
+  role: string | null;
+  surveyCompanySize: number | null;
+  surveyRole: string | null;
+  surveySource: string | null;
+  userId: string;
+};
+
+let previousState: PreviousOnboardingState | undefined;
+
+export async function setupOnboardingTestState() {
+  previousState = undefined;
+
+  await withClient(async (client) => {
+    const result = await client.query<PreviousOnboardingState>(
+      `SELECT
+         u.id AS "userId",
+         ea.id AS "emailAccountId",
+         u."completedOnboardingAt",
+         u."onboardingAnswers",
+         u."surveyRole",
+         u."surveyCompanySize",
+         u."surveySource",
+         ea.role
+       FROM "User" u
+       INNER JOIN "EmailAccount" ea ON ea."userId" = u.id
+       WHERE ea.email = $1`,
+      [PLAYWRIGHT_TEST_EMAIL],
+    );
+    const candidateState = result.rows[0];
+    if (!candidateState) {
+      throw new Error("Could not find the Playwright onboarding account");
+    }
+
+    const rules = await client.query<{ count: number }>(
+      `SELECT count(*)::int AS count
+       FROM "Rule"
+       WHERE "emailAccountId" = $1`,
+      [candidateState.emailAccountId],
+    );
+    if (rules.rows[0]?.count !== 0) {
+      throw new Error("The Playwright onboarding account must start fresh");
+    }
+
+    previousState = candidateState;
+    await client.query(
+      `UPDATE "User"
+       SET "completedOnboardingAt" = NULL,
+           "onboardingAnswers" = NULL,
+           "surveyRole" = NULL,
+           "surveyCompanySize" = NULL,
+           "surveySource" = NULL
+       WHERE id = $1`,
+      [candidateState.userId],
+    );
+    await client.query(`UPDATE "EmailAccount" SET role = NULL WHERE id = $1`, [
+      candidateState.emailAccountId,
+    ]);
+  });
+}
+
+export async function resetOnboardingTestState() {
+  if (!previousState) return;
+  const state = previousState;
+
+  try {
+    await withClient(async (client) => {
+      await client.query(`DELETE FROM "Rule" WHERE "emailAccountId" = $1`, [
+        state.emailAccountId,
+      ]);
+      await client.query(
+        `UPDATE "User"
+         SET "completedOnboardingAt" = $2,
+             "onboardingAnswers" = $3,
+             "surveyRole" = $4,
+             "surveyCompanySize" = $5,
+             "surveySource" = $6
+         WHERE id = $1`,
+        [
+          state.userId,
+          state.completedOnboardingAt,
+          state.onboardingAnswers
+            ? JSON.stringify(state.onboardingAnswers)
+            : null,
+          state.surveyRole,
+          state.surveyCompanySize,
+          state.surveySource,
+        ],
+      );
+      await client.query(`UPDATE "EmailAccount" SET role = $2 WHERE id = $1`, [
+        state.emailAccountId,
+        state.role,
+      ]);
+    });
+  } finally {
+    previousState = undefined;
+  }
+}
+
+export async function openControlOnboarding(page: Page) {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.goto(`/${emailAccountId}/onboarding?step=who&variant=control`);
+  await expect(
+    page.getByRole("heading", { name: "What do you do?" }),
+  ).toBeVisible({ timeout: 60_000 });
+}
+
+export async function getPersistedOnboardingState() {
+  return withClient(async (client) => {
+    const result = await client.query<{
+      completed: boolean;
+      draftRepliesEnabled: boolean;
+      role: string | null;
+      surveyCompanySize: number | null;
+      surveyRole: string | null;
+      surveySource: string | null;
+      systemRuleCount: number;
+    }>(
+      `SELECT
+         u."completedOnboardingAt" IS NOT NULL AS completed,
+         ea.role,
+         u."surveyRole",
+         u."surveyCompanySize",
+         u."surveySource",
+         count(DISTINCT r.id)::int AS "systemRuleCount",
+         coalesce(bool_or(
+           r."systemType" = 'TO_REPLY'
+           AND r.enabled
+           AND a.type = 'DRAFT_EMAIL'
+         ), false) AS "draftRepliesEnabled"
+       FROM "User" u
+       INNER JOIN "EmailAccount" ea ON ea."userId" = u.id
+       LEFT JOIN "Rule" r ON r."emailAccountId" = ea.id
+       LEFT JOIN "Action" a ON a."ruleId" = r.id
+       WHERE ea.email = $1
+       GROUP BY u.id, ea.id`,
+      [PLAYWRIGHT_TEST_EMAIL],
+    );
+    return result.rows[0];
+  });
+}
+
+async function getEmailAccountId(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string }[];
+  };
+  const emailAccountId = emailAccounts[0]?.id;
+  if (!emailAccountId) throw new Error("The setup project created no account");
+  return emailAccountId;
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/settings/appearance.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/appearance.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { openSettings } from "./settings-test-helpers";
+
+let previousTheme: string | null | undefined;
+
+test.beforeEach(() => {
+  previousTheme = undefined;
+});
+
+test.afterEach(async ({ page }) => {
+  if (previousTheme === undefined) return;
+
+  await page.evaluate((theme) => {
+    if (theme === null) localStorage.removeItem("theme");
+    else localStorage.setItem("theme", theme);
+  }, previousTheme);
+  await page.reload();
+});
+
+test("persists the global appearance across reloads", async ({ page }) => {
+  await openSettings(page);
+
+  previousTheme = await page.evaluate(() => localStorage.getItem("theme"));
+  const darkModeToggle = page.getByRole("switch", {
+    name: "Toggle dark mode",
+  });
+  await expect(darkModeToggle).toBeEnabled();
+  const enableDarkMode = !(await darkModeToggle.isChecked());
+  const expectedTheme = enableDarkMode ? "dark" : "light";
+
+  await darkModeToggle.click();
+  await expect(darkModeToggle).toBeChecked({ checked: enableDarkMode });
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+    .toBe(expectedTheme);
+  await expectThemeClass(page, enableDarkMode);
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Settings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(
+    page.getByRole("switch", { name: "Toggle dark mode" }),
+  ).toBeChecked({ checked: enableDarkMode });
+  await expectThemeClass(page, enableDarkMode);
+});
+
+async function expectThemeClass(
+  page: Parameters<typeof openSettings>[0],
+  dark: boolean,
+) {
+  const html = page.locator("html");
+  if (dark) await expect(html).toHaveClass(/dark/);
+  else await expect(html).not.toHaveClass(/dark/);
+}

--- a/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
@@ -71,12 +71,14 @@ test("persists draft cleanup settings and disables all account rules", async ({
   ).toBeVisible({ timeout: 60_000 });
   accountCard = getEmailAccountSettingsCard(page, settingsFixture.email);
   await expect(accountCard.toggle).toBeVisible({ timeout: 60_000 });
-  const rulesResponse = page.waitForResponse(
-    (response) =>
-      new URL(response.url()).pathname === "/api/user/rules" && response.ok(),
-  );
-  await accountCard.toggle.click();
-  await rulesResponse;
+  const [rulesResponse] = await Promise.all([
+    page.waitForResponse(
+      (response) => new URL(response.url()).pathname === "/api/user/rules",
+      { timeout: 60_000 },
+    ),
+    accountCard.toggle.click(),
+  ]);
+  expect(rulesResponse.ok()).toBeTruthy();
   cleanupDaysInput = accountCard.card.getByRole("spinbutton", {
     name: "Draft cleanup age in days",
   });

--- a/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
@@ -71,14 +71,7 @@ test("persists draft cleanup settings and disables all account rules", async ({
   ).toBeVisible({ timeout: 60_000 });
   accountCard = getEmailAccountSettingsCard(page, settingsFixture.email);
   await expect(accountCard.toggle).toBeVisible({ timeout: 60_000 });
-  const [rulesResponse] = await Promise.all([
-    page.waitForResponse(
-      (response) => new URL(response.url()).pathname === "/api/user/rules",
-      { timeout: 60_000 },
-    ),
-    accountCard.toggle.click(),
-  ]);
-  expect(rulesResponse.ok()).toBeTruthy();
+  await accountCard.toggle.click();
   cleanupDaysInput = accountCard.card.getByRole("spinbutton", {
     name: "Draft cleanup age in days",
   });

--- a/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/email-account-settings.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanUpSettingsFixture,
+  getEmailAccountSettingsCard,
+  getSettingsDatabaseState,
+  openSettings,
+  prepareSettingsFixture,
+  type SettingsFixture,
+} from "./settings-test-helpers";
+
+let fixture: SettingsFixture | undefined;
+
+test.beforeEach(async ({ page }) => {
+  fixture = undefined;
+  fixture = await prepareSettingsFixture(page);
+});
+
+test.afterEach(async () => {
+  if (fixture) await cleanUpSettingsFixture(fixture);
+});
+
+test("persists draft cleanup settings and disables all account rules", async ({
+  page,
+}) => {
+  if (!fixture) throw new Error("The Settings fixture was not prepared");
+  const settingsFixture = fixture;
+  await openSettings(page);
+
+  let accountCard = getEmailAccountSettingsCard(page, settingsFixture.email);
+  await expect(accountCard.toggle).toBeVisible({ timeout: 60_000 });
+  await accountCard.toggle.click();
+
+  let cleanupDaysInput = accountCard.card.getByRole("spinbutton", {
+    name: "Draft cleanup age in days",
+  });
+  await expect(cleanupDaysInput).toHaveValue("7", { timeout: 60_000 });
+  await cleanupDaysInput.fill("21");
+  await cleanupDaysInput
+    .locator('xpath=ancestor::*[@data-slot="item-actions"]')
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect(
+    page.getByText("Draft cleanup settings updated.", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  const disableRulesItem = accountCard.card
+    .locator('[data-slot="item"]')
+    .filter({ hasText: "Disable All Rules" });
+  await expect(disableRulesItem).toBeVisible({ timeout: 60_000 });
+  await disableRulesItem.getByRole("button", { name: "Disable All" }).click();
+  const confirmation = page.getByRole("alertdialog", {
+    name: "Disable all rules?",
+  });
+  await confirmation.getByRole("button", { name: "Disable All" }).click();
+  await expect(
+    page.getByText("All rules disabled", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await expect
+    .poll(() => getSettingsDatabaseState(settingsFixture))
+    .toEqual({
+      draftCleanupDays: 21,
+      followUpAwaitingReplyDays: null,
+      followUpNeedsReplyDays: null,
+      ruleEnabled: false,
+    });
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Settings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  accountCard = getEmailAccountSettingsCard(page, settingsFixture.email);
+  await expect(accountCard.toggle).toBeVisible({ timeout: 60_000 });
+  const rulesResponse = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === "/api/user/rules" && response.ok(),
+  );
+  await accountCard.toggle.click();
+  await rulesResponse;
+  cleanupDaysInput = accountCard.card.getByRole("spinbutton", {
+    name: "Draft cleanup age in days",
+  });
+  await expect(cleanupDaysInput).toHaveValue("21", { timeout: 60_000 });
+  await expect(accountCard.card.getByText("Disable All Rules")).toHaveCount(0);
+});

--- a/apps/web/__tests__/playwright/emulated/settings/settings-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/settings-test-helpers.ts
@@ -1,0 +1,173 @@
+import { expect, type Page } from "@playwright/test";
+import { Client } from "pg";
+
+const SETTINGS_RULE_NAME = "Playwright settings rule";
+
+export type SettingsFixture = {
+  emailAccountId: string;
+  email: string;
+  ruleId: string;
+  previousDraftCleanupDays: number | null;
+  previousFollowUpAwaitingReplyDays: number | null;
+  previousFollowUpNeedsReplyDays: number | null;
+  previousRuleStates: { id: string; enabled: boolean }[];
+};
+
+export async function prepareSettingsFixture(
+  page: Page,
+): Promise<SettingsFixture> {
+  const { id: emailAccountId, email } = await getEmailAccount(page);
+  const ruleId = `playwright_settings_rule_${emailAccountId}`;
+
+  return withClient(async (client) => {
+    const accountResult = await client.query<{
+      draftCleanupDays: number | null;
+      followUpAwaitingReplyDays: number | null;
+      followUpNeedsReplyDays: number | null;
+    }>(
+      `SELECT
+         "draftCleanupDays",
+         "followUpAwaitingReplyDays",
+         "followUpNeedsReplyDays"
+       FROM "EmailAccount"
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+    const account = accountResult.rows[0];
+    if (!account) throw new Error("The Playwright email account was not found");
+
+    const ruleResult = await client.query<{ id: string; enabled: boolean }>(
+      `SELECT id, enabled
+       FROM "Rule"
+       WHERE "emailAccountId" = $1 AND id <> $2`,
+      [emailAccountId, ruleId],
+    );
+
+    await client.query(`DELETE FROM "Rule" WHERE id = $1`, [ruleId]);
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET
+         "draftCleanupDays" = 7,
+         "followUpAwaitingReplyDays" = 3,
+         "followUpNeedsReplyDays" = 5,
+         "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [emailAccountId],
+    );
+    await client.query(
+      `INSERT INTO "Rule" (
+         id, "createdAt", "updatedAt", name, enabled, automate,
+         "runOnThreads", instructions, "emailAccountId"
+       )
+       VALUES (
+         $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, true, true,
+         false, 'Archive routine settings test messages', $3
+       )`,
+      [ruleId, SETTINGS_RULE_NAME, emailAccountId],
+    );
+
+    return {
+      emailAccountId,
+      email,
+      ruleId,
+      previousDraftCleanupDays: account.draftCleanupDays,
+      previousFollowUpAwaitingReplyDays: account.followUpAwaitingReplyDays,
+      previousFollowUpNeedsReplyDays: account.followUpNeedsReplyDays,
+      previousRuleStates: ruleResult.rows,
+    };
+  });
+}
+
+export async function cleanUpSettingsFixture(fixture: SettingsFixture) {
+  await withClient(async (client) => {
+    await client.query(`DELETE FROM "Rule" WHERE id = $1`, [fixture.ruleId]);
+    for (const rule of fixture.previousRuleStates) {
+      await client.query(
+        `UPDATE "Rule"
+         SET enabled = $2, "updatedAt" = CURRENT_TIMESTAMP
+         WHERE id = $1 AND "emailAccountId" = $3`,
+        [rule.id, rule.enabled, fixture.emailAccountId],
+      );
+    }
+    await client.query(
+      `UPDATE "EmailAccount"
+       SET
+         "draftCleanupDays" = $2,
+         "followUpAwaitingReplyDays" = $3,
+         "followUpNeedsReplyDays" = $4,
+         "updatedAt" = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [
+        fixture.emailAccountId,
+        fixture.previousDraftCleanupDays,
+        fixture.previousFollowUpAwaitingReplyDays,
+        fixture.previousFollowUpNeedsReplyDays,
+      ],
+    );
+  });
+}
+
+export async function getSettingsDatabaseState(fixture: SettingsFixture) {
+  return withClient(async (client) => {
+    const result = await client.query<{
+      draftCleanupDays: number | null;
+      followUpAwaitingReplyDays: number | null;
+      followUpNeedsReplyDays: number | null;
+      ruleEnabled: boolean;
+    }>(
+      `SELECT
+         ea."draftCleanupDays",
+         ea."followUpAwaitingReplyDays",
+         ea."followUpNeedsReplyDays",
+         r.enabled AS "ruleEnabled"
+       FROM "EmailAccount" ea
+       JOIN "Rule" r ON r.id = $2 AND r."emailAccountId" = ea.id
+       WHERE ea.id = $1`,
+      [fixture.emailAccountId, fixture.ruleId],
+    );
+    const state = result.rows[0];
+    if (!state) throw new Error("The Playwright settings state was not found");
+    return state;
+  });
+}
+
+export async function openSettings(page: Page) {
+  await page.goto("/settings");
+  await expect(
+    page.getByRole("heading", { name: "Settings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+}
+
+export function getEmailAccountSettingsCard(page: Page, email: string) {
+  const emailAccountsSection = page.locator("section").filter({
+    has: page.getByRole("heading", { name: "Email Accounts", exact: true }),
+  });
+  const toggle = emailAccountsSection
+    .getByRole("button")
+    .filter({ hasText: email });
+  return {
+    card: toggle.locator("xpath=.."),
+    toggle,
+  };
+}
+
+async function getEmailAccount(page: Page) {
+  const response = await page.request.get("/api/user/email-accounts");
+  expect(response.ok()).toBeTruthy();
+  const { emailAccounts } = (await response.json()) as {
+    emailAccounts: { id: string; email: string }[];
+  };
+  const emailAccount = emailAccounts[0];
+  if (!emailAccount) throw new Error("The setup project created no account");
+  return emailAccount;
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -11,7 +11,11 @@ const suites = [
   "cleanup/analytics.spec.ts",
   "cleanup/bulk-archive.spec.ts",
   "cleanup/bulk-unsubscribe.spec.ts",
+  "integrations",
   "mail",
+  "meetings",
+  "onboarding",
+  "settings",
 ];
 const blobReportDir = path.resolve(".tmp/playwright/blob-report");
 const htmlReportDir = path.resolve("playwright-report");
@@ -38,6 +42,9 @@ for (const suite of suites) {
     {
       PLAYWRIGHT_BLOB_REPORT_FILE: path.join(blobReportDir, `${suiteName}.zip`),
       PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, suiteName),
+      ...(suite === "integrations"
+        ? { NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true" }
+        : {}),
     },
   );
 

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+const suites = [
+  "attachments",
+  "automation",
+  "calendars",
+  "channels",
+  "chat",
+  "cleanup/analytics.spec.ts",
+  "cleanup/bulk-archive.spec.ts",
+  "cleanup/bulk-unsubscribe.spec.ts",
+  "mail",
+];
+const blobReportDir = path.resolve(".tmp/playwright/blob-report");
+const htmlReportDir = path.resolve("playwright-report");
+const testResultsDir = path.resolve("test-results");
+
+rmSync(blobReportDir, { force: true, recursive: true });
+rmSync(htmlReportDir, { force: true, recursive: true });
+rmSync(testResultsDir, { force: true, recursive: true });
+mkdirSync(blobReportDir, { recursive: true });
+mkdirSync(testResultsDir, { recursive: true });
+
+let failed = false;
+
+for (const suite of suites) {
+  const suiteName = suite.replaceAll(/[/.]/g, "-");
+  const result = runPlaywright(
+    [
+      "test",
+      "-c",
+      "playwright.config.mjs",
+      "--project=emulated",
+      `__tests__/playwright/emulated/${suite}`,
+    ],
+    {
+      PLAYWRIGHT_BLOB_REPORT_FILE: path.join(blobReportDir, `${suiteName}.zip`),
+      PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, suiteName),
+    },
+  );
+
+  if (result.status !== 0) failed = true;
+}
+
+const mergeResult = runPlaywright(
+  ["merge-reports", "--reporter=html", blobReportDir],
+  { PLAYWRIGHT_HTML_OPEN: "never" },
+);
+
+if (mergeResult.status !== 0) failed = true;
+process.exitCode = failed ? 1 : 0;
+
+function runPlaywright(args, extraEnv) {
+  const result = spawnSync("pnpm", ["exec", "playwright", ...args], {
+    env: { ...process.env, ...extraEnv },
+    stdio: "inherit",
+  });
+
+  if (result.error) throw result.error;
+  return result;
+}

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -53,7 +53,8 @@ if (mergeResult.status !== 0) failed = true;
 process.exitCode = failed ? 1 : 0;
 
 function runPlaywright(args, extraEnv) {
-  const result = spawnSync("pnpm", ["exec", "playwright", ...args], {
+  const pnpmExecutable = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  const result = spawnSync(pnpmExecutable, ["exec", "playwright", ...args], {
     env: { ...process.env, ...extraEnv },
     stdio: "inherit",
   });

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
-const suites = [
+const fullSuites = [
   "attachments",
   "automation",
   "calendars",
@@ -17,55 +17,219 @@ const suites = [
   "onboarding",
   "settings",
 ];
-const blobReportDir = path.resolve(".tmp/playwright/blob-report");
+const cleanupSuites = fullSuites.filter((suite) =>
+  suite.startsWith("cleanup/"),
+);
+const changedTargetFiles = getChangedPlaywrightTargetFiles();
+const targets = changedTargetFiles.length
+  ? getChangedPlaywrightTargets(changedTargetFiles)
+  : getFullSuiteTargets();
+const dryRun = process.env.PLAYWRIGHT_DRY_RUN === "1";
+const playwrightRunRootDir = path.resolve(".tmp/playwright");
+const blobReportDir = path.join(playwrightRunRootDir, "blob-report");
 const htmlReportDir = path.resolve("playwright-report");
 const testResultsDir = path.resolve("test-results");
 
-rmSync(blobReportDir, { force: true, recursive: true });
-rmSync(htmlReportDir, { force: true, recursive: true });
-rmSync(testResultsDir, { force: true, recursive: true });
-mkdirSync(blobReportDir, { recursive: true });
-mkdirSync(testResultsDir, { recursive: true });
+if (!dryRun) {
+  rmSync(blobReportDir, { force: true, recursive: true });
+  rmSync(htmlReportDir, { force: true, recursive: true });
+  rmSync(testResultsDir, { force: true, recursive: true });
+  mkdirSync(blobReportDir, { recursive: true });
+  mkdirSync(testResultsDir, { recursive: true });
+}
 
 let failed = false;
 
-for (const suite of suites) {
-  const suiteName = suite.replaceAll(/[/.]/g, "-");
-  const result = runPlaywright(
-    [
-      "test",
-      "-c",
-      "playwright.config.mjs",
-      "--project=emulated",
-      `__tests__/playwright/emulated/${suite}`,
-    ],
-    {
-      PLAYWRIGHT_BLOB_REPORT_FILE: path.join(blobReportDir, `${suiteName}.zip`),
-      PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, suiteName),
-      ...(suite === "integrations"
-        ? { NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true" }
-        : {}),
-    },
+if (changedTargetFiles.length) {
+  console.log(
+    `Running ${targets.length} Playwright target(s) for changed files.`,
   );
+}
+
+for (const target of targets) {
+  console.log(`\n=== Running Playwright target: ${target.name} ===\n`);
+  const targetRunId = dryRun
+    ? `dry-run-${target.name}`
+    : `${process.pid}-${target.name}-${Date.now()}`;
+  const targetRunDir = path.join(playwrightRunRootDir, targetRunId);
+  let result;
+
+  try {
+    result = runPlaywright(
+      [
+        "test",
+        "-c",
+        "playwright.config.mjs",
+        "--project=emulated",
+        ...target.paths,
+      ],
+      {
+        PLAYWRIGHT_BLOB_REPORT_FILE: path.join(
+          blobReportDir,
+          `${target.name}.zip`,
+        ),
+        PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, target.name),
+        PLAYWRIGHT_RUN_ID: targetRunId,
+        ...(target.paths.some(isIntegrationsTarget)
+          ? { NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true" }
+          : {}),
+      },
+    );
+  } finally {
+    if (!dryRun) rmSync(targetRunDir, { force: true, recursive: true });
+  }
 
   if (result.status !== 0) failed = true;
 }
 
-const mergeResult = runPlaywright(
-  ["merge-reports", "--reporter=html", blobReportDir],
-  { PLAYWRIGHT_HTML_OPEN: "never" },
-);
+if (!dryRun) {
+  const mergeResult = runPlaywright(
+    ["merge-reports", "--reporter=html", blobReportDir],
+    { PLAYWRIGHT_HTML_OPEN: "never" },
+  );
 
-if (mergeResult.status !== 0) failed = true;
+  if (mergeResult.status !== 0) failed = true;
+}
 process.exitCode = failed ? 1 : 0;
 
 function runPlaywright(args, extraEnv) {
   const pnpmExecutable = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-  const result = spawnSync(pnpmExecutable, ["exec", "playwright", ...args], {
+  const pnpmArgs = ["exec", "playwright", ...args];
+  const command = [pnpmExecutable, ...pnpmArgs];
+
+  if (dryRun) {
+    console.log(command.join(" "));
+    if (Object.keys(extraEnv).length) {
+      console.log(JSON.stringify(extraEnv, null, 2));
+    }
+    return { status: 0 };
+  }
+
+  const result = spawnSync(pnpmExecutable, pnpmArgs, {
     env: { ...process.env, ...extraEnv },
     stdio: "inherit",
   });
 
   if (result.error) throw result.error;
   return result;
+}
+
+function getChangedPlaywrightTargetFiles() {
+  const changedFilesInput = process.env.PLAYWRIGHT_CHANGED_TEST_FILES?.trim();
+  if (!changedFilesInput) return [];
+
+  const normalizedFiles = [
+    ...new Set(
+      changedFilesInput
+        .split(/\r?\n/)
+        .map((file) => file.trim())
+        .filter(Boolean)
+        .map((file) => file.replace(/^apps\/web\//, "")),
+    ),
+  ];
+
+  if (
+    normalizedFiles.some((file) =>
+      file.startsWith("__tests__/playwright/emulated/setup/"),
+    )
+  ) {
+    console.log("Playwright setup changed; running the full emulated suite.");
+    return [];
+  }
+
+  const changedSpecFiles = normalizedFiles.filter((file) =>
+    isEmulatedSpecFile(file),
+  );
+  const changedSupportBoundaries = new Set(
+    normalizedFiles
+      .filter((file) => isEmulatedSupportFile(file))
+      .flatMap(getChangedSupportBoundaries),
+  );
+
+  return [
+    ...changedSpecFiles,
+    ...[...changedSupportBoundaries].map((boundary) =>
+      getPlaywrightTargetPath(boundary),
+    ),
+  ];
+}
+
+function getFullSuiteTargets() {
+  return fullSuites.map((suite) => ({
+    name: suite.replaceAll(/[/.]/g, "-"),
+    paths: [`__tests__/playwright/emulated/${suite}`],
+  }));
+}
+
+function getChangedPlaywrightTargets(files) {
+  const filesByBoundary = new Map();
+
+  for (const file of files) {
+    const boundary = getChangedFileBoundary(file);
+    const existingFiles = filesByBoundary.get(boundary) ?? [];
+    existingFiles.push(file);
+    filesByBoundary.set(boundary, existingFiles);
+  }
+
+  const knownBoundaries = new Set(fullSuites);
+  const orderedTargets = fullSuites
+    .map((suite) => {
+      const filesForSuite = filesByBoundary.get(suite);
+      if (!filesForSuite?.length) return;
+      const suitePath = getPlaywrightTargetPath(suite);
+
+      return {
+        name: suite.replaceAll(/[/.]/g, "-"),
+        paths: filesForSuite.includes(suitePath) ? [suitePath] : filesForSuite,
+      };
+    })
+    .filter(Boolean);
+
+  const extraTargets = [...filesByBoundary.entries()]
+    .filter(([boundary]) => !knownBoundaries.has(boundary))
+    .map(([boundary, filesForBoundary]) => ({
+      name: boundary.replaceAll(/[/.]/g, "-"),
+      paths: filesForBoundary.includes(getPlaywrightTargetPath(boundary))
+        ? [getPlaywrightTargetPath(boundary)]
+        : filesForBoundary,
+    }));
+
+  return [...orderedTargets, ...extraTargets];
+}
+
+function getChangedFileBoundary(file) {
+  const relativePath = file.replace(/^__tests__\/playwright\/emulated\//, "");
+
+  if (relativePath.startsWith("cleanup/")) return relativePath;
+
+  return relativePath.split("/")[0];
+}
+
+function getChangedSupportBoundaries(file) {
+  const boundary = getChangedFileBoundary(file);
+
+  if (boundary.startsWith("cleanup/")) return cleanupSuites;
+
+  return [boundary];
+}
+
+function getPlaywrightTargetPath(target) {
+  if (target.startsWith("__tests__/playwright/")) return target;
+  return `__tests__/playwright/emulated/${target}`;
+}
+
+function isEmulatedSpecFile(file) {
+  return /^__tests__\/playwright\/emulated\/.*\.spec\.[cm]?[jt]sx?$/.test(file);
+}
+
+function isEmulatedSupportFile(file) {
+  return (
+    file.startsWith("__tests__/playwright/emulated/") &&
+    !file.startsWith("__tests__/playwright/emulated/setup/") &&
+    !isEmulatedSpecFile(file)
+  );
+}
+
+function isIntegrationsTarget(targetPath) {
+  return /\/integrations(?:\/|$)/.test(targetPath);
 }

--- a/apps/web/emulate.playwright.config.yaml
+++ b/apps/web/emulate.playwright.config.yaml
@@ -153,6 +153,38 @@ google:
         - INBOX
         - UNREAD
       internal_date: "1735038000000"
+    - id: msg_playwright_cleanup_block
+      thread_id: thr_playwright_cleanup_block
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Cleanup Weekly <cleanup-block@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Cleanup Block Candidate
+      body_text: This sender is reserved for the bulk unsubscribe flow.
+      label_ids:
+        - INBOX
+        - UNREAD
+      internal_date: "1786838400000"
+    - id: msg_playwright_cleanup_archive
+      thread_id: thr_playwright_cleanup_archive
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Cleanup Newsletter <cleanup-archive@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Cleanup Category Archive Candidate
+      body_text: This sender is reserved for the bulk archive flow.
+      label_ids:
+        - INBOX
+        - UNREAD
+      internal_date: "1786752000000"
+    - id: msg_playwright_cleanup_keep
+      thread_id: thr_playwright_cleanup_keep
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      from: Cleanup Keep <cleanup-keep@example.com>
+      to: __PLAYWRIGHT_TEST_EMAIL__
+      subject: Cleanup Category Keep Candidate
+      body_text: This message must remain in the inbox after selective cleanup.
+      label_ids:
+        - INBOX
+      internal_date: "1786665600000"
   calendars:
     - id: primary
       user_email: __PLAYWRIGHT_TEST_EMAIL__

--- a/apps/web/emulate.playwright.config.yaml
+++ b/apps/web/emulate.playwright.config.yaml
@@ -192,6 +192,21 @@ google:
       primary: true
       selected: true
       time_zone: UTC
+  calendar_events:
+    - id: evt_playwright_meeting_bot
+      user_email: __PLAYWRIGHT_TEST_EMAIL__
+      calendar_id: primary
+      summary: Product planning with notetaker
+      start_date_time: "__PLAYWRIGHT_MEETING_START__"
+      end_date_time: "__PLAYWRIGHT_MEETING_END__"
+      hangout_link: https://meet.google.com/abc-defg-hij
+      attendees:
+        - email: __PLAYWRIGHT_TEST_EMAIL__
+        - email: external-attendee@example.com
+          display_name: External Teammate
+      conference_entry_points:
+        - entry_point_type: video
+          uri: https://meet.google.com/abc-defg-hij
   drive_items:
     - id: drv_root_child
       user_email: __PLAYWRIGHT_TEST_EMAIL__

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,7 @@ const withMDX = nextMdx({
 
 const isDevelopment = process.env.NODE_ENV === "development";
 const isProductionBuild = process.env.NODE_ENV === "production";
+const playwrightRunId = process.env.PLAYWRIGHT_RUN_ID;
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const nextPackageRoot = path.dirname(
   realpathSync(require.resolve("next/package.json")),
@@ -26,6 +27,13 @@ const zodV4CorePath = path.join(
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
+  // Sequential Playwright feature groups use separate dev servers. Isolating
+  // their caches prevents a new Turbopack process from restoring stale tasks.
+  ...(playwrightRunId
+    ? {
+        distDir: path.join(".tmp", "playwright", playwrightRunId, "next"),
+      }
+    : {}),
   experimental:
     isDevelopment || isProductionBuild
       ? {
@@ -39,6 +47,11 @@ const nextConfig: NextConfig = {
                 // route modules into memory at startup during local
                 // development.
                 preloadEntriesOnStart: false,
+                // Playwright already isolates feature groups in short-lived
+                // dev servers. Restarting one mid-test aborts active requests.
+                ...(playwrightRunId
+                  ? { devMemoryThresholdRestart: false }
+                  : {}),
               }
             : {}),
           ...(isProductionBuild

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
     "telegram:setup": "dotenv -e .env.local -- tsx scripts/setup-telegram-bot.ts",
     "test": "cross-env RUN_AI_TESTS=false vitest",
     "test:playwright": "playwright test -c playwright.config.mjs",
-    "test:playwright:emulated": "playwright test -c playwright.config.mjs --project=emulated",
+    "test:playwright:emulated": "node __tests__/playwright/run-emulated-suite.mjs",
     "test:playwright:emulated:setup": "playwright test -c playwright.config.mjs --project=emulated-setup",
     "test-ai": "cross-env RUN_AI_TESTS=true vitest --run",
     "test-db": "cross-env RUN_DB_TESTS=true vitest --run --dir __tests__/db",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -15,6 +15,7 @@ const emulateBaseUrl =
   process.env.GOOGLE_BASE_URL ?? `http://localhost:${await getAvailablePort()}`;
 const emulatePort = getUrlPort(emulateBaseUrl);
 const internalApiKey = process.env.INTERNAL_API_KEY ?? "secret";
+const nodeOptions = process.env.NODE_OPTIONS ?? "--max_old_space_size=6144";
 const runId = process.env.PLAYWRIGHT_RUN_ID ?? `${process.pid}-${Date.now()}`;
 const playwrightTestEmail =
   process.env.PLAYWRIGHT_TEST_EMAIL ??
@@ -41,6 +42,7 @@ process.env.DATABASE_URL = databaseUrl;
 process.env.GOOGLE_BASE_URL = emulateBaseUrl;
 process.env.INTERNAL_API_KEY = internalApiKey;
 process.env.NEXT_PUBLIC_BASE_URL = baseURL;
+process.env.NODE_OPTIONS = nodeOptions;
 process.env.PLAYWRIGHT_AUTH_FILE = authStatePath;
 process.env.PLAYWRIGHT_RUN_ID = runId;
 process.env.PLAYWRIGHT_TEST_EMAIL = playwrightTestEmail;
@@ -97,7 +99,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `pnpm exec next dev --webpack --port ${basePort}`,
+      command: `pnpm exec next dev --turbopack --port ${basePort}`,
       cwd: process.cwd(),
       url: `${baseURL}/login`,
       timeout: 240_000,
@@ -105,6 +107,7 @@ export default defineConfig({
       env: {
         ...process.env,
         NODE_ENV: "development",
+        NODE_OPTIONS: nodeOptions,
         NEXT_PUBLIC_BASE_URL: baseURL,
         DATABASE_URL: databaseUrl,
         AUTH_SECRET: process.env.AUTH_SECRET ?? "secret",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -19,6 +19,7 @@ const runId = process.env.PLAYWRIGHT_RUN_ID ?? `${process.pid}-${Date.now()}`;
 const playwrightTestEmail =
   process.env.PLAYWRIGHT_TEST_EMAIL ??
   `playwright-test+${runId}@gmail.com`.toLowerCase();
+const blobReportFile = process.env.PLAYWRIGHT_BLOB_REPORT_FILE;
 const authStatePath = path.join(
   process.cwd(),
   ".tmp",
@@ -46,6 +47,7 @@ process.env.PLAYWRIGHT_TEST_EMAIL = playwrightTestEmail;
 
 export default defineConfig({
   testDir: "./__tests__/playwright",
+  outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR,
   forbidOnly: !!process.env.CI,
   fullyParallel: false,
   // Every browser test shares one seeded provider and one authenticated account.
@@ -55,11 +57,17 @@ export default defineConfig({
   expect: {
     timeout: 20_000,
   },
-  reporter: [
-    ...(process.env.CI ? [["github"]] : []),
-    ["list"],
-    ["html", { open: "never", outputFolder: "playwright-report" }],
-  ],
+  reporter: blobReportFile
+    ? [
+        ...(process.env.CI ? [["github"]] : []),
+        ["list"],
+        ["blob", { outputFile: blobReportFile }],
+      ]
+    : [
+        ...(process.env.CI ? [["github"]] : []),
+        ["list"],
+        ["html", { open: "never", outputFolder: "playwright-report" }],
+      ],
   use: {
     baseURL,
     trace: "retain-on-failure",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -140,6 +140,8 @@ export default defineConfig({
         NEXT_PUBLIC_DUB_REFER_DOMAIN: "",
         NEXT_PUBLIC_IS_RESEND_CONFIGURED: "",
         NEXT_PUBLIC_CONTACTS_ENABLED: "false",
+        NEXT_PUBLIC_MEETING_RECORDER_ENABLED:
+          process.env.NEXT_PUBLIC_MEETING_RECORDER_ENABLED ?? "true",
         PLAYWRIGHT_TEST_EMAIL: playwrightTestEmail,
       },
     },
@@ -154,13 +156,17 @@ function writeEmulateSeed({ baseURL, playwrightTestEmail, runId }) {
   const outputDir = path.join(process.cwd(), ".tmp", "playwright", runId);
   const outputPath = path.join(outputDir, "emulate.playwright.generated.yaml");
   const redirectUri = new URL("/api/auth/oauth2/callback/google", baseURL).href;
+  const meetingStart = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  const meetingEnd = new Date(meetingStart.getTime() + 30 * 60 * 1000);
 
   fs.mkdirSync(outputDir, { recursive: true });
 
   const seed = fs
     .readFileSync(templatePath, "utf8")
     .replaceAll("__PLAYWRIGHT_TEST_EMAIL__", playwrightTestEmail)
-    .replaceAll("__PLAYWRIGHT_TEST_REDIRECT_URI__", redirectUri);
+    .replaceAll("__PLAYWRIGHT_TEST_REDIRECT_URI__", redirectUri)
+    .replaceAll("__PLAYWRIGHT_MEETING_START__", meetingStart.toISOString())
+    .replaceAll("__PLAYWRIGHT_MEETING_END__", meetingEnd.toISOString());
 
   fs.writeFileSync(outputPath, seed);
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260817-115807_pr-3316_8653a7a5b551/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds emulator-backed Playwright coverage for core sidebar flows beyond Mail and shards the emulated suite by product area to keep the Next development server within its memory budget.

- cover Chat, Assistant, Channels, Cleanup, Calendars, and Attachments core user flows
- add deterministic database and provider fixtures plus seeded cleanup messages
- preserve existing Mail coverage and merge per-shard reports
- validate 29 expected executions with 0 unexpected, skipped, or flaky results

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->