### PR TITLE
fix: notetaker continues recording past scheduled end time (INB-331)

### DIFF
--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -75,6 +75,7 @@ describe("RecallBotProvider", () => {
       join_at: "2026-05-04T09:00:00.000Z",
       automatic_leave: {
         everyone_left_timeout: { timeout: 2 },
+        in_call_timeout: { timeout: 4 * 60 * 60 },
       },
     });
   });

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -34,6 +34,13 @@ const DEFAULT_RECALL_REGION = "us-west-2";
 // is not the call's actual lifetime.
 const EVERYONE_LEFT_TIMEOUT_SECONDS = 2;
 
+// When in_call_timeout is not set, Recall derives a default from the meeting's
+// calendar schedule, which causes recording to stop at the scheduled end time
+// even if participants are still on the call. Setting an explicit cap overrides
+// that implicit behaviour. Four hours covers any realistic overrun while still
+// preventing the bot from being stranded in a room indefinitely.
+const IN_CALL_TIMEOUT_SECONDS = 4 * 60 * 60;
+
 // Overridden only to point at the local emulator, same as GOOGLE_BASE_URL.
 function getRecallApiBase(): string {
   if (env.RECALL_BASE_URL) {
@@ -91,6 +98,7 @@ export class RecallBotProvider implements MeetingBotProvider {
         join_at: joinAt.toISOString(),
         automatic_leave: {
           everyone_left_timeout: { timeout: EVERYONE_LEFT_TIMEOUT_SECONDS },
+          in_call_timeout: { timeout: IN_CALL_TIMEOUT_SECONDS },
         },
         ...(cameraImage && {
           automatic_video_output: {


### PR DESCRIPTION
﻿## Summary

- Fixes the Inbox Zero Notetaker stopping recording at the scheduled meeting end time when participants are still on the call
- Adds an explicit in_call_timeout of 4 hours to the Recall bot configuration

## Root cause

When in_call_timeout is not set in the Recall bot creation request, Recall derives a default from the calendar event's scheduled end time (detected from the meeting URL). This causes recording to stop exactly at the scheduled end time, even if the call is still ongoing and participants are still present.

The bot correctly remained in the room (the call session stayed active) but stopped recording because Recall's implicit calendar-derived timeout fired.

## Changes

- pps/web/utils/recall/client.ts: Add in_call_timeout: { timeout: 4 * 60 * 60 } to utomatic_leave in bot creation
  - The 4-hour cap overrides the Recall implicit calendar-based default
  - everyone_left_timeout: 2s remains the primary exit trigger (bot leaves 2 seconds after all participants leave)
  - 4 hours provides a safety ceiling to prevent the bot being stranded indefinitely in an abandoned room

## Test plan

- [ ] Join a meeting that runs past its scheduled end time - verify the notetaker continues recording
- [ ] Confirm the notetaker still leaves promptly (within a few seconds) when all participants leave


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

