### PR TITLE
fix: Recover conflicting Gmail labels

### DIFF
--- a/apps/web/utils/gmail/label.test.ts
+++ b/apps/web/utils/gmail/label.test.ts
@@ -55,6 +55,32 @@ describe("createLabel conflict handling", () => {
     expect(list).toHaveBeenCalledTimes(2);
   });
 
+  it("returns existing nested label when the requested name uses punctuation separators", async () => {
+    const list = vi.fn().mockResolvedValue(
+      labelsResponse([
+        { id: "parent", name: "Projects", type: "user" },
+        {
+          id: "existing",
+          name: "Projects/Client updates",
+          type: "user",
+        },
+      ]),
+    );
+    const create = vi
+      .fn()
+      .mockRejectedValue(new Error("Label name exists or conflicts"));
+    const gmail = gmailClient({ create, list });
+
+    const label = await createLabel({
+      gmail,
+      name: "Projects-Client_updates",
+    });
+
+    expect(label.id).toBe("existing");
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
   it("returns existing label when creation fails with Precondition check failed", async () => {
     const list = vi
       .fn()

--- a/apps/web/utils/gmail/label.ts
+++ b/apps/web/utils/gmail/label.ts
@@ -415,7 +415,10 @@ export async function getOrCreateInboxZeroLabel({
 function normalizeLabelForConflictLookup(name: string) {
   const normalizedUnicode = name.normalize("NFKC");
   const normalizedPath = normalizeSlashPath(normalizedUnicode);
-  return normalizeLabelName(stripInvisibleCharacters(normalizedPath));
+  const collapsedSeparators = stripInvisibleCharacters(
+    normalizedPath,
+  ).replaceAll("/", " ");
+  return normalizeLabelName(collapsedSeparators);
 }
 
 function normalizeSlashPath(name: string) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260820-130504_pr-3342_5322e9fcd046/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves label creation recovery when Gmail reports a naming conflict.

- Treats hierarchy and punctuation separators equivalently only during post-conflict lookup.
- Adds focused regression coverage for returning the existing label.

Validation: `pnpm test utils/gmail/label.test.ts` and targeted Biome checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->