### PR TITLE
fix: Attach SSO provider to existing organization instead of failing

### DIFF
--- a/apps/web/app/(app)/admin/RegisterSSOModal.tsx
+++ b/apps/web/app/(app)/admin/RegisterSSOModal.tsx
@@ -90,6 +90,17 @@ export function RegisterSSOModal() {
 
             <Input
               type="text"
+              name="organizationId"
+              label="Existing Organization ID (optional)"
+              placeholder="Required when attaching SSO to an existing organization"
+              registerProps={register("organizationId", {
+                setValueAs: (value) => value || undefined,
+              })}
+              error={errors.organizationId}
+            />
+
+            <Input
+              type="text"
               name="providerId"
               label="Provider ID"
               placeholder="e.g., your-company-saml"

--- a/apps/web/prisma/migrations/20260822220000_make_sso_provider_organization_unique/migration.sql
+++ b/apps/web/prisma/migrations/20260822220000_make_sso_provider_organization_unique/migration.sql
@@ -1,2 +1,4 @@
+DROP INDEX "ssoProvider_organizationId_idx";
+
 CREATE UNIQUE INDEX "ssoProvider_organizationId_key"
 ON "ssoProvider"("organizationId");

--- a/apps/web/prisma/migrations/20260822220000_make_sso_provider_organization_unique/migration.sql
+++ b/apps/web/prisma/migrations/20260822220000_make_sso_provider_organization_unique/migration.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "ssoProvider_organizationId_key"
+ON "ssoProvider"("organizationId");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -259,7 +259,7 @@ model Organization {
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt
   members      Member[]
-  SsoProvider  SsoProvider[]
+  SsoProvider  SsoProvider?
   ScimProvider ScimProvider[]
   sessions     Session[]
   invitations  Invitation[]
@@ -370,7 +370,7 @@ model SsoProvider {
   emailAccountId String?
   emailAccount   EmailAccount? @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
   providerId     String        @unique
-  organizationId String?
+  organizationId String?       @unique
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   domain         String
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -375,7 +375,6 @@ model SsoProvider {
   domain         String
 
   @@index([emailAccountId])
-  @@index([organizationId])
   @@map("ssoProvider")
 }
 

--- a/apps/web/utils/actions/sso.test.ts
+++ b/apps/web/utils/actions/sso.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/__mocks__/prisma";
 import { registerSSOProviderAction } from "./sso";
 
@@ -35,6 +36,14 @@ const input = {
   providerId: "acme-saml",
   domain: "acme.com",
   idpMetadata: IDP_METADATA,
+};
+
+const EXISTING_ORGANIZATION = {
+  id: "org-existing",
+  name: "Acme Corp",
+  slug: "acme-corp",
+  SsoProvider: null,
+  members: [{ emailAccount: { email: "owner@acme.com" } }],
 };
 
 describe("registerSSOProviderAction", () => {
@@ -82,18 +91,26 @@ describe("registerSSOProviderAction", () => {
   });
 
   it("attaches the SSO provider to an existing organization without SSO", async () => {
-    prisma.organization.findUnique.mockResolvedValue({
-      id: "org-existing",
-      name: "Acme Corp",
-      slug: "acme-corp",
-      SsoProvider: [],
-      members: [{ emailAccount: { email: "owner@acme.com" } }],
-    } as never);
+    prisma.organization.findUnique.mockResolvedValue(
+      EXISTING_ORGANIZATION as never,
+    );
 
-    const result = await registerSSOProviderAction(input);
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-existing",
+    });
 
     expect(result?.serverError).toBeUndefined();
     expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.organization.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          members: expect.objectContaining({
+            where: { role: { in: ["admin", "owner"] } },
+          }),
+        }),
+      }),
+    );
     expect(prisma.ssoProvider.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ organizationId: "org-existing" }),
@@ -101,32 +118,93 @@ describe("registerSSOProviderAction", () => {
     );
   });
 
