### PR TITLE
Improve is-agentic trust signals: Organization schema + /about

### DIFF
--- a/apps/web/app/(landing)/about/page.tsx
+++ b/apps/web/app/(landing)/about/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BasicLayout } from "@/components/layouts/BasicLayout";
+import {
+  PageHeading,
+  Paragraph,
+  Subheading,
+} from "@/components/new-landing/common/Typography";
+import { BRAND_NAME, getBrandTitle, SUPPORT_EMAIL } from "@/utils/branding";
+
+export const metadata: Metadata = {
+  title: getBrandTitle("About"),
+  description: `About ${BRAND_NAME}: the open-source AI email assistant for labels, drafts, unsubscribe, cold email blocking, and analytics.`,
+  alternates: { canonical: "/about" },
+};
+
+export default function AboutPage() {
+  return (
+    <BasicLayout>
+      <div className="mx-auto max-w-3xl py-16 md:py-24">
+        <PageHeading>About {BRAND_NAME}</PageHeading>
+        <Paragraph size="lg" className="mt-6" color="dark">
+          {BRAND_NAME} is an AI email assistant that helps you reach inbox zero
+          faster. It organizes your inbox with smart labels, drafts replies in
+          your voice, unsubscribes from unwanted mail in bulk, blocks cold
+          emails, and shows analytics so you can see where your time goes.
+        </Paragraph>
+
+        <section className="mt-12 space-y-4">
+          <Subheading>What {BRAND_NAME} does</Subheading>
+          <Paragraph color="dark">
+            Connect Gmail, Google Workspace, or Microsoft Outlook and let the
+            assistant handle routine email work. Use plain-English rules to
+            automate labels and actions, review pre-written drafts before you
+            send, clean newsletters with bulk unsubscribe, and keep spammy cold
+            outreach out of your way. Analytics highlight volume and trends so
+            you can stay on top of your inbox without living in it.
+          </Paragraph>
+        </section>
+
+        <section className="mt-12 space-y-4">
+          <Subheading>Open source and secure</Subheading>
+          <Paragraph color="dark">
+            {BRAND_NAME} is open source. The code is public on{" "}
+            <Link
+              href="https://github.com/elie222/inbox-zero"
+              className="underline underline-offset-2 hover:text-gray-900"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </Link>
+            , so you can inspect how it works, self-host, or contribute. The
+            hosted product is SOC 2 compliant. Learn more about our security
+            posture at{" "}
+            <Link
+              href="https://security.getinboxzero.com"
+              className="underline underline-offset-2 hover:text-gray-900"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              security.getinboxzero.com
+            </Link>
+            .
+          </Paragraph>
+        </section>
+
+        <section className="mt-12 space-y-4">
+          <Subheading>Who it is for</Subheading>
+          <Paragraph color="dark">
+            {BRAND_NAME} is built for founders, operators, and professionals who
+            get more email than they can reasonably handle by hand. If you want
+            an AI assistant that labels, drafts, unsubscribes, and blocks cold
+            email—without locking you into a closed inbox replacement—
+            {BRAND_NAME} is designed for that workflow.
+          </Paragraph>
+        </section>
+
+        <section className="mt-12 space-y-4">
+          <Subheading>Contact</Subheading>
+          <Paragraph color="dark">
+            Questions, feedback, or support requests: email{" "}
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              className="underline underline-offset-2 hover:text-gray-900"
+            >
+              {SUPPORT_EMAIL}
+            </a>
+            . You can also visit our{" "}
+            <Link
+              href="/support"
+              className="underline underline-offset-2 hover:text-gray-900"
+            >
+              support
+            </Link>
+            ,{" "}
+            <Link
+              href="/privacy"
+              className="underline underline-offset-2 hover:text-gray-900"
+            >
+              privacy
+            </Link>
+            , and{" "}
+            <Link
+              href="/terms"
+              className="underline underline-offset-2 hover:text-gray-900"
+            >
+              terms
+            </Link>{" "}
+            pages.
+          </Paragraph>
+        </section>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -98,6 +98,7 @@ export const footerNavigation = {
     { name: "OpenClaw Skill", href: "/openclaw" },
   ],
   company: [
+    { name: "About", href: "/about" },
     { name: "Affiliates", href: "/affiliates", target: "_blank" },
     { name: "Blog", href: "/blog" },
     { name: "Case Studies", href: "/case-studies" },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,7 +8,7 @@ import { GoogleTagManager } from "@next/third-parties/google";
 import { Analytics as DubAnalytics } from "@dub/analytics/react";
 import { Geist } from "next/font/google";
 import localFont from "next/font/local";
-import type { WebApplication, WithContext } from "schema-dts";
+import type { Graph, WebApplication } from "schema-dts";
 import "../styles/globals.css";
 import { PostHogPageview, PostHogProvider } from "@/providers/PostHogProvider";
 import { env } from "@/env";
@@ -16,7 +16,11 @@ import { GlobalProviders } from "@/providers/GlobalProviders";
 import { UTM } from "@/app/utm";
 import { startupImage } from "@/app/startup-image";
 import { Toaster } from "@/components/Toast";
-import { BRAND_ICON_URL, BRAND_NAME, toAbsoluteUrl } from "@/utils/branding";
+import { BRAND_NAME } from "@/utils/branding";
+import {
+  getOrganizationId,
+  getOrganizationJsonLd,
+} from "@/utils/organization-json-ld";
 
 const aeonikFont = localFont({
   src: "../styles/aeonik-medium.woff",
@@ -36,8 +40,10 @@ const description =
   "Your AI executive assistant to reach inbox zero fast. Automate emails, bulk unsubscribe, block cold emails, and analytics. Open-source";
 
 // JSON-LD structured data
-const jsonLd: WithContext<WebApplication> = {
-  "@context": "https://schema.org",
+// Organization contact/address sourced from public legal pages (privacy policy).
+const organization = getOrganizationJsonLd();
+
+const webApplication: WebApplication = {
   "@type": "WebApplication",
   name: BRAND_NAME,
   url: env.NEXT_PUBLIC_BASE_URL,
@@ -64,19 +70,12 @@ const jsonLd: WithContext<WebApplication> = {
     "Email Analytics",
     "Newsletter Management",
   ],
-  publisher: {
-    "@type": "Organization",
-    name: BRAND_NAME,
-    url: env.NEXT_PUBLIC_BASE_URL,
-    logo: {
-      "@type": "ImageObject",
-      url: toAbsoluteUrl(BRAND_ICON_URL),
-    },
-    sameAs: [
-      "https://x.com/inboxzero_ai",
-      "https://github.com/elie222/inbox-zero",
-    ],
-  },
+  publisher: { "@id": getOrganizationId() },
+};
+
+const jsonLd: Graph = {
+  "@context": "https://schema.org",
+  "@graph": [organization, webApplication],
 };
 
 export const metadata: Metadata = {

--- a/apps/web/utils/organization-json-ld.test.ts
+++ b/apps/web/utils/organization-json-ld.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getOrganizationId,
+  getOrganizationJsonLd,
+} from "@/utils/organization-json-ld";
+import { BRAND_NAME, SUPPORT_EMAIL } from "@/utils/branding";
+import { env } from "@/env";
+
+describe("getOrganizationJsonLd", () => {
+  it("includes contactPoint with support email", () => {
+    const organization = getOrganizationJsonLd();
+
+    expect(organization["@type"]).toBe("Organization");
+    expect(organization["@id"]).toBe(getOrganizationId());
+    expect(organization.url).toBe(env.NEXT_PUBLIC_BASE_URL);
+    expect(organization.contactPoint).toEqual({
+      "@type": "ContactPoint",
+      email: SUPPORT_EMAIL,
+      contactType: "customer support",
+    });
+  });
+
+  it("includes the public Inbox Zero Inc. PostalAddress when branded as Inbox Zero", () => {
+    // Default cloud/local brand is Inbox Zero; address comes from the public privacy policy.
+    if (BRAND_NAME !== "Inbox Zero") {
+      expect(getOrganizationJsonLd().address).toBeUndefined();
+      return;
+    }
+
+    expect(getOrganizationJsonLd().address).toEqual({
+      "@type": "PostalAddress",
+      streetAddress: "131 Continental Dr, Suite 305",
+      addressLocality: "Newark",
+      addressRegion: "DE",
+      postalCode: "19713",
+      addressCountry: "US",
+    });
+    expect(getOrganizationJsonLd().name).toBe("Inbox Zero Inc.");
+  });
+});

--- a/apps/web/utils/organization-json-ld.ts
+++ b/apps/web/utils/organization-json-ld.ts
@@ -1,0 +1,47 @@
+import type { Organization } from "schema-dts";
+import {
+  BRAND_ICON_URL,
+  BRAND_NAME,
+  SUPPORT_EMAIL,
+  toAbsoluteUrl,
+} from "@/utils/branding";
+import { env } from "@/env";
+
+/** Public legal address from getinboxzero.com/privacy (Inbox Zero Inc.). */
+const INBOX_ZERO_ADDRESS = {
+  "@type": "PostalAddress" as const,
+  streetAddress: "131 Continental Dr, Suite 305",
+  addressLocality: "Newark",
+  addressRegion: "DE",
+  postalCode: "19713",
+  addressCountry: "US",
+};
+
+export function getOrganizationId() {
+  return `${env.NEXT_PUBLIC_BASE_URL}/#organization`;
+}
+
+export function getOrganizationJsonLd(): Organization {
+  const isInboxZeroBrand = BRAND_NAME === "Inbox Zero";
+
+  return {
+    "@type": "Organization",
+    "@id": getOrganizationId(),
+    name: isInboxZeroBrand ? "Inbox Zero Inc." : BRAND_NAME,
+    url: env.NEXT_PUBLIC_BASE_URL,
+    logo: {
+      "@type": "ImageObject",
+      url: toAbsoluteUrl(BRAND_ICON_URL),
+    },
+    sameAs: [
+      "https://x.com/inboxzero_ai",
+      "https://github.com/elie222/inbox-zero",
+    ],
+    contactPoint: {
+      "@type": "ContactPoint",
+      email: SUPPORT_EMAIL,
+      contactType: "customer support",
+    },
+    ...(isInboxZeroBrand ? { address: INBOX_ZERO_ADDRESS } : {}),
+  };
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260822-221755_pr-3349_64b18fb86241/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes gaps from the [is-agentic.com scan of getinboxzero.com](https://is-agentic.com/scan/getinboxzero.com) (score 73): incomplete Organization schema and missing About trust-anchor page.

## Changes

- **Organization JSON-LD**: Emit a standalone Organization node in a schema.org `@graph` (alongside the existing WebApplication), with:
  - `contactPoint` using `support@getinboxzero.com` / customer support
  - `PostalAddress` from the public privacy policy (Inbox Zero Inc., 131 Continental Dr, Suite 305, Newark, DE 19713, US)
  - WebApplication `publisher` linked via `@id`
- **/about**: New marketing page (500+ characters) covering what Inbox Zero is, open source (GitHub), AI email features, SOC 2, who it is for, and support contact. Linked from the footer Company section.
- Unit coverage for Organization schema fields in `organization-json-ld.test.ts`.

## Notes

- Privacy/terms/support remain in the private marketing package; `/about` ships in the public `(landing)` routes so agents can verify it without inventing facts.
- No phone number added (none published on the site).
- Optional homepage heading-hierarchy tweak skipped: section components already use `h2` via `SectionHeading`.

## Validation

- `pnpm test utils/organization-json-ld.test.ts` (2 passed)
- CI on HEAD `64b18fb86`: build, test, playwright, CodeQL, Socket — success
- CLA status remains pending for the cloud agent identity (needs a human CLA signature)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27a49524-bc7d-4151-af35-4face0800b07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27a49524-bc7d-4151-af35-4face0800b07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive About page with product information, security details, open-source highlights, audience guidance, and contact links.
  * Added an About link to the website footer.
  * Improved structured metadata for clearer organization and application information in search results.

* **Tests**
  * Added coverage to verify organization metadata, support contact details, branding, and address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->