### PR TITLE
INB-329: Restore billing options for organization owners and admins

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -519,9 +519,11 @@ export function getCalendarConnection({
 
 export function getMockOrganizationMembership({
   role,
+  ownerUserId = "org-owner",
   ownerPremiumId = null,
 }: {
   role: string;
+  ownerUserId?: string;
   ownerPremiumId?: string | null;
 }) {
   return {
@@ -530,7 +532,7 @@ export function getMockOrganizationMembership({
       members: [
         {
           emailAccount: {
-            user: { premiumId: ownerPremiumId },
+            user: { id: ownerUserId, premiumId: ownerPremiumId },
           },
         },
       ],

--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -516,3 +516,24 @@ export function getCalendarConnection({
     calendars: calendarIds.map((id) => ({ calendarId: id })),
   };
 }
+
+export function getMockOrganizationMembership({
+  role,
+  ownerPremiumId = null,
+}: {
+  role: string;
+  ownerPremiumId?: string | null;
+}) {
+  return {
+    role,
+    organization: {
+      members: [
+        {
+          emailAccount: {
+            user: { premiumId: ownerPremiumId },
+          },
+        },
+      ],
+    },
+  };
+}

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -51,7 +51,7 @@ describe("user/me route", () => {
                 members: [
                   {
                     emailAccount: {
-                      user: { premiumId: null },
+                      user: { id: "org-owner", premiumId: null },
                     },
                   },
                 ],
@@ -126,6 +126,9 @@ describe("user/me route", () => {
           {
             id: "user-1",
           },
+          {
+            id: "org-owner",
+          },
         ],
       },
       emailAccounts: [
@@ -142,7 +145,7 @@ describe("user/me route", () => {
                 members: [
                   {
                     emailAccount: {
-                      user: { premiumId: "premium-1" },
+                      user: { id: "org-owner", premiumId: "premium-1" },
                     },
                   },
                 ],

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -48,6 +48,13 @@ describe("user/me route", () => {
               role: "admin",
               organization: {
                 name: "Example Org",
+                members: [
+                  {
+                    emailAccount: {
+                      user: { premiumId: null },
+                    },
+                  },
+                ],
               },
             },
           ],
@@ -118,11 +125,6 @@ describe("user/me route", () => {
         admins: [
           {
             id: "user-1",
-            emailAccounts: [
-              {
-                members: [{ organizationId: "org-1", role: "member" }],
-              },
-            ],
           },
         ],
       },
@@ -135,7 +137,16 @@ describe("user/me route", () => {
             {
               organizationId: "org-1",
               role: "member",
-              organization: { name: "Example Org" },
+              organization: {
+                name: "Example Org",
+                members: [
+                  {
+                    emailAccount: {
+                      user: { premiumId: "premium-1" },
+                    },
+                  },
+                ],
+              },
             },
           ],
         },

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -10,6 +10,7 @@ import {
 import {
   billingAccessPremiumSelect,
   canManageBilling,
+  organizationOwnerPremiumSelect,
 } from "@/utils/premium/billing-access";
 
 export type UserResponse = Awaited<ReturnType<typeof getUser>> | null;
@@ -61,6 +62,7 @@ async function getUser({
               role: true,
               organization: {
                 select: {
+                  ...organizationOwnerPremiumSelect,
                   name: true,
                 },
               },
@@ -74,8 +76,10 @@ async function getUser({
   if (!user) throw new SafeError("User not found");
 
   const members = user.emailAccounts.flatMap((account) =>
-    account.members.map((member) => ({
-      ...member,
+    account.members.map(({ organizationId, role, organization }) => ({
+      organizationId,
+      role,
+      organization: { name: organization.name },
       emailAccountId: account.id,
     })),
   );

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -324,7 +324,7 @@ model Member {
   id                     String       @id @default(cuid())
   organizationId         String
   emailAccountId         String
-  role                   String       @default("member") // "admin" | "member"
+  role                   String       @default("member") // "owner" | "admin" | "member"
   allowOrgAdminAnalytics Boolean      @default(false)
   createdAt              DateTime     @default(now())
   updatedAt              DateTime     @updatedAt

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockOrganizationMembership } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   endStripeTrialAction,
@@ -111,20 +112,16 @@ describe("getBillingPortalUrlAction", () => {
         stripeSubscriptionItemId: "si_test",
         stripeSubscriptionStatus: "active",
         users: [{ _count: { emailAccounts: 1 } }],
-        admins: [
-          {
-            id: "user-1",
-            emailAccounts: [
-              {
-                members: [{ organizationId: "billing-org", role: "member" }],
-              },
-            ],
-          },
-        ],
+        admins: [{ id: "user-1" }],
       },
       emailAccounts: [
         {
-          members: [{ organizationId: "billing-org", role: "member" }],
+          members: [
+            getMockOrganizationMembership({
+              role: "member",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
         },
       ],
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
@@ -150,18 +147,18 @@ describe("getBillingPortalUrlAction", () => {
         stripeSubscriptionItemId: "si_test",
         stripeSubscriptionStatus: "active",
         users: [{ _count: { emailAccounts: 1 } }],
-        admins: [
-          {
-            id: "another-user",
-            emailAccounts: [
-              {
-                members: [{ organizationId: "billing-org", role: "owner" }],
-              },
-            ],
-          },
-        ],
+        admins: [{ id: "another-user" }],
       },
-      emailAccounts: [{ members: [{ organizationId: "billing-org", role }] }],
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role,
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+      ],
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
     mocks.createBillingPortalSession.mockResolvedValue({
       url: "https://billing.stripe.test",

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -112,13 +112,14 @@ describe("getBillingPortalUrlAction", () => {
         stripeSubscriptionItemId: "si_test",
         stripeSubscriptionStatus: "active",
         users: [{ _count: { emailAccounts: 1 } }],
-        admins: [{ id: "user-1" }],
+        admins: [{ id: "user-1" }, { id: "org-owner" }],
       },
       emailAccounts: [
         {
           members: [
             getMockOrganizationMembership({
               role: "member",
+              ownerUserId: "org-owner",
               ownerPremiumId: "premium-1",
             }),
           ],
@@ -154,6 +155,7 @@ describe("getBillingPortalUrlAction", () => {
           members: [
             getMockOrganizationMembership({
               role,
+              ownerUserId: "another-user",
               ownerPremiumId: "premium-1",
             }),
           ],

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getMockOrganizationMembership } from "@/__tests__/helpers";
 import { canManageBilling } from "./billing-access";
 
 describe("canManageBilling", () => {
@@ -7,7 +8,7 @@ describe("canManageBilling", () => {
       premium: null,
       emailAccounts: [
         {
-          members: [{ organizationId: "org-1", role: "member" }],
+          members: [getMockOrganizationMembership({ role: "member" })],
         },
       ],
     });
@@ -24,6 +25,34 @@ describe("canManageBilling", () => {
     expect(result).toBe(true);
   });
 
+  it.each([
+    "admin",
+    "owner",
+  ])("allows an organization %s when the plan admin has no organization membership", (role) => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [
+          {
+            id: "premium-admin",
+          },
+        ],
+      },
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role,
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+  });
+
   it("does not use an admin role from an unrelated organization", () => {
     const result = canManageBilling("user-1", {
       premium: {
@@ -31,20 +60,25 @@ describe("canManageBilling", () => {
         admins: [
           {
             id: "premium-owner",
-            emailAccounts: [
-              {
-                members: [{ organizationId: "billing-org", role: "owner" }],
-              },
-            ],
           },
         ],
       },
       emailAccounts: [
         {
-          members: [{ organizationId: "other-org", role: "admin" }],
+          members: [
+            getMockOrganizationMembership({
+              role: "admin",
+              ownerPremiumId: "other-premium",
+            }),
+          ],
         },
         {
-          members: [{ organizationId: "billing-org", role: "member" }],
+          members: [
+            getMockOrganizationMembership({
+              role: "member",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
         },
       ],
     });

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -28,7 +28,7 @@ describe("canManageBilling", () => {
   it.each([
     "admin",
     "owner",
-  ])("allows an organization %s when the plan admin has no organization membership", (role) => {
+  ])("allows an organization %s of the organization owned by the plan admin", (role) => {
     const result = canManageBilling("user-1", {
       premium: {
         id: "premium-1",
@@ -43,6 +43,7 @@ describe("canManageBilling", () => {
           members: [
             getMockOrganizationMembership({
               role,
+              ownerUserId: "premium-admin",
               ownerPremiumId: "premium-1",
             }),
           ],
@@ -51,6 +52,63 @@ describe("canManageBilling", () => {
     });
 
     expect(result).toBe(true);
+  });
+
+  it("allows an organization admin when the owner holds a legacy premium", () => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "legacy-owner",
+        admins: [],
+      },
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role: "admin",
+              ownerUserId: "legacy-owner",
+              ownerPremiumId: "legacy-owner",
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("denies a premium seat member who owns an organization of their own", () => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [
+          {
+            id: "premium-admin",
+          },
+        ],
+      },
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role: "member",
+              ownerUserId: "premium-admin",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+        {
+          members: [
+            getMockOrganizationMembership({
+              role: "owner",
+              ownerUserId: "user-1",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
   });
 
   it("does not use an admin role from an unrelated organization", () => {
@@ -76,6 +134,7 @@ describe("canManageBilling", () => {
           members: [
             getMockOrganizationMembership({
               role: "member",
+              ownerUserId: "premium-owner",
               ownerPremiumId: "premium-1",
             }),
           ],

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -1,11 +1,32 @@
+import type { Prisma } from "@/generated/prisma/client";
 import { SafeError } from "@/utils/error";
 import { isAdminForPremium } from "@/utils/premium";
 import { isOrganizationAdmin } from "@/utils/organizations/roles";
 
+export const organizationOwnerPremiumSelect = {
+  members: {
+    where: { role: "owner" },
+    select: {
+      emailAccount: {
+        select: { user: { select: { premiumId: true } } },
+      },
+    },
+  },
+} as const;
+
+const billingAccessMembershipSelect = {
+  role: true,
+  organization: {
+    select: organizationOwnerPremiumSelect,
+  },
+} as const;
+
 export const billingAccessSelect = {
   emailAccounts: {
     select: {
-      members: { select: { organizationId: true, role: true } },
+      members: {
+        select: billingAccessMembershipSelect,
+      },
     },
   },
 } as const;
@@ -15,26 +36,17 @@ export const billingAccessPremiumSelect = {
   admins: {
     select: {
       id: true,
-      emailAccounts: {
-        select: {
-          members: { select: { organizationId: true, role: true } },
-        },
-      },
     },
   },
 } as const;
 
-type OrganizationMembership = { organizationId: string; role: string };
+type OrganizationMembership = Prisma.MemberGetPayload<{
+  select: typeof billingAccessMembershipSelect;
+}>;
 
 type BillingAccessUser = {
   premium:
-    | {
-        id: string;
-        admins: Array<{
-          id: string;
-          emailAccounts: Array<{ members: OrganizationMembership[] }>;
-        }>;
-      }
+    | Prisma.PremiumGetPayload<{ select: typeof billingAccessPremiumSelect }>
     | null
     | undefined;
   emailAccounts: Array<{ members: OrganizationMembership[] }>;
@@ -45,34 +57,23 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
   const organizationMemberships = user.emailAccounts.flatMap(
     (emailAccount) => emailAccount.members,
   );
-  const premiumAdminMemberships =
-    premium?.admins.flatMap((admin) =>
-      (admin.emailAccounts ?? []).flatMap(
-        (emailAccount) => emailAccount.members,
-      ),
-    ) ?? [];
-  const ownerOrganizationIds = new Set(
-    premiumAdminMemberships
-      .filter((membership) => membership.role === "owner")
-      .map((membership) => membership.organizationId),
-  );
-  const premiumOrganizationIds = ownerOrganizationIds.size
-    ? ownerOrganizationIds
-    : new Set(
-        premiumAdminMemberships.map((membership) => membership.organizationId),
-      );
-  const premiumOrganizationMemberships = organizationMemberships.filter(
-    (membership) => premiumOrganizationIds.has(membership.organizationId),
-  );
 
-  if (!premium && organizationMemberships.length > 0) {
+  if (!premium) {
+    if (organizationMemberships.length === 0) return true;
     return isOrganizationAdmin(organizationMemberships);
   }
+
+  const premiumOrganizationMemberships = organizationMemberships.filter(
+    (membership) =>
+      membership.organization.members.some(
+        (owner) => owner.emailAccount.user.premiumId === premium.id,
+      ),
+  );
+
   if (premiumOrganizationMemberships.length > 0) {
     return isOrganizationAdmin(premiumOrganizationMemberships);
   }
 
-  if (!premium) return true;
   if (premium.admins.length > 0) {
     return isAdminForPremium(premium.admins, userId);
   }

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -8,7 +8,7 @@ export const organizationOwnerPremiumSelect = {
     where: { role: "owner" },
     select: {
       emailAccount: {
-        select: { user: { select: { premiumId: true } } },
+        select: { user: { select: { id: true, premiumId: true } } },
       },
     },
   },
@@ -63,11 +63,16 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
     return isOrganizationAdmin(organizationMemberships);
   }
 
+  // Every invited seat user shares the premium id and can own their own
+  // organization, so anchor on the purchaser: a premium admin, or the legacy
+  // owner whose user id doubles as the premium id.
+  const premiumAdminIds = new Set(premium.admins.map((admin) => admin.id));
   const premiumOrganizationMemberships = organizationMemberships.filter(
     (membership) =>
-      membership.organization.members.some(
-        (owner) => owner.emailAccount.user.premiumId === premium.id,
-      ),
+      membership.organization.members.some(({ emailAccount: { user } }) => {
+        if (user.premiumId !== premium.id) return false;
+        return premiumAdminIds.has(user.id) || user.id === premium.id;
+      }),
   );
 
   if (premiumOrganizationMemberships.length > 0) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260819-092109_pr-3330_d060a17a5b0d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restores billing controls for organization owners and admins by resolving authorization through the organization owner’s premium record. Organization members and unrelated organization admins remain blocked, while direct plan-admin and legacy-owner access is preserved.

- Scope billing roles to the premium-owning organization without exposing owner details in the user API response
- Update the Prisma selection and role metadata; no database migration is required
- Add regression coverage for owner/admin access and denied member/unrelated-admin cases
- Tests: `pnpm test utils/premium/billing-access.test.ts utils/actions/premium.test.ts app/api/user/me/route.test.ts` (26 passed)
- Formatting: focused Ultracite check passed
- Performance: reuses existing user/premium queries with a nested owner relation selection; no new database or network round trips and no added client hot-path work
- Linear: https://linear.app/inbox-zero-ai/issue/INB-329/billing-options-are-missing-for-owner-and-admin-members

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->