### PR TITLE
INB-327: Clarify meeting processing status

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -26,7 +26,6 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/meeting-detail-state";
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
-import { STILL_CAPTURING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
 import { getEmailDraftUrl } from "@/utils/url";
 
@@ -45,9 +44,6 @@ export function MeetingDetail({
 
   const summary = data?.summary;
   const transcript = data?.recording?.transcript;
-  const isStillCapturing =
-    !!data?.recording?.status &&
-    STILL_CAPTURING_STATUSES.includes(data.recording.status);
 
   const state = getMeetingDetailState({
     hasSummary: !!summary,
@@ -105,9 +101,8 @@ export function MeetingDetail({
 
           {state === "processing" && (
             <MutedText>
-              {isStillCapturing
-                ? "The notetaker is recording this call. The transcript and notes will appear here after it ends."
-                : "The call has ended. The transcript and notes are being prepared, and this view will update automatically."}
+              The recording is being processed. Notes will appear here when they
+              are ready.
             </MutedText>
           )}
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260819-091218_pr-3327_bde47577430f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates the meeting detail processing state to use one neutral status message, avoiding assumptions about whether recording has ended.

- Removed the lifecycle-status branch and its unused import
- Updated the processing copy to say notes will appear when ready
- Validation: focused Ultracite check passed on the changed component
- Performance: no added runtime work, database or network calls, or hot-path risk

Linear issue: https://linear.app/inbox-zero-ai/issue/INB-327/adjust-modal-message-for-recording-processing-status