### PR TITLE
desktop: Keep macOS distribution direct-download

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -59,7 +59,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#desktop-v}"
           pnpm --filter @inboxzero/desktop exec npm version "$VERSION" --no-git-tag-version --allow-same-version
 
-      - name: Write App Store Connect API key
+      - name: Write Apple notarization API key
         if: runner.os == 'macOS'
         env:
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 # production
 /build
 /apps/desktop/release
+/apps/desktop/build/*.provisionprofile
 
 # misc
 .DS_Store

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -29,17 +29,21 @@ pnpm --filter @inboxzero/desktop dist:mac
 pnpm --filter @inboxzero/desktop dist:win
 ```
 
-Installers land in `apps/desktop/release/`. Unsigned local builds are fine for testing; macOS Gatekeeper will warn until the app is signed and notarized.
+Installers land in `apps/desktop/release/`. Use `pnpm dev` for unsigned local testing; packaged macOS builds require the Developer ID certificate configured below.
+
+The Mac app is distributed directly as a signed and notarized DMG/ZIP. It is not a Mac App Store build, so it does not use Apple's App Sandbox or Mac App Store update and payment policies.
 
 ## Release
 
 Push a `desktop-v*` tag or run the **Desktop Release** workflow. That builds macOS (dmg/zip, arm64 + x64) and Windows (NSIS, x64 + arm64) and can publish a GitHub Release.
 
-Signing is optional until these GitHub secrets exist:
+The macOS release requires these GitHub secrets:
 
 - `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` — Developer ID Application `.p12` (base64) for signed Mac builds
-- `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` — Windows Authenticode `.p12` (base64)
+- `APPLE_API_KEY_ID` / `APPLE_API_ISSUER` / `APPLE_API_KEY_P8` / `APPLE_TEAM_ID` — Apple credentials used to notarize the signed build
 
-Signing secrets do not notarize. `mac.notarize` is hardcoded off in `electron-builder.yml`; Gatekeeper still warns until that is turned on with Apple notarization credentials. Same Apple Developer team as the iOS app can issue the Developer ID certificate; that is not a Mac App Store build.
+Windows signing uses `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` for the Authenticode `.p12`.
+
+`electron-builder.yml` keeps `mac.notarize` enabled. App Store Connect API credentials are also accepted by Apple's notarization service; using them here does not make the output a Mac App Store build.
 
 Packaged apps check `https://github.com/elie222/inbox-zero/releases/download/desktop-updates` for `latest-mac.yml` / `latest.yml`. That feed is a stable GitHub release; the installers stay on `desktop-v*` releases.


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260822-231112_pr-3352_6c2edfe627eb/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Desktop distribution is intentionally kept on the Developer ID and notarized direct-download channel.

- document DMG/ZIP as the supported Mac distribution path
- correct the notarization credentials and workflow label
- ignore local provisioning profiles to prevent accidental commits

Validation: staged-file Ultracite check, git diff --check, and gitleaks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->