### PR TITLE
desktop: Add native Check for Updates flow

### DIFF
--- a/apps/desktop/src/application-menu.ts
+++ b/apps/desktop/src/application-menu.ts
@@ -1,0 +1,51 @@
+import { app, Menu, type MenuItemConstructorOptions } from "electron";
+
+const PRODUCT_NAME = "Inbox Zero";
+
+export function configureDesktopApplicationMenu(
+  checkForUpdates: () => void,
+  platform = process.platform,
+) {
+  app.setAboutPanelOptions({ applicationName: PRODUCT_NAME });
+
+  const checkForUpdatesItem: MenuItemConstructorOptions = {
+    label: "Check for Updates…",
+    click: checkForUpdates,
+  };
+  const template: MenuItemConstructorOptions[] = [
+    ...(platform === "darwin"
+      ? [
+          {
+            label: PRODUCT_NAME,
+            submenu: [
+              { label: `About ${PRODUCT_NAME}`, role: "about" },
+              { type: "separator" },
+              checkForUpdatesItem,
+              { type: "separator" },
+              { role: "services" },
+              { type: "separator" },
+              { label: `Hide ${PRODUCT_NAME}`, role: "hide" },
+              { role: "hideOthers" },
+              { role: "unhide" },
+              { type: "separator" },
+              { label: `Quit ${PRODUCT_NAME}`, role: "quit" },
+            ],
+          } satisfies MenuItemConstructorOptions,
+        ]
+      : []),
+    { role: "fileMenu" },
+    { role: "editMenu" },
+    { role: "viewMenu" },
+    { role: "windowMenu" },
+    ...(platform === "darwin"
+      ? []
+      : [
+          {
+            role: "help",
+            submenu: [checkForUpdatesItem],
+          } satisfies MenuItemConstructorOptions,
+        ]),
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -1,25 +1,43 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { startDesktopAutoUpdate } from "./auto-update";
+import {
+  checkForDesktopUpdatesManually,
+  DESKTOP_UPDATE_INTERVAL_MS,
+  startDesktopAutoUpdate,
+} from "./auto-update";
 
-const { autoUpdater, app } = vi.hoisted(() => ({
-  app: { isPackaged: true },
+const { autoUpdater, app, dialog } = vi.hoisted(() => ({
+  app: { getVersion: vi.fn(() => "0.1.0"), isPackaged: true },
   autoUpdater: {
     autoDownload: false,
     autoInstallOnAppQuit: false,
+    checkForUpdates: vi.fn(),
     checkForUpdatesAndNotify: vi.fn(),
+    downloadUpdate: vi.fn(),
+    once: vi.fn(),
+    quitAndInstall: vi.fn(),
     setFeedURL: vi.fn(),
   },
+  dialog: { showMessageBox: vi.fn() },
 }));
 
-vi.mock("electron", () => ({ app }));
+vi.mock("electron", () => ({ app, dialog }));
 vi.mock("electron-updater", () => ({ autoUpdater }));
 
 describe("startDesktopAutoUpdate", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    autoUpdater.checkForUpdates.mockReset();
     autoUpdater.checkForUpdatesAndNotify.mockReset();
+    autoUpdater.downloadUpdate.mockReset();
+    autoUpdater.once.mockReset();
+    autoUpdater.quitAndInstall.mockReset();
     autoUpdater.setFeedURL.mockReset();
+    dialog.showMessageBox.mockReset();
+    dialog.showMessageBox.mockResolvedValue({
+      checkboxChecked: false,
+      response: 1,
+    });
     app.isPackaged = true;
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -50,5 +68,147 @@ describe("startDesktopAutoUpdate", () => {
     await expect(startDesktopAutoUpdate(true)).resolves.toBe(false);
     expect(console.error).toHaveBeenCalledWith("invalid feed URL");
     expect(autoUpdater.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+  });
+
+  it("keeps checking for updates while the app remains open", async () => {
+    vi.useFakeTimers();
+    autoUpdater.checkForUpdatesAndNotify.mockResolvedValue(null);
+
+    try {
+      await expect(startDesktopAutoUpdate(true)).resolves.toBe(true);
+      await vi.advanceTimersByTimeAsync(DESKTOP_UPDATE_INTERVAL_MS);
+
+      expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops periodic checks after an update downloads", async () => {
+    vi.useFakeTimers();
+    autoUpdater.checkForUpdatesAndNotify.mockResolvedValue(null);
+    let notifyDownloaded: (() => void) | undefined;
+    autoUpdater.once.mockImplementation((event, listener) => {
+      if (event === "update-downloaded") notifyDownloaded = listener;
+    });
+
+    try {
+      await startDesktopAutoUpdate(true);
+      notifyDownloaded?.();
+      await vi.advanceTimersByTimeAsync(DESKTOP_UPDATE_INTERVAL_MS);
+
+      expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("checkForDesktopUpdatesManually", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    autoUpdater.checkForUpdates.mockReset();
+    autoUpdater.downloadUpdate.mockReset();
+    autoUpdater.once.mockReset();
+    autoUpdater.quitAndInstall.mockReset();
+    autoUpdater.setFeedURL.mockReset();
+    dialog.showMessageBox.mockReset();
+    dialog.showMessageBox.mockResolvedValue({
+      checkboxChecked: false,
+      response: 1,
+    });
+    app.getVersion.mockReturnValue("0.1.0");
+    app.isPackaged = true;
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("explains that development builds cannot check for updates", async () => {
+    const beforeInstall = vi.fn();
+
+    await expect(
+      checkForDesktopUpdatesManually(beforeInstall, false),
+    ).resolves.toBe(false);
+
+    expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Updates are unavailable in development builds",
+      }),
+    );
+  });
+
+  it("confirms when the installed app is current", async () => {
+    autoUpdater.checkForUpdates.mockResolvedValue({
+      isUpdateAvailable: false,
+      updateInfo: { version: "0.1.0" },
+    });
+
+    await expect(checkForDesktopUpdatesManually(vi.fn(), true)).resolves.toBe(
+      true,
+    );
+
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: "Inbox Zero 0.1.0 is the latest version.",
+        message: "You're up to date",
+      }),
+    );
+  });
+
+  it("downloads an available update and restarts when requested", async () => {
+    const beforeInstall = vi.fn();
+    const downloadPromise = Promise.resolve(["update.zip"]);
+    autoUpdater.checkForUpdates.mockResolvedValue({
+      downloadPromise,
+      isUpdateAvailable: true,
+      updateInfo: { version: "0.2.0" },
+    });
+    dialog.showMessageBox
+      .mockResolvedValueOnce({ checkboxChecked: false, response: 0 })
+      .mockResolvedValueOnce({ checkboxChecked: false, response: 0 });
+
+    await expect(
+      checkForDesktopUpdatesManually(beforeInstall, true),
+    ).resolves.toBe(true);
+
+    expect(dialog.showMessageBox).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: "Downloading Inbox Zero 0.2.0" }),
+    );
+    expect(dialog.showMessageBox).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        buttons: ["Restart to Update", "Later"],
+        message: "An update is ready to install",
+      }),
+    );
+    expect(beforeInstall).toHaveBeenCalledOnce();
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledOnce();
+    expect(beforeInstall.mock.invocationCallOrder[0]).toBeLessThan(
+      autoUpdater.quitAndInstall.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("shows a useful error when the manual check fails", async () => {
+    autoUpdater.checkForUpdates.mockRejectedValue(
+      new Error("feed unavailable"),
+    );
+
+    await expect(checkForDesktopUpdatesManually(vi.fn(), true)).resolves.toBe(
+      false,
+    );
+
+    expect(console.error).toHaveBeenCalledWith("feed unavailable");
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Couldn't check for updates",
+        type: "error",
+      }),
+    );
   });
 });

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,5 +1,8 @@
-import { app } from "electron";
+import { app, dialog } from "electron";
+import type { AppUpdater } from "electron-updater";
 import { getDesktopUpdateFeedUrl } from "./update-feed";
