### PR TITLE
fix: restore billing access when premium.admins is empty (INB-329)

### DIFF
--- a/apps/web/ee/billing/stripe/sync-stripe.ts
+++ b/apps/web/ee/billing/stripe/sync-stripe.ts
@@ -152,8 +152,25 @@ export async function syncStripeDataToDb({
       select: {
         id: true,
         users: { select: { id: true } },
+        admins: { select: { id: true } },
       },
     });
+
+    // If no admin is recorded (legacy or webhook-created premium), designate
+    // the first linked user as purchaser. This self-heals existing records and
+    // prevents the empty-admins fallback from granting billing access to all
+    // seat users. The claimPremiumAdminAction exists as a manual override.
+    if (updatedPremium.admins.length === 0 && updatedPremium.users.length > 0) {
+      await prisma.premium.update({
+        where: { id: updatedPremium.id },
+        data: { admins: { connect: { id: updatedPremium.users[0].id } } },
+      });
+      logger.info("Recorded missing Stripe premium admin", {
+        customerId,
+        premiumId: updatedPremium.id,
+        userId: updatedPremium.users[0].id,
+      });
+    }
 
     // Handle Loops events based on state changes
     await handleLoopsEvents({

--- a/apps/web/ee/billing/stripe/sync-stripe.ts
+++ b/apps/web/ee/billing/stripe/sync-stripe.ts
@@ -1,4 +1,5 @@
 import { after } from "next/server";
+import type Stripe from "stripe";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { getStripe } from "@/ee/billing/stripe";
@@ -156,19 +157,17 @@ export async function syncStripeDataToDb({
       },
     });
 
-    // If no admin is recorded (legacy or webhook-created premium), designate
-    // the first linked user as purchaser. This self-heals existing records and
-    // prevents the empty-admins fallback from granting billing access to all
-    // seat users. The claimPremiumAdminAction exists as a manual override.
+    // If no admin is recorded, resolve the purchaser from the Stripe customer's
+    // trusted metadata.userId (written on customer creation) and verify they
+    // are still linked to this premium before connecting. Skips if the metadata
+    // is absent or the user is no longer linked; claimPremiumAdminAction exists
+    // as a manual override for those cases.
     if (updatedPremium.admins.length === 0 && updatedPremium.users.length > 0) {
-      await prisma.premium.update({
-        where: { id: updatedPremium.id },
-        data: { admins: { connect: { id: updatedPremium.users[0].id } } },
-      });
-      logger.info("Recorded missing Stripe premium admin", {
+      await connectPurchaserAsAdmin({
+        stripe,
         customerId,
-        premiumId: updatedPremium.id,
-        userId: updatedPremium.users[0].id,
+        premium: updatedPremium,
+        logger,
       });
     }
 
@@ -220,3 +219,63 @@ function getEffectiveStripeSubscriptionStatus(subscription: {
 }
 
 export { getEffectiveStripeSubscriptionStatus };
+
+// Resolves the purchaser from the Stripe customer's trusted metadata.userId
+// (written at customer-creation time) and connects them as premium admin only
+// if they are still linked to this premium. Exported for use in the backfill
+// admin action.
+// Returns true if an admin was connected, false if the purchaser could not be
+// established (deleted customer, missing metadata.userId, or userId not linked
+// to this premium).
+export async function connectPurchaserAsAdmin({
+  stripe,
+  customerId,
+  premium,
+  logger,
+}: {
+  stripe: Stripe;
+  customerId: string;
+  premium: { id: string; users: { id: string }[] };
+  logger: Logger;
+}): Promise<boolean> {
+  const customer = await stripe.customers.retrieve(customerId);
+
+  if (customer.deleted) {
+    logger.warn("Stripe customer deleted; cannot establish purchaser", {
+      customerId,
+      premiumId: premium.id,
+    });
+    return false;
+  }
+
+  const purchaserUserId = customer.metadata?.userId;
+  const linkedUserIds = new Set(premium.users.map((u) => u.id));
+
+  if (!purchaserUserId || !linkedUserIds.has(purchaserUserId)) {
+    logger.warn(
+      "Cannot establish purchaser from Stripe metadata; skipping admin assignment",
+      {
+        customerId,
+        premiumId: premium.id,
+        hasMetadataUserId: !!purchaserUserId,
+        metadataUserIsLinked: purchaserUserId
+          ? linkedUserIds.has(purchaserUserId)
+          : false,
+      },
+    );
+    return false;
+  }
+
+  await prisma.premium.update({
+    where: { id: premium.id },
+    data: { admins: { connect: { id: purchaserUserId } } },
+  });
+
+  logger.info("Recorded Stripe purchaser as premium admin", {
+    customerId,
+    premiumId: premium.id,
+    userId: purchaserUserId,
+  });
+
+  return true;
+}

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -6,7 +6,10 @@ import { deleteUser } from "@/utils/user/delete";
 import prisma from "@/utils/prisma";
 import { adminActionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
-import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
+import {
+  syncStripeDataToDb,
+  connectPurchaserAsAdmin,
+} from "@/ee/billing/stripe/sync-stripe";
 import { getStripe } from "@/ee/billing/stripe";
 import { premiumEntitlementSelect } from "@/utils/premium";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -677,12 +680,16 @@ export const adminCleanupDraftsAction = adminActionClient
     };
   });
 
-// Backfills premium.admins for Stripe-created premiums that were never given an
-// admin record. Designates the first linked user as the purchaser. Run once
-// after deploying the syncStripeDataToDb admin-persistence fix.
+// Backfills premium.admins for Stripe-created premiums that have no recorded
+// admin. Resolves the purchaser from the Stripe customer's trusted
+// metadata.userId (written at customer-creation time) and validates they are
+// still linked to the premium. Records with no resolvable purchaser are skipped
+// and logged rather than guessed. Run once after deploying this fix.
 export const adminBackfillPremiumAdminsAction = adminActionClient
   .metadata({ name: "adminBackfillPremiumAdmins" })
   .action(async ({ ctx: { logger } }) => {
+    const stripe = getStripe();
+
     const premiumsWithoutAdmins = await prisma.premium.findMany({
       where: {
         stripeCustomerId: { not: null },
@@ -692,7 +699,7 @@ export const adminBackfillPremiumAdminsAction = adminActionClient
       select: {
         id: true,
         stripeCustomerId: true,
-        users: { select: { id: true }, take: 1 },
+        users: { select: { id: true } },
       },
     });
 
@@ -701,17 +708,34 @@ export const adminBackfillPremiumAdminsAction = adminActionClient
     });
 
     let backfilled = 0;
+    let skipped = 0;
+
     for (const premium of premiumsWithoutAdmins) {
-      if (premium.users.length === 0) continue;
-      await prisma.premium.update({
-        where: { id: premium.id },
-        data: { admins: { connect: { id: premium.users[0].id } } },
-      });
-      backfilled++;
+      if (!premium.stripeCustomerId) continue;
+      try {
+        const connected = await connectPurchaserAsAdmin({
+          stripe,
+          customerId: premium.stripeCustomerId,
+          premium,
+          logger,
+        });
+        if (connected) {
+          backfilled++;
+        } else {
+          skipped++;
+        }
+      } catch (error) {
+        logger.error("Failed to backfill premium admin", {
+          premiumId: premium.id,
+          stripeCustomerId: premium.stripeCustomerId,
+          error,
+        });
+        skipped++;
+      }
     }
 
-    logger.info("Completed premium admin backfill", { backfilled });
-    return { backfilled };
+    logger.info("Completed premium admin backfill", { backfilled, skipped });
+    return { backfilled, skipped };
   });
 
 async function findUserWithDetails(email?: string, userId?: string) {

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -677,6 +677,43 @@ export const adminCleanupDraftsAction = adminActionClient
     };
   });
 
