### PR TITLE
fix(desktop): Use product display name

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@inboxzero/desktop",
+  "productName": "Inbox Zero",
   "private": true,
   "version": "0.1.0",
   "description": "Electron shell for the Inbox Zero web app",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260822-232223_pr-3355_ca9178137409/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- Add the desktop product display name to runtime package metadata.
- Keep generated application menu labels aligned with the packaged app name.

## Validation

- `pnpm --filter @inboxzero/desktop test` (28 tests passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->