### PR TITLE
INB-328: Open related meeting draft

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -3,7 +3,6 @@
 import { useAccount } from "@/providers/EmailAccountProvider";
 import type { ReactNode } from "react";
 import { format } from "date-fns";
-import Link from "next/link";
 import { ChevronDownIcon, MailPlusIcon, TextQuoteIcon } from "lucide-react";
 import { LoadingContent } from "@/components/LoadingContent";
 import { MutedText } from "@/components/Typography";
@@ -28,7 +27,6 @@ import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/mee
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
 import { STILL_CAPTURING_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
-import { getEmailDraftUrl } from "@/utils/url";
 
 export function MeetingDetail({
   meetingId,
@@ -37,7 +35,7 @@ export function MeetingDetail({
   meetingId: string | null;
   onClose: () => void;
 }) {
-  const { emailAccountId, provider, userEmail } = useAccount();
+  const { emailAccountId } = useAccount();
   const { data, isLoading, error } = useMeetingRecorderMeeting(
     meetingId,
     emailAccountId,
@@ -177,16 +175,13 @@ export function MeetingDetail({
                   attendees. Nothing was sent for you.
                 </MutedText>
                 <Button asChild variant="outline" size="sm">
-                  <Link
-                    href={getEmailDraftUrl(
-                      data.followUpDraftId,
-                      userEmail,
-                      provider,
-                    )}
+                  <a
+                    href={getFollowUpDraftUrl(data.id, emailAccountId)}
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     Go to drafts
-                  </Link>
+                  </a>
                 </Button>
               </CardContent>
             </CardBlue>
@@ -267,6 +262,10 @@ function SummaryList({ title, items }: { title: string; items: string[] }) {
       </ul>
     </div>
   );
+}
+
+function getFollowUpDraftUrl(meetingId: string, emailAccountId: string) {
+  return `/api/user/meeting-recorder/meetings/${encodeURIComponent(meetingId)}/draft?emailAccountId=${encodeURIComponent(emailAccountId)}`;
 }
 
 function formatMeetingTimeRange(

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+const { createEmailProviderMock, emailProvider, getEmailAccountMock } =
+  vi.hoisted(() => {
+    const emailProvider = { getDraft: vi.fn() };
+
+    return {
+      createEmailProviderMock: vi.fn().mockResolvedValue(emailProvider),
+      emailProvider,
+      getEmailAccountMock: vi.fn(),
+    };
+  });
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: unknown[]) => createEmailProviderMock(...args),
+}));
+vi.mock("@/utils/redis/account-validation", () => ({
+  getEmailAccount: (...args: unknown[]) => getEmailAccountMock(...args),
+}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAuthTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithAuthTestMiddleware({
+    auth: { userId: "user-1" },
+  });
+});
+
+import { GET } from "./route";
+
+const requestUrl =
+  "http://localhost:3000/api/user/meeting-recorder/meetings/meeting-1/draft?emailAccountId=email-account-1";
+const routeContext = { params: Promise.resolve({ meetingId: "meeting-1" }) };
+
+describe("meeting follow-up draft route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEmailAccountMock.mockResolvedValue("user@gmail.com");
+  });
+
+  it("opens the related Gmail draft using its embedded message ID", async () => {
+    prisma.meeting.findFirst.mockResolvedValue({
+      followUpDraftId: "draft-resource-123",
+      emailAccount: { account: { provider: "google" } },
+    } as never);
+    emailProvider.getDraft.mockResolvedValue({ id: "draft-message-123" });
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(prisma.meeting.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "meeting-1", emailAccountId: "email-account-1" },
+      }),
+    );
+    expect(emailProvider.getDraft).toHaveBeenCalledWith("draft-resource-123");
+    expect(response.headers.get("location")).toBe(
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+    );
+  });
+
+  it("rejects email accounts the user does not own", async () => {
+    getEmailAccountMock.mockResolvedValue(null);
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(getEmailAccountMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+    });
+    expect(response.status).toBe(403);
+    expect(prisma.meeting.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when the meeting has no related draft", async () => {
+    prisma.meeting.findFirst.mockResolvedValue(null);
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(response.status).toBe(404);
+    expect(createEmailProviderMock).not.toHaveBeenCalled();
+    expect(emailProvider.getDraft).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { createEmailProvider } from "@/utils/email/provider";
+import { withAuth } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { getEmailAccount } from "@/utils/redis/account-validation";
+import { getEmailDraftUrl } from "@/utils/url";
+
+export const GET = withAuth(
+  "user/meeting-recorder/meeting-draft",
+  async (request, { params }) => {
+    const { meetingId } = await params;
+    const emailAccountId = request.nextUrl.searchParams.get("emailAccountId");
+
+    if (!emailAccountId) {
+      return NextResponse.json(
+        { error: "Email account ID is required." },
+        { status: 400 },
+      );
+    }
+
+    const email = await getEmailAccount({
+      userId: request.auth.userId,
+      emailAccountId,
+    });
+
+    if (!email) {
+      return NextResponse.json(
+        { error: "Invalid account ID" },
+        { status: 403 },
+      );
+    }
+
+    const meeting = await prisma.meeting.findFirst({
+      where: { id: meetingId, emailAccountId },
+      select: {
+        followUpDraftId: true,
+        emailAccount: { select: { account: { select: { provider: true } } } },
+      },
+    });
+
+    if (!meeting?.followUpDraftId) return draftNotFound();
+
+    const provider = meeting.emailAccount.account.provider;
+    const emailProvider = await createEmailProvider({
+      emailAccountId,
+      provider,
+      logger: request.logger,
+    });
+    const draft = await emailProvider.getDraft(meeting.followUpDraftId);
+
+    if (!draft) return draftNotFound();
+
+    return NextResponse.redirect(getEmailDraftUrl(draft.id, email, provider));
+  },
+);
+
+function draftNotFound() {
+  return NextResponse.json(
+    { error: "Meeting follow-up draft not found." },
+    { status: 404 },
+  );
+}

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -170,33 +170,37 @@ describe("getEmailDraftUrl", () => {
   it.each([
     {
       name: "Google account",
-      draftId: "draft-123",
+      draftMessageId: "draft-message-123",
       emailAddress: "user@gmail.com",
       provider: "google",
       expected:
-        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
     },
     {
       name: "personal Microsoft account",
-      draftId: "draft-123",
+      draftMessageId: "draft-123",
       emailAddress: "user@outlook.com",
       provider: "microsoft",
-      expected: "https://outlook.live.com/mail/0/drafts/id/draft-123",
+      expected:
+        "https://outlook.live.com/mail/0/deeplink/compose?itemid=draft-123&exvsurl=1",
     },
     {
       name: "business Microsoft account",
-      draftId: "draft+123/abc",
+      draftMessageId: "draft+123/abc",
       emailAddress: "user@contoso.com",
       provider: "microsoft",
-      expected: "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
+      expected:
+        "https://outlook.office.com/mail/deeplink/compose?itemid=draft%2B123%2Fabc&exvsurl=1",
     },
   ])("opens the draft for a $name", ({
-    draftId,
+    draftMessageId,
     emailAddress,
     provider,
     expected,
   }) => {
-    expect(getEmailDraftUrl(draftId, emailAddress, provider)).toBe(expected);
+    expect(getEmailDraftUrl(draftMessageId, emailAddress, provider)).toBe(
+      expected,
+    );
   });
 });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -44,64 +44,53 @@ function getOutlookBaseUrl(emailAddress?: string | null) {
     : "https://outlook.office.com/mail";
 }
 
-const PROVIDER_CONFIG: Record<
-  string,
-  {
-    requiresMessageId: boolean;
-    buildUrl: (
-      messageOrThreadId: string,
-      emailAddress?: string | null,
-    ) => string;
-    buildDraftUrl: (draftId: string, emailAddress?: string | null) => string;
-    selectId: (messageId: string, threadId: string) => string;
-    buildSearchUrl: (from: string, emailAddress?: string | null) => string;
-  }
-> = {
+type ProviderUrlConfig = {
+  requiresMessageId: boolean;
+  buildUrl: (messageOrThreadId: string, emailAddress?: string | null) => string;
+  buildDraftUrl: (
+    draftMessageId: string,
+    emailAddress?: string | null,
+  ) => string;
+  selectId: (messageId: string, threadId: string) => string;
+  buildSearchUrl: (from: string, emailAddress?: string | null) => string;
+};
+
+const GOOGLE_CONFIG: ProviderUrlConfig = {
+  requiresMessageId: false,
+  buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
+    getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
+  buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
+    getGmailUrlForFragment(
+      `inbox?compose=${encodeURIComponent(draftMessageId)}`,
+      emailAddress,
+    ),
+  selectId: (messageId: string, _threadId: string) => messageId,
+  buildSearchUrl: (from: string, emailAddress?: string | null) =>
+    getGmailUrlForFragment(
+      `advanced-search/from=${encodeURIComponent(from)}`,
+      emailAddress,
+    ),
+};
+
+const PROVIDER_CONFIG: Record<string, ProviderUrlConfig> = {
   microsoft: {
     requiresMessageId: true,
     buildUrl: (messageOrThreadId: string, emailAddress?: string | null) => {
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
-    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
-      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draftId)}`,
+    buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
+      `${getOutlookBaseUrl(emailAddress)}/deeplink/compose?itemid=${encodeURIComponent(draftMessageId)}&exvsurl=1`,
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
       return `${getOutlookBaseUrl(emailAddress)}/search/q/${query}`;
     },
   },
-  google: {
-    requiresMessageId: false,
-    buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
-    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(
-        `drafts/${encodeURIComponent(draftId)}`,
-        emailAddress,
-      ),
-    selectId: (messageId: string, _threadId: string) => messageId,
-    buildSearchUrl: (from: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(
-        `advanced-search/from=${encodeURIComponent(from)}`,
-        emailAddress,
-      ),
-  },
+  google: GOOGLE_CONFIG,
   default: {
-    requiresMessageId: false,
-    buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
-    buildDraftUrl: (draftId: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(
-        `drafts/${encodeURIComponent(draftId)}`,
-        emailAddress,
-      ),
+    ...GOOGLE_CONFIG,
     selectId: (_messageId: string, threadId: string) => threadId,
-    buildSearchUrl: (from: string, emailAddress?: string | null) =>
-      getGmailUrlForFragment(
-        `advanced-search/from=${encodeURIComponent(from)}`,
-        emailAddress,
-      ),
   },
 } as const;
 
@@ -121,13 +110,18 @@ export function getEmailUrl(
   return config.buildUrl(messageOrThreadId, emailAddress);
 }
 
+/**
+ * Takes the draft's underlying *message* id, not the draft resource id — on
+ * Gmail those differ (and the message id changes on every draft edit), so
+ * resolve it via `EmailProvider.getDraft` at link time.
+ */
 export function getEmailDraftUrl(
-  draftId: string,
+  draftMessageId: string,
   emailAddress?: string | null,
   provider?: string,
 ): string {
   const config = getProviderConfig(provider);
-  return config.buildDraftUrl(draftId, emailAddress);
+  return config.buildDraftUrl(draftMessageId, emailAddress);
 }
 
 /**


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260819-091631_pr-3328_c875f58c47a4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix the meeting follow-up action so it resolves the latest provider draft message and opens it in Gmail or Outlook. This prevents stale draft resource identifiers from producing broken draft links.

- Add an authenticated redirect route scoped to the signed-in mailbox and meeting.
- Build provider-specific compose links from resolved draft message IDs.
- Validate route authorization, missing-draft behavior, and provider URL generation with 46 focused tests.
- Performance: adds one ownership lookup, one meeting query, and one provider draft fetch only when the button is clicked; no ongoing work or hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-328/go-to-drafts-button-does-not-open-related-draft

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->