### PR TITLE
desktop: Keep Mac traffic lights from overlapping the wordmark

### DIFF
--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -169,5 +169,9 @@ describe("desktop shell helpers", () => {
     expect(getDesktopWindowDragCss("darwin")).toBe(DESKTOP_WINDOW_DRAG_CSS);
     expect(getDesktopWindowDragCss("win32")).toBeNull();
     expect(getDesktopWindowDragCss("linux")).toBeNull();
+    expect(DESKTOP_WINDOW_DRAG_CSS).toContain("[data-hide-on-desktop-mac]");
+    expect(DESKTOP_WINDOW_DRAG_CSS).toContain(
+      "--desktop-traffic-lights-width: 78px",
+    );
   });
 });

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -153,6 +153,13 @@ export function findDesktopProtocolUrl(argv: readonly string[]): string | null {
 
 const DESKTOP_WINDOW_BACKGROUND = "#ffffff";
 
+/** Vertically centers the lights in the 52px left drag region. */
+export const DESKTOP_MAC_TRAFFIC_LIGHT_POSITION = { x: 16, y: 18 } as const;
+export const DESKTOP_MAC_TITLEBAR_HEIGHT = 52;
+export const DESKTOP_MAC_TRAFFIC_LIGHTS_WIDTH = 78;
+/** Web chrome marked with this is hidden by the Mac desktop stylesheet. */
+export const DESKTOP_MAC_HIDE_ATTRIBUTE = "data-hide-on-desktop-mac";
+
 export function getDesktopWindowChrome(platform = process.platform): {
   autoHideMenuBar?: boolean;
   backgroundColor: string;
@@ -168,7 +175,7 @@ export function getDesktopWindowChrome(platform = process.platform): {
     return {
       backgroundColor: DESKTOP_WINDOW_BACKGROUND,
       titleBarStyle: "hiddenInset",
-      trafficLightPosition: { x: 16, y: 18 },
+      trafficLightPosition: { ...DESKTOP_MAC_TRAFFIC_LIGHT_POSITION },
     };
   }
 
@@ -203,14 +210,23 @@ html::after {
 
 html::before {
   left: 0;
-  width: 140px;
-  height: 52px;
+  width: ${DESKTOP_MAC_TRAFFIC_LIGHTS_WIDTH}px;
+  height: ${DESKTOP_MAC_TITLEBAR_HEIGHT}px;
 }
 
 html::after {
-  left: 140px;
+  left: ${DESKTOP_MAC_TRAFFIC_LIGHTS_WIDTH}px;
   right: 0;
   height: 12px;
+}
+
+:root {
+  --desktop-traffic-lights-width: ${DESKTOP_MAC_TRAFFIC_LIGHTS_WIDTH}px;
+  --desktop-traffic-lights-height: ${DESKTOP_MAC_TITLEBAR_HEIGHT}px;
+}
+
+[${DESKTOP_MAC_HIDE_ATTRIBUTE}] {
+  display: none !important;
 }
 `.trim();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -28,7 +28,14 @@ export function ListToolbar({
   const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
 
   return (
-    <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3">
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-2 px-3 pt-3 pb-3",
+        // Mac traffic lights hang past the collapsed 3rem sidebar.
+        showSidebarToggle &&
+          "lg:pl-[max(0.75rem,calc(var(--desktop-traffic-lights-width,0px)-3rem))]",
+      )}
+    >
       {showSidebarToggle ? (
         <SidebarTrigger name="left-sidebar" className="hidden lg:inline-flex" />
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -162,10 +162,13 @@ export function MailSidebar({
       <div className="mb-2.5 flex shrink-0 items-center gap-1">
         <Link
           href={backToAppHref}
+          data-desktop-mac-end
           className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <ArrowLeftIcon className="size-3.5 shrink-0" />
-          <span className="flex-1 truncate">Inbox Zero</span>
+          <span className="flex-1 truncate" data-hide-on-desktop-mac>
+            Inbox Zero
+          </span>
         </Link>
         <SidebarTrigger
           name="left-sidebar"

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboarding.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/ChatOnboarding.tsx
@@ -709,8 +709,10 @@ export function ChatOnboarding() {
     <div className="flex h-dvh flex-col bg-background">
       <EmailStatsPreloader />
 
-      <header className="flex h-14 shrink-0 items-center justify-between border-b px-5">
-        <Logo className="h-4 w-auto text-foreground" />
+      <header className="flex h-14 shrink-0 items-center justify-end border-b px-5">
+        <span data-hide-on-desktop-mac className="mr-auto">
+          <Logo className="h-4 w-auto text-foreground" />
+        </span>
         <OnboardingAccountMenu />
       </header>
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -135,6 +135,15 @@ export default async function RootLayout({
         className={`h-full ${env.NEXT_PUBLIC_USE_AEONIK_FONT ? aeonikFont.variable : ""} ${geist.variable} font-sans antialiased`}
       >
         <script
+          // Marks the Mac Electron shell before paint so traffic-light
+          // insets apply without a logo flash. Harmless in the browser.
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static UA check, no user input
+          dangerouslySetInnerHTML={{
+            __html:
+              'if(window.inboxZeroDesktop&&/Mac/i.test(navigator.userAgent))document.documentElement.dataset.macDesktop=""',
+          }}
+        />
+        <script
           type="application/ld+json"
           // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON.stringify on controlled object is safe
           dangerouslySetInnerHTML={{

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -280,14 +280,14 @@ export function SideNav({
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader className="gap-0 pb-0">
         {state.includes("left-sidebar") ? (
-          <div className="flex items-center rounded-md pl-2 pr-0.5 py-3 text-foreground justify-between">
-            <Link href={navigation.homeHref}>
+          <div className="flex items-center rounded-md pl-2 pr-0.5 py-3 text-foreground">
+            <Link href={navigation.homeHref} data-hide-on-desktop-mac>
               <Logo className="h-3.5" />
             </Link>
-            <SidebarTrigger name="left-sidebar" />
+            <SidebarTrigger name="left-sidebar" className="ml-auto" />
           </div>
         ) : (
-          <div className="pb-2">
+          <div className="pb-2 pt-[var(--desktop-traffic-lights-height,0px)]">
             <SidebarTrigger name="left-sidebar" />
           </div>
         )}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -269,3 +269,19 @@
     justify-content: flex-end;
   }
 }
+
+/* Mac desktop shell: leave the traffic-light row empty. Set by a
+   before-hydration script when window.inboxZeroDesktop is present. */
+html[data-mac-desktop] {
+  --desktop-traffic-lights-width: 78px;
+  --desktop-traffic-lights-height: 52px;
+}
+
+html[data-mac-desktop] [data-hide-on-desktop-mac] {
+  display: none !important;
+}
+
+html[data-mac-desktop] [data-desktop-mac-end] {
+  flex: none;
+  margin-left: auto;
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260818-135354_pr-3324_ee530e501207/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
The Mac desktop wordmark sat under the traffic lights. Hide it on Mac desktop and leave that header row empty so the lights and sidebar toggle do not collide.

- Hide the sidebar and onboarding wordmarks on Mac desktop; keep the sidebar toggle on the right
- Narrow the Mac drag overlay to the traffic-light cluster and inset collapsed/mail chrome
- Browser layout is unchanged

## Test plan
- [ ] Open the Mac desktop app against this web build and confirm the lights no longer overlap INBOX ZERO
- [ ] Confirm the sidebar toggle still works expanded and collapsed
- [ ] Check mail sidebar back control and onboarding header on Mac desktop
- [ ] Confirm the browser app still shows the wordmark
- [ ] `pnpm --filter @inboxzero/desktop test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->