### PR TITLE
fix(reply-zero): fix Resolved tab 500 (operator is not unique: unknown ->> unknown)

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/Resolved.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/Resolved.tsx
@@ -25,7 +25,7 @@ export async function Resolved({
       SELECT MAX(id) as id
       FROM "ThreadTracker"
       WHERE "emailAccountId" = ${emailAccountId}
-      ${dateFilter ? Prisma.sql`AND "sentAt" <= (${dateFilter}->>'lte')::timestamp` : Prisma.empty}
+      ${dateFilter ? Prisma.sql`AND "sentAt" <= ${dateFilter.lte}` : Prisma.empty}
       GROUP BY "threadId"
       HAVING bool_and(resolved) = true
       ORDER BY MAX(id) DESC
@@ -38,7 +38,7 @@ export async function Resolved({
         SELECT 1
         FROM "ThreadTracker"
         WHERE "emailAccountId" = ${emailAccountId}
-        ${dateFilter ? Prisma.sql`AND "sentAt" <= (${dateFilter}->>'lte')::timestamp` : Prisma.empty}
+        ${dateFilter ? Prisma.sql`AND "sentAt" <= ${dateFilter.lte}` : Prisma.empty}
         GROUP BY "threadId"
         HAVING bool_and(resolved) = true
       ) t


### PR DESCRIPTION
## Problem

Opening the Reply Zero **Resolved** tab with any time range other than "All time" (i.e. `3d` / `1w` / `2w` / `1m`) returns an HTTP 500. The server logs show:

```
Error [PrismaClientKnownRequestError]: Raw query failed.
Code: `42725`. Message: `operator is not unique: unknown ->> unknown`
code: 'P2010'
```

## Cause

In `apps/web/app/(app)/[emailAccountId]/reply-zero/Resolved.tsx`, the raw query interpolates the whole `getDateFilter()` result and applies the JSON `->>` operator to it:

```ts
${dateFilter ? Prisma.sql`AND "sentAt" <= (${dateFilter}->>'lte')::timestamp` : Prisma.empty}
```

But `getDateFilter()` (`date-filter.ts`) returns a plain JS object `{ lte: Date }`, not a jsonb value. `${dateFilter}` binds it as an untyped query parameter, and Postgres can't resolve `->>` against an `unknown`-typed parameter — hence `42725: operator is not unique: unknown ->> unknown`, surfaced by Prisma as `P2010` and by Next.js as a server error digest → 500.

The `timeRange="all"` case is unaffected because `getDateFilter` returns `undefined` and the clause is skipped (`Prisma.empty`).

## Fix

Bind the date value directly with `${dateFilter.lte}` — matching the existing correct pattern already used in `fetch-trackers.ts`:

```ts
// fetch-trackers.ts
const dateClause = dateFilter ? Prisma.sql`AND "sentAt" <= ${dateFilter.lte}` : Prisma.empty;
```

Both occurrences in `Resolved.tsx` (the `SELECT MAX(id)` query and the `COUNT(*)` subquery) are updated.
