### PR TITLE
web: Open the desktop app from the HTTPS auth callback

### DIFF
--- a/apps/web/app/auth-callback/AuthCallbackHandoff.tsx
+++ b/apps/web/app/auth-callback/AuthCallbackHandoff.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+
+const APP_CALLBACK_PREFIX = "inboxzero://auth-callback";
+
+export function AuthCallbackHandoff({ href }: { href: string }) {
+  useEffect(() => {
+    if (!href.startsWith(APP_CALLBACK_PREFIX)) return;
+    window.location.assign(href);
+  }, [href]);
+
+  return null;
+}

--- a/apps/web/app/auth-callback/AuthCallbackHandoff.tsx
+++ b/apps/web/app/auth-callback/AuthCallbackHandoff.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
-
-const APP_CALLBACK_PREFIX = "inboxzero://auth-callback";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export function AuthCallbackHandoff({ href }: { href: string }) {
   useEffect(() => {
-    if (!href.startsWith(APP_CALLBACK_PREFIX)) return;
-    window.location.assign(href);
+    redirectToSafeUrl(href, { allowAppCallback: true });
   }, [href]);
 
   return null;

--- a/apps/web/app/auth-callback/page.tsx
+++ b/apps/web/app/auth-callback/page.tsx
@@ -1,9 +1,27 @@
-export default function AuthCallbackPage() {
+import { AuthCallbackHandoff } from "./AuthCallbackHandoff";
+import { getInboxZeroCustomSchemeCallbackUrl } from "@/utils/mobile-auth/app-callback-url";
+
+export default async function AuthCallbackPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const appUrl = getInboxZeroCustomSchemeCallbackUrl(await searchParams);
+
   return (
-    <main className="flex min-h-screen items-center justify-center px-6 text-center">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      {appUrl ? <AuthCallbackHandoff href={appUrl} /> : null}
       <p className="text-muted-foreground text-sm">
         Return to Inbox Zero to finish signing in.
       </p>
+      {appUrl ? (
+        <a
+          href={appUrl}
+          className="text-sm font-medium text-foreground underline underline-offset-4"
+        >
+          Open Inbox Zero
+        </a>
+      ) : null}
     </main>
   );
 }

--- a/apps/web/utils/mobile-auth/app-callback-url.test.ts
+++ b/apps/web/utils/mobile-auth/app-callback-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getInboxZeroCustomSchemeCallbackUrl } from "./app-callback-url";
+import {
+  getInboxZeroCustomSchemeCallbackUrl,
+  isInboxZeroAppCallbackUrl,
+} from "./app-callback-url";
 
 describe("getInboxZeroCustomSchemeCallbackUrl", () => {
   it("opens the desktop app with a one-time code and state", () => {
@@ -44,5 +47,16 @@ describe("getInboxZeroCustomSchemeCallbackUrl", () => {
         state: "ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA",
       }),
     ).toBeNull();
+  });
+
+  it("recognizes sanitized Inbox Zero app callback URLs", () => {
+    expect(
+      isInboxZeroAppCallbackUrl(
+        "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+      ),
+    ).toBe(true);
+    expect(
+      isInboxZeroAppCallbackUrl("https://www.getinboxzero.com/auth-callback"),
+    ).toBe(false);
   });
 });

