### PR TITLE
mail: Prepare adjacent email content

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
@@ -10,10 +10,17 @@ const cache = vi.hoisted(() => ({
   read: vi.fn(),
   write: vi.fn(),
 }));
+const emailHtml = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
 
 vi.mock("@/utils/email-cache/threads", () => ({
   readCachedThread: cache.read,
   writeCachedThread: cache.write,
+}));
+
+vi.mock("@/utils/email/prepare-html.client", () => ({
+  prepareEmailHtml: emailHtml.prepare,
 }));
 
 describe("useAdjacentThreadPrefetch", () => {
@@ -21,6 +28,7 @@ describe("useAdjacentThreadPrefetch", () => {
     vi.clearAllMocks();
     cache.read.mockResolvedValue(undefined);
     cache.write.mockResolvedValue(undefined);
+    emailHtml.prepare.mockResolvedValue(undefined);
     Object.defineProperty(window, "requestIdleCallback", {
       configurable: true,
       value: (callback: IdleRequestCallback) => {
@@ -77,6 +85,56 @@ describe("useAdjacentThreadPrefetch", () => {
       await Promise.resolve();
     });
     expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("prepares the visible message html while prefetching a conversation", async () => {
+    const fetcher = vi.fn((key: [string, string]) => {
+      const threadId = key[0].includes("thread-1") ? "thread-1" : "thread-3";
+      return Promise.resolve({
+        thread: {
+          id: threadId,
+          messages: [
+            {
+              id: `${threadId}-older`,
+              labelIds: [],
+              textHtml: `<p>${threadId} older</p>`,
+            },
+            {
+              id: `${threadId}-draft`,
+              labelIds: ["DRAFT"],
+              textHtml: `<p>${threadId} draft</p>`,
+            },
+            {
+              id: `${threadId}-latest`,
+              labelIds: [],
+              textHtml: `<p>${threadId} latest</p>`,
+            },
+          ],
+        },
+      });
+    });
+
+    renderHook(
+      () =>
+        useAdjacentThreadPrefetch({
+          currentThreadId: "thread-2",
+          emailAccountId: "account-1",
+          threadIds: ["thread-1", "thread-2", "thread-3"],
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    await waitFor(() => expect(emailHtml.prepare).toHaveBeenCalledTimes(2));
+    expect(emailHtml.prepare.mock.calls.map(([input]) => input)).toEqual([
+      {
+        messageId: "thread-1-latest",
+        html: "<p>thread-1 latest</p>",
+      },
+      {
+        messageId: "thread-3-latest",
+        html: "<p>thread-3 latest</p>",
+      },
+    ]);
   });
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
@@ -11,6 +11,7 @@ import {
   readCachedThread,
   writeCachedThread,
 } from "@/utils/email-cache/threads";
+import { prepareEmailHtml } from "@/utils/email/prepare-html.client";
 
 export function useAdjacentThreadPrefetch({
   currentThreadId,
@@ -59,6 +60,7 @@ export function useAdjacentThreadPrefetch({
                   revalidate: false,
                 },
               );
+              await prepareVisibleMessageHtml(cached.data);
               return;
             }
 
@@ -72,12 +74,15 @@ export function useAdjacentThreadPrefetch({
               populateCache: true,
               revalidate: false,
             });
-            await writeCachedThread({
-              emailAccountId,
-              threadId,
-              variant: request.variant,
-              data,
-            });
+            await Promise.all([
+              writeCachedThread({
+                emailAccountId,
+                threadId,
+                variant: request.variant,
+                data,
+              }),
+              prepareVisibleMessageHtml(data),
+            ]);
           })
           .catch(() => {
             // Prefetch failures are intentionally silent; opening still retries normally.
@@ -97,6 +102,14 @@ export function useAdjacentThreadPrefetch({
       if (timeout !== undefined) window.clearTimeout(timeout);
     };
   }, [adjacentThreadIds, emailAccountId, fetcher, mutate]);
+}
+
+async function prepareVisibleMessageHtml(data: ThreadResponse) {
+  const message = data.thread.messages.findLast(
+    (candidate) => !candidate.labelIds?.includes("DRAFT"),
+  );
+  if (!message?.textHtml) return;
+  await prepareEmailHtml({ messageId: message.id, html: message.textHtml });
 }
 
 function shouldPrefetch() {

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -653,7 +653,7 @@ function EmailPreview({
   const body = (
     <>
       {lastMessage.textHtml ? (
-        <HtmlEmail html={lastMessage.textHtml} />
+        <HtmlEmail html={lastMessage.textHtml} messageId={lastMessage.id} />
       ) : (
         <PlainEmail
           text={

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -37,18 +37,18 @@ describe("HtmlEmail", () => {
     vi.unstubAllGlobals();
   });
 
-  it("requests fresh rewritten html after remounting the same email", async () => {
+  it("reuses recently prepared html after remounting the same email", async () => {
     const html = "<p>Hello</p>";
 
-    const firstRender = render(<HtmlEmail html={html} />);
+    const firstRender = render(<HtmlEmail html={html} messageId="message-1" />);
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
     firstRender.unmount();
 
-    render(<HtmlEmail html={html} />);
+    render(<HtmlEmail html={html} messageId="message-1" />);
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -64,7 +64,10 @@ describe("HtmlEmail", () => {
     );
 
     const { getByTitle } = render(
-      <HtmlEmail html={'<img src="https://cdn.example.com/photo.png" />'} />,
+      <HtmlEmail
+        html={'<img src="https://cdn.example.com/photo.png" />'}
+        messageId="message-2"
+      />,
     );
 
     await waitFor(() => {
@@ -87,7 +90,10 @@ describe("HtmlEmail", () => {
     );
 
     const { getByTitle } = render(
-      <HtmlEmail html={'<img src="https://cdn.example.com/photo.png" />'} />,
+      <HtmlEmail
+        html={'<img src="https://cdn.example.com/photo.png" />'}
+        messageId="message-3"
+      />,
     );
 
     await waitFor(() => {

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -1,20 +1,14 @@
 import { startTransition, useMemo, useState, useRef, useEffect } from "react";
 import { useTheme } from "next-themes";
-import DOMPurify from "dompurify";
-import { env } from "@/env";
 import { decodeHtmlEntities } from "@/utils/gmail/decode";
-import { getImageProxyBaseUrl } from "@/utils/email/image-proxy-config";
+import {
+  getPreparedEmailHtml,
+  IMAGE_PROXY_BASE_URL,
+  IMAGE_PROXY_ORIGIN,
+  prepareSanitizedEmailHtml,
+  sanitizeEmailHtml,
+} from "@/utils/email/prepare-html.client";
 
-const IMAGE_PROXY_BASE_URL = getImageProxyBaseUrl({
-  baseUrl: env.NEXT_PUBLIC_BASE_URL,
-  externalProxyBaseUrl: env.NEXT_PUBLIC_IMAGE_PROXY_BASE_URL,
-  useAppRoute: env.NEXT_PUBLIC_IMAGE_PROXY_USE_APP_ROUTE,
-});
-const IMAGE_PROXY_ORIGIN = IMAGE_PROXY_BASE_URL
-  ? new URL(IMAGE_PROXY_BASE_URL).origin
-  : null;
-const IMAGE_PROXY_ENABLED = Boolean(IMAGE_PROXY_BASE_URL);
-const IMAGE_PROXY_RENDER_ROUTE = "/api/email/render-html";
 const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
 /**
  * Reading size for a message body that brought no styling of its own. Shared by
@@ -23,28 +17,32 @@ const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystem
  */
 const BODY_TYPE = { fontSize: "14.5px", lineHeight: 1.65 } as const;
 
-export function HtmlEmail({ html }: { html: string }) {
-  const sanitizedHtml = useMemo(() => sanitize(html), [html]);
+export function HtmlEmail({
+  html,
+  messageId,
+}: {
+  html: string;
+  messageId: string;
+}) {
+  const sanitizedHtml = useMemo(() => sanitizeEmailHtml(html), [html]);
   const [showReplies, setShowReplies] = useState(false);
-  const [renderHtml, setRenderHtml] = useState(() => sanitizedHtml);
+  const [renderHtml, setRenderHtml] = useState(
+    () =>
+      getPreparedEmailHtml({ messageId, sourceHtml: sanitizedHtml }) ??
+      sanitizedHtml,
+  );
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { theme } = useTheme();
   const isDarkMode = theme === "dark";
 
   useEffect(() => {
     let cancelled = false;
-    const controller = new AbortController();
+    setRenderHtml(
+      getPreparedEmailHtml({ messageId, sourceHtml: sanitizedHtml }) ??
+        sanitizedHtml,
+    );
 
-    setRenderHtml(sanitizedHtml);
-
-    if (!IMAGE_PROXY_ENABLED) {
-      return () => {
-        cancelled = true;
-        controller.abort();
-      };
-    }
-
-    rewriteHtmlWithProxy(sanitizedHtml, controller.signal).then(
+    prepareSanitizedEmailHtml({ messageId, sourceHtml: sanitizedHtml }).then(
       (rewrittenHtml) => {
         if (cancelled) return;
         startTransition(() => setRenderHtml(rewrittenHtml));
@@ -57,9 +55,8 @@ export function HtmlEmail({ html }: { html: string }) {
 
     return () => {
       cancelled = true;
-      controller.abort();
     };
-  }, [sanitizedHtml]);
+  }, [messageId, sanitizedHtml]);
 
   const { mainContent, hasReplies } = useMemo(
     () => getEmailContent(renderHtml),
@@ -291,25 +288,6 @@ function getIframeHtml(
 
   const htmlWithHead = wrapWithProperStructure(html);
   return addDarkModeClass(htmlWithHead, isDarkMode);
-}
-
-const sanitize = (html: string) =>
-  DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
-
-async function rewriteHtmlWithProxy(html: string, signal: AbortSignal) {
-  const response = await fetch(IMAGE_PROXY_RENDER_ROUTE, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ html }),
-    signal,
-  });
-
-  if (!response.ok) return html;
-
-  const data = await response.json();
-  return typeof data?.html === "string" ? data.html : html;
 }
 
 function addDarkModeClass(html: string, isDarkMode: boolean) {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -97,7 +97,7 @@ export function EmailMessage({
           {showDetails && <EmailDetails message={message} />}
 
           {message.textHtml ? (
-            <HtmlEmail html={message.textHtml} />
+            <HtmlEmail html={message.textHtml} messageId={message.id} />
           ) : (
             <PlainEmail text={message.textPlain || ""} />
           )}

--- a/apps/web/utils/email/prepare-html.client.ts
+++ b/apps/web/utils/email/prepare-html.client.ts
@@ -1,0 +1,121 @@
+import DOMPurify from "dompurify";
+import { env } from "@/env";
+import { getImageProxyBaseUrl } from "@/utils/email/image-proxy-config";
+
+export const IMAGE_PROXY_BASE_URL = getImageProxyBaseUrl({
+  baseUrl: env.NEXT_PUBLIC_BASE_URL,
+  externalProxyBaseUrl: env.NEXT_PUBLIC_IMAGE_PROXY_BASE_URL,
+  useAppRoute: env.NEXT_PUBLIC_IMAGE_PROXY_USE_APP_ROUTE,
+});
+export const IMAGE_PROXY_ORIGIN = IMAGE_PROXY_BASE_URL
+  ? new URL(IMAGE_PROXY_BASE_URL).origin
+  : null;
+
+const IMAGE_PROXY_RENDER_ROUTE = "/api/email/render-html";
+const PREPARED_HTML_MAX_AGE_MS = 5 * 60 * 1000;
+const PREPARED_HTML_CACHE_SIZE = 20;
+const preparedHtml = new Map<
+  string,
+  { sourceHtml: string; html: string; preparedAt: number }
+>();
+const inFlightPreparation = new Map<
+  string,
+  { sourceHtml: string; promise: Promise<string> }
+>();
+
+export function sanitizeEmailHtml(html: string) {
+  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+}
+
+export function getPreparedEmailHtml({
+  messageId,
+  sourceHtml,
+}: {
+  messageId: string;
+  sourceHtml: string;
+}) {
+  const prepared = preparedHtml.get(messageId);
+  if (
+    !prepared ||
+    prepared.sourceHtml !== sourceHtml ||
+    Date.now() - prepared.preparedAt > PREPARED_HTML_MAX_AGE_MS
+  ) {
+    if (prepared) preparedHtml.delete(messageId);
+    return;
+  }
+
+  preparedHtml.delete(messageId);
+  preparedHtml.set(messageId, prepared);
+  return prepared.html;
+}
+
+export function prepareEmailHtml({
+  messageId,
+  html,
+}: {
+  messageId: string;
+  html: string;
+}) {
+  const sourceHtml = sanitizeEmailHtml(html);
+  return prepareSanitizedEmailHtml({ messageId, sourceHtml });
+}
+
+export function prepareSanitizedEmailHtml({
+  messageId,
+  sourceHtml,
+}: {
+  messageId: string;
+  sourceHtml: string;
+}) {
+  if (!IMAGE_PROXY_BASE_URL) return Promise.resolve(sourceHtml);
+
+  const cached = getPreparedEmailHtml({ messageId, sourceHtml });
+  if (cached !== undefined) return Promise.resolve(cached);
+
+  const inFlight = inFlightPreparation.get(messageId);
+  if (inFlight?.sourceHtml === sourceHtml) return inFlight.promise;
+
+  const promise = rewriteHtmlWithProxy(sourceHtml)
+    .then((renderedHtml) => {
+      if (renderedHtml === undefined) return sourceHtml;
+      if (inFlightPreparation.get(messageId)?.promise !== promise) {
+        return renderedHtml;
+      }
+
+      preparedHtml.set(messageId, {
+        sourceHtml,
+        html: renderedHtml,
+        preparedAt: Date.now(),
+      });
+      while (preparedHtml.size > PREPARED_HTML_CACHE_SIZE) {
+        const oldestMessageId = preparedHtml.keys().next().value;
+        if (!oldestMessageId) break;
+        preparedHtml.delete(oldestMessageId);
+      }
+      return renderedHtml;
+    })
+    .catch(() => sourceHtml)
+    .finally(() => {
+      if (inFlightPreparation.get(messageId)?.promise === promise) {
+        inFlightPreparation.delete(messageId);
+      }
+    });
+
+  inFlightPreparation.set(messageId, { sourceHtml, promise });
+  return promise;
+}
+
+async function rewriteHtmlWithProxy(html: string) {
+  const response = await fetch(IMAGE_PROXY_RENDER_ROUTE, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ html }),
+  });
+
+  if (!response.ok) return;
+
+  const data = await response.json();
+  return typeof data?.html === "string" ? data.html : undefined;
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-205031_pr-3319_5f288898bf72/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prepare adjacent conversations so keyboard navigation can display message content with less waiting.

- reuse the existing adjacent-thread prefetch path for display-ready HTML
- keep preparation bounded and avoid eagerly loading remote assets
- cover bidirectional prefetch and cache reuse with focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->