-  it("errors when the existing organization already has an SSO provider", async () => {
-    prisma.organization.findUnique.mockResolvedValue({
-      id: "org-existing",
-      name: "Acme Corp",
-      slug: "acme-corp",
-      SsoProvider: [{ providerId: "existing-saml" }],
-      members: [{ emailAccount: { email: "owner@acme.com" } }],
-    } as never);
+  it("requires the exact organization ID before attaching SSO to an existing organization", async () => {
+    prisma.organization.findUnique.mockResolvedValue(
+      EXISTING_ORGANIZATION as never,
+    );
 
     const result = await registerSSOProviderAction(input);
+
+    expect(result?.serverError).toMatch(/organization ID/i);
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a different organization ID for an existing organization", async () => {
+    prisma.organization.findUnique.mockResolvedValue(
+      EXISTING_ORGANIZATION as never,
+    );
+
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-other",
+    });
+
+    expect(result?.serverError).toMatch(/exact organization ID/i);
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an organization ID that does not match the organization name", async () => {
+    prisma.organization.findUnique.mockResolvedValue(null);
+
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-other",
+    });
+
+    expect(result?.serverError).toMatch(/does not match/i);
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
+  });
+
+  it("errors when the existing organization already has an SSO provider", async () => {
+    prisma.organization.findUnique.mockResolvedValue({
+      ...EXISTING_ORGANIZATION,
+      SsoProvider: { providerId: "existing-saml" },
+    } as never);
+
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-existing",
+    });
 
     expect(result?.serverError).toMatch(/already has an SSO provider/i);
     expect(prisma.organization.create).not.toHaveBeenCalled();
     expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
   });
 
