### PR TITLE
desktop: Fix electron-updater crash on Dynamic require of fs

### DIFF
--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -1,4 +1,5 @@
 import * as esbuild from "esbuild";
+import { ESM_MAIN_REQUIRE_BANNER } from "./esm-main-banner.mjs";
 
 const shared = {
   bundle: true,
@@ -13,6 +14,9 @@ await esbuild.build({
   entryPoints: ["src/main.ts"],
   outfile: "dist/main.js",
   format: "esm",
+  // electron-updater and fs-extra are CJS. esbuild rewrites their require("fs")
+  // calls to a helper that throws in ESM unless require exists in this module.
+  banner: { js: ESM_MAIN_REQUIRE_BANNER },
 });
 
 await esbuild.build({

--- a/apps/desktop/esbuild.config.mjs
+++ b/apps/desktop/esbuild.config.mjs
@@ -1,16 +1,11 @@
 import * as esbuild from "esbuild";
-import { ESM_MAIN_REQUIRE_BANNER } from "./esm-main-banner.mjs";
-
-const shared = {
-  bundle: true,
-  platform: "node",
-  target: "node22",
-  external: ["electron"],
-  sourcemap: true,
-};
+import {
+  desktopEsbuildShared,
+  ESM_MAIN_REQUIRE_BANNER,
+} from "./esm-main-banner.mjs";
 
 await esbuild.build({
-  ...shared,
+  ...desktopEsbuildShared,
   entryPoints: ["src/main.ts"],
   outfile: "dist/main.js",
   format: "esm",
@@ -20,7 +15,7 @@ await esbuild.build({
 });
 
 await esbuild.build({
-  ...shared,
+  ...desktopEsbuildShared,
   entryPoints: ["src/preload.ts"],
   outfile: "dist/preload.cjs",
   format: "cjs",

--- a/apps/desktop/esm-main-banner.mjs
+++ b/apps/desktop/esm-main-banner.mjs
@@ -1,2 +1,10 @@
 export const ESM_MAIN_REQUIRE_BANNER =
   'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);';
+
+export const desktopEsbuildShared = {
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  external: ["electron"],
+  sourcemap: true,
+};

--- a/apps/desktop/esm-main-banner.mjs
+++ b/apps/desktop/esm-main-banner.mjs
@@ -1,0 +1,2 @@
+export const ESM_MAIN_REQUIRE_BANNER =
+  'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);';

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startDesktopAutoUpdate } from "./auto-update";
 
 const { autoUpdater, app } = vi.hoisted(() => ({
@@ -7,7 +7,6 @@ const { autoUpdater, app } = vi.hoisted(() => ({
     autoDownload: false,
     autoInstallOnAppQuit: false,
     checkForUpdatesAndNotify: vi.fn(),
-    logger: { error: vi.fn() },
     setFeedURL: vi.fn(),
   },
 }));
@@ -16,11 +15,17 @@ vi.mock("electron", () => ({ app }));
 vi.mock("electron-updater", () => ({ autoUpdater }));
 
 describe("startDesktopAutoUpdate", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     autoUpdater.checkForUpdatesAndNotify.mockReset();
-    autoUpdater.logger.error.mockReset();
     autoUpdater.setFeedURL.mockReset();
     app.isPackaged = true;
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
   it("skips the update check in development", async () => {
@@ -34,7 +39,7 @@ describe("startDesktopAutoUpdate", () => {
     );
 
     await expect(startDesktopAutoUpdate(true)).resolves.toBe(false);
-    expect(autoUpdater.logger.error).toHaveBeenCalledWith("feed unavailable");
+    expect(console.error).toHaveBeenCalledWith("feed unavailable");
   });
 
   it("records feed setup failures from setFeedURL", async () => {
@@ -43,7 +48,7 @@ describe("startDesktopAutoUpdate", () => {
     });
 
     await expect(startDesktopAutoUpdate(true)).resolves.toBe(false);
-    expect(autoUpdater.logger.error).toHaveBeenCalledWith("invalid feed URL");
+    expect(console.error).toHaveBeenCalledWith("invalid feed URL");
     expect(autoUpdater.checkForUpdatesAndNotify).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,9 +1,8 @@
 import { app } from "electron";
-import { autoUpdater } from "electron-updater";
 import { getDesktopUpdateFeedUrl } from "./update-feed";
 
 export function logDesktopUpdateError(error: unknown) {
-  autoUpdater.logger?.error(
+  console.error(
     error instanceof Error ? error.message : "Desktop update check failed",
   );
 }
@@ -14,6 +13,7 @@ export async function startDesktopAutoUpdate(
   if (!isPackaged) return false;
 
   try {
+    const { autoUpdater } = await import("electron-updater");
     autoUpdater.setFeedURL({
       provider: "generic",
       url: getDesktopUpdateFeedUrl(),

--- a/apps/desktop/src/esm-bundle-require.test.ts
+++ b/apps/desktop/src/esm-bundle-require.test.ts
@@ -1,0 +1,69 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import * as esbuild from "esbuild";
+import { describe, expect, it } from "vitest";
+import { ESM_MAIN_REQUIRE_BANNER } from "../esm-main-banner.mjs";
+
+const DYNAMIC_FS_CJS =
+  'module.exports = { exists: require("fs" + "").existsSync };\n';
+
+async function bundleFixture(dir: string, banner?: string) {
+  writeFileSync(path.join(dir, "dep.cjs"), DYNAMIC_FS_CJS);
+  writeFileSync(
+    path.join(dir, "entry.js"),
+    'import dep from "./dep.cjs"; export const exists = dep.exists(".");\n',
+  );
+  const outfile = path.join(dir, "out.mjs");
+  await esbuild.build({
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    entryPoints: [path.join(dir, "entry.js")],
+    outfile,
+    ...(banner ? { banner: { js: banner } } : {}),
+  });
+  return outfile;
+}
+
+describe("esm main bundle require banner", () => {
+  it("is applied to the Electron main process build", () => {
+    const config = readFileSync(
+      new URL("../esbuild.config.mjs", import.meta.url),
+      "utf8",
+    );
+    expect(config).toContain("ESM_MAIN_REQUIRE_BANNER");
+    expect(config).toContain('format: "esm"');
+  });
+
+  it("lets bundled CJS dependencies require node builtins", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "desktop-esm-require-"));
+    try {
+      const outfile = await bundleFixture(dir, ESM_MAIN_REQUIRE_BANNER);
+      const mod = (await import(pathToFileURL(outfile).href)) as {
+        exists: boolean;
+      };
+      expect(mod.exists).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws without the banner when Node loads the ESM bundle", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "desktop-esm-require-"));
+    try {
+      const outfile = await bundleFixture(dir);
+      const result = spawnSync(process.execPath, [outfile], {
+        encoding: "utf8",
+      });
+      expect(result.status).not.toBe(0);
+      expect(`${result.stderr}${result.stdout}`).toMatch(
+        /Dynamic require of "fs" is not supported/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/esm-bundle-require.test.ts
+++ b/apps/desktop/src/esm-bundle-require.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import * as esbuild from "esbuild";
 import { describe, expect, it } from "vitest";
-import { ESM_MAIN_REQUIRE_BANNER } from "../esm-main-banner.mjs";
+import {
+  desktopEsbuildShared,
+  ESM_MAIN_REQUIRE_BANNER,
+} from "../esm-main-banner.mjs";
 
 const DYNAMIC_FS_CJS =
   'module.exports = { exists: require("fs" + "").existsSync };\n';
@@ -18,8 +21,7 @@ async function bundleFixture(dir: string, banner?: string) {
   );
   const outfile = path.join(dir, "out.mjs");
   await esbuild.build({
-    bundle: true,
-    platform: "node",
+    ...desktopEsbuildShared,
     format: "esm",
     entryPoints: [path.join(dir, "entry.js")],
     outfile,
@@ -34,6 +36,7 @@ describe("esm main bundle require banner", () => {
       new URL("../esbuild.config.mjs", import.meta.url),
       "utf8",
     );
+    expect(config).toContain("desktopEsbuildShared");
     expect(config).toContain("ESM_MAIN_REQUIRE_BANNER");
     expect(config).toContain('format: "esm"');
   });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260816-202221_pr-3318_4d9aab9703cd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Packaged 0.1.2 crashes on launch with `Dynamic require of \"fs\" is not supported` because `electron-updater` (CJS) is bundled into an ESM main file.
- Inject `createRequire` so those `require(\"fs\")` calls work, and log updater failures with `console.error` so a load error cannot take down the app.

## Test plan
- [ ] `pnpm --filter @inboxzero/desktop test`
- [ ] Packaged Mac app opens without the main-process JavaScript error dialog
- [ ] Auto-update still checks the generic `desktop-updates` feed after sign-in


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->