### PR TITLE
fix(auth): resolve deduplicated OAuth callback redirects against base URL

### DIFF
--- a/apps/web/utils/oauth/auth-callback-deduplication.test.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.test.ts
@@ -27,6 +27,10 @@ vi.mock("@/utils/redis/oauth-code", () => ({
   setOAuthCodeResult: mockSetOAuthCodeResult,
 }));
 
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_BASE_URL: "https://app.example.com" },
+}));
+
 import { deduplicateOAuthCallback } from "./auth-callback-deduplication";
 
 const logger = createScopedLogger("test/auth-callback-deduplication");
@@ -160,6 +164,49 @@ describe("deduplicateOAuthCallback", () => {
     expect(handleRequest).not.toHaveBeenCalled();
   });
 
+  it("resolves a relative cached redirect against the configured base URL", async () => {
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: {
+          redirect: "/welcome-redirect",
+          status: "302",
+        },
+        requestFingerprint: REQUEST_FINGERPRINT,
+        status: "success",
+      },
+      status: "success",
+      waited: false,
+    });
+    const handleRequest = vi.fn();
+
+    const response = await deduplicateOAuthCallback({
+      request: createInternalOriginCallbackRequest(),
+      handleRequest,
+      logger,
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://app.example.com/welcome-redirect",
+    );
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the welcome page on the configured base URL when the callback wait times out", async () => {
+    mockClaimOAuthCodeAndWait.mockResolvedValue({ status: "timeout" });
+
+    const response = await deduplicateOAuthCallback({
+      request: createInternalOriginCallbackRequest(),
+      handleRequest: vi.fn(),
+      logger,
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://app.example.com/welcome-redirect",
+    );
+  });
+
   it("does not replay session cookies to a different OAuth state", async () => {
     mockClaimOAuthCodeAndWait.mockResolvedValue({
       result: {
@@ -254,6 +301,15 @@ describe("deduplicateOAuthCallback", () => {
 function createGoogleCallbackRequest() {
   return new Request(
     "https://example.com/api/auth/callback/google?code=oauth-code&state=oauth-state",
+    { headers: { cookie: OAUTH_STATE_COOKIE } },
+  );
+}
+
+// Self-hosted standalone Next.js reports the server's internal origin
+// (e.g. the Docker container hostname) in request.url, not the public origin.
+function createInternalOriginCallbackRequest() {
+  return new Request(
+    "https://0a1b2c3d4e5f:3000/api/auth/callback/google?code=oauth-code&state=oauth-state",
     { headers: { cookie: OAUTH_STATE_COOKIE } },
   );
 }

--- a/apps/web/utils/oauth/auth-callback-deduplication.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
 import {
   claimOAuthCodeAndWait,
@@ -47,7 +48,10 @@ export async function deduplicateOAuthCallback({
       error: claim.error,
       provider,
     });
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(
+      new URL(WELCOME_PATH, env.NEXT_PUBLIC_BASE_URL),
+      302,
+    );
   }
 
   if (claim.status === "success") {
@@ -58,7 +62,6 @@ export async function deduplicateOAuthCallback({
       { provider },
     );
     return createCachedRedirect({
-      request,
       requestFingerprint,
       result: claim.result,
     });
@@ -66,7 +69,10 @@ export async function deduplicateOAuthCallback({
 
   if (claim.status === "timeout") {
     logger.warn("OAuth callback wait timed out", { provider });
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(
+      new URL(WELCOME_PATH, env.NEXT_PUBLIC_BASE_URL),
+      302,
+    );
   }
 
   try {
@@ -125,11 +131,9 @@ function getOAuthCallback(request: Request) {
 }
 
 function createCachedRedirect({
-  request,
   requestFingerprint,
   result,
 }: {
-  request: Request;
   requestFingerprint?: string;
   result: OAuthCodeResult;
 }) {
@@ -138,10 +142,13 @@ function createCachedRedirect({
   const status = Number(params.status);
 
   if (!redirect) {
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(
+      new URL(WELCOME_PATH, env.NEXT_PUBLIC_BASE_URL),
+      302,
+    );
   }
 
-  const redirectUrl = new URL(redirect, request.url);
+  const redirectUrl = new URL(redirect, env.NEXT_PUBLIC_BASE_URL);
   const redirectStatus = REDIRECT_STATUSES.has(status) ? status : 302;
   const headers = new Headers({ location: redirectUrl.toString() });
 


### PR DESCRIPTION
Fixes #3326

On self-hosted standalone deployments, `request.url` carries the server's internal origin (e.g. the Docker container hostname), so the deduplicated OAuth callback response redirected users to `https://<container-id>:3000/welcome-redirect` (`ERR_NAME_NOT_RESOLVED`). better-auth returns a relative `Location`, which only breaks when the cached (second) response absolutizes it against `request.url`.

- resolve cached redirects and the welcome-path fallbacks against `env.NEXT_PUBLIC_BASE_URL` instead of `request.url`
- drop the now-unused `request` param from `createCachedRedirect`
- add regression tests: a relative cached redirect and the wait-timeout path, both with an internal-origin request URL

Validation: `pnpm test utils/oauth/auth-callback-deduplication.test.ts` — 11 passed; the two new tests reproduced the container-origin redirect before the fix. No behavior change on Vercel, where `request.url` and `NEXT_PUBLIC_BASE_URL` share the same origin.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

