### PR TITLE
Keep the start and end of long emails for conversation status

### DIFF
--- a/apps/web/utils/ai/reply/determine-thread-status.ts
+++ b/apps/web/utils/ai/reply/determine-thread-status.ts
@@ -5,6 +5,7 @@ import type { EmailForLLM, RuleWithActions } from "@/utils/types";
 import { getModel, type ModelType } from "@/utils/llms/model";
 import { getUserInfoPrompt, getEmailListPrompt } from "@/utils/ai/helpers";
 import type { ConversationStatus } from "@/utils/reply-tracker/conversation-status-config";
+import { THREAD_STATUS_LATEST_MESSAGE_MAX_LENGTH } from "@/utils/reply-tracker/thread-status-context";
 import { SystemType } from "@/generated/prisma/enums";
 import { getRuleConfig } from "@/utils/rule/consts";
 
@@ -125,7 +126,7 @@ Email thread (in chronological order, oldest to newest):
 <thread>
 ${getEmailListPrompt({
   messages: threadMessages,
-  messageMaxLength: 1000,
+  messageMaxLength: THREAD_STATUS_LATEST_MESSAGE_MAX_LENGTH,
 })}
 </thread>
 

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -87,6 +87,41 @@ describe("emailToContent", () => {
       expect(result.length).toBe(2003);
       expect(result.endsWith("...")).toBe(true);
     });
