### PR TITLE
Allow rule updates after losing digest plan access

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -81,6 +81,7 @@ import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import type { GetMessagingChannelsResponse } from "@/app/api/user/messaging-channels/route";
 import { usePremium } from "@/hooks/usePremium";
 import { hasTierAccess } from "@/utils/premium";
+import { shouldIncludeDigestAction } from "@/utils/premium/digest";
 import { UpgradeToPlusButton } from "@/components/UpgradeToPlusButton";
 import { useIntegrationActionsEnabled } from "@/hooks/useFeatureFlags";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
@@ -241,15 +242,16 @@ export function RuleForm({
         isDraftReplyActionType(action.type),
       );
 
-      // When the user lacks digest access the toggle is hidden, so preserve
-      // any existing DIGEST action rather than silently dropping it.
       const actionsToSubmit = [...normalizedActions];
       const existingDigestAction = rule.actions.find(
         (action) => action.type === ActionType.DIGEST,
       );
-      const includeDigestAction = hasDigestAccess
-        ? data.digest
-        : !!existingDigestAction;
+      const includeDigestAction = shouldIncludeDigestAction({
+        digestFeatureEnabled: !!env.NEXT_PUBLIC_DIGEST_ENABLED,
+        hasDigestAccess,
+        wantsDigest: !!data.digest,
+        hasExistingDigest: !!existingDigestAction,
+      });
       if (includeDigestAction) {
         actionsToSubmit.push({
           id: existingDigestAction?.id,
@@ -608,9 +610,14 @@ export function RuleForm({
                 {env.NEXT_PUBLIC_DIGEST_ENABLED && (
                   <AdvancedRow
                     title="Include in digest"
-                    description="Show matched emails in your digest summary."
+                    description={
+                      !hasDigestAccess && watch("digest")
+                        ? "Digests are available on the Plus plan. Turn this off to update this rule on your current plan."
+                        : "Show matched emails in your digest summary."
+                    }
                   >
-                    {isLoadingPremium ? null : hasDigestAccess ? (
+                    {isLoadingPremium ? null : hasDigestAccess ||
+                      watch("digest") ? (
                       <Toggle
                         name="digest"
                         enabled={watch("digest") || false}

--- a/apps/web/app/api/v1/rules/[id]/route.ts
+++ b/apps/web/app/api/v1/rules/[id]/route.ts
@@ -39,16 +39,20 @@ export const PUT = withAccountApiKey(
     const body = ruleRequestBodySchema.parse(await request.json());
     const ruleInput = toRuleWriteInput(body);
 
-    await assertCanUseDigestsIfNeeded(userId, ruleInput.actions);
-
     const existingRule = await prisma.rule.findFirst({
       where: { id: routeParams.id, emailAccountId },
-      select: { id: true },
+      select: { id: true, actions: { select: { type: true } } },
     });
 
     if (!existingRule) {
       return NextResponse.json({ error: "Rule not found" }, { status: 404 });
     }
+
+    await assertCanUseDigestsIfNeeded(
+      userId,
+      ruleInput.actions,
+      existingRule.actions,
+    );
 
     await updateRule({
       ruleId: routeParams.id,

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -130,7 +130,12 @@ export const updateRuleAction = actionClient
     }) => {
       await assertRuleIsNotOrgManaged({ ruleId: id, emailAccountId });
 
-      await assertCanUseDigestsIfNeeded(userId, actions);
+      const existingRule = await prisma.rule.findFirst({
+        where: { id, emailAccountId },
+        select: { actions: { select: { type: true } } },
+      });
+
+      await assertCanUseDigestsIfNeeded(userId, actions, existingRule?.actions);
 
       const conditions = flattenConditions(conditionsInput, logger);
 

--- a/apps/web/utils/premium/digest.test.ts
+++ b/apps/web/utils/premium/digest.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { ActionType } from "@/generated/prisma/enums";
+import { isAddingDigestAction, shouldIncludeDigestAction } from "./digest";
+
+describe("isAddingDigestAction", () => {
+  it("is false when the request does not include digest", () => {
+    expect(
+      isAddingDigestAction({
+        requestedActions: [{ type: ActionType.ARCHIVE }],
+        existingActions: [{ type: ActionType.DIGEST }],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when an existing rule already includes digest", () => {
+    expect(
+      isAddingDigestAction({
+        requestedActions: [
+          { type: ActionType.ARCHIVE },
+          { type: ActionType.DIGEST },
+        ],
+        existingActions: [{ type: ActionType.DIGEST }],
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when digest is being added to a rule that did not have it", () => {
+    expect(
+      isAddingDigestAction({
+        requestedActions: [{ type: ActionType.DIGEST }],
+        existingActions: [{ type: ActionType.ARCHIVE }],
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when creating a rule with digest and there are no existing actions", () => {
+    expect(
+      isAddingDigestAction({
+        requestedActions: [{ type: ActionType.DIGEST }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldIncludeDigestAction", () => {
+  it("preserves an existing digest when the digest feature is hidden", () => {
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: false,
+        hasDigestAccess: false,
+        wantsDigest: false,
+        hasExistingDigest: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("follows the user's choice when they have digest access", () => {
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: true,
+        hasDigestAccess: true,
+        wantsDigest: true,
+        hasExistingDigest: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: true,
+        hasDigestAccess: true,
+        wantsDigest: false,
+        hasExistingDigest: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("lets a user without digest access turn an existing digest off", () => {
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: true,
+        hasDigestAccess: false,
+        wantsDigest: false,
+        hasExistingDigest: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let a user without digest access add digest", () => {
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: true,
+        hasDigestAccess: false,
+        wantsDigest: true,
+        hasExistingDigest: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps an existing digest when a user without access leaves it enabled", () => {
+    expect(
+      shouldIncludeDigestAction({
+        digestFeatureEnabled: true,
+        hasDigestAccess: false,
+        wantsDigest: true,
+        hasExistingDigest: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/utils/premium/digest.ts
+++ b/apps/web/utils/premium/digest.ts
@@ -1,0 +1,33 @@
+import { ActionType } from "@/generated/prisma/enums";
+
+export function hasDigestAction(
+  actions: { type: ActionType }[] | undefined,
+): boolean {
+  return !!actions?.some((action) => action.type === ActionType.DIGEST);
+}
+
+export function isAddingDigestAction({
+  requestedActions,
+  existingActions,
+}: {
+  requestedActions: { type: ActionType }[];
+  existingActions?: { type: ActionType }[];
+}): boolean {
+  return hasDigestAction(requestedActions) && !hasDigestAction(existingActions);
+}
+
+export function shouldIncludeDigestAction({
+  digestFeatureEnabled,
+  hasDigestAccess,
+  wantsDigest,
+  hasExistingDigest,
+}: {
+  digestFeatureEnabled: boolean;
+  hasDigestAccess: boolean;
+  wantsDigest: boolean;
+  hasExistingDigest: boolean;
+}): boolean {
+  if (!digestFeatureEnabled) return hasExistingDigest;
+  if (hasDigestAccess) return wantsDigest;
+  return wantsDigest && hasExistingDigest;
+}

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -1,6 +1,6 @@
 import { after } from "next/server";
 import prisma from "@/utils/prisma";
-import { ActionType, type PremiumTier } from "@/generated/prisma/enums";
+import type { ActionType, PremiumTier } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import {
@@ -11,6 +11,7 @@ import {
 } from "@/utils/premium";
 import { SafeError } from "@/utils/error";
 import { env } from "@/env";
+import { isAddingDigestAction } from "@/utils/premium/digest";
 
 const logger = createScopedLogger("premium");
 
@@ -178,10 +179,13 @@ export async function assertCanUseDigests(userId: string) {
 export async function assertCanUseDigestsIfNeeded(
   userId: string,
   actions: { type: ActionType }[],
+  existingActions?: { type: ActionType }[],
 ) {
-  if (actions.some((action) => action.type === ActionType.DIGEST)) {
-    await assertCanUseDigests(userId);
+  if (!isAddingDigestAction({ requestedActions: actions, existingActions })) {
+    return;
   }
+
+  await assertCanUseDigests(userId);
 }
 
 export async function checkHasAccess({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260820-075402_pr-3340_79a729deeacf/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Users who lose digest plan access can still edit rules that already include digest.
- The rule editor keeps the Include in digest toggle available so they can turn it off.
- Adding digest to a rule still requires Plus.

## Test plan
- [ ] Open a rule that already includes digest on a plan without digest access and save other changes
- [ ] Turn Include in digest off and confirm the rule saves
- [ ] Confirm a user without digest access still cannot add digest to a new or existing rule


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->