--- a/apps/web/utils/mobile-auth/app-callback-url.test.ts
+++ b/apps/web/utils/mobile-auth/app-callback-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getInboxZeroCustomSchemeCallbackUrl } from "./app-callback-url";
+
+describe("getInboxZeroCustomSchemeCallbackUrl", () => {
+  it("opens the desktop app with a one-time code and state", () => {
+    expect(
+      getInboxZeroCustomSchemeCallbackUrl({
+        code: "xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+        state: "ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA",
+      }),
+    ).toBe(
+      "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+    );
+  });
+
+  it("opens the desktop app with auth errors", () => {
+    expect(
+      getInboxZeroCustomSchemeCallbackUrl({
+        error: "missing_session",
+        error_description: "Authentication session was not found",
+        state: "ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA",
+      }),
+    ).toBe(
+      "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&error=missing_session&error_description=Authentication+session+was+not+found",
+    );
+  });
+
+  it("ignores extra query values that are not part of the handoff", () => {
+    expect(
+      getInboxZeroCustomSchemeCallbackUrl({
+        code: "xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+        cookie: "better-auth.session_token=session",
+        next: "https://evil.example",
+        state: "ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA",
+      }),
+    ).toBe(
+      "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+    );
+  });
+
+  it("does not open the app without a code or error", () => {
+    expect(
+      getInboxZeroCustomSchemeCallbackUrl({
+        state: "ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/utils/mobile-auth/app-callback-url.ts
+++ b/apps/web/utils/mobile-auth/app-callback-url.ts
@@ -1,0 +1,46 @@
+export const INBOX_ZERO_APP_SCHEME = "inboxzero";
+export const INBOX_ZERO_APP_CALLBACK_HOST = "auth-callback";
+
+const STATE_PATTERN = /^[A-Za-z0-9._~-]{16,256}$/u;
+const CODE_PATTERN = /^[A-Za-z0-9._~-]{16,256}$/u;
+const ERROR_PATTERN = /^[A-Za-z0-9._-]{1,64}$/u;
+const ERROR_DESCRIPTION_PATTERN = /^[\w .,+'-]{1,200}$/u;
+
+export function getInboxZeroCustomSchemeCallbackUrl(
+  params: Record<string, string | string[] | undefined>,
+): string | null {
+  const state = firstSearchParam(params.state);
+  const code = firstSearchParam(params.code);
+  const error = firstSearchParam(params.error);
+  const errorDescription = firstSearchParam(params.error_description);
+
+  const url = new URL(
+    `${INBOX_ZERO_APP_SCHEME}://${INBOX_ZERO_APP_CALLBACK_HOST}`,
+  );
+
+  if (state && STATE_PATTERN.test(state)) {
+    url.searchParams.set("state", state);
+  }
+  if (code && CODE_PATTERN.test(code)) {
+    url.searchParams.set("code", code);
+  }
+  if (error && ERROR_PATTERN.test(error)) {
+    url.searchParams.set("error", error);
+  }
+  if (errorDescription && ERROR_DESCRIPTION_PATTERN.test(errorDescription)) {
+    url.searchParams.set("error_description", errorDescription);
+  }
+
+  if (!url.searchParams.has("code") && !url.searchParams.has("error")) {
+    return null;
+  }
+
+  return url.toString();
+}
+
+function firstSearchParam(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}

--- a/apps/web/utils/mobile-auth/app-callback-url.ts
+++ b/apps/web/utils/mobile-auth/app-callback-url.ts
@@ -38,6 +38,21 @@ export function getInboxZeroCustomSchemeCallbackUrl(
   return url.toString();
 }
 
+export function isInboxZeroAppCallbackUrl(redirectUrl: string): boolean {
+  try {
+    const parsedUrl = new URL(redirectUrl);
+    const path = `${parsedUrl.hostname}${parsedUrl.pathname}`
+      .replace(/^\/+/u, "")
+      .replace(/\/+$/u, "");
+    return (
+      parsedUrl.protocol === `${INBOX_ZERO_APP_SCHEME}:` &&
+      path === INBOX_ZERO_APP_CALLBACK_HOST
+    );
+  } catch {
+    return false;
+  }
+}
+
 function firstSearchParam(
   value: string | string[] | undefined,
 ): string | undefined {

--- a/apps/web/utils/redirect.test.ts
+++ b/apps/web/utils/redirect.test.ts
@@ -125,4 +125,26 @@ describe("getSafeRedirectUrl", () => {
       }),
     ).toBe("/login");
   });
+
+  it("opens the Inbox Zero app callback only when explicitly allowed", () => {
+    expect(
+      getSafeRedirectUrl(
+        "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+      ),
+    ).toBe("/");
+    expect(
+      getSafeRedirectUrl(
+        "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+        { allowAppCallback: true },
+      ),
+    ).toBe(
+      "inboxzero://auth-callback?state=ADUZf5bSBOBSBzj58yThh17uiqgEg1PmsNzu-s4cMMA&code=xz5IkObSXqOpdCvBARrwRnqhOrxRQNX9qPeoT9G-jws",
+    );
+    expect(
+      getSafeRedirectUrl("inboxzero://settings", {
+        allowAppCallback: true,
+        fallbackUrl: "/login",
+      }),
+    ).toBe("/login");
+  });
 });

--- a/apps/web/utils/redirect.ts
+++ b/apps/web/utils/redirect.ts
@@ -1,6 +1,8 @@
 import { normalizeInternalPath } from "@/utils/path";
+import { isInboxZeroAppCallbackUrl } from "@/utils/mobile-auth/app-callback-url";
 
 type SafeRedirectUrlOptions = {
+  allowAppCallback?: boolean;
   allowExternal?: boolean;
   fallbackUrl?: `/${string}`;
 };
@@ -49,6 +51,10 @@ export function getSafeRedirectUrl(
           `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
         ) ?? fallbackUrl
       );
+    }
+
+    if (options.allowAppCallback && isInboxZeroAppCallbackUrl(redirectUrl)) {
+      return parsedUrl.toString();
     }
 
     if (!options.allowExternal) return fallbackUrl;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260816-221810_pr-3322_13a8f3e00492/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Desktop OAuth currently lands on `https://www.getinboxzero.com/auth-callback?code&state` and stops. That page is the mobile universal-link fallback; Electron never sees it.
- The page now opens `inboxzero://auth-callback` with the sanitized code/state, and shows an **Open Inbox Zero** link if the browser blocks the automatic redirect.

## Test plan
- [ ] In the desktop app, Sign in with Google: Safari/Chrome should bounce back into Electron and finish login
- [ ] If the automatic open is blocked, clicking **Open Inbox Zero** completes sign-in
- [ ] iOS universal links to `/auth-callback` still open the mobile app
- [ ] Query params other than code/state/error are not copied onto the custom scheme


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->