+
+    it("keeps the closing ask when keepTailLength is set", () => {
+      const email = {
+        textPlain: `${"Feature list. ".repeat(200)}Can you send the updated timeline when you have it?`,
+        textHtml: undefined,
+        snippet: "",
+      };
+
+      const result = emailToContent(email, {
+        maxLength: 200,
+        keepTailLength: 80,
+      });
+
+      expect(result.length).toBeLessThanOrEqual(200);
+      expect(result).toContain("Feature list.");
+      expect(result).toContain("send the updated timeline");
+    });
+
+    it("strips a plain-text signature before truncating", () => {
+      const email = {
+        textPlain: `${"Please review the proposal. ".repeat(80)}\n-- \nBest regards,\nAlex\nThis email is confidential and intended only for the addressee.`,
+        textHtml: undefined,
+        snippet: "",
+      };
+
+      const result = emailToContent(email, {
+        maxLength: 200,
+        keepTailLength: 80,
+        stripSignature: true,
+      });
+
+      expect(result).toContain("Please review the proposal.");
+      expect(result).not.toContain("confidential");
+      expect(result).not.toContain("Best regards");
+    });
   });
 
   describe("removeForwarded option", () => {

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -2,7 +2,15 @@ import "server-only";
 import EmailReplyParser from "email-reply-parser";
 import { convert, type FormatCallback } from "html-to-text";
 import type { ParsedMessage } from "@/utils/types";
-import { removeExcessiveWhitespace, truncate } from "@/utils/string";
+import {
+  stripPlainTextSignature,
+  stripProviderSignatureHtml,
+} from "@/utils/email/signature-normalization";
+import {
+  removeExcessiveWhitespace,
+  truncate,
+  truncateHeadTail,
+} from "@/utils/string";
 import { env } from "@/env";
 import { SafeError } from "@/utils/error";
 
@@ -117,8 +125,10 @@ export function stripForwardedContent(text: string): string {
 
 export type EmailToContentOptions = {
   maxLength?: number;
+  keepTailLength?: number;
   extractReply?: boolean;
   removeForwarded?: boolean;
+  stripSignature?: boolean;
   includeLinkUrls?: boolean;
   includeImageAltText?: boolean;
 };
@@ -127,8 +137,10 @@ export function emailToContent(
   email: Pick<ParsedMessage, "textHtml" | "textPlain" | "snippet">,
   {
     maxLength = 2000,
+    keepTailLength,
     extractReply = false,
     removeForwarded = false,
+    stripSignature = false,
     includeLinkUrls = false,
     includeImageAltText = false,
   }: EmailToContentOptions = {},
@@ -136,7 +148,10 @@ export function emailToContent(
   let content = "";
 
   if (email.textHtml) {
-    content = htmlToText(email.textHtml, {
+    const html = stripSignature
+      ? stripProviderSignatureHtml(email.textHtml)
+      : email.textHtml;
+    content = htmlToText(html, {
       includeLinkUrls,
       includeImageAltText,
     });
@@ -154,9 +169,17 @@ export function emailToContent(
     content = stripForwardedContent(content);
   }
 
+  if (stripSignature) {
+    content = stripPlainTextSignature(content);
+  }
+
   content = removeExcessiveWhitespace(content);
 
-  return maxLength ? truncate(content, maxLength) : content;
+  if (!maxLength) return content;
+  if (keepTailLength) {
+    return truncateHeadTail(content, maxLength, keepTailLength);
+  }
+  return truncate(content, maxLength);
 }
 
 export function convertEmailHtmlToText({

--- a/apps/web/utils/reply-tracker/thread-status-context.test.ts
+++ b/apps/web/utils/reply-tracker/thread-status-context.test.ts
@@ -34,7 +34,11 @@ describe("buildThreadStatusMessagesForLLM", () => {
     expect(getEmailForLLM).toHaveBeenNthCalledWith(
       1,
       messages[0],
-      expect.objectContaining({ maxLength: 500 }),
+      expect.objectContaining({
+        maxLength: 500,
+        extractReply: true,
+        stripSignature: true,
+      }),
     );
     expect(getEmailForLLM).toHaveBeenNthCalledWith(
       2,
@@ -44,7 +48,12 @@ describe("buildThreadStatusMessagesForLLM", () => {
     expect(getEmailForLLM).toHaveBeenNthCalledWith(
       3,
       messages[2],
-      expect.objectContaining({ maxLength: 2000 }),
+      expect.objectContaining({
+        maxLength: 2000,
+        keepTailLength: 1000,
+        extractReply: true,
+        stripSignature: true,
+      }),
     );
   });
 
@@ -93,7 +102,11 @@ describe("buildThreadStatusMessagesForLLM", () => {
     expect(getEmailForLLM).toHaveBeenNthCalledWith(
       12,
       messages[11],
-      expect.objectContaining({ maxLength: 2000 }),
+      expect.objectContaining({
+        maxLength: 2000,
+        keepTailLength: 1000,
+        stripSignature: true,
+      }),
     );
   });
 });

--- a/apps/web/utils/reply-tracker/thread-status-context.ts
+++ b/apps/web/utils/reply-tracker/thread-status-context.ts
@@ -4,22 +4,32 @@ import type { ParsedMessage, EmailForLLM } from "@/utils/types";
 const THREAD_STATUS_FIRST_MESSAGE_MAX_LENGTH = 500;
 const THREAD_STATUS_MIDDLE_MESSAGE_MAX_LENGTH = 120;
 const THREAD_STATUS_RECENT_TAIL_MESSAGE_MAX_LENGTH = 500;
-const THREAD_STATUS_LATEST_MESSAGE_MAX_LENGTH = 2000;
+export const THREAD_STATUS_LATEST_MESSAGE_MAX_LENGTH = 2000;
+// ~150-200 English words. Characters, not words, so this stays stable across languages.
+const THREAD_STATUS_LATEST_MESSAGE_TAIL_LENGTH = 1000;
 const THREAD_STATUS_RECENT_TAIL_MESSAGES = 8;
 
 export function buildThreadStatusMessagesForLLM(
   sortedMessages: ParsedMessage[],
 ): EmailForLLM[] {
-  return sortedMessages.map((message, index) =>
-    getEmailForLLM(message, {
+  const latestMessageIndex = sortedMessages.length - 1;
+
+  return sortedMessages.map((message, index) => {
+    const isLatest = index === latestMessageIndex;
+
+    return getEmailForLLM(message, {
       maxLength: getMaxLengthForThreadStatusMessage({
         index,
         totalMessages: sortedMessages.length,
       }),
+      keepTailLength: isLatest
+        ? THREAD_STATUS_LATEST_MESSAGE_TAIL_LENGTH
+        : undefined,
       extractReply: true,
+      stripSignature: true,
       removeForwarded: false,
-    }),
-  );
+    });
+  });
 }
 
 function getMaxLengthForThreadStatusMessage({

--- a/apps/web/utils/string.test.ts
+++ b/apps/web/utils/string.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   removeExcessiveWhitespace,
   truncate,
+  truncateHeadTail,
   generalizeSubject,
   convertNewlinesToBr,
   escapeHtml,
@@ -25,6 +26,32 @@ describe("string utils", () => {
       },
     ])("handles $name", ({ input, length, expected }) => {
       expect(truncate(input, length)).toBe(expected);
+    });
+  });
+
+  describe("truncateHeadTail", () => {
+    it("keeps short strings unchanged", () => {
+      expect(truncateHeadTail("hello", 10, 4)).toBe("hello");
+    });
+
+    it("keeps the start and the closing ask of a long recap", () => {
+      const head = "Here is the summary of what we discussed. ";
+      const middle = "Feature list item. ".repeat(80);
+      const tail =
+        "Can you send the updated timeline when you have it? Also free Friday or Monday.";
+      const content = `${head}${middle}${tail}`;
+
+      const result = truncateHeadTail(content, 200, 80);
+
+      expect(result.length).toBe(200);
+      expect(result.startsWith("Here is the summary")).toBe(true);
+      expect(result).toContain("\n...\n");
+      expect(result).toContain("send the updated timeline");
+    });
+
+    it("falls back to the tail when the head budget is exhausted", () => {
+      const result = truncateHeadTail("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 10, 20);
+      expect(result).toBe("\n...\nVWXYZ");
     });
   });
 

--- a/apps/web/utils/string.ts
+++ b/apps/web/utils/string.ts
@@ -25,6 +25,31 @@ export function truncate(str: string, length: number) {
   return str.length > length ? `${str.slice(0, length)}...` : str;
 }
 
+const HEAD_TAIL_ELLIPSIS = "\n...\n";
+
+// Keep the start and end of a long string so closing asks/CTAs survive truncation.
+export function truncateHeadTail(
+  str: string,
+  maxLength: number,
+  tailLength: number,
+) {
+  if (str.length <= maxLength) return str;
+
+  const ellipsis = HEAD_TAIL_ELLIPSIS;
+  if (maxLength <= ellipsis.length) return str.slice(0, maxLength);
+
+  const clampedTailLength = Math.max(
+    0,
+    Math.min(tailLength, maxLength - ellipsis.length),
+  );
+  const headLength = maxLength - clampedTailLength - ellipsis.length;
+  if (headLength <= 0) {
+    return `${ellipsis}${str.slice(-(maxLength - ellipsis.length))}`;
+  }
+
+  return `${str.slice(0, headLength)}${ellipsis}${str.slice(-clampedTailLength)}`;
+}
+
 export function trimToNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== "string") return;
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260820-090459_pr-3341_88461754c930/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- Preserve the start and end of the latest message when classifying conversation status (inbound and outbound), instead of keeping only the beginning.
- Strip signatures before truncation so the kept tail is the actual close of the email, and stop a second prompt-length cap from cutting that tail off.

## Test plan
- [ ] Confirm a long inbound recap with a question at the end is classified as needing a reply, not FYI.
- [ ] Confirm a long outbound send still gets conversation-status labels through the outbound path.
- [ ] Confirm short emails are unchanged and still classified as before.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->