### PR TITLE
feat(llms): add experimental grok-cli provider

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -195,6 +195,7 @@ LLM_API_KEY=
 # CODEX_CLI_ALLOW_NPX=false
 # CODEX_CLI_PATH=
 # DEFAULT_LLMS=claude-code:sonnet
+# GROK_CLI_PATH=
 
 # --- Deprecated legacy LLM env vars ---
 # These are still converted into the corresponding *_LLMS value at startup.

--- a/apps/web/env-legacy-llms.test.ts
+++ b/apps/web/env-legacy-llms.test.ts
@@ -34,6 +34,15 @@ describe("buildLegacyLlmsEnv", () => {
         OPENAI_COMPATIBLE_MODEL: "local:model",
       }).DEFAULT_LLMS,
     ).toBe("openai-compatible:local:model");
+    expect(
+      buildLegacyLlmsEnv({ DEFAULT_LLM_PROVIDER: "codex-cli" }).DEFAULT_LLMS,
+    ).toBe("codex-cli:gpt-5.3-codex");
+    expect(
+      buildLegacyLlmsEnv({ DEFAULT_LLM_PROVIDER: "claude-code" }).DEFAULT_LLMS,
+    ).toBe("claude-code:sonnet");
+    expect(
+      buildLegacyLlmsEnv({ DEFAULT_LLM_PROVIDER: "grok-cli" }).DEFAULT_LLMS,
+    ).toBe("grok-cli:default");
   });
 
   it("converts role primary models with the same fallback inheritance as legacy resolver", () => {

--- a/apps/web/env-legacy-llms.ts
+++ b/apps/web/env-legacy-llms.ts
@@ -156,6 +156,7 @@ function getLegacyProviderDefaultModel(
     "openai-compatible": env.OPENAI_COMPATIBLE_MODEL,
     "codex-cli": "gpt-5.3-codex",
     "claude-code": "sonnet",
+    "grok-cli": "default",
   };
 
   return defaultModelByLegacyProvider[provider];

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -19,6 +19,7 @@ const llmProviderEnum = z.enum([
   "openai-compatible",
   "codex-cli",
   "claude-code",
+  "grok-cli",
 ]);
 
 /** For Vercel preview deployments, auto-detect from VERCEL_URL. */
@@ -184,6 +185,7 @@ const parsedEnv = createEnv({
     CLI_LLM_ENABLED: booleanString.optional().default(false),
     CODEX_CLI_ALLOW_NPX: booleanString.optional().default(false),
     CODEX_CLI_PATH: z.string().optional(),
+    GROK_CLI_PATH: z.string().optional(),
 
     OPENAI_ZERO_DATA_RETENTION: booleanString.optional().default(false),
 

--- a/apps/web/utils/llms/cli-provider.test.ts
+++ b/apps/web/utils/llms/cli-provider.test.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { Provider } from "./config";
 
 describe("createCliLanguageModel", () => {
@@ -11,6 +15,7 @@ describe("createCliLanguageModel", () => {
     vi.doUnmock("@/env");
     vi.doUnmock("ai-sdk-provider-codex-cli");
     vi.doUnmock("ai-sdk-provider-claude-code");
+    vi.doUnmock("ai-sdk-provider-grok-build");
   });
 
   it("loads the Codex provider lazily once and forwards calls", async () => {
@@ -174,6 +179,239 @@ describe("createCliLanguageModel", () => {
     expect(doStream).toHaveBeenCalledWith("stream-request");
   });
 
+  it("loads the Grok provider with isolated HOME and Inbox Zero tool clamp", async () => {
+    const grok = makeGrokConstructors();
+
+    const { createCliLanguageModel } = await loadCliProviderModule({
+      envOverrides: { GROK_CLI_PATH: "/usr/local/bin/grok" },
+      grokModule: grok.module,
+    });
+
+    const model = createCliLanguageModel({
+      provider: Provider.GROK_CLI,
+      modelName: "default",
+    }) as any;
+
+    await model.doGenerate("generate-request");
+
+    expect(grok.modelOptions[0].id).toBe("default");
+    expect(grok.modelOptions[0].settings).toMatchObject({
+      authMethod: "cached_token",
+      executablePath: "/usr/local/bin/grok",
+    });
+    expect(String(grok.acpOptions[0].cwd)).toContain(
+      `${os.tmpdir()}${path.sep}inbox-zero-grok-`,
+    );
+    expect(String(grok.acpOptions[0].env.HOME)).toContain(`${path.sep}home`);
+    expect(grok.acpOptions[0].env.GROK_AUTH_PATH).toBe(
+      path.join(os.homedir(), ".grok", "auth.json"),
+    );
+    expect(grok.sessions[0]._meta.agentProfile.tools).toEqual([
+      "search_tool",
+      "use_tool",
+    ]);
+    expect(fs.existsSync(path.dirname(grok.acpOptions[0].cwd))).toBe(false);
+  });
+
+  it("approves only search_tool and use_tool by structured ACP identity", async () => {
+    const grok = makeGrokConstructors();
+    const { createCliLanguageModel } = await loadCliProviderModule({
+      grokModule: grok.module,
+    });
+    const model = createCliLanguageModel({
+      provider: Provider.GROK_CLI,
+      modelName: "default",
+    }) as any;
+    await model.doGenerate("generate-request");
+
+    const handler = grok.acpOptions[0].onPermissionRequest as (request: {
+      options: Array<{ kind: string; optionId: string }>;
+      toolCall?: unknown;
+    }) => { outcome: { outcome: string; optionId?: string } };
+    const options = [
+      { optionId: "reject", kind: "reject_once" },
+      { optionId: "allow", kind: "allow_once" },
+    ];
+
+    expect(
+      handler({
+        options,
+        toolCall: { _meta: { "x.ai/tool": { name: "use_tool" } } },
+      }),
+    ).toEqual({ outcome: { outcome: "selected", optionId: "allow" } });
+    expect(
+      handler({
+        options,
+        toolCall: { _meta: { "x.ai/tool": { name: "search_tool" } } },
+      }),
+    ).toEqual({ outcome: { outcome: "selected", optionId: "allow" } });
+    expect(
+      handler({
+        options,
+        toolCall: { _meta: { "x.ai/tool": { name: "run_terminal_command" } } },
+      }),
+    ).toEqual({ outcome: { outcome: "cancelled" } });
+    expect(
+      handler({
+        options,
+        toolCall: {
+          title: "Read inboxzero notes",
+          rawInput: { path: "/tmp/inboxzero.md" },
+          _meta: { "x.ai/tool": { name: "read_file" } },
+        },
+      }),
+    ).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  it("bridges AI SDK tools to Grok through a request-scoped loopback MCP endpoint", async () => {
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "inboxzero__searchInbox",
+          input: JSON.stringify({ query: "hello" }),
+        },
+      ],
+    });
+    const grok = makeGrokConstructors({ doGenerate });
+    const execute = vi.fn().mockResolvedValue({ emails: [] });
+
+    const { createGrokCliLanguageModelWithBridgedTools } =
+      await loadCliProviderModule({ grokModule: grok.module });
+
+    const model = (await createGrokCliLanguageModelWithBridgedTools({
+      modelName: "default",
+      tools: {
+        searchInbox: {
+          description: "Search inbox",
+          inputSchema: z.object({ query: z.string() }),
+          execute,
+        },
+      },
+    })) as any;
+
+    const settings = grok.modelOptions[0].settings as {
+      mcpServers: Array<{
+        type: string;
+        name: string;
+        url: string;
+        headers: Array<{ name: string; value: string }>;
+      }>;
+    };
+    const mcpServer = settings.mcpServers[0];
+    expect(mcpServer.type).toBe("http");
+    expect(mcpServer.name).toBe("inboxzero");
+    expect(mcpServer.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+
+    const unauthorized = await fetch(mcpServer.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const callMcp = async (body: Record<string, unknown>) => {
+      const response = await fetch(mcpServer.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: mcpServer.headers[0].value,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", ...body }),
+      });
+      return response.json();
+    };
+
+    await callMcp({
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    const listed = await callMcp({ id: 2, method: "tools/list", params: {} });
+    expect(listed.result.tools[0]).toMatchObject({
+      name: "searchInbox",
+      description: "Search inbox",
+    });
+    const called = await callMcp({
+      id: 3,
+      method: "tools/call",
+      params: { name: "searchInbox", arguments: { query: "unread" } },
+    });
+    expect(execute).toHaveBeenCalledWith(
+      { query: "unread" },
+      expect.objectContaining({ toolCallId: expect.any(String) }),
+    );
+    expect(called.result.content).toEqual([
+      { type: "text", text: JSON.stringify({ emails: [] }) },
+    ]);
+
+    const generated = await model.doGenerate("generate-request");
+    expect(generated.content[0].toolName).toBe("searchInbox");
+    expect(generated.content[0].input).toBe(JSON.stringify({ query: "hello" }));
+
+    await expect(fetch(mcpServer.url, { method: "POST" })).rejects.toThrow();
+  });
+
+  it("strips the inboxzero MCP prefix from provider-normalized stream parts", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "tool-input-start",
+          id: "call_1",
+          toolName: "inboxzero__createRule",
+        });
+        controller.enqueue({
+          type: "tool-input-delta",
+          id: "call_1",
+          delta: '{"label":"later"}',
+        });
+        controller.enqueue({
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "inboxzero__createRule",
+          input: JSON.stringify({ label: "later" }),
+        });
+        controller.close();
+      },
+    });
+    const grok = makeGrokConstructors({
+      doStream: vi.fn().mockResolvedValue({ stream }),
+    });
+
+    const { createGrokCliLanguageModelWithBridgedTools } =
+      await loadCliProviderModule({ grokModule: grok.module });
+    const model = (await createGrokCliLanguageModelWithBridgedTools({
+      modelName: "default",
+      tools: {
+        createRule: {
+          description: "Create rule",
+          inputSchema: {},
+          execute: vi.fn(),
+        },
+      },
+    })) as any;
+
+    const result = await model.doStream("stream-request");
+    const reader = result.stream.getReader();
+    const parts: any[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parts.push(value);
+    }
+
+    expect(parts[0].toolName).toBe("createRule");
+    expect(parts[1].delta).toBe(JSON.stringify({ label: "later" }));
+    expect(parts[2].toolName).toBe("createRule");
+    expect(parts[2].input).toBe(JSON.stringify({ label: "later" }));
+  });
+
   it("surfaces a clear error when the provider package is missing its factory export", async () => {
     const { createCliLanguageModel } = await loadCliProviderModule({
       codexModule: { codexExec: undefined },
@@ -213,20 +451,24 @@ async function loadCliProviderModule({
   envOverrides,
   codexModule,
   claudeModule,
+  grokModule,
 }: {
   envOverrides?: Partial<{
     CLI_LLM_ENABLED: boolean;
     CODEX_CLI_ALLOW_NPX: boolean;
     CODEX_CLI_PATH: string | undefined;
+    GROK_CLI_PATH: string | undefined;
   }>;
   codexModule?: Record<string, unknown>;
   claudeModule?: Record<string, unknown>;
+  grokModule?: Record<string, unknown>;
 } = {}) {
   vi.doMock("@/env", () => ({
     env: {
       CLI_LLM_ENABLED: true,
       CODEX_CLI_ALLOW_NPX: false,
       CODEX_CLI_PATH: undefined,
+      GROK_CLI_PATH: undefined,
       ...envOverrides,
     },
   }));
@@ -239,5 +481,80 @@ async function loadCliProviderModule({
     vi.doMock("ai-sdk-provider-claude-code", () => claudeModule);
   }
 
+  if (grokModule) {
+    vi.doMock("ai-sdk-provider-grok-build", () => grokModule);
+  }
+
   return import("./cli-provider");
+}
+
+function makeGrokConstructors(
+  impl: {
+    doGenerate?: (...args: unknown[]) => unknown;
+    doStream?: (...args: unknown[]) => unknown;
+  } = {},
+) {
+  const acpOptions: any[] = [];
+  const sessions: any[] = [];
+  const modelOptions: Array<{
+    id: string;
+    settings: Record<string, unknown>;
+    clientFactory: (opts: unknown) => any;
+  }> = [];
+
+  function AcpClient(this: any, opts: Record<string, unknown>) {
+    acpOptions.push(opts);
+    this.newSession = async (params: unknown) => {
+      sessions.push(params);
+      return { sessionId: "s" };
+    };
+    this.dispose = vi.fn().mockResolvedValue(undefined);
+  }
+
+  function GrokBuildLanguageModel(
+    this: any,
+    options: {
+      id: string;
+      settings: Record<string, unknown>;
+      clientFactory: (opts: unknown) => any;
+    },
+  ) {
+    modelOptions.push(options);
+    const run = async (
+      fn: ((...args: unknown[]) => unknown) | undefined,
+      fallback: unknown,
+      args: unknown[],
+    ) => {
+      const client = options.clientFactory({});
+      try {
+        await client.newSession({ mcpServers: options.settings.mcpServers });
+        return fn ? await fn(...args) : fallback;
+      } finally {
+        await client.dispose();
+      }
+    };
+    this.specificationVersion = "v3";
+    this.provider = "grok-build";
+    this.modelId = options.id;
+    this.supportedUrls = {};
+    this.doGenerate = (...args: unknown[]) =>
+      run(impl.doGenerate, { text: "generated" }, args);
+    this.doStream = (...args: unknown[]) =>
+      run(impl.doStream, { stream: emptyStream() }, args);
+  }
+
+  return {
+    module: { GrokBuildLanguageModel, AcpClient },
+    modelOptions,
+    acpOptions,
+    sessions,
+  };
+}
+
+function emptyStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
 }

--- a/apps/web/utils/llms/cli-provider.test.ts
+++ b/apps/web/utils/llms/cli-provider.test.ts
@@ -203,9 +203,25 @@ describe("createCliLanguageModel", () => {
       `${os.tmpdir()}${path.sep}inbox-zero-grok-`,
     );
     expect(String(grok.acpOptions[0].env.HOME)).toContain(`${path.sep}home`);
-    expect(grok.acpOptions[0].env.GROK_AUTH_PATH).toBe(
+    expect(String(grok.acpOptions[0].env.GROK_AUTH_PATH)).toContain(
+      `${path.sep}home${path.sep}.grok${path.sep}auth.json`,
+    );
+    expect(grok.acpOptions[0].env.GROK_AUTH_PATH).not.toBe(
       path.join(os.homedir(), ".grok", "auth.json"),
     );
+    expect(grok.acpOptions[0].env.GROK_SANDBOX).toBe("strict");
+    expect(grok.acpOptions[0].args).toEqual([
+      "--no-auto-update",
+      "--sandbox",
+      "strict",
+      "--tools",
+      "search_tool,use_tool",
+      "--disable-web-search",
+      "--disallowed-tools",
+      "Agent",
+      "agent",
+      "stdio",
+    ]);
     expect(grok.sessions[0]._meta.agentProfile.tools).toEqual([
       "search_tool",
       "use_tool",
@@ -525,7 +541,9 @@ function makeGrokConstructors(
       fallback: unknown,
       args: unknown[],
     ) => {
-      const client = options.clientFactory({});
+      const client = options.clientFactory({
+        args: ["--no-auto-update", "agent", "stdio"],
+      });
       try {
         await client.newSession({ mcpServers: options.settings.mcpServers });
         return fn ? await fn(...args) : fallback;

--- a/apps/web/utils/llms/cli-provider.ts
+++ b/apps/web/utils/llms/cli-provider.ts
@@ -1,7 +1,15 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { env } from "@/env";
 import { SafeError } from "@/utils/error";
 import { Provider } from "@/utils/llms/config";
+import {
+  type GrokMcpBridge,
+  type McpBridgedTool,
+  startGrokMcpBridge,
+} from "@/utils/llms/grok-mcp-bridge";
 
 type CliProvider = string;
 
@@ -11,12 +19,6 @@ type CliModelFactory = (
   modelName: string,
   settings?: Record<string, unknown>,
 ) => LanguageModelV3;
-
-type McpBridgedTool = {
-  description?: string;
-  inputSchema: unknown;
-  execute?: (input: never, options?: unknown) => unknown;
-};
 
 type McpBridgeFactory = (
   name: string,
@@ -189,6 +191,8 @@ async function loadCliLanguageModel({
       return createCodexCliLanguageModel(modelName);
     case Provider.CLAUDE_CODE:
       return createClaudeCodeLanguageModel(modelName);
+    case Provider.GROK_CLI:
+      return createGrokCliLanguageModel(modelName);
     default:
       throw new SafeError(`Unsupported CLI LLM provider: ${provider}`);
   }
@@ -224,6 +228,329 @@ async function createClaudeCodeLanguageModel(modelName: string) {
     permissionMode: "default",
     sandbox: { enabled: true },
   });
+}
+
+async function createGrokCliLanguageModel(modelName: string) {
+  return createRestrictedGrokModel(await loadGrokModule(), modelName);
+}
+
+const GROK_MCP_SERVER_NAME = "inboxzero";
+const GROK_TOOL_NAME_PREFIX = `${GROK_MCP_SERVER_NAME}__`;
+const ALLOWED_GROK_PERMISSION_TOOLS = new Set(["search_tool", "use_tool"]);
+
+export async function createGrokCliLanguageModelWithBridgedTools({
+  modelName,
+  tools,
+}: {
+  modelName: string;
+  tools: Record<string, McpBridgedTool>;
+}): Promise<LanguageModelV3> {
+  assertCliLlmEnabled(Provider.GROK_CLI);
+  if (Object.keys(tools).length === 0) {
+    return createGrokCliLanguageModel(modelName);
+  }
+
+  const module = await loadGrokModule();
+  const bridge = await startGrokMcpBridge(tools);
+  try {
+    return wrapGrokModel({
+      model: createRestrictedGrokModel(module, modelName, {
+        mcpServers: [
+          {
+            type: "http",
+            name: GROK_MCP_SERVER_NAME,
+            url: bridge.url,
+            headers: [{ name: "Authorization", value: bridge.authorization }],
+          },
+        ],
+      }),
+      bridge,
+    });
+  } catch (error) {
+    await bridge.close();
+    throw error;
+  }
+}
+
+const GROK_AGENT_PROFILE = {
+  name: "inboxzero",
+  description: "Inbox Zero tools only",
+  tools: ["search_tool", "use_tool"],
+};
+
+function createRestrictedGrokModel(
+  module: CliProviderModule,
+  modelName: string,
+  extra: Record<string, unknown> = {},
+): LanguageModelV3 {
+  const GrokBuildLanguageModel = getGrokConstructor(
+    module,
+    "GrokBuildLanguageModel",
+  );
+  const AcpClient = getGrokConstructor(module, "AcpClient");
+  return new GrokBuildLanguageModel({
+    id: modelName,
+    settings: grokCliSettings(extra),
+    clientFactory: (options: Record<string, unknown>) =>
+      createIsolatedGrokClient(AcpClient, options),
+  }) as LanguageModelV3;
+}
+
+function createIsolatedGrokClient(
+  AcpClient: new (
+    options: Record<string, unknown>,
+  ) => {
+    newSession: (params: unknown, signal?: unknown) => Promise<unknown>;
+    dispose?: (...args: unknown[]) => unknown;
+  },
+  options: Record<string, unknown>,
+) {
+  const workspace = createGrokWorkspace();
+  try {
+    writeGrokHomeConfig(workspace.home);
+    const noProxy = withLoopbackNoProxy(
+      process.env.NO_PROXY ?? process.env.no_proxy,
+    );
+    const client = new AcpClient({
+      ...options,
+      cwd: workspace.cwd,
+      env: {
+        ...((options.env as Record<string, string | undefined> | undefined) ??
+          {}),
+        HOME: workspace.home,
+        GROK_HOME: workspace.home,
+        GROK_AUTH_PATH: path.join(os.homedir(), ".grok", "auth.json"),
+        NO_PROXY: noProxy,
+        no_proxy: noProxy,
+      },
+      fileSystem: { readTextFile: false, writeTextFile: false },
+      onPermissionRequest: allowInboxZeroToolsOnly,
+    });
+    const newSession = client.newSession.bind(client);
+    client.newSession = (params, signal) =>
+      newSession(withInboxZeroSession(params, workspace.cwd), signal);
+    const dispose = client.dispose?.bind(client);
+    let removed = false;
+    client.dispose = async (...args: unknown[]) => {
+      try {
+        return await dispose?.(...args);
+      } finally {
+        if (!removed) {
+          removed = true;
+          workspace.remove();
+        }
+      }
+    };
+    return client;
+  } catch (error) {
+    workspace.remove();
+    throw error;
+  }
+}
+
+function withInboxZeroSession(params: unknown, cwd: string) {
+  const base =
+    params && typeof params === "object"
+      ? (params as Record<string, unknown>)
+      : {};
+  const meta =
+    base._meta && typeof base._meta === "object"
+      ? (base._meta as Record<string, unknown>)
+      : {};
+  return {
+    ...base,
+    cwd,
+    _meta: { ...meta, agentProfile: GROK_AGENT_PROFILE },
+  };
+}
+
+function allowInboxZeroToolsOnly(request: {
+  options: Array<{ kind: string; optionId: string }>;
+  toolCall?: unknown;
+}) {
+  const name = grokPermissionToolName(request.toolCall);
+  if (!name || !ALLOWED_GROK_PERMISSION_TOOLS.has(name)) {
+    return { outcome: { outcome: "cancelled" as const } };
+  }
+  const option =
+    request.options.find((candidate) => candidate.kind === "allow_once") ??
+    request.options.find((candidate) => candidate.kind === "allow_always");
+  if (!option) return { outcome: { outcome: "cancelled" as const } };
+  return {
+    outcome: { outcome: "selected" as const, optionId: option.optionId },
+  };
+}
+
+function grokPermissionToolName(toolCall: unknown): string | undefined {
+  if (!toolCall || typeof toolCall !== "object") return;
+  const record = toolCall as Record<string, unknown>;
+  const meta = record._meta;
+  if (meta && typeof meta === "object") {
+    const tool = (meta as Record<string, unknown>)["x.ai/tool"];
+    if (tool && typeof tool === "object") {
+      const name = (tool as { name?: unknown }).name;
+      if (typeof name === "string" && name.length > 0) return name;
+    }
+  }
+  return typeof record.title === "string" &&
+    ALLOWED_GROK_PERMISSION_TOOLS.has(record.title)
+    ? record.title
+    : undefined;
+}
+
+function createGrokWorkspace() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-zero-grok-"));
+  const home = path.join(root, "home");
+  const cwd = path.join(root, "cwd");
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(cwd, { recursive: true, mode: 0o700 });
+  return {
+    home,
+    cwd,
+    remove: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function writeGrokHomeConfig(home: string) {
+  fs.writeFileSync(
+    path.join(home, "config.toml"),
+    `disable_web_search = true
+
+[marketplace]
+official_marketplace_auto_installed = true
+
+[plugins]
+enabled = []
+`,
+    { mode: 0o600 },
+  );
+}
+
+function wrapGrokModel({
+  model,
+  bridge,
+}: {
+  model: LanguageModelV3;
+  bridge: GrokMcpBridge;
+}): LanguageModelV3 {
+  let terminated = false;
+  const terminate = async () => {
+    if (terminated) return;
+    terminated = true;
+    try {
+      await bridge.close();
+    } catch {}
+  };
+
+  const wrapped = {
+    specificationVersion: model.specificationVersion,
+    provider: model.provider,
+    modelId: model.modelId,
+    supportedUrls: model.supportedUrls,
+    async doGenerate(...args: unknown[]) {
+      const doGenerate = getModelMethod(model, "doGenerate", Provider.GROK_CLI);
+      try {
+        const result = (await doGenerate(...args)) as {
+          content?: unknown[];
+        } & Record<string, unknown>;
+        return {
+          ...result,
+          ...(Array.isArray(result.content)
+            ? { content: result.content.map(unprefixGrokPart) }
+            : {}),
+        };
+      } finally {
+        await terminate();
+      }
+    },
+    async doStream(...args: unknown[]) {
+      const doStream = getModelMethod(model, "doStream", Provider.GROK_CLI);
+      let result: { stream: ReadableStream<unknown> } & Record<string, unknown>;
+      try {
+        result = (await doStream(...args)) as typeof result;
+      } catch (error) {
+        await terminate();
+        throw error;
+      }
+      const reader = result.stream.getReader();
+      const stream = new ReadableStream<unknown>({
+        async pull(controller) {
+          try {
+            const { done, value } = await reader.read();
+            if (done) {
+              await terminate();
+              controller.close();
+              return;
+            }
+            controller.enqueue(unprefixGrokPart(value));
+          } catch (error) {
+            await terminate();
+            controller.error(error);
+          }
+        },
+        async cancel(reason) {
+          await terminate();
+          await reader.cancel(reason);
+        },
+      });
+      return { ...result, stream };
+    },
+  };
+  return wrapped as unknown as LanguageModelV3;
+}
+
+function unprefixGrokPart(part: unknown): unknown {
+  if (!part || typeof part !== "object") return part;
+  const record = part as Record<string, unknown>;
+  if (typeof record.toolName !== "string") return part;
+  if (!record.toolName.startsWith(GROK_TOOL_NAME_PREFIX)) return part;
+  return {
+    ...record,
+    toolName: record.toolName.slice(GROK_TOOL_NAME_PREFIX.length),
+  };
+}
+
+function withLoopbackNoProxy(existing: string | undefined): string {
+  const entries = (existing ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  for (const host of ["127.0.0.1", "localhost", "::1"]) {
+    if (!entries.includes(host)) entries.push(host);
+  }
+  return entries.join(",");
+}
+
+async function loadGrokModule() {
+  return importOptionalProviderPackage(
+    "ai-sdk-provider-grok-build",
+    Provider.GROK_CLI,
+  );
+}
+
+function grokCliSettings(extra: Record<string, unknown> = {}) {
+  // Stock grok 1.0.4 rejects --no-native-tools; do not set inferenceOnly.
+  return {
+    authMethod: "cached_token",
+    ...(env.GROK_CLI_PATH ? { executablePath: env.GROK_CLI_PATH } : {}),
+    ...extra,
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: constructor signatures vary by package
+type CliConstructor = new (...args: any[]) => any;
+
+function getGrokConstructor(
+  module: CliProviderModule,
+  exportName: string,
+): CliConstructor {
+  const ctor = module[exportName];
+  if (typeof ctor !== "function") {
+    throw new SafeError(
+      `CLI LLM provider "${Provider.GROK_CLI}" package does not export "${exportName}". Pin ai-sdk-provider-grok-build@0.2.0.`,
+    );
+  }
+  return ctor as CliConstructor;
 }
 
 async function importOptionalProviderPackage(

--- a/apps/web/utils/llms/cli-provider.ts
+++ b/apps/web/utils/llms/cli-provider.ts
@@ -314,12 +314,16 @@ function createIsolatedGrokClient(
     const client = new AcpClient({
       ...options,
       cwd: workspace.cwd,
+      args: withInboxZeroGrokArgs(
+        options.args as readonly string[] | undefined,
+      ),
       env: {
         ...((options.env as Record<string, string | undefined> | undefined) ??
           {}),
         HOME: workspace.home,
         GROK_HOME: workspace.home,
-        GROK_AUTH_PATH: path.join(os.homedir(), ".grok", "auth.json"),
+        GROK_AUTH_PATH: copyGrokAuthIntoHome(workspace.home),
+        GROK_SANDBOX: "strict",
         NO_PROXY: noProxy,
         no_proxy: noProxy,
       },
@@ -528,8 +532,40 @@ async function loadGrokModule() {
   );
 }
 
+function withInboxZeroGrokArgs(args: readonly string[] | undefined): string[] {
+  // `grok agent stdio` rejects --sandbox/--tools/--no-native-tools. Those
+  // clamps have to sit on the root command, before `agent`.
+  const base =
+    args && args.length > 0
+      ? [...args]
+      : ["--no-auto-update", "agent", "stdio"];
+  const extras = [
+    "--sandbox",
+    "strict",
+    "--tools",
+    "search_tool,use_tool",
+    "--disable-web-search",
+    "--disallowed-tools",
+    "Agent",
+  ];
+  const agentAt = base.indexOf("agent");
+  if (agentAt === -1) return [...base, ...extras];
+  return [...base.slice(0, agentAt), ...extras, ...base.slice(agentAt)];
+}
+
+function copyGrokAuthIntoHome(home: string): string {
+  const destDir = path.join(home, ".grok");
+  fs.mkdirSync(destDir, { recursive: true, mode: 0o700 });
+  const dest = path.join(destDir, "auth.json");
+  try {
+    fs.copyFileSync(path.join(os.homedir(), ".grok", "auth.json"), dest);
+    fs.chmodSync(dest, 0o600);
+  } catch {}
+  return dest;
+}
+
 function grokCliSettings(extra: Record<string, unknown> = {}) {
-  // Stock grok 1.0.4 rejects --no-native-tools; do not set inferenceOnly.
+  // 1.0.4 rejects --no-native-tools after stdio; do not set inferenceOnly.
   return {
     authMethod: "cached_token",
     ...(env.GROK_CLI_PATH ? { executablePath: env.GROK_CLI_PATH } : {}),

--- a/apps/web/utils/llms/config.ts
+++ b/apps/web/utils/llms/config.ts
@@ -15,6 +15,7 @@ export const Provider = {
   OPENAI_COMPATIBLE: "openai-compatible",
   CODEX_CLI: "codex-cli",
   CLAUDE_CODE: "claude-code",
+  GROK_CLI: "grok-cli",
 };
 
 export const providerOptions: { label: string; value: string }[] = [

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -14,6 +14,7 @@ const {
   mockGetPosthogLlmClient,
   mockIsPosthogLlmEvalApproved,
   mockCreateClaudeCodeLanguageModelWithBridgedTools,
+  mockCreateGrokCliLanguageModelWithBridgedTools,
 } = vi.hoisted(() => ({
   mockGenerateText: vi.fn(),
   mockSaveAiUsage: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockGetPosthogLlmClient: vi.fn(),
   mockIsPosthogLlmEvalApproved: vi.fn(),
   mockCreateClaudeCodeLanguageModelWithBridgedTools: vi.fn(),
+  mockCreateGrokCliLanguageModelWithBridgedTools: vi.fn(),
 }));
 
 vi.mock("ai", async () => {
@@ -56,6 +58,8 @@ vi.mock("@/utils/llms/cli-provider", async () => {
     ...actual,
     createClaudeCodeLanguageModelWithBridgedTools:
       mockCreateClaudeCodeLanguageModelWithBridgedTools,
+    createGrokCliLanguageModelWithBridgedTools:
+      mockCreateGrokCliLanguageModelWithBridgedTools,
   };
 });
 
@@ -282,6 +286,52 @@ describe("createGenerateText fallback chain", () => {
       tools,
     });
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  it("bridges Grok CLI tools and disables AI SDK retries", async () => {
+    const originalModel = createModel("grok-cli-model");
+    const bridgedModel = createModel("grok-cli-bridged-model");
+    const tools = {
+      finalizeResults: {
+        description: "Finalize results",
+        inputSchema: {},
+        execute: vi.fn(),
+      },
+    };
+    mockCreateGrokCliLanguageModelWithBridgedTools.mockResolvedValue(
+      bridgedModel,
+    );
+    mockGenerateText.mockImplementation(async (request) => {
+      expect(request.model).toBe(bridgedModel);
+      expect(request.tools).toBeUndefined();
+      expect(request.maxRetries).toBe(0);
+      return createTextResult();
+    });
+
+    const generateText = createGenerateTextForTest({
+      label: "Grok CLI bridge",
+      modelOptions: createModelOptions({
+        provider: "grok-cli",
+        modelName: "default",
+        model: originalModel,
+      }),
+    });
+
+    await generateText({
+      prompt: "hello",
+      model: originalModel,
+      tools,
+    });
+
+    expect(mockCreateGrokCliLanguageModelWithBridgedTools).toHaveBeenCalledWith(
+      {
+        modelName: "default",
+        tools,
+      },
+    );
+    expect(
+      mockCreateClaudeCodeLanguageModelWithBridgedTools,
+    ).not.toHaveBeenCalled();
   });
 
   it("sets openrouter user from internal user id", async () => {

--- a/apps/web/utils/llms/grok-mcp-bridge.ts
+++ b/apps/web/utils/llms/grok-mcp-bridge.ts
@@ -1,0 +1,180 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import http from "node:http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { asSchema } from "ai";
+import { createScopedLogger } from "@/utils/logger";
+
+const logger = createScopedLogger("grok-mcp-bridge");
+
+export type McpBridgedTool = {
+  description?: string;
+  inputSchema: unknown;
+  execute?: (input: never, options?: unknown) => unknown;
+};
+
+export type GrokMcpBridge = {
+  url: string;
+  authorization: string;
+  close: () => Promise<void>;
+};
+
+const MCP_PATH = "/mcp";
+
+export async function startGrokMcpBridge(
+  tools: Record<string, McpBridgedTool>,
+): Promise<GrokMcpBridge> {
+  const authorization = `Bearer ${randomBytes(32).toString("hex")}`;
+  const preparedTools = prepareTools(tools);
+
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      if (req.headers.authorization !== authorization) {
+        res.writeHead(401).end();
+        return;
+      }
+      if (!req.url?.startsWith(MCP_PATH)) {
+        res.writeHead(404).end();
+        return;
+      }
+      if (req.method !== "POST") {
+        res.writeHead(405).end();
+        return;
+      }
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      const server = createMcpToolServer(preparedTools);
+      res.on("close", () => {
+        transport.close().catch(() => {});
+        server.close().catch(() => {});
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      logger.error("Grok MCP bridge request failed", { error });
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    }
+  });
+  httpServer.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Grok MCP bridge failed to bind a loopback port");
+  }
+
+  let closed = false;
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    await new Promise<void>((resolve) => {
+      httpServer.close(() => resolve());
+      httpServer.closeAllConnections();
+    });
+  };
+
+  return {
+    url: `http://127.0.0.1:${address.port}${MCP_PATH}`,
+    authorization,
+    close,
+  };
+}
+
+type PreparedTool = {
+  description?: string;
+  execute?: McpBridgedTool["execute"];
+  schema: () => ReturnType<typeof asSchema>;
+};
+
+function prepareTools(
+  tools: Record<string, McpBridgedTool>,
+): Map<string, PreparedTool> {
+  return new Map(
+    Object.entries(tools).map(([name, tool]) => {
+      let cached: ReturnType<typeof asSchema> | undefined;
+      return [
+        name,
+        {
+          description: tool.description,
+          execute: tool.execute,
+          schema: () => {
+            cached ??= asSchema(
+              tool.inputSchema as Parameters<typeof asSchema>[0],
+            );
+            return cached;
+          },
+        },
+      ];
+    }),
+  );
+}
+
+function createMcpToolServer(preparedTools: Map<string, PreparedTool>): Server {
+  const server = new Server(
+    { name: "inbox-zero", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [...preparedTools.entries()].map(([name, tool]) => ({
+      name,
+      description: tool.description,
+      inputSchema: tool.schema().jsonSchema as { type: "object" },
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const name = request.params.name;
+    const tool = preparedTools.get(name);
+    if (!tool?.execute) {
+      return toolError(`Unknown tool: ${name}`);
+    }
+    try {
+      const args = request.params.arguments ?? {};
+      const validated = await tool.schema().validate?.(args);
+      if (validated && !validated.success) {
+        return toolError(`Invalid input for ${name}: ${validated.error}`);
+      }
+      const input = validated?.success ? validated.value : args;
+      const result = await tool.execute(input as never, {
+        toolCallId: `grok-mcp-${randomUUID()}`,
+        messages: [],
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              typeof result === "string"
+                ? result
+                : JSON.stringify(result ?? null),
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error("Bridged tool execution failed", { toolName: name, error });
+      return toolError(
+        error instanceof Error ? error.message : "Tool execution failed",
+      );
+    }
+  });
+
+  return server;
+}
+
+function toolError(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -60,7 +60,11 @@ import {
   shouldForceNanoModel,
 } from "@/utils/llms/model-usage-guard";
 import { Provider } from "@/utils/llms/config";
-import { createClaudeCodeLanguageModelWithBridgedTools } from "@/utils/llms/cli-provider";
+import {
+  createClaudeCodeLanguageModelWithBridgedTools,
+  createGrokCliLanguageModelWithBridgedTools,
+} from "@/utils/llms/cli-provider";
+import type { McpBridgedTool } from "@/utils/llms/grok-mcp-bridge";
 import {
   appendOllamaOnlySystemGuidance,
   OLLAMA_STRUCTURED_OUTPUT_GUIDANCE,
@@ -89,11 +93,9 @@ const logger = createScopedLogger("llms");
 
 const MAX_LOG_LENGTH = 200;
 
-// The Claude Code CLI provider drops AI SDK tools at the LanguageModelV3
-// boundary. Route tool-bearing calls through the package's MCP bridge so the
-// CLI can execute them locally; clear `tools` so the AI SDK does not also try
-// to drive them. No-op for every other provider and for tool-less calls.
-async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
+// Inbox Zero tools are the only app-executed tools on CLI providers. Grok's
+// bridge is request-scoped, so retries must not reuse a closed listener.
+async function bridgeCliToolsIfNeeded<T extends Record<string, Tool>>({
   provider,
   modelName,
   model,
@@ -109,12 +111,15 @@ async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
   model: LanguageModelV3;
   tools: T | undefined;
   bridged: boolean;
+  callOptions: { maxRetries?: number };
 }> {
-  if (provider !== Provider.CLAUDE_CODE)
-    return { model, tools, bridged: false };
+  if (provider !== Provider.CLAUDE_CODE && provider !== Provider.GROK_CLI)
+    return { model, tools, bridged: false, callOptions: {} };
   if (!tools || Object.keys(tools).length === 0) {
-    return { model, tools, bridged: false };
+    return { model, tools, bridged: false, callOptions: {} };
   }
+
+  const callOptions = provider === Provider.GROK_CLI ? { maxRetries: 0 } : {};
 
   const activeToolSet =
     activeTools === undefined ? undefined : new Set(activeTools);
@@ -126,21 +131,18 @@ async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
         ) as T);
 
   if (Object.keys(toolsToBridge).length === 0) {
-    return { model, tools: undefined, bridged: true };
+    return { model, tools: undefined, bridged: true, callOptions };
   }
 
-  const bridged = await createClaudeCodeLanguageModelWithBridgedTools({
+  const createBridgedModel =
+    provider === Provider.GROK_CLI
+      ? createGrokCliLanguageModelWithBridgedTools
+      : createClaudeCodeLanguageModelWithBridgedTools;
+  const bridged = await createBridgedModel({
     modelName,
-    tools: toolsToBridge as unknown as Record<
-      string,
-      {
-        description?: string;
-        inputSchema: unknown;
-        execute?: (input: never, options?: unknown) => unknown;
-      }
-    >,
+    tools: toolsToBridge as unknown as Record<string, McpBridgedTool>,
   });
-  return { model: bridged, tools: undefined, bridged: true };
+  return { model: bridged, tools: undefined, bridged: true, callOptions };
 }
 
 function prepareOptionsForToolBridge<TOptions extends { tools?: unknown }>({
@@ -331,7 +333,7 @@ export function createGenerateText({
         emailAccountId: emailAccount.id,
       });
 
-      const bridged = await bridgeClaudeCodeToolsIfNeeded({
+      const bridged = await bridgeCliToolsIfNeeded({
         provider: candidate.provider,
         modelName: candidate.modelName,
         model: candidate.model,
@@ -348,6 +350,7 @@ export function createGenerateText({
           ...(bridged.tools ? { tools: bridged.tools } : {}),
           ...commonOptions,
           providerOptions,
+          ...bridged.callOptions,
           model: withPosthogTracing({
             model: bridged.model,
             userEmail: emailAccount.email,
@@ -764,7 +767,7 @@ export async function chatCompletionStream(
       userId,
       emailAccountId,
     });
-    const bridgedChat = await bridgeClaudeCodeToolsIfNeeded({
+    const bridgedChat = await bridgeCliToolsIfNeeded({
       provider: candidate.provider,
       modelName: candidate.modelName,
       model: candidate.model,
@@ -787,6 +790,7 @@ export async function chatCompletionStream(
         tools: bridgedChat.tools,
         stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
         ...commonOptions,
+        ...bridgedChat.callOptions,
         providerOptions: providerOptions,
         experimental_transform: smoothStream({ chunking: "word" }),
         onStepFinish,
@@ -921,7 +925,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
       userId,
       emailAccountId,
     });
-    const bridgedAgent = await bridgeClaudeCodeToolsIfNeeded({
+    const bridgedAgent = await bridgeCliToolsIfNeeded({
       provider: candidate.provider,
       modelName: candidate.modelName,
       model: candidate.model,
@@ -974,6 +978,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
       stopWhen: stopWhen ?? (maxSteps ? stepCountIs(maxSteps) : undefined),
       temperature,
       ...commonOptions,
+      ...bridgedAgent.callOptions,
       providerOptions,
       onFinish: async (result) => {
         const usagePromise = saveUsageWithMetadata({

--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -1395,6 +1395,22 @@ describe("Models", () => {
       });
     });
 
+    it("should configure Grok CLI provider when explicitly enabled", () => {
+      const userAi = defaultUserAi();
+
+      setDefaultLlms(Provider.GROK_CLI, "default");
+      vi.mocked(env).CLI_LLM_ENABLED = true;
+
+      const result = getModel(userAi);
+
+      expect(result.provider).toBe(Provider.GROK_CLI);
+      expect(result.modelName).toBe("default");
+      expect(result.model).toMatchObject({
+        provider: Provider.GROK_CLI,
+        modelId: "default",
+      });
+    });
+
     it("should skip CLI fallback providers when CLI LLMs are disabled", () => {
       const userAi = defaultUserAi();
 

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -314,6 +314,17 @@ function selectModel(
         }),
       };
     }
+    case Provider.GROK_CLI: {
+      const modelName = aiModel || "default";
+      return {
+        provider: Provider.GROK_CLI,
+        modelName,
+        model: createCliLanguageModel({
+          provider: Provider.GROK_CLI,
+          modelName,
+        }),
+      };
+    }
 
     case Provider.BEDROCK: {
       const modelName = aiModel || "global.anthropic.claude-sonnet-4-6";
@@ -564,6 +575,7 @@ function getProviderApiKey(provider: string) {
       env.LLM_API_KEY || process.env.LLM_API_KEY || "not-required",
     [Provider.CODEX_CLI]: getCliProviderAvailability(Provider.CODEX_CLI),
     [Provider.CLAUDE_CODE]: getCliProviderAvailability(Provider.CLAUDE_CODE),
+    [Provider.GROK_CLI]: getCliProviderAvailability(Provider.GROK_CLI),
   };
 
   return providerApiKeys[provider];

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -108,9 +108,10 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `OPENAI_COMPATIBLE_MODEL` | No | OpenAI-compatible model name when configured separately from the selected LLM tier model | — |
 | `OPENAI_COMPATIBLE_AUTH_HEADER` | No | Header style for the OpenAI-compatible API key: `authorization` or `api-key` | `authorization` |
 | **CLI LLM Providers (Experimental)** ||||
-| `CLI_LLM_ENABLED` | No | Enables community CLI-backed LLM providers (`codex-cli`, `claude-code`). Self-host only; requires installing optional provider packages. | `false` |
+| `CLI_LLM_ENABLED` | No | Enables community CLI-backed LLM providers (`codex-cli`, `claude-code`, `grok-cli`). Self-host only; requires installing optional provider packages. | `false` |
 | `CODEX_CLI_ALLOW_NPX` | No | Allows the Codex community provider to fall back to `npx @openai/codex` if `codex` is not on PATH. Leave disabled unless you trust that install path. | `false` |
 | `CODEX_CLI_PATH` | No | Optional path to the `codex` binary when using `codex-cli`. | — |
+| `GROK_CLI_PATH` | No | Optional path to the `grok` binary when using `grok-cli`. | — |
 | **AI Content Controls** ||||
 | `SENSITIVE_DATA_POLICY_DEFAULT` | No | Default policy for handling sensitive data matches in LLM requests (`ALLOW`, `REDACT`, or `BLOCK`) | `ALLOW` |
 | `NEXT_PUBLIC_SENSITIVE_DATA_POLICY_LOCKED` | No | Set to `true` to enforce the default policy for all accounts, disable account-level edits, and hide the setting in the UI | `false` |

--- a/docs/hosting/llm-setup.mdx
+++ b/docs/hosting/llm-setup.mdx
@@ -152,12 +152,13 @@ DEFAULT_LLMS=grok-cli:default
 `default` selects Grok's current default model.
 
 Tool-bearing Inbox Zero calls always go through a request-scoped loopback
-MCP server. Each Grok process runs in an isolated HOME/cwd. The session
-requests an agent profile with Grok's `search_tool` (tool discovery) and
-`use_tool` (MCP invoke). Stock Grok 1.0.4 rejects `--no-native-tools`, so
-`inferenceOnly` is not set and the profile is not fail-closed. Permission
-prompts are allowed only when ACP `_meta["x.ai/tool"].name` is
-`search_tool` or `use_tool`; other permission requests are cancelled.
-Native tools that never ask permission can still run. Isolated
-`GROK_HOME/config.toml` sets `disable_web_search = true` as a hosted-search
-backstop; the AI SDK provider does not read that file.
+MCP server. Each Grok process runs in an isolated HOME/cwd. Stock Grok
+1.0.4 rejects `--no-native-tools` on `agent stdio`, so `inferenceOnly` is
+not set. Instead the root command gets `--sandbox strict`,
+`--tools search_tool,use_tool`, `--disable-web-search`, and
+`--disallowed-tools Agent` (those flags are invalid after `stdio`).
+`GROK_SANDBOX=strict` is set as well. Permission prompts are allowed only
+when ACP `_meta["x.ai/tool"].name` is `search_tool` or `use_tool`. Auth
+is copied into the isolated HOME so the process does not read the host
+`~/.grok/auth.json` path. Built-in sandbox profiles can log a warning and
+continue unsandboxed if the kernel cannot apply them.

--- a/docs/hosting/llm-setup.mdx
+++ b/docs/hosting/llm-setup.mdx
@@ -34,6 +34,7 @@ Use one of these provider values before the colon in `*_LLMS` entries:
 | OpenAI-compatible (LM Studio, vLLM, LiteLLM, etc.) | `openai-compatible` |
 | Codex CLI (experimental, self-host only) | `codex-cli` |
 | Claude Code (experimental, self-host only) | `claude-code` |
+| Grok Build CLI (experimental, self-host only) | `grok-cli` |
 
 ## Tiers
 
@@ -96,13 +97,13 @@ The old `DEFAULT_LLM_PROVIDER` / `DEFAULT_LLM_MODEL`, role-specific `*_LLM_PROVI
 
 ### CLI LLM providers
 
-`codex-cli` and `claude-code` are experimental self-host options. They use
-third-party community AI SDK provider packages that spawn local CLI tools, so
-they are disabled unless `CLI_LLM_ENABLED=true`.
+`codex-cli`, `claude-code`, and `grok-cli` are experimental self-host options.
+They use third-party community AI SDK provider packages that spawn local CLI
+tools, so they are disabled unless `CLI_LLM_ENABLED=true`.
 
 Use them only on trusted self-hosted deployments. Review the provider package
 source, pin exact package versions, and make sure you comply with the relevant
-OpenAI or Anthropic terms for your authentication method.
+OpenAI, Anthropic, or xAI terms for your authentication method.
 
 Codex example:
 
@@ -131,3 +132,32 @@ claude auth login
 CLI_LLM_ENABLED=true
 DEFAULT_LLMS=claude-code:sonnet
 ```
+
+Grok Build CLI example:
+
+```bash
+cd apps/web
+pnpm add ai-sdk-provider-grok-build@0.2.0
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok login
+```
+
+```env
+CLI_LLM_ENABLED=true
+DEFAULT_LLMS=grok-cli:default
+```
+
+`grok-cli` uses the session cached by `grok login`; it does not need
+`XAI_API_KEY`. Set `GROK_CLI_PATH` if `grok` is not on `PATH`. The model id
+`default` selects Grok's current default model.
+
+Tool-bearing Inbox Zero calls always go through a request-scoped loopback
+MCP server. Each Grok process runs in an isolated HOME/cwd. The session
+requests an agent profile with Grok's `search_tool` (tool discovery) and
+`use_tool` (MCP invoke). Stock Grok 1.0.4 rejects `--no-native-tools`, so
+`inferenceOnly` is not set and the profile is not fail-closed. Permission
+prompts are allowed only when ACP `_meta["x.ai/tool"].name` is
+`search_tool` or `use_tool`; other permission requests are cancelled.
+Native tools that never ask permission can still run. Isolated
+`GROK_HOME/config.toml` sets `disable_web_search = true` as a hosted-search
+backstop; the AI SDK provider does not read that file.

--- a/turbo.json
+++ b/turbo.json
@@ -106,6 +106,7 @@
         "CLI_LLM_ENABLED",
         "CODEX_CLI_ALLOW_NPX",
         "CODEX_CLI_PATH",
+        "GROK_CLI_PATH",
         "PERPLEXITY_API_KEY",
 
         "UPSTASH_REDIS_URL",


### PR DESCRIPTION
Inbox Zero already has experimental self-host CLI providers (`codex-cli`, `claude-code`). This adds `grok-cli` in the same shape, so a local [Grok Build CLI](https://x.ai/cli) session can run Inbox Zero LLM work.

Off unless `CLI_LLM_ENABLED=true`. The package is optional (`ai-sdk-provider-grok-build@0.2.0`), same pattern as the others. Auth is `grok login` (cached token), not `XAI_API_KEY`. Model id `default` is Grok’s current default.

**Tools**

Grok can’t run AI SDK tools in-process. Tool-bearing calls go through a request-scoped loopback MCP server (bearer, `127.0.0.1` only). Each Grok process gets an isolated HOME/cwd. We request an agent profile with only Grok’s `search_tool` (discover tools) and `use_tool` (call MCP). Permission prompts are allowed only for those two; anything else is cancelled. Inbox Zero callers still see the original tool names (`inboxzero__` prefix stripped).

**Limit**

Stock Grok 1.0.4 rejects `--no-native-tools`, so this is not fail-closed. Native tools that never ask permission can still run. Isolated `GROK_HOME/config.toml` sets `disable_web_search = true` as a hosted-search backstop; the AI SDK provider does not read that file.

**Enable**

```bash
cd apps/web
pnpm add ai-sdk-provider-grok-build@0.2.0
grok login
```

```env
CLI_LLM_ENABLED=true
DEFAULT_LLMS=grok-cli:default
```

Set `GROK_CLI_PATH` if `grok` is not on `PATH`.

**Tests**

Provider load, isolated HOME, permission identity, MCP auth/list/call + prefix strip, `createGenerateText` sets `maxRetries: 0` so a closed loopback listener is not reused.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

