### PR TITLE
INB-330: Send pending composer recipients

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -11,7 +11,6 @@ import { CheckCircleIcon, TrashIcon, XIcon } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import useSWR from "swr";
-import { z } from "zod";
 import { Input, Label } from "@/components/Input";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -19,14 +18,16 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonLoader } from "@/components/Loading";
 import { env } from "@/env";
-import { extractNameFromEmail } from "@/utils/email";
+import { extractNameFromEmail, isValidEmail } from "@/utils/email";
 import { Tiptap, type TiptapHandle } from "@/components/editor/Tiptap";
 import { sendEmailAction } from "@/utils/actions/mail";
 import type { ContactsResponse } from "@/app/api/google/contacts/route";
 import type { SendEmailBody } from "@/utils/gmail/mail";
 import { CommandShortcut } from "@/components/ui/command";
+import { getActionErrorMessage } from "@/utils/error";
 import { useModifierKey } from "@/hooks/useModifierKey";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { resolveComposeRecipients } from "./compose-recipients";
 
 export type ReplyingToEmail = {
   threadId?: string;
@@ -55,6 +56,7 @@ export const ComposeEmailForm = ({
 }) => {
   const { emailAccountId } = useAccount();
   const [showFullContent, setShowFullContent] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const { symbol } = useModifierKey();
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -76,8 +78,18 @@ export const ComposeEmailForm = ({
 
   const onSubmit: SubmitHandler<SendEmailBody> = useCallback(
     async (data) => {
+      const to = resolveComposeRecipients({
+        selectedRecipients: data.to,
+        pendingRecipient: searchQuery,
+      });
+      if (!to) {
+        toastError({ description: "Enter a valid recipient email address." });
+        return;
+      }
+
       const enrichedData = {
         ...data,
+        to,
         replyToEmail: getReplyToEmailPayload(data.replyToEmail),
         messageHtml: showFullContent
           ? data.messageHtml || ""
@@ -86,13 +98,15 @@ export const ComposeEmailForm = ({
 
       try {
         const res = await sendEmailAction(emailAccountId, enrichedData);
-        if (res?.serverError) {
-          toastError({
-            description: "There was an error sending the email :(",
-          });
-        } else if (res?.data) {
+        if (res?.data) {
           toastSuccess({ description: "Email sent!" });
           onSuccess?.(res.data.messageId ?? "", res.data.threadId ?? "");
+        } else {
+          toastError({
+            description: getActionErrorMessage(res ?? {}, {
+              prefix: "There was an error sending the email",
+            }),
+          });
         }
       } catch (error) {
         console.error(error);
@@ -101,7 +115,14 @@ export const ComposeEmailForm = ({
 
       refetch?.();
     },
-    [refetch, onSuccess, showFullContent, replyingToEmail, emailAccountId],
+    [
+      refetch,
+      onSuccess,
+      showFullContent,
+      replyingToEmail,
+      emailAccountId,
+      searchQuery,
+    ],
   );
 
   useHotkeys(
@@ -119,7 +140,6 @@ export const ComposeEmailForm = ({
     },
   );
 
-  const [searchQuery, setSearchQuery] = useState("");
   const { data } = useSWR<ContactsResponse, { error: string }>(
     env.NEXT_PUBLIC_CONTACTS_ENABLED
       ? `/api/google/contacts?query=${searchQuery}`
@@ -143,8 +163,7 @@ export const ComposeEmailForm = ({
     // this assumes last value given by combobox is user typed value
     const lastValue = values[values.length - 1];
 
-    const { success } = z.string().email().safeParse(lastValue);
-    if (success) {
+    if (isValidEmail(lastValue)) {
       setValue("to", values.join(","));
       setSearchQuery("");
     }
@@ -231,9 +250,13 @@ export const ComposeEmailForm = ({
                       onKeyUp={(event) => {
                         if (event.key === "Enter") {
                           event.preventDefault();
+                          if (!isValidEmail(searchQuery.trim())) return;
                           setValue(
                             "to",
-                            [...selectedEmailAddressses, searchQuery].join(","),
+                            resolveComposeRecipients({
+                              selectedRecipients: watch("to"),
+                              pendingRecipient: searchQuery,
+                            }),
                           );
                           setSearchQuery("");
                         }

--- a/apps/web/app/(app)/[emailAccountId]/compose/compose-recipients.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/compose-recipients.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveComposeRecipients } from "./compose-recipients";
+
+describe("resolveComposeRecipients", () => {
+  it("commits a valid recipient that is still in the contact search input", () => {
+    expect(
+      resolveComposeRecipients({
+        selectedRecipients: undefined,
+        pendingRecipient: "recipient@example.com",
+      }),
+    ).toBe("recipient@example.com");
+  });
+
+  it("appends the pending recipient to committed recipients", () => {
+    expect(
+      resolveComposeRecipients({
+        selectedRecipients: "first@example.com",
+        pendingRecipient: " second@example.com ",
+      }),
+    ).toBe("first@example.com,second@example.com");
+  });
+
+  it("does not re-add a recipient already present with a display name", () => {
+    expect(
+      resolveComposeRecipients({
+        selectedRecipients: '"Doe, John" <john@example.com>',
+        pendingRecipient: "John@example.com",
+      }),
+    ).toBe('"Doe, John" <john@example.com>');
+  });
+
+  it("does not send incomplete contact search text", () => {
+    expect(
+      resolveComposeRecipients({
+        selectedRecipients: "first@example.com",
+        pendingRecipient: "second@",
+      }),
+    ).toBe("first@example.com");
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/compose/compose-recipients.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/compose-recipients.ts
@@ -1,0 +1,17 @@
+import { isValidEmail, splitRecipientList } from "@/utils/email";
+import { mergeAndDedupeRecipients } from "@/utils/email/reply-all";
+
+export function resolveComposeRecipients({
+  selectedRecipients,
+  pendingRecipient,
+}: {
+  selectedRecipients: string | undefined;
+  pendingRecipient: string;
+}) {
+  const selected = splitRecipientList(selectedRecipients ?? "");
+  const pending = pendingRecipient.trim();
+
+  if (!isValidEmail(pending)) return selected.join(",");
+
+  return mergeAndDedupeRecipients(selected, pending).join(",");
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260819-092501_pr-3331_9d8edf9100fa/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensures the composer sends a valid address still pending in the contact input and reports send-action errors clearly.

- Resolve, validate, and deduplicate selected and pending recipients before sending.
- Add focused unit coverage for pending, existing, duplicate, and incomplete recipients.
- Tests: `pnpm test "app/(app)/[emailAccountId]/compose/compose-recipients.test.ts"`
- Linear: https://linear.app/inbox-zero-ai/issue/INB-330/email-not-sent-when-using-composer-in-mail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->