### PR TITLE
INB-331: Keep notetaker recording for the full call

### DIFF
--- a/apps/web/utils/meeting-recorder/bot-provider.ts
+++ b/apps/web/utils/meeting-recorder/bot-provider.ts
@@ -42,6 +42,10 @@ export interface MeetingBotProvider {
   /** Tolerant: media that is already gone is not an error. */
   deleteMedia(externalBotId: string): Promise<void>;
   fetchTranscript(externalTranscriptId: string): Promise<NormalizedTranscript>;
+  /**
+   * The bot stays for the life of the call, not the calendar slot: it must
+   * leave when the participants do, not at a scheduled end time.
+   */
   scheduleBot(params: {
     botName?: string;
     meetingUrl: string;

--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -73,6 +73,9 @@ describe("RecallBotProvider", () => {
       meeting_url: "https://meet.google.com/abc-defg-hij",
       bot_name: "Inbox Zero Notetaker",
       join_at: "2026-05-04T09:00:00.000Z",
+      automatic_leave: {
+        everyone_left_timeout: { timeout: 2 },
+      },
     });
   });
 

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -30,6 +30,10 @@ export function isRecallConfigured(): boolean {
 
 const DEFAULT_RECALL_REGION = "us-west-2";
 
+// Use participant presence to end successful recordings; a calendar duration
+// is not the call's actual lifetime.
+const EVERYONE_LEFT_TIMEOUT_SECONDS = 2;
+
 // Overridden only to point at the local emulator, same as GOOGLE_BASE_URL.
 function getRecallApiBase(): string {
   if (env.RECALL_BASE_URL) {
@@ -85,6 +89,9 @@ export class RecallBotProvider implements MeetingBotProvider {
         meeting_url: meetingUrl,
         bot_name: botName,
         join_at: joinAt.toISOString(),
+        automatic_leave: {
+          everyone_left_timeout: { timeout: EVERYONE_LEFT_TIMEOUT_SECONDS },
+        },
         ...(cameraImage && {
           automatic_video_output: {
             in_call_recording: {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260819-093713_pr-3334_c8688a5e2fcd/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Configures Recall bots to remain in meetings until participants leave, preventing recordings from ending at the calendar slot boundary. It also documents this provider behavior and locks the request shape with unit coverage.

- Set `automatic_leave.everyone_left_timeout` on scheduled bots
- Document participant-based meeting lifetime in the provider contract
- Test: `pnpm test utils/recall/client.test.ts` (3 passed)
- Formatting: Ultracite check passed for all changed files
- Performance: adds a small field to the existing Recall scheduling request; no extra runtime passes, database calls, or network requests, with negligible hot-path risk
- Linear: https://linear.app/inbox-zero-ai/issue/INB-331/notetaker-stops-recording-at-scheduled-end-time-instead-of-when-the

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->