### PR TITLE
ci: Stabilize Docker image builds under concurrent main pushes

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -7,6 +7,12 @@ on:
     tags: ["v*"] # Also build on version tags for releases
   workflow_dispatch: # Allow manual trigger
 
+# Dual-arch Next.js image builds are memory-heavy on Depot. Overlapping
+# pushes to main previously OOMed the builders (keepalive ping timeout).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
@@ -22,6 +28,7 @@ jobs:
     if: github.repository == 'elie222/inbox-zero'
     name: "Build Docker Image"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -58,7 +58,10 @@ const nextConfig: NextConfig = {
             ? {
                 // Keep the static build from fanning out too many workers at
                 // once. This trades a bit of build time for lower peak RAM.
-                staticGenerationMaxConcurrency: 4,
+                // Docker image builds share Depot workers; keep concurrency
+                // even lower there to avoid OOM keepalive failures.
+                staticGenerationMaxConcurrency:
+                  process.env.DOCKER_BUILD === "true" ? 2 : 4,
                 staticGenerationMinPagesPerWorker: 100,
               }
             : {}),
@@ -392,7 +395,8 @@ const nextConfig: NextConfig = {
       },
     },
   },
-  // Skip TypeScript checking during E2E CI builds to save memory
+  // Skip TypeScript checking during Docker/E2E CI builds to save memory.
+  // App typechecking is covered by the Build Check workflow.
   typescript: {
     ignoreBuildErrors: process.env.SKIP_TYPE_CHECK === "true",
   },

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -48,6 +48,9 @@ COPY . .
 ENV NODE_ENV=production
 # Increase V8 heap for the production build.
 ENV NODE_OPTIONS=--max_old_space_size=8192
+# Typechecking is covered by the Build Check workflow. Skipping it here
+# keeps peak RAM down so Depot workers do not OOM during next build.
+ENV SKIP_TYPE_CHECK=true
 ARG NEXT_PUBLIC_BASE_URL="http://NEXT_PUBLIC_BASE_URL_PLACEHOLDER"
 ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
 ARG NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS="NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS_PLACEHOLDER"


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260819-100708_pr-3336_845a351b6662/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Serialize Docker image builds so overlapping pushes to the same ref no longer stack dual-arch Next.js builds on Depot workers.
- Skip TypeScript in the production image build and lower static generation concurrency there to cut peak RAM; app typechecking stays in Build Check.
- Cap the image job at 45 minutes.

## Test plan
- [ ] Confirm the Docker image workflow starts only one in-progress run per ref
- [ ] Confirm a Docker image build completes without a keepalive/OOM failure


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->