+  it("returns the configured-provider error when a concurrent registration wins", async () => {
+    prisma.organization.findUnique.mockResolvedValue(
+      EXISTING_ORGANIZATION as never,
+    );
+    prisma.ssoProvider.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["organizationId"] },
+      }),
+    );
+
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-existing",
+    });
+
+    expect(result?.serverError).toMatch(/already has an SSO provider/i);
+  });
+
   it("refuses to attach SSO to an existing organization when no owner/admin is on the SSO domain", async () => {
     prisma.organization.findUnique.mockResolvedValue({
+      ...EXISTING_ORGANIZATION,
       id: "org-squatted",
-      name: "Acme Corp",
-      slug: "acme-corp",
-      SsoProvider: [],
       members: [{ emailAccount: { email: "attacker@evil.com" } }],
     } as never);
 
-    const result = await registerSSOProviderAction(input);
+    const result = await registerSSOProviderAction({
+      ...input,
+      organizationId: "org-squatted",
+    });
 
     expect(result?.serverError).toMatch(/none of its owners or admins/i);
     expect(prisma.organization.create).not.toHaveBeenCalled();

--- a/apps/web/utils/actions/sso.test.ts
+++ b/apps/web/utils/actions/sso.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { registerSSOProviderAction } from "./sso";
+
+const { mockAuth } = vi.hoisted(() => ({ mockAuth: vi.fn() }));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({ auth: mockAuth }));
+vi.mock("@/env", () => ({
+  env: {
+    ADMINS: ["admin@example.com"],
+    NEXT_PUBLIC_BASE_URL: "https://example.com",
+    NODE_ENV: "test",
+  },
+}));
+
+const IDP_METADATA = `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`;
+
+const input = {
+  organizationName: "Acme Corp",
+  providerId: "acme-saml",
+  domain: "acme.com",
+  idpMetadata: IDP_METADATA,
+};
+
+describe("registerSSOProviderAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "admin-user", email: "admin@example.com" },
+    });
+    prisma.ssoProvider.findUnique.mockResolvedValue(null);
+    prisma.ssoProvider.create.mockImplementation(
+      async ({ data }) =>
+        ({
+          id: "sso-1",
+          providerId: data.providerId,
+          domain: data.domain,
+          organization: {
+            id: data.organizationId,
+            name: input.organizationName,
+            slug: "acme-corp",
+          },
+        }) as never,
+    );
+  });
+
+  it("creates a new organization when none exists with that name", async () => {
+    prisma.organization.findUnique.mockResolvedValue(null);
+    prisma.organization.create.mockResolvedValue({
+      id: "org-new",
+      name: "Acme Corp",
+      slug: "acme-corp",
+    } as never);
+
+    const result = await registerSSOProviderAction(input);
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.organization.create).toHaveBeenCalledWith({
+      data: { name: "Acme Corp", slug: "acme-corp" },
+      select: { id: true, name: true, slug: true },
+    });
+    expect(prisma.ssoProvider.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ organizationId: "org-new" }),
+      }),
+    );
+  });
+
+  it("attaches the SSO provider to an existing organization without SSO", async () => {
+    prisma.organization.findUnique.mockResolvedValue({
+      id: "org-existing",
+      name: "Acme Corp",
+      slug: "acme-corp",
+      SsoProvider: [],
+    } as never);
+
+    const result = await registerSSOProviderAction(input);
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ organizationId: "org-existing" }),
+      }),
+    );
+  });
+
+  it("errors when the existing organization already has an SSO provider", async () => {
+    prisma.organization.findUnique.mockResolvedValue({
+      id: "org-existing",
+      name: "Acme Corp",
+      slug: "acme-corp",
+      SsoProvider: [{ providerId: "existing-saml" }],
+    } as never);
+
+    const result = await registerSSOProviderAction(input);
+
+    expect(result?.serverError).toMatch(/already has an SSO provider/i);
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/sso.test.ts
+++ b/apps/web/utils/actions/sso.test.ts
@@ -87,6 +87,7 @@ describe("registerSSOProviderAction", () => {
       name: "Acme Corp",
       slug: "acme-corp",
       SsoProvider: [],
+      members: [{ emailAccount: { email: "owner@acme.com" } }],
     } as never);
 
     const result = await registerSSOProviderAction(input);
@@ -106,11 +107,28 @@ describe("registerSSOProviderAction", () => {
       name: "Acme Corp",
       slug: "acme-corp",
       SsoProvider: [{ providerId: "existing-saml" }],
+      members: [{ emailAccount: { email: "owner@acme.com" } }],
     } as never);
 
     const result = await registerSSOProviderAction(input);
 
     expect(result?.serverError).toMatch(/already has an SSO provider/i);
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses to attach SSO to an existing organization when no owner/admin is on the SSO domain", async () => {
+    prisma.organization.findUnique.mockResolvedValue({
+      id: "org-squatted",
+      name: "Acme Corp",
+      slug: "acme-corp",
+      SsoProvider: [],
+      members: [{ emailAccount: { email: "attacker@evil.com" } }],
+    } as never);
+
+    const result = await registerSSOProviderAction(input);
+
+    expect(result?.serverError).toMatch(/none of its owners or admins/i);
     expect(prisma.organization.create).not.toHaveBeenCalled();
     expect(prisma.ssoProvider.create).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/actions/sso.ts
+++ b/apps/web/utils/actions/sso.ts
@@ -47,22 +47,29 @@ export const registerSSOProviderAction = adminActionClient
 
       const existingOrganization = await prisma.organization.findUnique({
         where: { slug: organizationSlug },
-        select: { id: true },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          SsoProvider: { select: { providerId: true } },
+        },
       });
 
-      if (existingOrganization) {
+      if (existingOrganization?.SsoProvider.length) {
         throw new SafeError(
-          "An organization with this name already exists. Please choose a different name.",
+          "This organization already has an SSO provider configured.",
         );
       }
 
-      const organization = await prisma.organization.create({
-        data: {
-          name: organizationName,
-          slug: organizationSlug,
-        },
-        select: { id: true, name: true, slug: true },
-      });
+      const organization =
+        existingOrganization ??
+        (await prisma.organization.create({
+          data: {
+            name: organizationName,
+            slug: organizationSlug,
+          },
+          select: { id: true, name: true, slug: true },
+        }));
 
       // Compute callback URL to store with config (informational)
       const callbackUrl = new URL(

--- a/apps/web/utils/actions/sso.ts
+++ b/apps/web/utils/actions/sso.ts
@@ -8,6 +8,7 @@ import { SafeError } from "@/utils/error";
 import { extractSSOProviderConfigFromXML } from "@/utils/sso/extract-sso-provider-config-from-xml";
 import prisma from "@/utils/prisma";
 import { validateIdpMetadata } from "@/utils/sso/validate-idp-metadata";
+import { ADMIN_ROLES } from "@/utils/organizations/roles";
 import { slugify } from "@/utils/string";
 
 export const registerSSOProviderAction = adminActionClient
@@ -52,13 +53,32 @@ export const registerSSOProviderAction = adminActionClient
           name: true,
           slug: true,
           SsoProvider: { select: { providerId: true } },
+          members: {
+            where: { role: { in: ADMIN_ROLES } },
+            select: { emailAccount: { select: { email: true } } },
+          },
         },
       });
 
