### PR TITLE
desktop: Simplify the download hero

### DIFF
--- a/apps/web/components/new-landing/BrandScroller.tsx
+++ b/apps/web/components/new-landing/BrandScroller.tsx
@@ -10,14 +10,16 @@ import { cn } from "@/utils";
 interface BrandScrollerProps {
   animate?: boolean;
   brandList?: Brand[];
+  className?: string;
 }
 
 export const BrandScroller = ({
   brandList = BRANDS_LIST.default,
   animate = true,
+  className,
 }: BrandScrollerProps) => (
   <BlurFade duration={0.4} delay={0.125 * 10}>
-    <div className="mt-12">
+    <div className={cn("mt-12", className)}>
       <Paragraph>
         Join {userCount} professionals, including people at:
       </Paragraph>

--- a/apps/web/components/new-landing/DesktopDownloadCta.tsx
+++ b/apps/web/components/new-landing/DesktopDownloadCta.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Apple, ArrowRight, Download, Monitor } from "lucide-react";
+import { Apple, Download, Monitor } from "lucide-react";
 import { BlurFade } from "@/components/new-landing/common/BlurFade";
 import { Button } from "@/components/new-landing/common/Button";
 import { Paragraph } from "@/components/new-landing/common/Typography";
-import { Gmail } from "@/components/new-landing/icons/Gmail";
-import { Outlook } from "@/components/new-landing/icons/Outlook";
 import {
   DESKTOP_GITHUB_REPO,
   detectDesktopClientPlatform,
@@ -72,7 +69,7 @@ export function DesktopDownloadCta({
   return (
     <>
       <BlurFade duration={0.4} delay={0.3}>
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex justify-center">
           {ctas.primary ? (
             <Button size="lg" asChild>
               <a href={ctas.primary.href}>
@@ -96,38 +93,14 @@ export function DesktopDownloadCta({
               </a>
             </Button>
           )}
-          <Button variant="secondary-two" size="lg" asChild>
-            <Link href="/login">
-              <span className="flex items-center gap-2">
-                Get started on web
-                <ArrowRight className="size-4" />
-              </span>
-            </Link>
-          </Button>
         </div>
       </BlurFade>
 
       <BlurFade duration={0.4} delay={0.4}>
-        <div className="mt-6 space-y-2">
-          <div className="flex items-center gap-2">
-            <Paragraph color="light" size="sm">
-              Works with
-            </Paragraph>
-            <Outlook />
-            <Gmail />
-          </div>
+        <div className="mt-4 text-center">
           <Paragraph color="light" size="sm">
-            {ctas.alternatives.map((item, index) => (
-              <span key={item.href}>
-                {index > 0 ? " · " : null}
-                <a href={item.href} className="underline underline-offset-2">
-                  {item.shortLabel}
-                </a>
-              </span>
-            ))}
-            {ctas.alternatives.length > 0 ? " · " : null}
             <a href={allDownloadsHref} className="underline underline-offset-2">
-              All downloads
+              Other downloads
             </a>
           </Paragraph>
         </div>

--- a/apps/web/utils/desktop/github-release.ts
+++ b/apps/web/utils/desktop/github-release.ts
@@ -116,14 +116,13 @@ export function getDesktopDownloadCtas(
   alternatives: DesktopDownloadCta[];
   primary: DesktopDownloadCta | null;
 } {
-  const versionSuffix = downloads.version ? ` ${downloads.version}` : "";
   const options: Array<DesktopDownloadCta & { match: boolean }> = [];
 
   if (downloads.macArm64Dmg) {
     options.push({
       href: downloads.macArm64Dmg,
       kind: "mac",
-      label: `Download for Mac (Apple Silicon)${versionSuffix}`,
+      label: "Download for Mac",
       match: platform.os === "mac" && platform.arch !== "x64",
       shortLabel: "Mac (Apple Silicon)",
     });
@@ -132,7 +131,7 @@ export function getDesktopDownloadCtas(
     options.push({
       href: downloads.macX64Dmg,
       kind: "mac",
-      label: `Download for Mac Intel${versionSuffix}`,
+      label: "Download for Mac",
       match: platform.os === "mac" && platform.arch === "x64",
       shortLabel: "Mac Intel",
     });
@@ -141,7 +140,7 @@ export function getDesktopDownloadCtas(
     options.push({
       href: downloads.winX64Exe,
       kind: "windows",
-      label: `Download for Windows${versionSuffix}`,
+      label: "Download for Windows",
       match: platform.os === "windows" && platform.arch !== "arm",
       shortLabel: "Windows",
     });
@@ -150,7 +149,7 @@ export function getDesktopDownloadCtas(
     options.push({
       href: downloads.winArm64Exe,
       kind: "windows",
-      label: `Download for Windows (ARM)${versionSuffix}`,
+      label: "Download for Windows",
       match: platform.os === "windows" && platform.arch === "arm",
       shortLabel: "Windows ARM",
     });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260816-201445_pr-3317_69ecb45b5341/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Center and streamline the desktop download experience. The matching marketing page has also been updated.\n\n- simplify platform-specific download labels and secondary links\n- support centered social proof with more spacing\n- validate desktop release selection with 11 focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->