### PR TITLE
Desktop and web snappiness: instant reopen, last-page restore, hover prefetch, persisted shell cache

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -18,6 +18,8 @@ INBOX_ZERO_APP_URL=http://localhost:3000 pnpm --filter @inboxzero/desktop dev
 
 Sign-in opens the system browser, then returns through `inboxzero://` and `/api/mobile-auth/exchange-code`. Google and Microsoft OAuth are not completed inside the Electron window.
 
+The window remembers the last in-app page (stored in `userData/last-app-url`) and restores it on launch instead of going through `/login` redirects. On macOS, closing the window hides it so reopening from the dock is instant; quit with Cmd+Q.
+
 The web app defaults `DESKTOP_AUTH_ORIGIN` to `inboxzero://`, the same scheme as mobile. Override that only if the desktop protocol scheme changes.
 
 ## Package

--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -6,6 +6,7 @@ import {
   getDesktopLoginUrl,
   DESKTOP_WINDOW_DRAG_CSS,
   getDesktopPostAuthUrl,
+  getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
   getDesktopWindowDragCss,
   isAllowedDesktopNavigation,
@@ -13,6 +14,7 @@ import {
   isDesktopAuthProvider,
   normalizeDesktopCallbackPath,
   parseDesktopAuthCallback,
+  shouldPersistDesktopUrl,
 } from "./desktop";
 
 describe("desktop shell helpers", () => {
@@ -159,6 +161,42 @@ describe("desktop shell helpers", () => {
       autoHideMenuBar: true,
       backgroundColor: "#ffffff",
     });
+  });
+
+  it("persists in-app pages but not auth or API URLs", () => {
+    const origin = "https://www.getinboxzero.com";
+    expect(
+      shouldPersistDesktopUrl(`${origin}/account-1/automation`, origin),
+    ).toBe(true);
+    expect(
+      shouldPersistDesktopUrl(`${origin}/account-1/mail?type=inbox`, origin),
+    ).toBe(true);
+    expect(shouldPersistDesktopUrl(`${origin}/login`, origin)).toBe(false);
+    expect(
+      shouldPersistDesktopUrl(`${origin}/login?next=%2Fmail`, origin),
+    ).toBe(false);
+    expect(shouldPersistDesktopUrl(`${origin}/api/user/me`, origin)).toBe(
+      false,
+    );
+    expect(
+      shouldPersistDesktopUrl("https://accounts.google.com/signin", origin),
+    ).toBe(false);
+    expect(shouldPersistDesktopUrl("not a url", origin)).toBe(false);
+    // "/loginish" is a real page, not the login route
+    expect(shouldPersistDesktopUrl(`${origin}/loginish`, origin)).toBe(true);
+  });
+
+  it("restores only validated same-origin URLs on launch", () => {
+    const origin = "https://www.getinboxzero.com";
+    expect(
+      getDesktopSessionRestoreUrl(origin, `${origin}/account-1/automation`),
+    ).toBe(`${origin}/account-1/automation`);
+    expect(getDesktopSessionRestoreUrl(origin, `${origin}/login`)).toBeNull();
+    expect(
+      getDesktopSessionRestoreUrl(origin, "https://evil.test/automation"),
+    ).toBeNull();
+    expect(getDesktopSessionRestoreUrl(origin, null)).toBeNull();
+    expect(getDesktopSessionRestoreUrl(origin, 42)).toBeNull();
   });
 
   it("scopes window dragging to a titlebar strip instead of the whole page", () => {

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -151,6 +151,38 @@ export function findDesktopProtocolUrl(argv: readonly string[]): string | null {
   return argv.find(isDesktopProtocolUrl) ?? null;
 }
 
+// Auth pages are the fallback start URL anyway, and API routes are not pages.
+const NON_RESTORABLE_PATH_PREFIXES = ["/login", "/api/"];
+
+export function shouldPersistDesktopUrl(
+  url: string,
+  appOrigin: string,
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.origin !== appOrigin) return false;
+
+  return !NON_RESTORABLE_PATH_PREFIXES.some(
+    (prefix) =>
+      parsed.pathname === prefix.replace(/\/$/u, "") ||
+      parsed.pathname.startsWith(prefix.endsWith("/") ? prefix : `${prefix}/`),
+  );
+}
+
+export function getDesktopSessionRestoreUrl(
+  appOrigin: string,
+  persistedUrl: unknown,
+): string | null {
+  if (typeof persistedUrl !== "string") return null;
+  if (!shouldPersistDesktopUrl(persistedUrl, appOrigin)) return null;
+  return new URL(persistedUrl).toString();
+}
+
 const DESKTOP_WINDOW_BACKGROUND = "#ffffff";
 
 export function getDesktopWindowChrome(platform = process.platform): {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   dialog,
   ipcMain,
   nativeTheme,
+  session,
   shell,
   type Session,
   type WebContents,
@@ -18,6 +19,7 @@ import {
   getDesktopBrowserStartUrl,
   getDesktopLoginUrl,
   getDesktopPostAuthUrl,
+  getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
   getDesktopWindowDragCss,
   isAllowedDesktopNavigation,
@@ -25,14 +27,17 @@ import {
   isDesktopAuthProvider,
   normalizeDesktopCallbackPath,
   parseDesktopAuthCallback,
+  shouldPersistDesktopUrl,
 } from "./desktop";
 
 const PARTITION = "persist:inbox-zero";
 const PENDING_CALLBACK_PATH_FILE = "pending-auth-callback-path";
+const LAST_APP_URL_FILE = "last-app-url";
 
 let mainWindow: BrowserWindow | null = null;
 let pendingAuthUrl: string | null = null;
 let pendingCallbackPath: string | null = null;
+let isQuitting = false;
 const appOrigin = getDesktopAppOrigin();
 const loginUrl = getDesktopLoginUrl(appOrigin);
 
@@ -90,7 +95,15 @@ function startDesktopApp() {
     },
   );
 
+  app.on("before-quit", () => {
+    isQuitting = true;
+  });
+
   app.whenReady().then(async () => {
+    // Overlap TLS/socket setup with window creation and page load.
+    session
+      .fromPartition(PARTITION)
+      .preconnect({ url: appOrigin, numSockets: 2 });
     createMainWindow();
     const startupAuthUrl =
       pendingAuthUrl ?? findDesktopProtocolUrl(process.argv);
@@ -108,9 +121,7 @@ function startDesktopApp() {
   });
 
   app.on("activate", () => {
-    if (!mainWindow) {
-      createMainWindow();
-    }
+    focusMainWindow();
   });
 }
 
@@ -134,13 +145,63 @@ function createMainWindow() {
   mainWindow.on("page-title-updated", (event) => {
     event.preventDefault();
   });
+  // Keep the window (and the loaded app) alive on macOS so reopening from the
+  // dock is instant instead of a cold page load.
+  mainWindow.on("close", (event) => {
+    if (process.platform === "darwin" && !isQuitting) {
+      event.preventDefault();
+      mainWindow?.hide();
+    }
+  });
   mainWindow.on("closed", () => {
     mainWindow = null;
   });
 
   applyNavigationPolicy(mainWindow.webContents);
   applyDesktopWindowDragRegion(mainWindow.webContents);
-  mainWindow.loadURL(loginUrl).catch(showSignInError);
+  trackLastAppUrl(mainWindow.webContents);
+  mainWindow.loadURL(getStartUrl()).catch(showSignInError);
+}
+
+function getStartUrl(): string {
+  return getDesktopSessionRestoreUrl(appOrigin, readLastAppUrl()) ?? loginUrl;
+}
+
+function trackLastAppUrl(contents: WebContents) {
+  contents.on("did-navigate", (_event, url) => {
+    persistLastAppUrl(url);
+  });
+  contents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+    if (isMainFrame) {
+      persistLastAppUrl(url);
+    }
+  });
+}
+
+function persistLastAppUrl(url: string) {
+  const file = path.join(app.getPath("userData"), LAST_APP_URL_FILE);
+  try {
+    if (shouldPersistDesktopUrl(url, appOrigin)) {
+      fs.writeFileSync(file, url, "utf8");
+    } else {
+      // Landing on /login means the session ended; a stale deep link would
+      // just bounce back there after re-auth.
+      fs.rmSync(file, { force: true });
+    }
+  } catch {
+    // Restoring the last page is best-effort; never break navigation over it.
+  }
+}
+
+function readLastAppUrl(): string | null {
+  try {
+    return fs.readFileSync(
+      path.join(app.getPath("userData"), LAST_APP_URL_FILE),
+      "utf8",
+    );
+  } catch {
+    return null;
+  }
 }
 
 function applyDesktopWindowDragRegion(contents: WebContents) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -45,6 +45,7 @@ import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threa
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
 import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
+import { useHoverThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
@@ -296,6 +297,19 @@ export function MailShell() {
     emailAccountId,
     threadIds: isAllAccounts ? [] : orderedIds,
   });
+  const { schedulePrefetch, cancelPrefetch } = useHoverThreadPrefetch({
+    emailAccountId,
+  });
+  const prefetchThreadAt = useCallback(
+    (index: number) => {
+      const thread = threads[index];
+      // Combined-view rows belong to other accounts, so this hook's account
+      // can't prefetch them; hover prefetch serves the single-account list.
+      if (!thread || "account" in thread) return;
+      schedulePrefetch(thread.id);
+    },
+    [schedulePrefetch, threads],
+  );
   const {
     data: openThreadData,
     error: openThreadError,
@@ -389,11 +403,21 @@ export function MailShell() {
       const next = clampIndex(clampedIndex + delta);
       setFocusedIndex(next);
       // Once a reader is open, navigation keeps its content and position in
-      // step. A closed list view still lets J/K move the row cursor alone.
+      // step. A closed list view still lets J/K move the row cursor alone —
+      // there the cursor still signals intent, so warm the row for Enter.
       if ((layout === "split" || openThreadId) && threads[next])
         setOpenThreadId(threads[next].id);
+      else prefetchThreadAt(next);
     },
-    [clampIndex, clampedIndex, threads, layout, openThreadId, setOpenThreadId],
+    [
+      clampIndex,
+      clampedIndex,
+      threads,
+      layout,
+      openThreadId,
+      prefetchThreadAt,
+      setOpenThreadId,
+    ],
   );
 
   const extendSelection = useCallback(
@@ -799,6 +823,8 @@ export function MailShell() {
                 onOpenThread={openAt}
                 onToggleSelect={selection.toggle}
                 onSelectRangeTo={selection.selectRangeTo}
+                onPrefetchThread={prefetchThreadAt}
+                onPrefetchCancel={cancelPrefetch}
                 onArchiveSelected={archiveTargets}
                 onDeleteSelected={trashTargets}
                 onClearSelection={selection.clear}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -32,6 +32,9 @@ export type ThreadListProps = {
   onOpenThread: (index: number) => void;
   onToggleSelect: (index: number) => void;
   onSelectRangeTo: (index: number) => void;
+  /** Open intent (pointer dwell or focus) — warms the thread before a click. */
+  onPrefetchThread: (index: number) => void;
+  onPrefetchCancel: () => void;
   onArchiveSelected: () => void;
   onDeleteSelected: () => void;
   onClearSelection: () => void;
@@ -56,6 +59,8 @@ export function ThreadList({
   onOpenThread,
   onToggleSelect,
   onSelectRangeTo,
+  onPrefetchThread,
+  onPrefetchCancel,
   onArchiveSelected,
   onDeleteSelected,
   onClearSelection,
@@ -176,6 +181,8 @@ export function ThreadList({
                     key={threadKey}
                     layout={layout}
                     onOpen={onOpenThread}
+                    onPrefetch={onPrefetchThread}
+                    onPrefetchCancel={onPrefetchCancel}
                     onSelectRangeTo={onSelectRangeTo}
                     onToggleSelect={onToggleSelect}
                     rowRef={index === focusedIndex ? focusedRowRef : undefined}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -41,6 +41,9 @@ export type ThreadRowProps = {
   onOpen: (index: number) => void;
   onToggleSelect: (index: number) => void;
   onSelectRangeTo: (index: number) => void;
+  /** Open intent (pointer dwell or focus) — warms the thread before a click. */
+  onPrefetch: (index: number) => void;
+  onPrefetchCancel: () => void;
   rowRef?: Ref<HTMLDivElement>;
 };
 
@@ -58,6 +61,8 @@ export const ThreadRow = memo(function ThreadRow({
   onOpen,
   onToggleSelect,
   onSelectRangeTo,
+  onPrefetch,
+  onPrefetchCancel,
   rowRef,
 }: ThreadRowProps) {
   const message = thread.messages.at(-1);
@@ -160,6 +165,10 @@ export const ThreadRow = memo(function ThreadRow({
         event.preventDefault();
         onOpen(index);
       }}
+      onMouseEnter={() => onPrefetch(index)}
+      onMouseLeave={onPrefetchCancel}
+      onFocus={() => onPrefetch(index)}
+      onBlur={onPrefetchCancel}
       role="option"
       tabIndex={isFocused ? 0 : -1}
     >

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
@@ -1,0 +1,95 @@
+import type { BareFetcher, ScopedMutator } from "swr";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
+import {
+  createThreadRequest,
+  fetchThreadRequest,
+} from "@/utils/email-cache/thread-request";
+import {
+  readCachedThread,
+  writeCachedThread,
+} from "@/utils/email-cache/threads";
+import { prepareEmailHtml } from "@/utils/email/prepare-html.client";
+
+/**
+ * Warms every layer an opened thread reads from: the SWR cache (via mutate so
+ * an open doesn't refetch), the IndexedDB copy, and the prepared HTML cache.
+ * Shared by the adjacent-thread and hover prefetchers so they can't drift.
+ */
+export async function prefetchThreadDetail({
+  emailAccountId,
+  threadId,
+  fetcher,
+  mutate,
+  isCancelled,
+}: {
+  emailAccountId: string;
+  threadId: string;
+  fetcher: BareFetcher;
+  mutate: ScopedMutator;
+  isCancelled?: () => boolean;
+}) {
+  const request = createThreadRequest({
+    emailAccountId,
+    threadId,
+    options: { includeDrafts: true },
+  });
+  const cached = await readCachedThread<ThreadResponse>({
+    emailAccountId,
+    threadId,
+    variant: request.variant,
+  });
+  if (isCancelled?.()) return;
+  if (cached) {
+    await mutate<ThreadResponse>(
+      request.key,
+      (current) => current ?? cached.data,
+      {
+        populateCache: true,
+        revalidate: false,
+      },
+    );
+    await prepareVisibleMessageHtml(cached.data);
+    return;
+  }
+
+  const data = await fetchThreadRequest<ThreadResponse | undefined>(
+    request,
+    async () => (await fetcher(request.key)) as ThreadResponse | undefined,
+  );
+  if (!data) return;
+  await mutate(request.key, data, {
+    populateCache: true,
+    revalidate: false,
+  });
+  await Promise.all([
+    writeCachedThread({
+      emailAccountId,
+      threadId,
+      variant: request.variant,
+      data,
+    }),
+    prepareVisibleMessageHtml(data),
+  ]);
+}
+
+export function shouldPrefetchThreads() {
+  if (document.visibilityState !== "visible") return false;
+  const connection = (
+    navigator as Navigator & {
+      connection?: { effectiveType?: string; saveData?: boolean };
+    }
+  ).connection;
+  return (
+    !connection?.saveData &&
+    connection?.effectiveType !== "slow-2g" &&
+    connection?.effectiveType !== "2g"
+  );
+}
+
+async function prepareVisibleMessageHtml(data: ThreadResponse) {
+  const message = data.thread.messages.findLast(
+    (candidate) => !candidate.labelIds?.includes("DRAFT"),
+  );
+  if (!message?.textHtml) return;
+  await prepareEmailHtml({ messageId: message.id, html: message.textHtml });
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
@@ -2,16 +2,10 @@
 
 import { useEffect, useMemo } from "react";
 import { useSWRConfig } from "swr";
-import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import {
-  createThreadRequest,
-  fetchThreadRequest,
-} from "@/utils/email-cache/thread-request";
-import {
-  readCachedThread,
-  writeCachedThread,
-} from "@/utils/email-cache/threads";
-import { prepareEmailHtml } from "@/utils/email/prepare-html.client";
+  prefetchThreadDetail,
+  shouldPrefetchThreads,
+} from "@/app/(app)/[emailAccountId]/mail/thread-prefetch";
 
 export function useAdjacentThreadPrefetch({
   currentThreadId,
@@ -34,59 +28,21 @@ export function useAdjacentThreadPrefetch({
   }, [currentThreadId, threadIds]);
 
   useEffect(() => {
-    if (!fetcher || !shouldPrefetch() || !adjacentThreadIds.length) return;
+    if (!fetcher || !shouldPrefetchThreads() || !adjacentThreadIds.length)
+      return;
     let cancelled = false;
 
     const prefetch = () => {
       for (const threadId of adjacentThreadIds) {
-        const request = createThreadRequest({
+        prefetchThreadDetail({
           emailAccountId,
           threadId,
-          options: { includeDrafts: true },
+          fetcher,
+          mutate,
+          isCancelled: () => cancelled,
+        }).catch(() => {
+          // Prefetch failures are intentionally silent; opening still retries normally.
         });
-        readCachedThread<ThreadResponse>({
-          emailAccountId,
-          threadId,
-          variant: request.variant,
-        })
-          .then(async (cached) => {
-            if (cancelled) return;
-            if (cached) {
-              await mutate<ThreadResponse>(
-                request.key,
-                (current) => current ?? cached.data,
-                {
-                  populateCache: true,
-                  revalidate: false,
-                },
-              );
-              await prepareVisibleMessageHtml(cached.data);
-              return;
-            }
-
-            const data = await fetchThreadRequest<ThreadResponse | undefined>(
-              request,
-              async () =>
-                (await fetcher(request.key)) as ThreadResponse | undefined,
-            );
-            if (!data) return;
-            await mutate(request.key, data, {
-              populateCache: true,
-              revalidate: false,
-            });
-            await Promise.all([
-              writeCachedThread({
-                emailAccountId,
-                threadId,
-                variant: request.variant,
-                data,
-              }),
-              prepareVisibleMessageHtml(data),
-            ]);
-          })
-          .catch(() => {
-            // Prefetch failures are intentionally silent; opening still retries normally.
-          });
       }
     };
 
@@ -102,26 +58,4 @@ export function useAdjacentThreadPrefetch({
       if (timeout !== undefined) window.clearTimeout(timeout);
     };
   }, [adjacentThreadIds, emailAccountId, fetcher, mutate]);
-}
-
-async function prepareVisibleMessageHtml(data: ThreadResponse) {
-  const message = data.thread.messages.findLast(
-    (candidate) => !candidate.labelIds?.includes("DRAFT"),
-  );
-  if (!message?.textHtml) return;
-  await prepareEmailHtml({ messageId: message.id, html: message.textHtml });
-}
-
-function shouldPrefetch() {
-  if (document.visibilityState !== "visible") return false;
-  const connection = (
-    navigator as Navigator & {
-      connection?: { effectiveType?: string; saveData?: boolean };
-    }
-  ).connection;
-  return (
-    !connection?.saveData &&
-    connection?.effectiveType !== "slow-2g" &&
-    connection?.effectiveType !== "2g"
-  );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { SWRConfig, unstable_serialize } from "swr";
+import type { Cache, State } from "swr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HOVER_PREFETCH_DELAY_MS,
+  useHoverThreadPrefetch,
+} from "./use-hover-thread-prefetch";
+
+const cache = vi.hoisted(() => ({
+  read: vi.fn(),
+  write: vi.fn(),
+}));
+const emailHtml = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/threads", () => ({
+  readCachedThread: cache.read,
+  writeCachedThread: cache.write,
+}));
+
+vi.mock("@/utils/email/prepare-html.client", () => ({
+  prepareEmailHtml: emailHtml.prepare,
+}));
+
+describe("useHoverThreadPrefetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    cache.read.mockResolvedValue(undefined);
+    cache.write.mockResolvedValue(undefined);
+    emailHtml.prepare.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prefetches a hovered conversation only after the dwell delay", async () => {
+    const fetcher = vi.fn((key: [string, string]) =>
+      Promise.resolve({ thread: { id: key[0], messages: [] } }),
+    );
+    const { result } = renderHook(
+      () => useHoverThreadPrefetch({ emailAccountId: "account-dwell" }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    result.current.schedulePrefetch("thread-1");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS - 1);
+    expect(fetcher).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(fetcher.mock.calls[0]?.[0]).toEqual([
+      "/api/threads/thread-1?includeDrafts=true",
+      "account-dwell",
+    ]);
+  });
+
+  it("does not prefetch when the pointer leaves before the delay", async () => {
+    const fetcher = vi.fn();
+    const { result } = renderHook(
+      () => useHoverThreadPrefetch({ emailAccountId: "account-leave" }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    result.current.schedulePrefetch("thread-1");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS - 10);
+    result.current.cancelPrefetch();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(cache.read).not.toHaveBeenCalled();
+  });
+
+  it("sweeping across rows fetches only the row the pointer settles on", async () => {
+    const fetcher = vi.fn((key: [string, string]) =>
+      Promise.resolve({ thread: { id: key[0], messages: [] } }),
+    );
+    const { result } = renderHook(
+      () => useHoverThreadPrefetch({ emailAccountId: "account-sweep" }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    result.current.schedulePrefetch("thread-1");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS - 10);
+    result.current.schedulePrefetch("thread-2");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(fetcher.mock.calls[0]?.[0]).toEqual([
+      "/api/threads/thread-2?includeDrafts=true",
+      "account-sweep",
+    ]);
+  });
+
+  it("skips conversations already in the SWR cache", async () => {
+    const fetcher = vi.fn();
+    const seeded = new Map<string, State>([
+      [
+        unstable_serialize([
+          "/api/threads/thread-1?includeDrafts=true",
+          "account-cached",
+        ]),
+        { data: { thread: { id: "thread-1", messages: [] } } },
+      ],
+    ]);
+    const { result } = renderHook(
+      () => useHoverThreadPrefetch({ emailAccountId: "account-cached" }),
+      { wrapper: createWrapper(fetcher, () => seeded) },
+    );
+
+    result.current.schedulePrefetch("thread-1");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS * 2);
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(cache.read).not.toHaveBeenCalled();
+  });
+
+  it("runs one prefetch at a time and keeps only the latest intent", async () => {
+    const resolvers = new Map<string, (value: unknown) => void>();
+    const fetcher = vi.fn(
+      (key: [string, string]) =>
+        new Promise((resolve) => {
+          resolvers.set(key[0], resolve);
+        }),
+    );
+    const { result } = renderHook(
+      () => useHoverThreadPrefetch({ emailAccountId: "account-flight" }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    result.current.schedulePrefetch("thread-1");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+
+    // Two more dwells while thread-1 is still in flight: only the newest runs.
+    result.current.schedulePrefetch("thread-2");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+    result.current.schedulePrefetch("thread-3");
+    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolvers.get("/api/threads/thread-1?includeDrafts=true")?.({
+      thread: { id: "thread-1", messages: [] },
+    });
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(fetcher.mock.calls.map(([key]) => key[0])).toEqual([
+      "/api/threads/thread-1?includeDrafts=true",
+      "/api/threads/thread-3?includeDrafts=true",
+    ]);
+
+    // Settle the remaining request so shared in-flight state doesn't leak.
+    resolvers.get("/api/threads/thread-3?includeDrafts=true")?.({
+      thread: { id: "thread-3", messages: [] },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+  });
+});
+
+function createWrapper(
+  fetcher: (key: [string, string]) => unknown,
+  provider: () => Cache = () => new Map(),
+) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <SWRConfig value={{ fetcher, provider }}>{children}</SWRConfig>;
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { unstable_serialize, useSWRConfig } from "swr";
+import {
+  prefetchThreadDetail,
+  shouldPrefetchThreads,
+} from "@/app/(app)/[emailAccountId]/mail/thread-prefetch";
+import {
+  createThreadRequest,
+  isThreadRequestInFlight,
+} from "@/utils/email-cache/thread-request";
+
+export const HOVER_PREFETCH_DELAY_MS = 90;
+
+/**
+ * Warms a thread's detail caches when a row signals open intent (pointer
+ * dwell, focus, or the J/K cursor settling on it), so opening feels instant.
+ */
+export function useHoverThreadPrefetch({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  const { cache, fetcher, mutate } = useSWRConfig();
+  const timerRef = useRef<number | undefined>(undefined);
+  const isPrefetchingRef = useRef(false);
+  const queuedThreadIdRef = useRef<string | null>(null);
+
+  const runPrefetch = useCallback(
+    function run(threadId: string) {
+      if (isPrefetchingRef.current) {
+        // One hover prefetch at a time; only the newest intent survives.
+        queuedThreadIdRef.current = threadId;
+        return;
+      }
+      if (!fetcher || !shouldPrefetchThreads()) return;
+      const request = createThreadRequest({
+        emailAccountId,
+        threadId,
+        options: { includeDrafts: true },
+      });
+      const alreadyCached =
+        cache.get(unstable_serialize(request.key))?.data !== undefined;
+      if (alreadyCached || isThreadRequestInFlight(request)) return;
+
+      isPrefetchingRef.current = true;
+      const finish = () => {
+        isPrefetchingRef.current = false;
+        const queued = queuedThreadIdRef.current;
+        queuedThreadIdRef.current = null;
+        if (queued) run(queued);
+      };
+      // Prefetch failures are intentionally silent; opening still retries normally.
+      prefetchThreadDetail({ emailAccountId, threadId, fetcher, mutate }).then(
+        finish,
+        finish,
+      );
+    },
+    [cache, emailAccountId, fetcher, mutate],
+  );
+
+  const cancelPrefetch = useCallback(() => {
+    if (timerRef.current !== undefined) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+    queuedThreadIdRef.current = null;
+  }, []);
+
+  const schedulePrefetch = useCallback(
+    (threadId: string) => {
+      cancelPrefetch();
+      // The dwell delay keeps sweeping the pointer (or holding J/K) across
+      // rows from firing a fetch per row.
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = undefined;
+        runPrefetch(threadId);
+      }, HOVER_PREFETCH_DELAY_MS);
+    },
+    [cancelPrefetch, runPrefetch],
+  );
+
+  useEffect(() => cancelPrefetch, [cancelPrefetch]);
+
+  return { schedulePrefetch, cancelPrefetch };
+}

--- a/apps/web/app/(app)/accounts/page.tsx
+++ b/apps/web/app/(app)/accounts/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/utils/outlook/scopes";
 import { MICROSOFT_DRIVE_SCOPES } from "@/utils/drive/scopes";
 import { clearEmailCacheForAccount } from "@/utils/email-cache/database";
+import { clearPersistedSwrCacheForAccount } from "@/utils/swr-persistence";
 
 export default function AccountsPage() {
   const { data, isLoading, error, mutate } = useAccounts();
@@ -162,6 +163,7 @@ function AccountOptionsDropdown({
         await logOut("/login");
       } else {
         clearEmailCacheForAccount(emailAccount.id).catch(() => {});
+        clearPersistedSwrCacheForAccount(emailAccount.id);
       }
     },
     onError: (error) => {

--- a/apps/web/providers/SWRProvider.test.tsx
+++ b/apps/web/providers/SWRProvider.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import type { Cache } from "swr";
+import { useSWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SWRProvider } from "./SWRProvider";
+import { resetSwrPersistenceBlocksForTesting } from "@/utils/swr-persistence";
+
+const accountState = { emailAccountId: "account-a" };
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => accountState,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: vi.fn(),
+}));
+
+let scopedCache: Cache | undefined;
+
+function CacheProbe() {
+  scopedCache = useSWRConfig().cache;
+  return null;
+}
+
+function snapshotKey(accountId: string) {
+  return `inbox-zero:swr:v1:${accountId}`;
+}
+
+describe("SWRProvider persisted cache", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetSwrPersistenceBlocksForTesting();
+    accountState.emailAccountId = "account-a";
+    scopedCache = undefined;
+  });
+
+  it("hydrates whitelisted entries into the live cache after mount", async () => {
+    window.localStorage.setItem(
+      snapshotKey("account-a"),
+      JSON.stringify({ "/api/labels": { labels: ["a-label"] } }),
+    );
+
+    render(
+      <SWRProvider>
+        <CacheProbe />
+      </SWRProvider>,
+    );
+
+    await waitFor(() => {
+      expect(scopedCache?.get("/api/labels")?.data).toEqual({
+        labels: ["a-label"],
+      });
+    });
+  });
+
+  it("replaces whitelisted entries on account switch instead of leaking them", async () => {
+    window.localStorage.setItem(
+      snapshotKey("account-a"),
+      JSON.stringify({
+        "/api/labels": { labels: ["a-label"] },
+        "/api/labels/counts": { counts: ["a-counts"] },
+      }),
+    );
+    window.localStorage.setItem(
+      snapshotKey("account-b"),
+      JSON.stringify({ "/api/labels": { labels: ["b-label"] } }),
+    );
+
+    const view = render(
+      <SWRProvider>
+        <CacheProbe />
+      </SWRProvider>,
+    );
+    await waitFor(() => {
+      expect(scopedCache?.get("/api/labels")?.data).toEqual({
+        labels: ["a-label"],
+      });
+    });
+
+    accountState.emailAccountId = "account-b";
+    view.rerender(
+      <SWRProvider>
+        <CacheProbe />
+      </SWRProvider>,
+    );
+
+    await waitFor(() => {
+      expect(scopedCache?.get("/api/labels")?.data).toEqual({
+        labels: ["b-label"],
+      });
+      // account-b has no counts snapshot: account-a's value must be gone.
+      expect(scopedCache?.get("/api/labels/counts")?.data).toBeUndefined();
+    });
+  });
+
+  it("persists the active account's whitelisted entries on pagehide", async () => {
+    window.localStorage.setItem(
+      snapshotKey("account-a"),
+      JSON.stringify({ "/api/labels": { labels: ["a-label"] } }),
+    );
+
+    render(
+      <SWRProvider>
+        <CacheProbe />
+      </SWRProvider>,
+    );
+    await waitFor(() => {
+      expect(scopedCache?.get("/api/labels")?.data).toBeDefined();
+    });
+
+    window.localStorage.clear();
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(
+      JSON.parse(window.localStorage.getItem(snapshotKey("account-a")) ?? "{}"),
+    ).toEqual({ "/api/labels": { labels: ["a-label"] } });
+  });
+
+  it("stops persisting an account after another tab removes its snapshot", async () => {
+    window.localStorage.setItem(
+      snapshotKey("account-a"),
+      JSON.stringify({ "/api/labels": { labels: ["a-label"] } }),
+    );
+
+    render(
+      <SWRProvider>
+        <CacheProbe />
+      </SWRProvider>,
+    );
+    await waitFor(() => {
+      expect(scopedCache?.get("/api/labels")?.data).toBeDefined();
+    });
+
+    // Another tab logging out removes the snapshot and fires a storage event.
+    window.localStorage.removeItem(snapshotKey("account-a"));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: snapshotKey("account-a"),
+        newValue: null,
+      }),
+    );
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(window.localStorage.getItem(snapshotKey("account-a"))).toBeNull();
+  });
+});

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -8,7 +8,7 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { SWRConfig, mutate } from "swr";
+import { SWRConfig, mutate, useSWRConfig } from "swr";
 import { captureException } from "@/utils/error";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
@@ -18,6 +18,10 @@ import {
 } from "@/utils/config";
 import { prefixPath } from "@/utils/path";
 import { redirectToSafeUrl } from "@/utils/redirect";
+import {
+  persistSwrEntries,
+  readPersistedSwrEntries,
+} from "@/utils/swr-persistence";
 
 // https://swr.vercel.app/docs/error-handling#status-code-and-error-object
 const fetcher = async (
@@ -166,11 +170,60 @@ export const SWRProvider = (props: { children: React.ReactNode }) => {
           ...getDevOnlySWRConfig(),
         }}
       >
+        <PersistedSwrCache />
         {props.children}
       </SWRConfig>
     </SWRContext.Provider>
   );
 };
+
+/**
+ * Hydrates whitelisted SWR entries from localStorage and snapshots them back.
+ * Must live inside SWRConfig: SWR initializes its cache from the provider
+ * exactly once, so only the scoped `cache`/`mutate` from useSWRConfig reach
+ * the live cache. Hydrating in an effect (after the hydration render) keeps
+ * client and server HTML identical.
+ */
+function PersistedSwrCache() {
+  const { cache, mutate: scopedMutate } = useSWRConfig();
+  const { emailAccountId } = useAccount();
+  const hydratedForRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!emailAccountId || hydratedForRef.current === emailAccountId) return;
+    hydratedForRef.current = emailAccountId;
+    for (const [key, state] of readPersistedSwrEntries(emailAccountId)) {
+      if (state.data !== undefined && cache.get(key)?.data === undefined) {
+        scopedMutate(key, state.data, {
+          populateCache: true,
+          revalidate: false,
+        });
+      }
+    }
+  }, [emailAccountId, cache, scopedMutate]);
+
+  // Snapshot when the app is backgrounded, closed, or this account unmounts;
+  // there is no per-write hook on the SWR cache, and the visibility event also
+  // covers the desktop shell hiding its window.
+  useEffect(() => {
+    if (!emailAccountId) return;
+
+    const persist = () => persistSwrEntries(emailAccountId, cache);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") persist();
+    };
+
+    window.addEventListener("pagehide", persist);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      persist();
+      window.removeEventListener("pagehide", persist);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [emailAccountId, cache]);
+
+  return null;
+}
 
 // Dev-only config to handle transient 404s during HMR
 function getDevOnlySWRConfig() {

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -19,6 +19,9 @@ import {
 import { prefixPath } from "@/utils/path";
 import { redirectToSafeUrl } from "@/utils/redirect";
 import {
+  accountIdFromSnapshotKey,
+  clearPersistedSwrCacheForAccount,
+  PERSISTED_SWR_KEYS,
   persistSwrEntries,
   readPersistedSwrEntries,
 } from "@/utils/swr-persistence";
@@ -191,16 +194,35 @@ function PersistedSwrCache() {
 
   useEffect(() => {
     if (!emailAccountId || hydratedForRef.current === emailAccountId) return;
+    const isAccountSwitch = hydratedForRef.current !== null;
     hydratedForRef.current = emailAccountId;
-    for (const [key, state] of readPersistedSwrEntries(emailAccountId)) {
-      if (state.data !== undefined && cache.get(key)?.data === undefined) {
-        scopedMutate(key, state.data, {
-          populateCache: true,
-          revalidate: false,
-        });
+    const persisted = readPersistedSwrEntries(emailAccountId);
+    for (const key of PERSISTED_SWR_KEYS) {
+      const data = persisted.get(key)?.data;
+      if (isAccountSwitch) {
+        // The provider reset doesn't reach the live scoped cache (SWR only
+        // initializes its provider once), so the previous account's values
+        // still occupy these keys. Replace them with this account's snapshot
+        // (or clear them) so they can't render or get persisted under the
+        // wrong account.
+        scopedMutate(key, data, { populateCache: true, revalidate: false });
+      } else if (data !== undefined && cache.get(key)?.data === undefined) {
+        scopedMutate(key, data, { populateCache: true, revalidate: false });
       }
     }
   }, [emailAccountId, cache, scopedMutate]);
+
+  // If another tab removes an account's snapshot (logout or account
+  // deletion), stop this tab from re-persisting it out of its warm cache.
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.newValue !== null) return;
+      const removedAccountId = accountIdFromSnapshotKey(event.key ?? "");
+      if (removedAccountId) clearPersistedSwrCacheForAccount(removedAccountId);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
 
   // Snapshot when the app is backgrounded, closed, or this account unmounts;
   // there is no per-write hook on the SWR cache, and the visibility event also

--- a/apps/web/utils/email-cache/thread-request.ts
+++ b/apps/web/utils/email-cache/thread-request.ts
@@ -32,6 +32,12 @@ export function createThreadRequest({
   };
 }
 
+export function isThreadRequestInFlight(
+  request: Pick<ThreadRequest, "cacheIdentity">,
+) {
+  return inFlightRequests.has(request.cacheIdentity);
+}
+
 export function fetchThreadRequest<T>(
   request: Pick<ThreadRequest, "cacheIdentity">,
   fetcher: () => T | PromiseLike<T>,

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  accountIdFromSnapshotKey,
   clearPersistedSwrCache,
   clearPersistedSwrCacheForAccount,
   persistSwrEntries,
   readPersistedSwrEntries,
+  resetSwrPersistenceBlocksForTesting,
 } from "./swr-persistence";
 
 const ACCOUNT_A = "account-a";
@@ -17,6 +19,7 @@ function cacheWith(entries: Record<string, unknown>) {
 describe("swr-persistence", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    resetSwrPersistenceBlocksForTesting();
   });
 
   it("round-trips whitelisted entries per account", () => {
@@ -63,6 +66,26 @@ describe("swr-persistence", () => {
     ).toBe(false);
   });
 
+  it("keeps previously persisted keys when the cache only has a subset", () => {
+    persistSwrEntries(
+      ACCOUNT_A,
+      cacheWith({
+        "/api/labels": { labels: ["old"] },
+        "/api/labels/counts": { counts: [7] },
+      }),
+    );
+
+    // A page that only fetched labels persists; counts must survive.
+    persistSwrEntries(
+      ACCOUNT_A,
+      cacheWith({ "/api/labels": { labels: ["new"] } }),
+    );
+
+    const restored = readPersistedSwrEntries(ACCOUNT_A);
+    expect(restored.get("/api/labels")?.data).toEqual({ labels: ["new"] });
+    expect(restored.get("/api/labels/counts")?.data).toEqual({ counts: [7] });
+  });
+
   it("returns nothing for a corrupt snapshot instead of throwing", () => {
     window.localStorage.setItem(`inbox-zero:swr:v1:${ACCOUNT_A}`, "{not json");
 
@@ -95,5 +118,34 @@ describe("swr-persistence", () => {
     expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
     expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(0);
     expect(window.localStorage.getItem("unrelated")).toBe("keep-me");
+  });
+
+  it("blocks persisting after logout so pagehide can't resurrect data", () => {
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+
+    clearPersistedSwrCache();
+    // The logout redirect fires pagehide, which persists from the warm cache.
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("blocks persisting only for a cleared account", () => {
+    clearPersistedSwrCacheForAccount(ACCOUNT_A);
+
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+    persistSwrEntries(ACCOUNT_B, cacheWith({ "/api/labels": { labels: [] } }));
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+    expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(1);
+  });
+
+  it("maps snapshot storage keys back to account ids", () => {
+    expect(accountIdFromSnapshotKey(`inbox-zero:swr:v1:${ACCOUNT_A}`)).toBe(
+      ACCOUNT_A,
+    );
+    expect(accountIdFromSnapshotKey("inbox-zero:swr:v1:")).toBeNull();
+    expect(accountIdFromSnapshotKey("unrelated-key")).toBeNull();
   });
 });

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearPersistedSwrCache,
+  clearPersistedSwrCacheForAccount,
+  persistSwrEntries,
+  readPersistedSwrEntries,
+} from "./swr-persistence";
+
+const ACCOUNT_A = "account-a";
+const ACCOUNT_B = "account-b";
+
+function cacheWith(entries: Record<string, unknown>) {
+  return new Map(Object.entries(entries).map(([key, data]) => [key, { data }]));
+}
+
+describe("swr-persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("round-trips whitelisted entries per account", () => {
+    persistSwrEntries(
+      ACCOUNT_A,
+      cacheWith({
+        "/api/labels": { labels: [{ id: "l1", name: "Newsletters" }] },
+        "/api/labels/counts": { counts: [{ id: "l1", unread: 3 }] },
+      }),
+    );
+
+    const restored = readPersistedSwrEntries(ACCOUNT_A);
+    expect(restored.get("/api/labels")).toEqual({
+      data: { labels: [{ id: "l1", name: "Newsletters" }] },
+      isLoading: false,
+      isValidating: false,
+    });
+    expect(restored.get("/api/labels/counts")?.data).toEqual({
+      counts: [{ id: "l1", unread: 3 }],
+    });
+  });
+
+  it("does not leak entries across accounts", () => {
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+
+    expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(0);
+  });
+
+  it("ignores non-whitelisted cache keys", () => {
+    persistSwrEntries(
+      ACCOUNT_A,
+      cacheWith({
+        "/api/labels": { labels: [] },
+        "/api/threads?limit=20": { threads: ["should not persist"] },
+      }),
+    );
+
+    const stored = window.localStorage.getItem(
+      `inbox-zero:swr:v1:${ACCOUNT_A}`,
+    );
+    expect(stored).not.toContain("should not persist");
+    expect(
+      readPersistedSwrEntries(ACCOUNT_A).has("/api/threads?limit=20"),
+    ).toBe(false);
+  });
+
+  it("returns nothing for a corrupt snapshot instead of throwing", () => {
+    window.localStorage.setItem(`inbox-zero:swr:v1:${ACCOUNT_A}`, "{not json");
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+  });
+
+  it("skips persisting when there is no whitelisted data", () => {
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/other": { x: 1 } }));
+
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("clears one account without touching others", () => {
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+    persistSwrEntries(ACCOUNT_B, cacheWith({ "/api/labels": { labels: [] } }));
+
+    clearPersistedSwrCacheForAccount(ACCOUNT_A);
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+    expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(1);
+  });
+
+  it("clears every account on logout but leaves unrelated storage", () => {
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+    persistSwrEntries(ACCOUNT_B, cacheWith({ "/api/labels": { labels: [] } }));
+    window.localStorage.setItem("unrelated", "keep-me");
+
+    clearPersistedSwrCache();
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+    expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(0);
+    expect(window.localStorage.getItem("unrelated")).toBe("keep-me");
+  });
+});

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -8,7 +8,7 @@ const STORAGE_PREFIX = "inbox-zero:swr:v1:";
 // These hooks use plain-string SWR keys that are not account-scoped (the
 // account travels in a request header), so the snapshot is namespaced by
 // emailAccountId instead.
-const PERSISTED_KEYS = [
+export const PERSISTED_SWR_KEYS = [
   "/api/labels",
   "/api/labels/counts",
   "/api/user/folders",
@@ -26,27 +26,22 @@ type ReadableCache = {
   get(key: string): SwrCacheState | undefined;
 };
 
+// Set by the clear functions so a later pagehide/visibility snapshot can't
+// resurrect cleared data from the still-warm in-memory cache — the logout
+// redirect itself fires pagehide. Module state resets on the next page load,
+// which is exactly the lifetime the block needs.
+let allPersistenceBlocked = false;
+const blockedAccountIds = new Set<string>();
+
 export function readPersistedSwrEntries(
   emailAccountId: string | null | undefined,
 ): Map<string, SwrCacheState> {
   const entries = new Map<string, SwrCacheState>();
   if (!emailAccountId || typeof window === "undefined") return entries;
 
-  try {
-    const raw = window.localStorage.getItem(storageKey(emailAccountId));
-    if (!raw) return entries;
-    const snapshot: unknown = JSON.parse(raw);
-    if (!snapshot || typeof snapshot !== "object") return entries;
-
-    for (const key of PERSISTED_KEYS) {
-      const data = (snapshot as Record<string, unknown>)[key];
-      if (data !== undefined) {
-        // Hydrated data is stale by definition; SWR revalidates on mount.
-        entries.set(key, { data, isLoading: false, isValidating: false });
-      }
-    }
-  } catch {
-    // Hydration is best-effort; a corrupt snapshot must never break the app.
+  for (const [key, data] of Object.entries(readRawSnapshot(emailAccountId))) {
+    // Hydrated data is stale by definition; SWR revalidates on mount.
+    entries.set(key, { data, isLoading: false, isValidating: false });
   }
   return entries;
 }
@@ -56,11 +51,14 @@ export function persistSwrEntries(
   cache: ReadableCache,
 ) {
   if (!emailAccountId || typeof window === "undefined") return;
+  if (allPersistenceBlocked || blockedAccountIds.has(emailAccountId)) return;
 
   try {
-    const snapshot: Record<string, unknown> = {};
+    // Seed from the stored snapshot so a page that only fetched a subset of
+    // the whitelisted keys doesn't drop the rest on overwrite.
+    const snapshot = readRawSnapshot(emailAccountId);
     let hasData = false;
-    for (const key of PERSISTED_KEYS) {
+    for (const key of PERSISTED_SWR_KEYS) {
       const data = cache.get(key)?.data;
       if (data !== undefined) {
         snapshot[key] = data;
@@ -78,6 +76,7 @@ export function persistSwrEntries(
 }
 
 export function clearPersistedSwrCache() {
+  allPersistenceBlocked = true;
   if (typeof window === "undefined") return;
   try {
     for (const key of persistedStorageKeys()) {
@@ -89,6 +88,7 @@ export function clearPersistedSwrCache() {
 }
 
 export function clearPersistedSwrCacheForAccount(emailAccountId: string) {
+  blockedAccountIds.add(emailAccountId);
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(storageKey(emailAccountId));
@@ -97,8 +97,38 @@ export function clearPersistedSwrCacheForAccount(emailAccountId: string) {
   }
 }
 
+/** Maps a localStorage key back to its account id; null for unrelated keys. */
+export function accountIdFromSnapshotKey(key: string): string | null {
+  if (!key.startsWith(STORAGE_PREFIX)) return null;
+  return key.slice(STORAGE_PREFIX.length) || null;
+}
+
+export function resetSwrPersistenceBlocksForTesting() {
+  allPersistenceBlocked = false;
+  blockedAccountIds.clear();
+}
+
 function storageKey(emailAccountId: string) {
   return `${STORAGE_PREFIX}${emailAccountId}`;
+}
+
+function readRawSnapshot(emailAccountId: string): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {};
+  try {
+    const raw = window.localStorage.getItem(storageKey(emailAccountId));
+    if (!raw) return snapshot;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return snapshot;
+    }
+    for (const key of PERSISTED_SWR_KEYS) {
+      const data = (parsed as Record<string, unknown>)[key];
+      if (data !== undefined) snapshot[key] = data;
+    }
+  } catch {
+    // A corrupt snapshot must never break the app.
+  }
+  return snapshot;
 }
 
 function persistedStorageKeys(): string[] {

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -1,0 +1,111 @@
+// Persists a small whitelist of SWR cache entries to localStorage so the app
+// shell (sidebar labels, counts, folders, mail settings) renders instantly on
+// a cold load instead of flashing empty. Mail content itself is persisted
+// separately in utils/email-cache (IndexedDB).
+
+const STORAGE_PREFIX = "inbox-zero:swr:v1:";
+
+// These hooks use plain-string SWR keys that are not account-scoped (the
+// account travels in a request header), so the snapshot is namespaced by
+// emailAccountId instead.
+const PERSISTED_KEYS = [
+  "/api/labels",
+  "/api/labels/counts",
+  "/api/user/folders",
+  "/api/mail/settings",
+] as const;
+
+type SwrCacheState = {
+  data?: unknown;
+  isLoading?: boolean;
+  isValidating?: boolean;
+};
+
+// Matches both a plain Map and SWR's Cache interface.
+type ReadableCache = {
+  get(key: string): SwrCacheState | undefined;
+};
+
+export function readPersistedSwrEntries(
+  emailAccountId: string | null | undefined,
+): Map<string, SwrCacheState> {
+  const entries = new Map<string, SwrCacheState>();
+  if (!emailAccountId || typeof window === "undefined") return entries;
+
+  try {
+    const raw = window.localStorage.getItem(storageKey(emailAccountId));
+    if (!raw) return entries;
+    const snapshot: unknown = JSON.parse(raw);
+    if (!snapshot || typeof snapshot !== "object") return entries;
+
+    for (const key of PERSISTED_KEYS) {
+      const data = (snapshot as Record<string, unknown>)[key];
+      if (data !== undefined) {
+        // Hydrated data is stale by definition; SWR revalidates on mount.
+        entries.set(key, { data, isLoading: false, isValidating: false });
+      }
+    }
+  } catch {
+    // Hydration is best-effort; a corrupt snapshot must never break the app.
+  }
+  return entries;
+}
+
+export function persistSwrEntries(
+  emailAccountId: string | null | undefined,
+  cache: ReadableCache,
+) {
+  if (!emailAccountId || typeof window === "undefined") return;
+
+  try {
+    const snapshot: Record<string, unknown> = {};
+    let hasData = false;
+    for (const key of PERSISTED_KEYS) {
+      const data = cache.get(key)?.data;
+      if (data !== undefined) {
+        snapshot[key] = data;
+        hasData = true;
+      }
+    }
+    if (!hasData) return;
+    window.localStorage.setItem(
+      storageKey(emailAccountId),
+      JSON.stringify(snapshot),
+    );
+  } catch {
+    // Quota or serialization failures must never break the app.
+  }
+}
+
+export function clearPersistedSwrCache() {
+  if (typeof window === "undefined") return;
+  try {
+    for (const key of persistedStorageKeys()) {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage failures during logout.
+  }
+}
+
+export function clearPersistedSwrCacheForAccount(emailAccountId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(storageKey(emailAccountId));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function storageKey(emailAccountId: string) {
+  return `${STORAGE_PREFIX}${emailAccountId}`;
+}
+
+function persistedStorageKeys(): string[] {
+  const keys: string[] = [];
+  for (let index = 0; index < window.localStorage.length; index++) {
+    const key = window.localStorage.key(index);
+    if (key?.startsWith(STORAGE_PREFIX)) keys.push(key);
+  }
+  return keys;
+}

--- a/apps/web/utils/user.ts
+++ b/apps/web/utils/user.ts
@@ -4,9 +4,11 @@ import { signOut } from "@/utils/auth-client";
 import { clearLastEmailAccountAction } from "@/utils/actions/email-account-cookie";
 import { redirectToSafeUrl } from "@/utils/redirect";
 import { clearEmailCache } from "@/utils/email-cache/database";
+import { clearPersistedSwrCache } from "@/utils/swr-persistence";
 
 export async function logOut(callbackUrl?: string) {
   clearLastEmailAccountAction();
+  clearPersistedSwrCache();
   await clearEmailCache();
 
   await signOut({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260817-193657_pr-3323_f058f45e5c8a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

Four perceived-latency improvements for the desktop shell and web app, benchmarked against the emulated backend with browser automation.

### Desktop shell (apps/desktop)
- **Restore last page on launch**: persist the last in-app URL and load it at startup instead of always paying the `/login` → `/welcome-redirect` → `/{account}/automation` server redirect chain (2 extra round trips). Auth and API paths are never persisted; landing on `/login` clears the stored URL.
- **Hide on close (macOS)**: closing the window hides it instead of destroying it, so reopening from the dock is instant instead of a full cold page load. Cmd+Q still quits.
- **Preconnect**: warm TLS/sockets to the app origin while the window is being created.

### Web app (apps/web)
- **Hover/focus thread prefetch**: rows warm the SWR cache, IndexedDB, and prepared HTML after a 90ms pointer dwell (also on focus and J/K cursor movement), reusing the existing adjacent-thread prefetch logic. Opening a hovered email no longer waits on the network.
- **Persisted app-shell cache**: a whitelist of small config responses (labels, label counts, folders, mail settings) is snapshotted to localStorage per account and hydrated after mount, so the sidebar renders instantly on cold loads. Cleared on logout and account deletion. Hydration goes through the scoped SWR cache (the provider function only runs once) and happens post-mount to avoid hydration mismatches.

## Benchmarks (emulated backend, browser automation, medians)

| Scenario | Before | After |
|---|---|---|
| Launch: login redirect chain vs direct restore (TTFB) | ~465ms, 2 redirects | ~340ms, 0 redirects |
| Open email with 400ms simulated API latency | ~560ms | ~120ms (hover-prefetched) |
| Sidebar labels with API unavailable | never renders | renders at ~530ms from snapshot |
| macOS dock reopen | full cold page load | instant (window kept alive) |

Notes: dev-server timings are noisy, so medians over repeated alternating trials were used; the thread-open test injected 400ms of latency into the thread-detail endpoint to model production provider API round trips (locally the emulator responds in ~50ms, hiding the effect).

## Tests
- New unit tests for desktop URL persistence helpers, hover prefetch dwell/gating behavior, and the localStorage snapshot module.
- `pnpm --filter @inboxzero/desktop test`: 28 passed. Mail + email-cache + persistence suites: 124 passed.

## Deferred (follow-ups)
- Service-worker offline navigation fallback: needs production-build QA; runtime caching for static assets is already covered by the Serwist precache.
- Optimistic reply/send, combined-view hover prefetch, persisting list pages beyond page 0.
- Pre-existing: the account-switch `resetCache` path swaps a Map that SWR no longer reads (SWR initializes its cache provider once); today's behavior is unchanged but worth revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->