-      if (existingOrganization?.SsoProvider.length) {
-        throw new SafeError(
-          "This organization already has an SSO provider configured.",
+      if (existingOrganization) {
+        if (existingOrganization.SsoProvider.length) {
+          throw new SafeError(
+            "This organization already has an SSO provider configured.",
+          );
+        }
+
+        // Guard against slug squatting: only attach SSO to an existing
+        // organization if one of its owners/admins belongs to the SSO domain.
+        const domainSuffix = `@${domain.toLowerCase()}`;
+        const hasAdminOnDomain = existingOrganization.members.some((member) =>
+          member.emailAccount.email.toLowerCase().endsWith(domainSuffix),
         );
+
+        if (!hasAdminOnDomain) {
+          throw new SafeError(
+            `An organization with this name already exists, but none of its owners or admins have an email on "${domain}". Verify the organization before attaching SSO, or choose a different name.`,
+          );
+        }
       }
 
       const organization =

--- a/apps/web/utils/actions/sso.ts
+++ b/apps/web/utils/actions/sso.ts
@@ -10,13 +10,20 @@ import prisma from "@/utils/prisma";
 import { validateIdpMetadata } from "@/utils/sso/validate-idp-metadata";
 import { ADMIN_ROLES } from "@/utils/organizations/roles";
 import { slugify } from "@/utils/string";
+import { isDuplicateError } from "@/utils/prisma-helpers";
 
 export const registerSSOProviderAction = adminActionClient
   .metadata({ name: "registerSSOProvider" })
   .inputSchema(ssoRegistrationBody)
   .action(
     async ({
-      parsedInput: { organizationName, idpMetadata, domain, providerId },
+      parsedInput: {
+        organizationName,
+        organizationId,
+        idpMetadata,
+        domain,
+        providerId,
+      },
     }) => {
       const session = await auth();
       const userId = session?.user?.id;
@@ -61,7 +68,13 @@ export const registerSSOProviderAction = adminActionClient
       });
 
       if (existingOrganization) {
-        if (existingOrganization.SsoProvider.length) {
+        if (existingOrganization.id !== organizationId) {
+          throw new SafeError(
+            "An organization with this name already exists. Enter its exact organization ID to attach SSO.",
+          );
+        }
+
+        if (existingOrganization.SsoProvider) {
           throw new SafeError(
             "This organization already has an SSO provider configured.",
           );
@@ -79,6 +92,10 @@ export const registerSSOProviderAction = adminActionClient
             `An organization with this name already exists, but none of its owners or admins have an email on "${domain}". Verify the organization before attaching SSO, or choose a different name.`,
           );
         }
+      } else if (organizationId) {
+        throw new SafeError(
+          "The organization name does not match the supplied organization ID.",
+        );
       }
 
       const organization =
@@ -117,23 +134,39 @@ export const registerSSOProviderAction = adminActionClient
         },
       } as const;
 
-      const created = await prisma.ssoProvider.create({
-        data: {
-          providerId,
-          issuer: ssoConfig.issuer,
-          domain,
-          samlConfig: JSON.stringify(samlConfig),
-          organizationId: organization.id,
-        },
-        select: {
-          id: true,
-          providerId: true,
-          domain: true,
-          organization: {
-            select: { id: true, name: true, slug: true },
+      const created = await prisma.ssoProvider
+        .create({
+          data: {
+            providerId,
+            issuer: ssoConfig.issuer,
+            domain,
+            samlConfig: JSON.stringify(samlConfig),
+            organizationId: organization.id,
           },
-        },
-      });
+          select: {
+            id: true,
+            providerId: true,
+            domain: true,
+            organization: {
+              select: { id: true, name: true, slug: true },
+            },
+          },
+        })
+        .catch((error: unknown) => {
+          if (isDuplicateError(error, "organizationId")) {
+            throw new SafeError(
+              "This organization already has an SSO provider configured.",
+            );
+          }
+
+          if (isDuplicateError(error, "providerId")) {
+            throw new SafeError(
+              `SSO provider with ID "${providerId}" already exists`,
+            );
+          }
+
+          throw error;
+        });
 
       return { ...created, callbackUrl };
     },

--- a/apps/web/utils/actions/sso.validation.ts
+++ b/apps/web/utils/actions/sso.validation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const ssoRegistrationBody = z.object({
   organizationName: z.string().min(1, "Organization name is required"),
+  organizationId: z.string().trim().min(1).optional(),
   providerId: z.string().min(1, "Provider ID is required"),
   domain: z.string().min(1, "Domain is required"),
   idpMetadata: z.string().min(1, "IDP metadata is required"),


### PR DESCRIPTION
Fixes #3337

## Summary

Allow administrators to attach an SSO provider to an existing organization without creating a duplicate organization.

## Changes

- Require the exact existing organization ID before reusing an organization.
- Require an owner or administrator with an email on the configured SSO domain.
- Enforce one SSO provider per organization at the database boundary.
- Return clear errors for existing and concurrent provider conflicts.
- Preserve the existing new-organization flow.

## Validation

- Added focused unit coverage for creation, authorized reuse, identifier mismatches, domain authorization, existing providers, and concurrent registration.
- `pnpm test utils/actions/sso.test.ts`
- `pnpm lint`
- `pnpm --filter inbox-zero-ai exec prisma validate`