+
+export const DESKTOP_UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 export function logDesktopUpdateError(error: unknown) {
   console.error(
@@ -13,17 +16,90 @@ export async function startDesktopAutoUpdate(
   if (!isPackaged) return false;
 
   try {
-    const { autoUpdater } = await import("electron-updater");
-    autoUpdater.setFeedURL({
-      provider: "generic",
-      url: getDesktopUpdateFeedUrl(),
-    });
-    autoUpdater.autoDownload = true;
-    autoUpdater.autoInstallOnAppQuit = true;
+    const autoUpdater = await getDesktopAutoUpdater();
+    scheduleDesktopUpdateChecks(autoUpdater);
     await autoUpdater.checkForUpdatesAndNotify();
     return true;
   } catch (error) {
     logDesktopUpdateError(error);
     return false;
   }
+}
+
+export async function checkForDesktopUpdatesManually(
+  prepareToQuit: () => void,
+  isPackaged = app.isPackaged,
+): Promise<boolean> {
+  if (!isPackaged) {
+    await dialog.showMessageBox({
+      type: "info",
+      message: "Updates are unavailable in development builds",
+      detail: "Install a released version of Inbox Zero to receive updates.",
+    });
+    return false;
+  }
+
+  try {
+    const autoUpdater = await getDesktopAutoUpdater();
+    const result = await autoUpdater.checkForUpdates();
+    if (!result) throw new Error("Desktop updater is unavailable");
+
+    if (!result.isUpdateAvailable) {
+      await dialog.showMessageBox({
+        type: "info",
+        message: "You're up to date",
+        detail: `Inbox Zero ${app.getVersion()} is the latest version.`,
+      });
+      return true;
+    }
+
+    await dialog.showMessageBox({
+      type: "info",
+      message: `Downloading Inbox Zero ${result.updateInfo.version}`,
+      detail:
+        "You can keep using Inbox Zero. We'll let you know when the update is ready.",
+    });
+    await (result.downloadPromise ?? autoUpdater.downloadUpdate());
+
+    const { response } = await dialog.showMessageBox({
+      type: "info",
+      buttons: ["Restart to Update", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+      message: "An update is ready to install",
+      detail: `Inbox Zero ${result.updateInfo.version} has been downloaded. Restart now to finish updating.`,
+    });
+    if (response === 0) {
+      prepareToQuit();
+      autoUpdater.quitAndInstall();
+    }
+    return true;
+  } catch (error) {
+    logDesktopUpdateError(error);
+    await dialog.showMessageBox({
+      type: "error",
+      message: "Couldn't check for updates",
+      detail: "Please try again later.",
+    });
+    return false;
+  }
+}
+
+async function getDesktopAutoUpdater(): Promise<AppUpdater> {
+  const { autoUpdater } = await import("electron-updater");
+  autoUpdater.setFeedURL({
+    provider: "generic",
+    url: getDesktopUpdateFeedUrl(),
+  });
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  return autoUpdater;
+}
+
+function scheduleDesktopUpdateChecks(autoUpdater: AppUpdater) {
+  const timer = setInterval(() => {
+    autoUpdater.checkForUpdatesAndNotify().catch(logDesktopUpdateError);
+  }, DESKTOP_UPDATE_INTERVAL_MS);
+  autoUpdater.once("update-downloaded", () => clearInterval(timer));
+  timer.unref();
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -11,7 +11,12 @@ import {
   type Session,
   type WebContents,
 } from "electron";
-import { startDesktopAutoUpdate, logDesktopUpdateError } from "./auto-update";
+import { configureDesktopApplicationMenu } from "./application-menu";
+import {
+  checkForDesktopUpdatesManually,
+  logDesktopUpdateError,
+  startDesktopAutoUpdate,
+} from "./auto-update";
 import {
   DESKTOP_PROTOCOL,
   findDesktopProtocolUrl,
@@ -100,6 +105,11 @@ function startDesktopApp() {
   });
 
   app.whenReady().then(async () => {
+    configureDesktopApplicationMenu(() => {
+      checkForDesktopUpdatesManually(() => {
+        isQuitting = true;
+      }).catch(logDesktopUpdateError);
+    });
     // Overlap TLS/socket setup with window creation and page load.
     session
       .fromPartition(PARTITION)


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260822-231245_pr-3354_b1ab5b21307c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds native update controls so installed desktop apps can explicitly check for and apply new releases.

- add Check for Updates to the macOS app menu and the Help menu elsewhere
- show current, downloading, restart, development-build, and error states
- recheck the GitHub update feed every six hours while the app stays open
- preserve macOS update installation when the window normally hides on close
- validate with 34 desktop tests and a focused TypeScript check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->