### PR TITLE
fix: open specific Gmail draft from Go to Drafts button (INB-328)

### DIFF
--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
@@ -42,7 +42,7 @@ describe("meeting follow-up draft route", () => {
     getEmailAccountMock.mockResolvedValue("user@gmail.com");
   });
 
-  it("opens the related Gmail draft using its embedded message ID", async () => {
+  it("redirects to the Gmail Drafts deeplink for the draft's message ID", async () => {
     prisma.meeting.findFirst.mockResolvedValue({
       followUpDraftId: "draft-resource-123",
       emailAccount: { account: { provider: "google" } },
@@ -58,7 +58,7 @@ describe("meeting follow-up draft route", () => {
     );
     expect(emailProvider.getDraft).toHaveBeenCalledWith("draft-resource-123");
     expect(response.headers.get("location")).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-message-123",
     );
   });
 

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -174,7 +174,7 @@ describe("getEmailDraftUrl", () => {
       emailAddress: "user@gmail.com",
       provider: "google",
       expected:
-        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-message-123",
     },
     {
       name: "personal Microsoft account",
@@ -182,7 +182,7 @@ describe("getEmailDraftUrl", () => {
       emailAddress: "user@outlook.com",
       provider: "microsoft",
       expected:
-        "https://outlook.live.com/mail/0/deeplink/compose?itemid=draft-123&exvsurl=1",
+        "https://outlook.live.com/mail/0/drafts/id/draft-123",
     },
     {
       name: "business Microsoft account",
@@ -190,7 +190,7 @@ describe("getEmailDraftUrl", () => {
       emailAddress: "user@contoso.com",
       provider: "microsoft",
       expected:
-        "https://outlook.office.com/mail/deeplink/compose?itemid=draft%2B123%2Fabc&exvsurl=1",
+        "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
     },
   ])("opens the draft for a $name", ({
     draftMessageId,

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -61,7 +61,7 @@ const GOOGLE_CONFIG: ProviderUrlConfig = {
     getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
   buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
     getGmailUrlForFragment(
-      `inbox?compose=${encodeURIComponent(draftMessageId)}`,
+      `drafts/${encodeURIComponent(draftMessageId)}`,
       emailAddress,
     ),
   selectId: (messageId: string, _threadId: string) => messageId,
@@ -80,7 +80,7 @@ const PROVIDER_CONFIG: Record<string, ProviderUrlConfig> = {
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
     buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
-      `${getOutlookBaseUrl(emailAddress)}/deeplink/compose?itemid=${encodeURIComponent(draftMessageId)}&exvsurl=1`,
+      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draftMessageId)}`,
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);


### PR DESCRIPTION
﻿## Summary

- Fixes the Go to Drafts button so it opens the specific draft email for both Gmail and Outlook users
- Gmail: changes from #inbox?compose=<id> (not a valid existing-draft URL) to #drafts/<id>
- Outlook: changes from /deeplink/compose?itemid=<id>&exvsurl=1 (expects EWS item ID) to /drafts/id/<id> (OWA-native format, consistent with how regular messages are opened)

## Root cause

PR #3328 introduced the redirect-to-draft flow with incorrect URL formats for both providers:

Gmail: #inbox?compose=<messageId> is not how Gmail opens an existing draft. The correct deeplink is #drafts/<threadId>. For standalone meeting follow-up drafts (not replies), messageId equals threadId so the existing draft.id value is correct.

Outlook: /deeplink/compose?itemid=<id>&exvsurl=1 expects an EWS-format item ID, but the Graph REST API returns a different ID format. The OWA-native URL /drafts/id/<restMessageId> works correctly with the Graph API message ID (consistent with how /inbox/id/<messageId> is used for regular messages).

## Changes

- apps/web/utils/url.ts: Fix buildDraftUrl for both google and microsoft configs
- Tests updated to reflect the correct URL formats for both providers

## Test plan

- Click Go to Drafts in the meetings modal for a Gmail meeting with a generated follow-up draft - verify the compose window opens pre-populated
- Click Go to Drafts in the meetings modal for an Outlook meeting - verify the draft opens for editing
