### PR TITLE
test: Centralize emulated account lookup

### DIFF
--- a/apps/web/__tests__/playwright/emulated/account-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/account-test-helpers.ts
@@ -1,0 +1,59 @@
+import type { Page } from "@playwright/test";
+
+const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
+const ACCOUNT_LOOKUP_RETRY_MS = 1000;
+
+type EmailAccount = {
+  email: string;
+  id: string;
+};
+
+type AccountLookupOptions = {
+  timeout?: number;
+};
+
+export async function getEmailAccount(
+  page: Page,
+  { timeout = ACCOUNT_LOOKUP_TIMEOUT_MS }: AccountLookupOptions = {},
+) {
+  let lastError: unknown;
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await page.request.get("/api/user/email-accounts");
+      if (response.ok()) {
+        const { emailAccounts } = (await response.json()) as {
+          emailAccounts: EmailAccount[];
+        };
+        const emailAccount = emailAccounts[0];
+        if (emailAccount) return emailAccount;
+        lastError = new Error("The setup project created no account");
+      } else {
+        lastError = new Error(
+          `Email accounts request failed with ${response.status()}`,
+        );
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await page.waitForTimeout(ACCOUNT_LOOKUP_RETRY_MS);
+  }
+
+  throw new Error(
+    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
+  );
+}
+
+export async function getEmailAccountId(
+  page: Page,
+  options?: AccountLookupOptions,
+) {
+  const emailAccount = await getEmailAccount(page, options);
+  return emailAccount.id;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/attachments/attachment-test-helpers.ts
@@ -1,25 +1,12 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccountId } from "../account-test-helpers";
 
 const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
 
 export async function openAttachments(page: Page) {
-  let emailAccountId: string | undefined;
-  await expect
-    .poll(
-      async () => {
-        try {
-          emailAccountId = await getEmailAccountId(page);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 120_000 },
-    )
-    .toBe(true);
-  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+  const emailAccountId = await getEmailAccountId(page, { timeout: 120_000 });
 
   await navigateUntilReady(
     page,
@@ -72,17 +59,6 @@ export async function resetAttachmentTestState() {
   } finally {
     await client.end();
   }
-}
-
-async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
 }
 
 async function resetAttachmentState(client: Client) {

--- a/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
@@ -7,7 +7,6 @@ export const HISTORY_EXECUTED_RULE_ID =
   "playwright-automation-history-execution";
 export const KNOWLEDGE_TITLE = "Playwright product context";
 export const UPDATED_KNOWLEDGE_TITLE = "Playwright customer context";
-const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
 
 type AutomationAccountSettings = {
   about: string | null;
@@ -51,10 +50,6 @@ export type AutomationSettingsCleanup = Awaited<
 > & {
   emailAccountId: string;
 };
-
-export async function getAutomationEmailAccountId(page: Page) {
-  return getEmailAccountIdWithRetry(page);
-}
 
 export async function markAutomationOnboardingViewed(page: Page) {
   await page.goto("/");
@@ -395,37 +390,6 @@ async function restoreDraftAction(client: Client, action: DraftActionSnapshot) {
   );
 }
 
-async function getEmailAccountIdWithRetry(page: Page) {
-  let lastError: unknown;
-  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await page.request.get("/api/user/email-accounts");
-      if (response.ok()) {
-        const { emailAccounts } = (await response.json()) as {
-          emailAccounts: { id: string }[];
-        };
-        const emailAccountId = emailAccounts[0]?.id;
-        if (emailAccountId) return emailAccountId;
-        lastError = new Error("The setup project created no account");
-      } else {
-        lastError = new Error(
-          `Email accounts request failed with ${response.status()}`,
-        );
-      }
-    } catch (error) {
-      lastError = error;
-    }
-
-    await page.waitForTimeout(1000);
-  }
-
-  throw new Error(
-    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
-  );
-}
-
 async function withClient<T>(callback: (client: Client) => Promise<T>) {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   await client.connect();
@@ -434,10 +398,6 @@ async function withClient<T>(callback: (client: Client) => Promise<T>) {
   } finally {
     await client.end();
   }
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function stringifyJson(value: unknown) {

--- a/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   cleanupAutomationHistory,
   expectVisibleAfterTransientFetch,
-  getAutomationEmailAccountId,
   HISTORY_RULE_ID,
   HISTORY_RULE_NAME,
   markAutomationOnboardingViewed,
@@ -16,7 +16,7 @@ test.afterEach(async () => {
 test("shows persisted execution history and preserves rule filters", async ({
   page,
 }) => {
-  const emailAccountId = await getAutomationEmailAccountId(page);
+  const emailAccountId = await getEmailAccountId(page);
   await seedAutomationHistory(emailAccountId);
   await markAutomationOnboardingViewed(page);
 

--- a/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/manual-rule-management.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   cleanupTestRules,
   getRuleState,
@@ -7,7 +8,6 @@ import {
 } from "./automation-test-helpers";
 import {
   expectVisibleAfterTransientFetch,
-  getAutomationEmailAccountId,
   markAutomationOnboardingViewed,
 } from "./automation-tabs-test-helpers";
 
@@ -24,7 +24,7 @@ test("creates, edits, toggles, and deletes a manual automation rule", async ({
   page,
 }) => {
   test.setTimeout(360_000);
-  const emailAccountId = await getAutomationEmailAccountId(page);
+  const emailAccountId = await getEmailAccountId(page);
   emailAccountIdForCleanup = emailAccountId;
   await cleanupTestRules(emailAccountId);
   await markAutomationOnboardingViewed(page);

--- a/apps/web/__tests__/playwright/emulated/automation/settings-controls.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/settings-controls.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   type AutomationSettingsCleanup,
   cleanupAutomationSettings,
-  getAutomationEmailAccountId,
   getAutomationSettingsCard,
   getAutomationSettingsState,
   markAutomationOnboardingViewed,
@@ -20,7 +20,7 @@ test("persists personalization, drafting, and advanced settings", async ({
   page,
 }) => {
   test.setTimeout(360_000);
-  const emailAccountId = await getAutomationEmailAccountId(page);
+  const emailAccountId = await getEmailAccountId(page);
   settingsCleanup = {
     ...(await seedAutomationSettings(emailAccountId)),
     emailAccountId,

--- a/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/settings-drafting-knowledge.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   type AutomationSettingsCleanup,
   cleanupAutomationSettings,
   expectVisibleAfterTransientFetch,
-  getAutomationEmailAccountId,
   getAutomationSettingsCard,
   getAutomationSettingsState,
   getKnowledgeState,
@@ -26,7 +26,7 @@ test("enables drafting and manages persisted draft knowledge", async ({
   page,
 }) => {
   test.setTimeout(360_000);
-  const emailAccountId = await getAutomationEmailAccountId(page);
+  const emailAccountId = await getEmailAccountId(page);
   settingsCleanup = {
     ...(await seedAutomationSettings(emailAccountId)),
     emailAccountId,

--- a/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
@@ -1,13 +1,11 @@
 import { expect, test } from "@playwright/test";
-import {
-  getAutomationEmailAccountId,
-  markAutomationOnboardingViewed,
-} from "./automation-tabs-test-helpers";
+import { getEmailAccountId } from "../account-test-helpers";
+import { markAutomationOnboardingViewed } from "./automation-tabs-test-helpers";
 
 test("preserves search, custom email, and Apply workspace state", async ({
   page,
 }) => {
-  const emailAccountId = await getAutomationEmailAccountId(page);
+  const emailAccountId = await getEmailAccountId(page);
   await markAutomationOnboardingViewed(page);
 
   const messagesResponse = await page.request.get("/api/messages", {

--- a/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/calendars/calendar-test-helpers.ts
@@ -1,25 +1,12 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccountId } from "../account-test-helpers";
 
 export const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
 
 export async function openCalendars(page: Page) {
-  let emailAccountId: string | undefined;
-  await expect
-    .poll(
-      async () => {
-        try {
-          emailAccountId = await getEmailAccountId(page);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 120_000 },
-    )
-    .toBe(true);
-  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+  const emailAccountId = await getEmailAccountId(page, { timeout: 120_000 });
 
   await navigateUntilReady(
     page,
@@ -130,17 +117,6 @@ export async function getCalendarTestState() {
   } finally {
     await client.end();
   }
-}
-
-async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
 }
 
 async function resetCalendarState(client: Client) {

--- a/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channel-routing.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   CHANNEL_ID,
   CHANNEL_RULE_NAME,
   cleanupSeededChannel,
   getChannelState,
-  getEmailAccountId,
   markAssistantOnboardingViewed,
   seedChannel,
 } from "./channels-test-helpers";

--- a/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/channels/channels-test-helpers.ts
@@ -4,38 +4,6 @@ import { Client } from "pg";
 export const CHANNEL_ID = "playwright-telegram-channel";
 export const CHANNEL_RULE_ID = "playwright-channel-rule";
 export const CHANNEL_RULE_NAME = "Playwright priority notifications";
-const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
-
-export async function getEmailAccountId(page: Page) {
-  let lastError: unknown;
-  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await page.request.get("/api/user/email-accounts");
-      if (response.ok()) {
-        const { emailAccounts } = (await response.json()) as {
-          emailAccounts: { id: string }[];
-        };
-        const emailAccountId = emailAccounts[0]?.id;
-        if (emailAccountId) return emailAccountId;
-        lastError = new Error("The setup project created no account");
-      } else {
-        lastError = new Error(
-          `Email accounts request failed with ${response.status()}`,
-        );
-      }
-    } catch (error) {
-      lastError = error;
-    }
-
-    await page.waitForTimeout(1000);
-  }
-
-  throw new Error(
-    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
-  );
-}
 
 export async function markAssistantOnboardingViewed(page: Page) {
   await page.goto("/");
@@ -144,8 +112,4 @@ async function deleteSeededState(client: Client) {
     CHANNEL_ID,
   ]);
   await client.query(`DELETE FROM "Rule" WHERE id = $1`, [CHANNEL_RULE_ID]);
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
@@ -2,38 +2,6 @@ import type { Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const SEEDED_CHAT_ID = "playwright-manage-chat";
-const ACCOUNT_LOOKUP_TIMEOUT_MS = 60_000;
-
-export async function getEmailAccountId(page: Page) {
-  let lastError: unknown;
-  const deadline = Date.now() + ACCOUNT_LOOKUP_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await page.request.get("/api/user/email-accounts");
-      if (response.ok()) {
-        const { emailAccounts } = (await response.json()) as {
-          emailAccounts: { id: string }[];
-        };
-        const emailAccountId = emailAccounts[0]?.id;
-        if (emailAccountId) return emailAccountId;
-        lastError = new Error("The setup project created no account");
-      } else {
-        lastError = new Error(
-          `Email accounts request failed with ${response.status()}`,
-        );
-      }
-    } catch (error) {
-      lastError = error;
-    }
-
-    await page.waitForTimeout(1000);
-  }
-
-  throw new Error(
-    `Could not read the setup email account: ${getErrorMessage(lastError)}`,
-  );
-}
 
 export async function markAssistantOnboardingViewed(page: Page) {
   await page.goto("/");
@@ -111,8 +79,4 @@ export async function getChatState(emailAccountId: string) {
 
 async function deleteSeededChat(client: Client) {
   await client.query(`DELETE FROM "Chat" WHERE id = $1`, [SEEDED_CHAT_ID]);
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import {
   cleanupSeededChat,
   getChatState,
-  getEmailAccountId,
   markAssistantOnboardingViewed,
   seedChat,
 } from "./chat-test-helpers";

--- a/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/cleanup-test-helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccount } from "../account-test-helpers";
 
 const CLEANUP_SENDERS = [
   "cleanup-block@example.com",
@@ -153,17 +154,6 @@ export async function openCleanupFeature(
   await expect(page).toHaveURL(
     new RegExp(`/${fixture.emailAccountId}/${expectedPath}(?:\\?.*)?$`),
   );
-}
-
-async function getEmailAccount(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string; email: string }[];
-  };
-  const emailAccount = emailAccounts[0];
-  if (!emailAccount) throw new Error("The setup project created no account");
-  return emailAccount;
 }
 
 async function connectToDatabase() {

--- a/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/integrations/integration-test-helpers.ts
@@ -1,26 +1,13 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccountId } from "../account-test-helpers";
 
 const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
 const INTEGRATION_ID = "playwright-mcp-notion";
 
 export async function openIntegrations(page: Page) {
-  let emailAccountId: string | undefined;
-  await expect
-    .poll(
-      async () => {
-        try {
-          emailAccountId = await getEmailAccountId(page);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 120_000 },
-    )
-    .toBe(true);
-  if (!emailAccountId) throw new Error("The Playwright account was not ready");
+  const emailAccountId = await getEmailAccountId(page, { timeout: 120_000 });
 
   await navigateUntilReady(
     page,
@@ -106,17 +93,6 @@ export function getIntegrationToolCard(page: Page, name: string) {
   return page
     .getByText(name, { exact: true })
     .locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
-}
-
-async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
 }
 
 async function resetIntegrationState(client: Client) {

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -8,6 +8,7 @@ import {
   type TestInfo,
 } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccountId } from "../account-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
 const SEEDED_THREAD_IDS = [
@@ -27,13 +28,7 @@ test.afterEach(async ({ request }) => {
 test("Command K acts on highlighted and selected conversations", async ({
   page,
 }, testInfo) => {
-  const accountsResponse = await page.request.get("/api/user/email-accounts");
-  expect(accountsResponse.ok()).toBeTruthy();
-  const { emailAccounts } = (await accountsResponse.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
+  const emailAccountId = await getEmailAccountId(page);
   emailAccountIdForCleanup = emailAccountId;
 
   await restoreActiveSnoozes(page.request, emailAccountId);

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 
 export async function openMail(page: Page) {
   const emailAccountId = await getEmailAccountId(page);
@@ -18,15 +19,4 @@ export function conversationWithSubject(
   return conversations
     .getByRole("option")
     .filter({ has: page.getByText(subject, { exact: true }) });
-}
-
-async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
 }

--- a/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccount } from "../account-test-helpers";
 
 const UPCOMING_EVENT_ID = "evt_playwright_meeting_bot";
 const RECORDED_MEETING_ID_PREFIX = "playwright_meeting_bot_recorded";
@@ -303,17 +304,6 @@ async function deleteFixtureRows(
   await client.query(`DELETE FROM "CalendarConnection" WHERE id = $1`, [
     fixture.calendarConnectionId,
   ]);
-}
-
-async function getEmailAccount(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccount = emailAccounts[0];
-  if (!emailAccount) throw new Error("The setup project created no account");
-  return emailAccount;
 }
 
 async function withClient<T>(callback: (client: Client) => Promise<T>) {

--- a/apps/web/__tests__/playwright/emulated/onboarding/onboarding-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/onboarding/onboarding-test-helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccountId } from "../account-test-helpers";
 
 const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
@@ -147,17 +148,6 @@ export async function getPersistedOnboardingState() {
     );
     return result.rows[0];
   });
-}
-
-async function getEmailAccountId(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string }[];
-  };
-  const emailAccountId = emailAccounts[0]?.id;
-  if (!emailAccountId) throw new Error("The setup project created no account");
-  return emailAccountId;
 }
 
 async function withClient<T>(callback: (client: Client) => Promise<T>) {

--- a/apps/web/__tests__/playwright/emulated/settings/settings-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/settings-test-helpers.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccount } from "../account-test-helpers";
 
 const SETTINGS_RULE_NAME = "Playwright settings rule";
 
@@ -149,17 +150,6 @@ export function getEmailAccountSettingsCard(page: Page, email: string) {
     card: toggle.locator("xpath=.."),
     toggle,
   };
-}
-
-async function getEmailAccount(page: Page) {
-  const response = await page.request.get("/api/user/email-accounts");
-  expect(response.ok()).toBeTruthy();
-  const { emailAccounts } = (await response.json()) as {
-    emailAccounts: { id: string; email: string }[];
-  };
-  const emailAccount = emailAccounts[0];
-  if (!emailAccount) throw new Error("The setup project created no account");
-  return emailAccount;
 }
 
 async function withClient<T>(callback: (client: Client) => Promise<T>) {

--- a/apps/web/__tests__/playwright/emulated/setup/auth.setup.ts
+++ b/apps/web/__tests__/playwright/emulated/setup/auth.setup.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { Client } from "pg";
+import { getEmailAccount } from "../account-test-helpers";
 
 const PLAYWRIGHT_TEST_EMAIL =
   process.env.PLAYWRIGHT_TEST_EMAIL || "playwright-test@gmail.com";
@@ -41,14 +42,8 @@ test("google emulator signs in and creates an app account", async ({
     .toContain(APP_BASE_URL);
 
   await markOnboardingComplete(PLAYWRIGHT_TEST_EMAIL);
-  const accountsResponse = await page.request.get("/api/user/email-accounts");
-  expect(accountsResponse.ok()).toBeTruthy();
-  const { emailAccounts } = (await accountsResponse.json()) as {
-    emailAccounts: { email: string }[];
-  };
-  expect(emailAccounts).toContainEqual(
-    expect.objectContaining({ email: PLAYWRIGHT_TEST_EMAIL }),
-  );
+  const emailAccount = await getEmailAccount(page);
+  expect(emailAccount.email).toBe(PLAYWRIGHT_TEST_EMAIL);
 
   const authStatePath = process.env.PLAYWRIGHT_AUTH_FILE;
   if (!authStatePath) throw new Error("PLAYWRIGHT_AUTH_FILE is not configured");


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260818-140441_pr-3325_57700bddf416/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Consolidates the emulator E2E account lookup and readiness behavior introduced in #3316.

- replace thirteen feature-local account lookups with one shared retry/error contract
- preserve extended cold-start timeouts where suites already relied on them
- validate all 31 emulator tests load and run auth plus a representative Mail flow

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->