### PR TITLE
ci: Fix Playwright report checkout

### DIFF
--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -29,9 +29,15 @@ jobs:
     steps:
       # workflow_run has repository secrets. Always use trusted default-branch code here;
       # never check out or execute the contributor's pull-request revision.
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.repository.default_branch }}
+      - name: Check out trusted source
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        shell: bash
+        run: |
+          git init .
+          git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          git fetch --depth=1 origin "$DEFAULT_BRANCH"
+          git checkout --detach FETCH_HEAD
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260823-000348_pr-3358_cf74babf2ddf/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes trusted source checkout for the Playwright report publisher.

The workflow now shallow-fetches the default branch without persisting a job token, avoiding the invalid submodule cleanup path while keeping credentials out of dependency installation.

Validation: workflow YAML parsing, action linting, and diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated Playwright report publishing workflow to use a streamlined repository checkout process.
  * No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->