### PR TITLE
INB-332: Show profile photo on booking pages

### DIFF
--- a/apps/web/app/book/[slug]/BookingSidebar.tsx
+++ b/apps/web/app/book/[slug]/BookingSidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import type { GetPublicBookingLinkResponse } from "@/app/api/public/booking-links/[slug]/route";
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Command,
   CommandEmpty,
@@ -63,9 +64,12 @@ export function BookingSidebar({
   return (
     <div className="flex min-h-0 flex-col gap-4 overflow-y-auto p-4 sm:p-6 md:p-7">
       {backButton}
-      <div className="flex size-12 items-center justify-center rounded-full bg-blue-50 text-lg font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300">
-        {initial}
-      </div>
+      <Avatar className="size-12">
+        <AvatarImage src={bookingLink.hostImage || undefined} alt={hostName} />
+        <AvatarFallback className="bg-blue-50 text-lg font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+          {initial}
+        </AvatarFallback>
+      </Avatar>
       <div>
         <div className="text-sm text-muted-foreground">{hostName}</div>
         <h1 className="mt-0.5 break-words text-2xl font-medium tracking-tight text-foreground">

--- a/apps/web/utils/booking/public.test.ts
+++ b/apps/web/utils/booking/public.test.ts
@@ -72,6 +72,7 @@ describe("public booking", () => {
       locationValue: "https://video.example.com/private-meeting",
       emailAccount: {
         name: "Host User",
+        image: "https://example.com/host-avatar.jpg",
       },
     });
 
@@ -85,6 +86,7 @@ describe("public booking", () => {
       locationType: BookingLinkLocationType.CUSTOM,
       locationValue: null,
       hostName: "Host User",
+      hostImage: "https://example.com/host-avatar.jpg",
     });
     expect(result).not.toHaveProperty("hostEmail");
     expect(result.locationValue).toBeNull();
@@ -993,6 +995,7 @@ describe("public booking", () => {
           description: "Talk through fit.",
           locationValue: "Room 3",
           hostName: "Host User",
+          hostImage: "https://example.com/host-avatar.jpg",
         }),
       }),
     );
@@ -1159,6 +1162,7 @@ function bookingRecordBase() {
       emailAccount: {
         email: "host@example.com",
         name: "Host User",
+        image: "https://example.com/host-avatar.jpg",
       },
     },
   };

--- a/apps/web/utils/booking/public.ts
+++ b/apps/web/utils/booking/public.ts
@@ -50,7 +50,7 @@ export async function getPublicBookingLinkMetadata(slug: string) {
       durationMinutes: true,
       locationType: true,
       emailAccount: {
-        select: { name: true },
+        select: { name: true, image: true },
       },
     },
   });
@@ -65,6 +65,7 @@ export async function getPublicBookingLinkMetadata(slug: string) {
     locationType: link.locationType,
     locationValue: null,
     hostName: link.emailAccount.name ?? null,
+    hostImage: link.emailAccount.image ?? null,
   };
 }
 
@@ -530,7 +531,7 @@ export async function getPublicBookingForManagement({
           locationType: true,
           locationValue: true,
           emailAccount: {
-            select: { name: true },
+            select: { name: true, image: true },
           },
         },
       },
@@ -554,6 +555,7 @@ export async function getPublicBookingForManagement({
       locationType: booking.bookingLink.locationType,
       locationValue: booking.bookingLink.locationValue,
       hostName: booking.bookingLink.emailAccount.name ?? null,
+      hostImage: booking.bookingLink.emailAccount.image ?? null,
     },
   };
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260819-093849_pr-3335_b292f88ed06e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Use the host profile photo in the public booking sidebar while preserving the initial fallback. Propagate the nullable image through both initial booking and management metadata so rescheduling stays consistent.

- Render the shared avatar component on booking pages.
- Include and test the host image in public booking metadata.
- Tests: pnpm test utils/booking/public.test.ts; focused Ultracite check passed.
- Performance: selects one additional column in existing queries and may add one browser image request; no extra database round trips or server network calls, with low hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-332/inbox-zero-booking-page-avatar-doesnt-inherit-profile-photo

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->