### PR TITLE
rules: Respect disabled organization actions

### DIFF
--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
@@ -21,18 +21,20 @@ import { RuleStep } from "@/app/(app)/[emailAccountId]/assistant/RuleStep";
 import { DelayInputControls } from "@/components/DelayInputControls";
 import { canActionBeDelayed } from "@/utils/delayed-actions";
 import { ACTION_TYPE_LABELS, getActionIcon } from "@/utils/action-display";
-import { ORGANIZATION_RULE_ACTION_TYPES } from "@/utils/organizations/rule-action-types";
+import { getAvailableOrganizationRuleActionTypes } from "@/utils/organizations/rule-action-types";
 import {
   EMPTY_ORG_ACTION,
   type OrgRuleFormValues,
   type OrgActionFormValue,
 } from "./orgRuleForm";
 
-const ACTION_TYPE_OPTIONS = ORGANIZATION_RULE_ACTION_TYPES.map((value) => ({
-  value,
-  label: ACTION_TYPE_LABELS[value],
-  icon: getActionIcon(value),
-}));
+const ACTION_TYPE_OPTIONS = getAvailableOrganizationRuleActionTypes().map(
+  (value) => ({
+    value,
+    label: ACTION_TYPE_LABELS[value],
+    icon: getActionIcon(value),
+  }),
+);
 
 export function OrgActionSteps({
   fields,

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
@@ -28,14 +28,6 @@ import {
   type OrgActionFormValue,
 } from "./orgRuleForm";
 
-const ACTION_TYPE_OPTIONS = getAvailableOrganizationRuleActionTypes().map(
-  (value) => ({
-    value,
-    label: ACTION_TYPE_LABELS[value],
-    icon: getActionIcon(value),
-  }),
-);
-
 export function OrgActionSteps({
   fields,
   register,
@@ -45,7 +37,7 @@ export function OrgActionSteps({
   append,
   remove,
 }: {
-  fields: Array<{ id: string }>;
+  fields: Array<{ fieldId: string }>;
   register: UseFormRegister<OrgRuleFormValues>;
   control: Control<OrgRuleFormValues>;
   watch: UseFormWatch<OrgRuleFormValues>;
@@ -63,8 +55,9 @@ export function OrgActionSteps({
     >
       {fields.map((field, index) => (
         <OrgActionCard
-          key={field.id}
+          key={field.fieldId}
           index={index}
+          id={actions[index]?.id}
           type={actions[index]?.type ?? ActionType.LABEL}
           register={register}
           watch={watch}
@@ -78,6 +71,7 @@ export function OrgActionSteps({
 
 function OrgActionCard({
   index,
+  id,
   type,
   register,
   watch,
@@ -85,13 +79,21 @@ function OrgActionCard({
   onRemove,
 }: {
   index: number;
+  id?: string;
   type: ActionType;
   register: UseFormRegister<OrgRuleFormValues>;
   watch: UseFormWatch<OrgRuleFormValues>;
   setValue: UseFormSetValue<OrgRuleFormValues>;
   onRemove: () => void;
 }) {
-  const selectedOption = ACTION_TYPE_OPTIONS.find(
+  const actionTypeOptions = getAvailableOrganizationRuleActionTypes(
+    id ? type : undefined,
+  ).map((value) => ({
+    value,
+    label: ACTION_TYPE_LABELS[value],
+    icon: getActionIcon(value),
+  }));
+  const selectedOption = actionTypeOptions.find(
     (option) => option.value === type,
   );
   const SelectedIcon = selectedOption?.icon;
@@ -120,7 +122,7 @@ function OrgActionCard({
           </SelectTrigger>
         </FormControl>
         <SelectContent>
-          {ACTION_TYPE_OPTIONS.map((option) => {
+          {actionTypeOptions.map((option) => {
             const Icon = option.icon;
             return (
               <SelectItem key={option.value} value={option.value}>

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
@@ -83,7 +83,7 @@ export function OrgRuleDialog({
     fields: actionFields,
     append: appendAction,
     remove: removeAction,
-  } = useFieldArray({ control, name: "actions" });
+  } = useFieldArray({ control, name: "actions", keyName: "fieldId" });
 
   const createAction = useAction(createOrganizationRuleAction);
   const updateAction = useAction(updateOrganizationRuleAction);
@@ -101,6 +101,7 @@ export function OrgRuleDialog({
     );
 
     const actions = formValues.actions.map((action) => ({
+      id: action.id,
       type: action.type as OrganizationRuleActionSchema["type"],
       label: action.label || null,
       subject: action.subject || null,
@@ -284,6 +285,7 @@ function toFormValues(rule?: OrgRule): OrgRuleFormValues {
     runOnThreads: rule?.runOnThreads ?? false,
     actions: rule?.actions.length
       ? rule.actions.map((action) => ({
+          id: action.id,
           type: action.type,
           label: action.label ?? "",
           subject: action.subject ?? "",

--- a/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
@@ -2,6 +2,7 @@ import { ActionType, type LogicalOperator } from "@/generated/prisma/enums";
 import type { ZodCondition } from "@/utils/actions/rule.validation";
 
 export type OrgActionFormValue = {
+  id?: string;
   type: ActionType;
   label: string;
   subject: string;

--- a/apps/web/utils/actions/organization-rule.ts
+++ b/apps/web/utils/actions/organization-rule.ts
@@ -39,7 +39,7 @@ export const createOrganizationRuleAction = actionClientUser
       const organizationRule = await createOrganizationRule({
         organizationId,
         data: rest,
-        actions: toActionInputs(actions),
+        actions: toActionInputs(actions, { includeIds: false }),
         logger,
       });
 
@@ -65,7 +65,7 @@ export const updateOrganizationRuleAction = actionClientUser
         organizationRuleId,
         organizationId,
         data: rest,
-        actions: toActionInputs(actions),
+        actions: toActionInputs(actions, { includeIds: true }),
         logger,
       });
     },
@@ -129,8 +129,10 @@ export const setMemberOrganizationRuleEnabledAction = actionClient
 
 function toActionInputs(
   actions: OrganizationRuleActionSchema[],
+  { includeIds }: { includeIds: boolean },
 ): OrganizationRuleActionInput[] {
   return actions.map((action) => ({
+    ...(includeIds && action.id ? { id: action.id } : {}),
     type: action.type,
     label: action.label ?? null,
     subject: action.subject ?? null,

--- a/apps/web/utils/actions/organization-rule.validation.test.ts
+++ b/apps/web/utils/actions/organization-rule.validation.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionType } from "@/generated/prisma/enums";
-import { createOrganizationRuleBody } from "./organization-rule.validation";
+import {
+  createOrganizationRuleBody,
+  updateOrganizationRuleBody,
+} from "./organization-rule.validation";
 
 const { mockEnv } = vi.hoisted(() => ({
   mockEnv: {
@@ -59,6 +62,56 @@ describe("createOrganizationRuleBody", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects webhook actions when webhooks are disabled", () => {
+    mockEnv.webhookActionEnabled = false;
+
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({
+        type: ActionType.CALL_WEBHOOK,
+        url: "https://example.com/webhook",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("requires delete actions to be explicitly enabled", () => {
+    mockEnv.deleteEmailActionEnabled = false;
+
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({ type: ActionType.DELETE }),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("preserves persisted disabled actions on update", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    const result = updateOrganizationRuleBody.safeParse({
+      ...organizationRuleWithAction({
+        id: "organization-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+      organizationRuleId: "organization-rule-1",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("does not let persisted action ids bypass create restrictions", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({
+        id: "organization-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts enabled actions", () => {
     const result = createOrganizationRuleBody.safeParse(
       organizationRuleWithAction({ type: ActionType.DRAFT_EMAIL }),
@@ -68,7 +121,12 @@ describe("createOrganizationRuleBody", () => {
   });
 });
 
-function organizationRuleWithAction(action: { type: ActionType; to?: string }) {
+function organizationRuleWithAction(action: {
+  id?: string;
+  type: ActionType;
+  to?: string;
+  url?: string;
+}) {
   return {
     organizationId: "organization-1",
     name: "Rule",

--- a/apps/web/utils/actions/organization-rule.validation.test.ts
+++ b/apps/web/utils/actions/organization-rule.validation.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionType } from "@/generated/prisma/enums";
+import { createOrganizationRuleBody } from "./organization-rule.validation";
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
+    autoDraftDisabled: false,
+    emailSendEnabled: true,
+    webhookActionEnabled: true,
+    deleteEmailActionEnabled: true,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    get NEXT_PUBLIC_AUTO_DRAFT_DISABLED() {
+      return mockEnv.autoDraftDisabled;
+    },
+    get NEXT_PUBLIC_EMAIL_SEND_ENABLED() {
+      return mockEnv.emailSendEnabled;
+    },
+    get NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED() {
+      return mockEnv.webhookActionEnabled;
+    },
+    get NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED() {
+      return mockEnv.deleteEmailActionEnabled;
+    },
+  },
+}));
+
+describe("createOrganizationRuleBody", () => {
+  beforeEach(() => {
+    mockEnv.autoDraftDisabled = false;
+    mockEnv.emailSendEnabled = true;
+    mockEnv.webhookActionEnabled = true;
+    mockEnv.deleteEmailActionEnabled = true;
+  });
+
+  it("rejects draft actions when auto-drafting is disabled", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({ type: ActionType.DRAFT_EMAIL }),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects send actions when email sending is disabled", () => {
+    mockEnv.emailSendEnabled = false;
+
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({
+        type: ActionType.SEND_EMAIL,
+        to: "recipient@example.com",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts enabled actions", () => {
+    const result = createOrganizationRuleBody.safeParse(
+      organizationRuleWithAction({ type: ActionType.DRAFT_EMAIL }),
+    );
+
+    expect(result.success).toBe(true);
+  });
+});
+
+function organizationRuleWithAction(action: { type: ActionType; to?: string }) {
+  return {
+    organizationId: "organization-1",
+    name: "Rule",
+    instructions: "Handle matching messages",
+    actions: [action],
+  };
+}

--- a/apps/web/utils/actions/organization-rule.validation.ts
+++ b/apps/web/utils/actions/organization-rule.validation.ts
@@ -14,6 +14,7 @@ const organizationRuleActionType = z.enum(ORGANIZATION_RULE_ACTION_TYPES);
 
 export const organizationRuleActionSchema = z
   .object({
+    id: z.string().optional(),
     type: organizationRuleActionType,
     label: z.string().nullish(),
     subject: z.string().nullish(),
@@ -57,8 +58,8 @@ export const organizationRuleActionSchema = z
         path: ["to"],
       });
     }
-    if (addDisabledRuleActionIssue(data.type, ctx)) return;
-    if (!isOrganizationRuleActionTypeAvailable(data.type)) {
+    if (!data.id && addDisabledRuleActionIssue(data.type, ctx)) return;
+    if (!data.id && !isOrganizationRuleActionTypeAvailable(data.type)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE,
@@ -127,7 +128,18 @@ export const createOrganizationRuleBody = z
     actions,
     ...conditionFields,
   })
-  .refine(hasAtLeastOneCondition, conditionRefinement);
+  .refine(hasAtLeastOneCondition, conditionRefinement)
+  .superRefine((data, ctx) => {
+    data.actions.forEach((action, index) => {
+      if (action.id && !isOrganizationRuleActionTypeAvailable(action.type)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE,
+          path: ["actions", index, "type"],
+        });
+      }
+    });
+  });
 export type CreateOrganizationRuleBody = z.infer<
   typeof createOrganizationRuleBody
 >;

--- a/apps/web/utils/actions/organization-rule.validation.ts
+++ b/apps/web/utils/actions/organization-rule.validation.ts
@@ -3,7 +3,11 @@ import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import { attachmentSourceInputSchema } from "@/utils/attachments/source-schema";
 import { delayInMinutesSchema } from "@/utils/actions/rule.validation";
 import { validateLabelNameBasic } from "@/utils/gmail/label-validation";
-import { ORGANIZATION_RULE_ACTION_TYPES } from "@/utils/organizations/rule-action-types";
+import {
+  isOrganizationRuleActionTypeAvailable,
+  ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE,
+  ORGANIZATION_RULE_ACTION_TYPES,
+} from "@/utils/organizations/rule-action-types";
 import { addDisabledRuleActionIssue } from "@/utils/rule-action-feature-gates";
 
 const organizationRuleActionType = z.enum(ORGANIZATION_RULE_ACTION_TYPES);
@@ -54,6 +58,14 @@ export const organizationRuleActionSchema = z
       });
     }
     if (addDisabledRuleActionIssue(data.type, ctx)) return;
+    if (!isOrganizationRuleActionTypeAvailable(data.type)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE,
+        path: ["type"],
+      });
+      return;
+    }
     if (data.type === ActionType.CALL_WEBHOOK && !data.url?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/apps/web/utils/organizations/rule-action-types.test.ts
+++ b/apps/web/utils/organizations/rule-action-types.test.ts
@@ -44,6 +44,14 @@ describe("getAvailableOrganizationRuleActionTypes", () => {
     );
   });
 
+  it("preserves a persisted disabled action for editing", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    expect(
+      getAvailableOrganizationRuleActionTypes(ActionType.DRAFT_EMAIL),
+    ).toContain(ActionType.DRAFT_EMAIL);
+  });
+
   it("excludes outbound actions when email sending is disabled", () => {
     mockEnv.emailSendEnabled = false;
 

--- a/apps/web/utils/organizations/rule-action-types.test.ts
+++ b/apps/web/utils/organizations/rule-action-types.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionType } from "@/generated/prisma/enums";
+import { getAvailableOrganizationRuleActionTypes } from "./rule-action-types";
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
+    autoDraftDisabled: false,
+    emailSendEnabled: true,
+    webhookActionEnabled: true,
+    deleteEmailActionEnabled: true,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    get NEXT_PUBLIC_AUTO_DRAFT_DISABLED() {
+      return mockEnv.autoDraftDisabled;
+    },
+    get NEXT_PUBLIC_EMAIL_SEND_ENABLED() {
+      return mockEnv.emailSendEnabled;
+    },
+    get NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED() {
+      return mockEnv.webhookActionEnabled;
+    },
+    get NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED() {
+      return mockEnv.deleteEmailActionEnabled;
+    },
+  },
+}));
+
+describe("getAvailableOrganizationRuleActionTypes", () => {
+  beforeEach(() => {
+    mockEnv.autoDraftDisabled = false;
+    mockEnv.emailSendEnabled = true;
+    mockEnv.webhookActionEnabled = true;
+    mockEnv.deleteEmailActionEnabled = true;
+  });
+
+  it("excludes drafting when auto-drafting is disabled", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    expect(getAvailableOrganizationRuleActionTypes()).not.toContain(
+      ActionType.DRAFT_EMAIL,
+    );
+  });
+
+  it("excludes outbound actions when email sending is disabled", () => {
+    mockEnv.emailSendEnabled = false;
+
+    const actionTypes = getAvailableOrganizationRuleActionTypes();
+
+    expect(actionTypes).not.toContain(ActionType.REPLY);
+    expect(actionTypes).not.toContain(ActionType.FORWARD);
+    expect(actionTypes).not.toContain(ActionType.SEND_EMAIL);
+  });
+
+  it("excludes other deployment-disabled actions", () => {
+    mockEnv.webhookActionEnabled = false;
+    mockEnv.deleteEmailActionEnabled = false;
+
+    const actionTypes = getAvailableOrganizationRuleActionTypes();
+
+    expect(actionTypes).not.toContain(ActionType.CALL_WEBHOOK);
+    expect(actionTypes).not.toContain(ActionType.DELETE);
+  });
+});

--- a/apps/web/utils/organizations/rule-action-types.ts
+++ b/apps/web/utils/organizations/rule-action-types.ts
@@ -21,9 +21,13 @@ export const ORGANIZATION_RULE_ACTION_TYPES = [
   ActionType.DELETE,
 ] as const;
 
-export function getAvailableOrganizationRuleActionTypes() {
+export function getAvailableOrganizationRuleActionTypes(
+  persistedActionType?: ActionType,
+) {
   return ORGANIZATION_RULE_ACTION_TYPES.filter(
-    isOrganizationRuleActionTypeAvailable,
+    (type) =>
+      type === persistedActionType ||
+      isOrganizationRuleActionTypeAvailable(type),
   );
 }
 

--- a/apps/web/utils/organizations/rule-action-types.ts
+++ b/apps/web/utils/organizations/rule-action-types.ts
@@ -1,4 +1,8 @@
 import { ActionType } from "@/generated/prisma/enums";
+import { env } from "@/env";
+
+export const ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE =
+  "This action is disabled in this deployment.";
 
 // Keep zod-free because client components import this list.
 export const ORGANIZATION_RULE_ACTION_TYPES = [
@@ -16,3 +20,33 @@ export const ORGANIZATION_RULE_ACTION_TYPES = [
   ActionType.DIGEST,
   ActionType.DELETE,
 ] as const;
+
+export function getAvailableOrganizationRuleActionTypes() {
+  return ORGANIZATION_RULE_ACTION_TYPES.filter(
+    isOrganizationRuleActionTypeAvailable,
+  );
+}
+
+export function isOrganizationRuleActionTypeAvailable(type: ActionType) {
+  if (type === ActionType.DRAFT_EMAIL) {
+    return !env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED;
+  }
+
+  if (
+    type === ActionType.REPLY ||
+    type === ActionType.FORWARD ||
+    type === ActionType.SEND_EMAIL
+  ) {
+    return env.NEXT_PUBLIC_EMAIL_SEND_ENABLED !== false;
+  }
+
+  if (type === ActionType.CALL_WEBHOOK) {
+    return env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false;
+  }
+
+  if (type === ActionType.DELETE) {
+    return env.NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED === true;
+  }
+
+  return true;
+}

--- a/apps/web/utils/organizations/rules.test.ts
+++ b/apps/web/utils/organizations/rules.test.ts
@@ -167,6 +167,18 @@ describe("assertOrganizationRuleActionsSupported", () => {
     ).toThrow();
   });
 
+  it("rejects repeated persisted action ids", () => {
+    expect(() =>
+      assertOrganizationRuleActionsSupported(
+        [
+          { id: "organization-action-1", type: ActionType.LABEL },
+          { id: "organization-action-1", type: ActionType.LABEL },
+        ],
+        [{ id: "organization-action-1", type: ActionType.LABEL }],
+      ),
+    ).toThrow();
+  });
+
   it("rejects outbound actions when email sending is disabled", () => {
     mockEnv.emailSendEnabled = false;
 

--- a/apps/web/utils/organizations/rules.test.ts
+++ b/apps/web/utils/organizations/rules.test.ts
@@ -145,6 +145,28 @@ describe("assertOrganizationRuleActionsSupported", () => {
     ).toThrow();
   });
 
+  it("allows an unchanged persisted action after it is disabled", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    expect(() =>
+      assertOrganizationRuleActionsSupported(
+        [{ id: "organization-action-1", type: ActionType.DRAFT_EMAIL }],
+        [{ id: "organization-action-1", type: ActionType.DRAFT_EMAIL }],
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects changing a persisted action to a disabled type", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    expect(() =>
+      assertOrganizationRuleActionsSupported(
+        [{ id: "organization-action-1", type: ActionType.DRAFT_EMAIL }],
+        [{ id: "organization-action-1", type: ActionType.LABEL }],
+      ),
+    ).toThrow();
+  });
+
   it("rejects outbound actions when email sending is disabled", () => {
     mockEnv.emailSendEnabled = false;
 

--- a/apps/web/utils/organizations/rules.test.ts
+++ b/apps/web/utils/organizations/rules.test.ts
@@ -14,6 +14,32 @@ import {
   syncOrganizationRulesForNewMember,
 } from "./rules";
 
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
+    autoDraftDisabled: false,
+    emailSendEnabled: true,
+    webhookActionEnabled: true,
+    deleteEmailActionEnabled: true,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    get NEXT_PUBLIC_AUTO_DRAFT_DISABLED() {
+      return mockEnv.autoDraftDisabled;
+    },
+    get NEXT_PUBLIC_EMAIL_SEND_ENABLED() {
+      return mockEnv.emailSendEnabled;
+    },
+    get NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED() {
+      return mockEnv.webhookActionEnabled;
+    },
+    get NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED() {
+      return mockEnv.deleteEmailActionEnabled;
+    },
+  },
+}));
+
 vi.mock("@/utils/prisma");
 
 const logger = createTestLogger();
@@ -80,6 +106,13 @@ describe("computeMemberRuleEnabled", () => {
 });
 
 describe("assertOrganizationRuleActionsSupported", () => {
+  beforeEach(() => {
+    mockEnv.autoDraftDisabled = false;
+    mockEnv.emailSendEnabled = true;
+    mockEnv.webhookActionEnabled = true;
+    mockEnv.deleteEmailActionEnabled = true;
+  });
+
   it("rejects messaging channel actions", () => {
     expect(() =>
       assertOrganizationRuleActionsSupported([
@@ -100,6 +133,30 @@ describe("assertOrganizationRuleActionsSupported", () => {
         { type: ActionType.ARCHIVE },
       ]),
     ).not.toThrow();
+  });
+
+  it("rejects draft actions when auto-drafting is disabled", () => {
+    mockEnv.autoDraftDisabled = true;
+
+    expect(() =>
+      assertOrganizationRuleActionsSupported([
+        { type: ActionType.DRAFT_EMAIL },
+      ]),
+    ).toThrow();
+  });
+
+  it("rejects outbound actions when email sending is disabled", () => {
+    mockEnv.emailSendEnabled = false;
+
+    for (const type of [
+      ActionType.REPLY,
+      ActionType.FORWARD,
+      ActionType.SEND_EMAIL,
+    ]) {
+      expect(() =>
+        assertOrganizationRuleActionsSupported([{ type }]),
+      ).toThrow();
+    }
   });
 });
 

--- a/apps/web/utils/organizations/rules.ts
+++ b/apps/web/utils/organizations/rules.ts
@@ -43,7 +43,7 @@ const UNSUPPORTED_ORGANIZATION_ACTION_TYPES: ActionType[] = [
 
 export type OrganizationRuleActionInput = Omit<
   Prisma.OrganizationRuleActionCreateManyOrganizationRuleInput,
-  "id" | "createdAt" | "updatedAt"
+  "createdAt" | "updatedAt"
 >;
 
 export type OrganizationRuleData = {
@@ -69,7 +69,8 @@ export function computeMemberRuleEnabled({
 }
 
 export function assertOrganizationRuleActionsSupported(
-  actions: { type: ActionType }[],
+  actions: { id?: string; type: ActionType }[],
+  existingActions: { id: string; type: ActionType }[] = [],
 ) {
   const messagingAction = actions.find((action) =>
     UNSUPPORTED_ORGANIZATION_ACTION_TYPES.includes(action.type),
@@ -91,8 +92,22 @@ export function assertOrganizationRuleActionsSupported(
     );
   }
 
+  const unknownAction = actions.find(
+    (action) =>
+      action.id &&
+      !existingActions.some((existing) => existing.id === action.id),
+  );
+  if (unknownAction) {
+    throw new SafeError("Organization rule action not found.");
+  }
+
   const disabledAction = actions.find(
-    (action) => !isOrganizationRuleActionTypeAvailable(action.type),
+    (action) =>
+      !isOrganizationRuleActionTypeAvailable(action.type) &&
+      !existingActions.some(
+        (existing) =>
+          existing.id === action.id && existing.type === action.type,
+      ),
   );
   if (disabledAction) {
     throw new SafeError(ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE);
@@ -167,13 +182,14 @@ export async function updateOrganizationRule({
   actions: OrganizationRuleActionInput[];
   logger: Logger;
 }) {
-  assertOrganizationRuleActionsSupported(actions);
-
   const existing = await prisma.organizationRule.findFirst({
     where: { id: organizationRuleId, organizationId },
-    select: { id: true },
+    select: { id: true, actions: { select: { id: true, type: true } } },
   });
   if (!existing) throw new SafeError("Organization rule not found");
+
+  assertOrganizationRuleActionsSupported(actions, existing.actions);
+  const actionsCreateData = actions.map(withoutOrganizationRuleActionId);
 
   const organizationRule = await prisma.organizationRule
     .update({
@@ -187,7 +203,7 @@ export async function updateOrganizationRule({
         to: data.to ?? null,
         subject: data.subject ?? null,
         body: data.body ?? null,
-        actions: { deleteMany: {}, createMany: { data: actions } },
+        actions: { deleteMany: {}, createMany: { data: actionsCreateData } },
       },
     })
     .catch(rethrowDuplicateNameError);
@@ -353,6 +369,13 @@ function rethrowDuplicateNameError(error: unknown): never {
     throw new SafeError("An organization rule with this name already exists.");
   }
   throw error;
+}
+
+function withoutOrganizationRuleActionId({
+  id: _id,
+  ...action
+}: OrganizationRuleActionInput) {
+  return action;
 }
 
 function mapOrganizationRuleActions(

--- a/apps/web/utils/organizations/rules.ts
+++ b/apps/web/utils/organizations/rules.ts
@@ -9,6 +9,11 @@ import { SafeError } from "@/utils/error";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import type { Logger } from "@/utils/logger";
 import type { RuleActionCreateData } from "@/utils/rule/rule";
+import {
+  isOrganizationRuleActionTypeAvailable,
+  ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE,
+  ORGANIZATION_RULE_ACTION_TYPES,
+} from "@/utils/organizations/rule-action-types";
 
 export const RULE_MANAGED_BY_ORGANIZATION_ERROR =
   "This rule is managed by your organization and can't be edited here. Ask an organization admin to change it.";
@@ -66,13 +71,31 @@ export function computeMemberRuleEnabled({
 export function assertOrganizationRuleActionsSupported(
   actions: { type: ActionType }[],
 ) {
-  const unsupported = actions.find((action) =>
+  const messagingAction = actions.find((action) =>
     UNSUPPORTED_ORGANIZATION_ACTION_TYPES.includes(action.type),
   );
-  if (unsupported) {
+  if (messagingAction) {
     throw new SafeError(
       "Messaging channel actions can't be used in organization rules because each member needs their own channel.",
     );
+  }
+
+  const supportedActionTypes: readonly ActionType[] =
+    ORGANIZATION_RULE_ACTION_TYPES;
+  const unsupportedAction = actions.find(
+    (action) => !supportedActionTypes.includes(action.type),
+  );
+  if (unsupportedAction) {
+    throw new SafeError(
+      "This action type can't be used in organization rules.",
+    );
+  }
+
+  const disabledAction = actions.find(
+    (action) => !isOrganizationRuleActionTypeAvailable(action.type),
+  );
+  if (disabledAction) {
+    throw new SafeError(ORGANIZATION_RULE_ACTION_DISABLED_MESSAGE);
   }
 }
 

--- a/apps/web/utils/organizations/rules.ts
+++ b/apps/web/utils/organizations/rules.ts
@@ -92,6 +92,11 @@ export function assertOrganizationRuleActionsSupported(
     );
   }
 
+  const actionIds = actions.flatMap((action) => (action.id ? [action.id] : []));
+  if (new Set(actionIds).size !== actionIds.length) {
+    throw new SafeError("Organization rule action specified more than once.");
+  }
+
   const unknownAction = actions.find(
     (action) =>
       action.id &&


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260816-211300_pr-3320_32eecbc9a470/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensures organization-managed rules honor deployment-level action availability.

- Hides unavailable actions from new organization rule choices while preserving stored actions during edits.
- Rejects disabled, unsupported, or invalid persisted actions in validation and service paths.
- Adds focused regression coverage; 35 tests pass.