### PR TITLE
INB-333: Generate conference links for personal Outlook

### DIFF
--- a/apps/web/utils/booking/emails.test.ts
+++ b/apps/web/utils/booking/emails.test.ts
@@ -112,6 +112,31 @@ describe("booking emails", () => {
     );
   });
 
+  it("tells the host when a Microsoft Teams link was not generated", async () => {
+    await sendBookingConfirmationEmails({
+      booking: bookingEmailPayload({
+        videoConferenceLink: null,
+        bookingLink: {
+          locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
+          locationValue: null,
+        },
+      }),
+      guestTimezone: "UTC",
+      cancelUrl: "https://example.com/book/cancel/booking-uid?token=token",
+      rescheduleUrl:
+        "https://example.com/book/reschedule/booking-uid?token=token",
+      logger,
+    });
+
+    expect(resendMocks.sendHostBookingConfirmationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailProps: expect.objectContaining({
+          location: "Microsoft Teams link was not generated",
+        }),
+      }),
+    );
+  });
+
   it("sends reschedule emails to guest and host with previous time", async () => {
     await sendBookingRescheduledEmails({
       booking: bookingEmailPayload(),

--- a/apps/web/utils/booking/emails.ts
+++ b/apps/web/utils/booking/emails.ts
@@ -49,6 +49,11 @@ export async function sendBookingConfirmationEmails({
   const link = booking.bookingLink;
   const host = link.emailAccount;
   const location = getLocationLabel(link);
+  const hostLocation =
+    link.locationType === BookingLinkLocationType.MICROSOFT_TEAMS &&
+    !booking.videoConferenceLink
+      ? "Microsoft Teams link was not generated"
+      : location;
   const hostTimezone = link.availabilitySchedule.timezone;
   const guestParts = formatBookingParts({
     startTime: booking.startTime,
@@ -91,7 +96,7 @@ export async function sendBookingConfirmationEmails({
           formattedTime: hostParts.formattedTime,
           guestEmail: booking.guestEmail,
           guestName: booking.guestName,
-          location,
+          location: hostLocation,
           dateMonth: hostParts.dateMonth,
           dateDay: hostParts.dateDay,
           dateWeekday: hostParts.dateWeekday,

--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -156,6 +156,7 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(createPayload).toEqual(
       expect.objectContaining({
         isOnlineMeeting: true,
+        onlineMeetingProvider: "teamsForBusiness",
         location: undefined,
         start: {
           dateTime: "2026-05-04T09:00:00.0000000",
@@ -167,7 +168,6 @@ describe("MicrosoftCalendarEventProvider", () => {
         },
       }),
     );
-    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
     expect(result).toEqual({
       id: "event-id",
       providerCalendarId: "calendar-id",
@@ -176,7 +176,7 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
   });
 
-  it("omits the explicit Teams provider when Teams is the calendar default", async () => {
+  it("passes the explicit Teams provider when Teams is the calendar default", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
       allowedOnlineMeetingProviders: ["teamsForBusiness"],
@@ -204,9 +204,11 @@ describe("MicrosoftCalendarEventProvider", () => {
 
     const createPayload = graphMocks.post.mock.calls[0]?.[0];
     expect(createPayload).toEqual(
-      expect.objectContaining({ isOnlineMeeting: true }),
+      expect.objectContaining({
+        isOnlineMeeting: true,
+        onlineMeetingProvider: "teamsForBusiness",
+      }),
     );
-    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
   });
 
   it("refetches the event when Graph initializes the Teams join URL asynchronously", async () => {
@@ -301,18 +303,20 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id");
     expect(graphMocks.patch).toHaveBeenCalledWith({
       isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
     });
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
   });
 
-  it("creates a regular event when the destination calendar does not support Teams", async () => {
+  it("falls back to a personal Outlook calendar's default meeting provider", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
-      allowedOnlineMeetingProviders: ["skypeForBusiness"],
-      defaultOnlineMeetingProvider: "skypeForBusiness",
+      allowedOnlineMeetingProviders: ["skypeForConsumer"],
+      defaultOnlineMeetingProvider: "skypeForConsumer",
     });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
+      onlineMeeting: { joinUrl: "https://join.skype.com/example" },
       webLink: "https://outlook.example.com/event",
     });
 
@@ -331,17 +335,21 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
 
     const createPayload = graphMocks.post.mock.calls[0]?.[0];
-    expect(createPayload).not.toHaveProperty("isOnlineMeeting");
-    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
+    expect(createPayload).toEqual(
+      expect.objectContaining({
+        isOnlineMeeting: true,
+        onlineMeetingProvider: "skypeForConsumer",
+      }),
+    );
     expect(result).toEqual({
       id: "event-id",
       providerCalendarId: "calendar-id",
       eventUrl: "https://outlook.example.com/event",
-      videoConferenceLink: undefined,
+      videoConferenceLink: "https://join.skype.com/example",
     });
   });
 
-  it("creates a regular event when Teams is not the calendar default", async () => {
+  it("prefers Teams when it is allowed but is not the calendar default", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
       allowedOnlineMeetingProviders: ["teamsForBusiness", "skypeForBusiness"],
@@ -349,6 +357,7 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
+      onlineMeeting: { joinUrl: "https://teams.example.com/join" },
       webLink: "https://outlook.example.com/event",
     });
 
@@ -367,15 +376,17 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
 
     const createPayload = graphMocks.post.mock.calls[0]?.[0];
-    expect(createPayload).not.toHaveProperty("isOnlineMeeting");
-    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
-    expect(graphMocks.api).not.toHaveBeenCalledWith("/me/events/event-id");
-    expect(graphMocks.patch).not.toHaveBeenCalled();
+    expect(createPayload).toEqual(
+      expect.objectContaining({
+        isOnlineMeeting: true,
+        onlineMeetingProvider: "teamsForBusiness",
+      }),
+    );
     expect(result).toEqual({
       id: "event-id",
       providerCalendarId: "calendar-id",
       eventUrl: "https://outlook.example.com/event",
-      videoConferenceLink: undefined,
+      videoConferenceLink: "https://teams.example.com/join",
     });
   });
 

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -11,8 +11,9 @@ import type {
 import { findVideoConferenceLink } from "@/utils/calendar/video-conference-link";
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
+import { sleep } from "@/utils/sleep";
 
-const TEAMS_JOIN_URL_POLL_DELAYS_MS = [500, 1000, 2000] as const;
+const ONLINE_MEETING_JOIN_URL_POLL_DELAYS_MS = [500, 1000, 2000] as const;
 const MICROSOFT_TEAMS_PROVIDER = "teamsForBusiness";
 
 export interface MicrosoftCalendarConnectionParams {
@@ -50,6 +51,7 @@ type MicrosoftCalendarOnlineMeetingSettings = {
 
 type MicrosoftOnlineMeetingFields = {
   isOnlineMeeting: true;
+  onlineMeetingProvider: string;
 };
 
 export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
@@ -148,13 +150,13 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
     const useMicrosoftTeams =
       input.locationType === BookingLinkLocationType.MICROSOFT_TEAMS;
     const onlineMeetingFields = useMicrosoftTeams
-      ? await getTeamsOnlineMeetingFields({
+      ? await getOnlineMeetingFields({
           calendarId: input.calendarId,
           client,
           logger: this.logger,
         })
       : null;
-    const requestedMicrosoftTeams = Boolean(onlineMeetingFields);
+    const requestedOnlineMeeting = Boolean(onlineMeetingFields);
     const response: MicrosoftEvent = await client
       .api(`/me/calendars/${input.calendarId}/events`)
       .post({
@@ -180,54 +182,55 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
         })),
         ...(onlineMeetingFields ?? {}),
         location:
-          !requestedMicrosoftTeams && input.locationValue
+          !requestedOnlineMeeting && input.locationValue
             ? { displayName: input.locationValue }
             : undefined,
       });
 
     let videoConferenceLink = getJoinUrl(response);
 
-    // Graph initializes the Teams meeting after the event is created, so the
+    // Graph initializes the online meeting after the event is created, so the
     // POST response sometimes returns before `onlineMeeting` is populated.
-    // Refetch the event to retrieve the join URL when we asked for Teams.
-    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
-      videoConferenceLink = await pollForTeamsJoinUrl({
+    // Refetch the event to retrieve the join URL when one was requested.
+    if (requestedOnlineMeeting && !videoConferenceLink && response.id) {
+      videoConferenceLink = await pollForOnlineMeetingJoinUrl({
         client,
         eventId: response.id,
         logger: this.logger,
       });
     }
 
-    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
+    if (requestedOnlineMeeting && !videoConferenceLink && response.id) {
       try {
         const patched: MicrosoftEvent = await client
           .api(`/me/events/${response.id}`)
-          .patch({
-            isOnlineMeeting: true,
-          });
+          .patch(onlineMeetingFields);
         videoConferenceLink = getJoinUrl(patched);
       } catch (error) {
-        this.logger.warn("Failed to enable Microsoft Teams on event", {
+        this.logger.warn("Failed to enable online meeting on Microsoft event", {
           eventId: response.id,
           error,
         });
       }
     }
 
-    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
-      videoConferenceLink = await pollForTeamsJoinUrl({
+    if (requestedOnlineMeeting && !videoConferenceLink && response.id) {
+      videoConferenceLink = await pollForOnlineMeetingJoinUrl({
         client,
         eventId: response.id,
         logger: this.logger,
       });
     }
 
-    if (requestedMicrosoftTeams && !videoConferenceLink) {
-      this.logger.warn("Microsoft Teams link missing after event creation", {
-        eventId: response.id,
-        isOnlineMeeting: response.isOnlineMeeting,
-        onlineMeetingProvider: response.onlineMeetingProvider,
-      });
+    if (requestedOnlineMeeting && !videoConferenceLink) {
+      this.logger.warn(
+        "Microsoft online meeting link missing after event creation",
+        {
+          eventId: response.id,
+          isOnlineMeeting: response.isOnlineMeeting,
+          onlineMeetingProvider: response.onlineMeetingProvider,
+        },
+      );
     }
 
     return {
@@ -297,7 +300,7 @@ function getJoinUrl(event: MicrosoftEvent): string | undefined {
   return event.onlineMeeting?.joinUrl || event.onlineMeetingUrl;
 }
 
-async function getTeamsOnlineMeetingFields({
+async function getOnlineMeetingFields({
   calendarId,
   client,
   logger,
@@ -312,37 +315,28 @@ async function getTeamsOnlineMeetingFields({
     logger,
   });
 
-  if (
-    settings?.allowedOnlineMeetingProviders &&
-    !settings.allowedOnlineMeetingProviders.includes(MICROSOFT_TEAMS_PROVIDER)
-  ) {
-    logger.warn("Microsoft Teams meetings are not supported for calendar", {
+  // Prefer Teams when the calendar allows it; otherwise fall back to the
+  // calendar's default provider (personal Outlook calendars don't allow
+  // teamsForBusiness). When the settings fetch fails, still request Teams.
+  const onlineMeetingProvider =
+    !settings ||
+    settings.allowedOnlineMeetingProviders?.includes(MICROSOFT_TEAMS_PROVIDER)
+      ? MICROSOFT_TEAMS_PROVIDER
+      : settings.defaultOnlineMeetingProvider;
+
+  if (!onlineMeetingProvider || onlineMeetingProvider === "unknown") {
+    logger.warn("No online meeting provider is available for calendar", {
       calendarId,
-      allowedOnlineMeetingProviders: settings.allowedOnlineMeetingProviders,
-      defaultOnlineMeetingProvider: settings.defaultOnlineMeetingProvider,
+      allowedOnlineMeetingProviders: settings?.allowedOnlineMeetingProviders,
+      defaultOnlineMeetingProvider: settings?.defaultOnlineMeetingProvider,
     });
     return null;
   }
 
-  if (
-    settings?.defaultOnlineMeetingProvider &&
-    settings.defaultOnlineMeetingProvider !== MICROSOFT_TEAMS_PROVIDER
-  ) {
-    logger.warn(
-      "Microsoft Teams is not the default online meeting provider for calendar",
-      {
-        calendarId,
-        allowedOnlineMeetingProviders: settings.allowedOnlineMeetingProviders,
-        defaultOnlineMeetingProvider: settings.defaultOnlineMeetingProvider,
-      },
-    );
-    return null;
-  }
-
-  // Graph can ignore explicit teamsForBusiness on some Outlook calendars and
-  // create a regular event instead, so let the calendar's online provider
-  // settings drive Teams generation.
-  return { isOnlineMeeting: true } satisfies MicrosoftOnlineMeetingFields;
+  return {
+    isOnlineMeeting: true,
+    onlineMeetingProvider,
+  } satisfies MicrosoftOnlineMeetingFields;
 }
 
 async function getCalendarOnlineMeetingSettings({
@@ -368,7 +362,7 @@ async function getCalendarOnlineMeetingSettings({
   }
 }
 
-async function pollForTeamsJoinUrl({
+async function pollForOnlineMeetingJoinUrl({
   client,
   eventId,
   logger,
@@ -377,7 +371,7 @@ async function pollForTeamsJoinUrl({
   eventId: string;
   logger: Logger;
 }) {
-  for (const delayMs of [0, ...TEAMS_JOIN_URL_POLL_DELAYS_MS]) {
+  for (const delayMs of [0, ...ONLINE_MEETING_JOIN_URL_POLL_DELAYS_MS]) {
     if (delayMs > 0) {
       await sleep(delayMs);
     }
@@ -398,7 +392,7 @@ async function pollForTeamsJoinUrl({
         return;
       }
     } catch (error) {
-      logger.warn("Failed to refetch Microsoft event for Teams join URL", {
+      logger.warn("Failed to refetch Microsoft event for online meeting URL", {
         eventId,
         error,
       });
@@ -406,8 +400,4 @@ async function pollForTeamsJoinUrl({
   }
 
   return;
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260820-103440_pr-3339_1b2c9c6e6043/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Generate supported Microsoft online-meeting links for personal Outlook calendars while preferring Teams where available. Notify hosts in booking confirmations when Microsoft Graph still fails to produce a link.

- Select the explicit allowed or default Microsoft online-meeting provider and reuse it during fallback updates.
- Poll for asynchronously generated join URLs and preserve the calendar event if no link appears.
- Add focused booking-email and Microsoft calendar provider coverage; 17 tests pass.
- Performance: no database changes; Teams bookings retain the calendar-settings request, while personal Outlook fallback can add join-link polling and one Graph update, with low broader hot-path risk.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-333/teams-conference-link-not-generated-for-personal-outlook

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->