+// Backfills premium.admins for Stripe-created premiums that were never given an
+// admin record. Designates the first linked user as the purchaser. Run once
+// after deploying the syncStripeDataToDb admin-persistence fix.
+export const adminBackfillPremiumAdminsAction = adminActionClient
+  .metadata({ name: "adminBackfillPremiumAdmins" })
+  .action(async ({ ctx: { logger } }) => {
+    const premiumsWithoutAdmins = await prisma.premium.findMany({
+      where: {
+        stripeCustomerId: { not: null },
+        admins: { none: {} },
+        users: { some: {} },
+      },
+      select: {
+        id: true,
+        stripeCustomerId: true,
+        users: { select: { id: true }, take: 1 },
+      },
+    });
+
+    logger.info("Starting premium admin backfill", {
+      count: premiumsWithoutAdmins.length,
+    });
+
+    let backfilled = 0;
+    for (const premium of premiumsWithoutAdmins) {
+      if (premium.users.length === 0) continue;
+      await prisma.premium.update({
+        where: { id: premium.id },
+        data: { admins: { connect: { id: premium.users[0].id } } },
+      });
+      backfilled++;
+    }
+
+    logger.info("Completed premium admin backfill", { backfilled });
+    return { backfilled };
+  });
+
 async function findUserWithDetails(email?: string, userId?: string) {
   return prisma.user.findUnique({
     where: email ? { email } : { id: userId },

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -111,10 +111,23 @@ describe("canManageBilling", () => {
     expect(result).toBe(false);
   });
 
+  it("allows the Stripe purchaser recorded as premium admin without an organization", () => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [{ id: "user-1" }],
+      },
+      emailAccounts: [],
+    });
+
+    expect(result).toBe(true);
+  });
+
   it.each([
     "admin",
     "owner",
-  ])("allows an organization %s when no premium admins are recorded (e.g. Stripe sync)", (role) => {
+    "member",
+  ])("denies when no premium admins are recorded regardless of org %s role (backfill required)", (role) => {
     const result = canManageBilling("user-1", {
       premium: {
         id: "premium-1",
@@ -125,28 +138,6 @@ describe("canManageBilling", () => {
           members: [
             getMockOrganizationMembership({
               role,
-              ownerUserId: "user-1",
-              ownerPremiumId: "premium-1",
-            }),
-          ],
-        },
-      ],
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("denies an organization member when no premium admins are recorded (e.g. Stripe sync)", () => {
-    const result = canManageBilling("user-1", {
-      premium: {
-        id: "premium-1",
-        admins: [],
-      },
-      emailAccounts: [
-        {
-          members: [
-            getMockOrganizationMembership({
-              role: "member",
               ownerUserId: "user-1",
               ownerPremiumId: "premium-1",
             }),

--- a/apps/web/utils/premium/billing-access.test.ts
+++ b/apps/web/utils/premium/billing-access.test.ts
@@ -111,6 +111,53 @@ describe("canManageBilling", () => {
     expect(result).toBe(false);
   });
 
+  it.each([
+    "admin",
+    "owner",
+  ])("allows an organization %s when no premium admins are recorded (e.g. Stripe sync)", (role) => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [],
+      },
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role,
+              ownerUserId: "user-1",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("denies an organization member when no premium admins are recorded (e.g. Stripe sync)", () => {
+    const result = canManageBilling("user-1", {
+      premium: {
+        id: "premium-1",
+        admins: [],
+      },
+      emailAccounts: [
+        {
+          members: [
+            getMockOrganizationMembership({
+              role: "member",
+              ownerUserId: "user-1",
+              ownerPremiumId: "premium-1",
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(false);
+  });
+
   it("does not use an admin role from an unrelated organization", () => {
     const result = canManageBilling("user-1", {
       premium: {

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -1,6 +1,5 @@
 import type { Prisma } from "@/generated/prisma/client";
 import { SafeError } from "@/utils/error";
-import { isAdminForPremium } from "@/utils/premium";
 import { isOrganizationAdmin } from "@/utils/organizations/roles";
 
 export const organizationOwnerPremiumSelect = {
@@ -63,18 +62,19 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
     return isOrganizationAdmin(organizationMemberships);
   }
 
-  // isAdminForPremium returns true when admins is empty — this covers Stripe
-  // subscribers (sync never writes admins) and legacy plans where the purchaser
-  // was not recorded. Fall back to requiring org admin/owner status.
-  if (isAdminForPremium(premium.admins, userId)) {
+  const premiumAdminIds = new Set(premium.admins.map((admin) => admin.id));
+
+  // Only the recorded purchaser/admin may manage billing. An empty admins array
+  // does NOT grant access — syncStripeDataToDb now persists the purchaser on
+  // every sync, and the backfill action covers existing records.
+  if (premiumAdminIds.has(userId)) {
     if (organizationMemberships.length === 0) return true;
     return isOrganizationAdmin(organizationMemberships);
   }
 
-  // Every invited seat user shares the premium id and can own their own
-  // organization, so anchor on the purchaser: a premium admin, or the legacy
-  // owner whose user id doubles as the premium id.
-  const premiumAdminIds = new Set(premium.admins.map((admin) => admin.id));
+  // Allow an org admin/owner whose org's owner holds this premium. The legacy
+  // identity check (user.id === premium.id) covers plans predating the admins
+  // relation.
   const premiumOrganizationMemberships = organizationMemberships.filter(
     (membership) =>
       membership.organization.members.some(({ emailAccount: { user } }) => {

--- a/apps/web/utils/premium/billing-access.ts
+++ b/apps/web/utils/premium/billing-access.ts
@@ -63,6 +63,14 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
     return isOrganizationAdmin(organizationMemberships);
   }
 
+  // isAdminForPremium returns true when admins is empty — this covers Stripe
+  // subscribers (sync never writes admins) and legacy plans where the purchaser
+  // was not recorded. Fall back to requiring org admin/owner status.
+  if (isAdminForPremium(premium.admins, userId)) {
+    if (organizationMemberships.length === 0) return true;
+    return isOrganizationAdmin(organizationMemberships);
+  }
+
   // Every invited seat user shares the premium id and can own their own
   // organization, so anchor on the purchaser: a premium admin, or the legacy
   // owner whose user id doubles as the premium id.
@@ -79,12 +87,7 @@ export function canManageBilling(userId: string, user: BillingAccessUser) {
     return isOrganizationAdmin(premiumOrganizationMemberships);
   }
 
-  if (premium.admins.length > 0) {
-    return isAdminForPremium(premium.admins, userId);
-  }
-
-  // The initial premium migration used the owner's user ID as the premium ID.
-  return premium.id === userId;
+  return false;
 }
 
 export function assertCanManageBilling(


### PR DESCRIPTION
The Stripe webhook sync never writes to premium.admins, leaving it empty for all Stripe subscribers. The previous fix (INB-329 / #3330) still fell through to `premium.id === userId` in that case, which is only true for legacy plans — so every modern Stripe user got canManageBilling=false.

Check isAdminForPremium first: it already returns true for an empty admins array (the intended "open" fallback) and for the direct purchaser. In both paths, gate on org admin/owner status when the user is in an organization. Non-admin seat users still fall through to the purchaser-org filter.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

