### PR TITLE
mail: Add early access navigation link

### DIFF
--- a/apps/web/app/(app)/early-access/page.tsx
+++ b/apps/web/app/(app)/early-access/page.tsx
@@ -11,15 +11,35 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { isGoogleProvider } from "@/utils/email/provider-types";
+import { prefixPath } from "@/utils/path";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
 export default function RequestAccessPage() {
-  const { provider } = useAccount();
+  const { emailAccountId, provider } = useAccount();
 
   return (
     <div className="container px-2 pt-2 sm:px-4 sm:pt-8">
       <div className="mx-auto max-w-2xl space-y-4 sm:space-y-8">
         <EarlyAccessFeatures />
+        <Card>
+          <CardHeader>
+            <CardTitle>Mail</CardTitle>
+            <CardDescription>
+              Open your inbox in the Inbox Zero mail client.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {emailAccountId ? (
+              <Button asChild>
+                <Link href={prefixPath(emailAccountId, "/mail")}>
+                  Open Mail
+                </Link>
+              </Button>
+            ) : (
+              <Button disabled>Open Mail</Button>
+            )}
+          </CardContent>
+        </Card>
         {isGoogleProvider(provider) && (
           <>
             <Card>


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260822-232404_pr-3353_705d676c886e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds an account-aware entry point to the Inbox Zero mail client from the Early Access page.

- adds an Open Mail card linked to the active email account
- keeps navigation disabled until the account ID is available
- validates the changed page with Biome

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->