### PR TITLE
mail: add local-first mailbox sync store

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
+import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
 import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
@@ -145,6 +146,7 @@ export function MailShell() {
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   const isAllAccounts = accountScope === "all";
+  useMailboxSync({ emailAccountId, enabled: !isAllAccounts });
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
   const layout = isAllAccounts ? "list" : accountLayout;

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -16,6 +16,11 @@ const cache = vi.hoisted(() => ({
   write: vi.fn(),
   writeRows: vi.fn(),
 }));
+const mailbox = vi.hoisted(() => ({
+  listeners: new Set<(emailAccountId: string) => void>(),
+  read: vi.fn(),
+  subscribe: vi.fn(),
+}));
 
 vi.mock("@/utils/email-cache/thread-lists", () => ({
   readCachedThreadList: cache.read,
@@ -23,6 +28,10 @@ vi.mock("@/utils/email-cache/thread-lists", () => ({
   restoreCachedThreadsToView: cache.restore,
   writeCachedThreadList: cache.write,
   writeCachedThreadRows: cache.writeRows,
+}));
+vi.mock("@/utils/email-cache/mailbox", () => ({
+  readSyncedMailboxThreads: mailbox.read,
+  subscribeToMailboxStore: mailbox.subscribe,
 }));
 
 describe("useMailThreads", () => {
@@ -32,6 +41,100 @@ describe("useMailThreads", () => {
     cache.restore.mockResolvedValue(undefined);
     cache.write.mockResolvedValue(undefined);
     cache.writeRows.mockResolvedValue(undefined);
+    mailbox.listeners.clear();
+    mailbox.read.mockResolvedValue(undefined);
+    mailbox.subscribe.mockImplementation(
+      (listener: (emailAccountId: string) => void) => {
+        mailbox.listeners.add(listener);
+        return () => mailbox.listeners.delete(listener);
+      },
+    );
+  });
+
+  it("supports optimistic actions before the server mailbox page arrives", async () => {
+    const network = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue(undefined);
+    mailbox.read.mockResolvedValue({
+      after: "2026-07-24T00:00:00.000Z",
+      complete: true,
+      syncedAt: 100,
+      threads: [createThread("local", ["INBOX", "UNREAD"])],
+    });
+    const query = { type: "inbox" };
+    const { result } = renderHook(
+      () => useMailThreads({ emailAccountId: "account-local", query }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["local"]);
+    });
+    expect(result.current.threads).toEqual([]);
+
+    act(() => result.current.restoreThreads(removal, ["local"]));
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "local",
+    ]);
+
+    act(() => {
+      result.current.optimisticallyUpdateThreads(["local"], (thread) => ({
+        ...thread,
+        snippet: "updated locally",
+      }));
+    });
+    expect(result.current.threads[0]?.snippet).toBe("updated locally");
+  });
+
+  it("uses newer synced messages without losing server rule metadata", async () => {
+    const plan = { id: "execution-1", rule: { id: "rule-1" } };
+    const remoteThread = {
+      ...createThread("shared"),
+      plan,
+      plans: [plan],
+      snippet: "remote",
+    };
+    remoteThread.messages[0]!.internalDate = "2026-08-22T00:00:00.000Z";
+    const syncedThread = {
+      ...createThread("shared"),
+      snippet: "synced",
+    };
+    syncedThread.messages[0]!.internalDate = "2026-08-23T00:00:00.000Z";
+    mailbox.read
+      .mockResolvedValueOnce({
+        after: "2026-07-24T00:00:00.000Z",
+        complete: true,
+        syncedAt: 1,
+        threads: [syncedThread],
+      })
+      .mockResolvedValue({
+        after: "2026-07-24T00:00:00.000Z",
+        complete: true,
+        syncedAt: Number.MAX_SAFE_INTEGER,
+        threads: [syncedThread],
+      });
+    const query = { type: "inbox" };
+    const { result } = renderHook(
+      () => useMailThreads({ emailAccountId: "account-merge", query }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({ threads: [remoteThread] }),
+        ),
+      },
+    );
+    await waitFor(() =>
+      expect(result.current.threads[0]?.snippet).toBe("remote"),
+    );
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("account-merge");
+    });
+
+    await waitFor(() =>
+      expect(result.current.threads[0]?.snippet).toBe("synced"),
+    );
+    expect(result.current.threads[0]).toMatchObject({ plan, plans: [plan] });
   });
 
   it("renders the cached first page while the server revalidates", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -60,9 +60,12 @@ describe("useMailThreads", () => {
       syncedAt: 100,
       threads: [createThread("local", ["INBOX", "UNREAD"])],
     });
-    const query = { type: "inbox" };
     const { result } = renderHook(
-      () => useMailThreads({ emailAccountId: "account-local", query }),
+      () =>
+        useMailThreads({
+          emailAccountId: "account-local",
+          query: { type: "inbox" },
+        }),
       { wrapper: createWrapper(() => network.promise) },
     );
     await waitFor(() => expect(result.current.threads).toHaveLength(1));
@@ -85,6 +88,7 @@ describe("useMailThreads", () => {
       }));
     });
     expect(result.current.threads[0]?.snippet).toBe("updated locally");
+    expect(mailbox.read).toHaveBeenCalledOnce();
   });
 
   it("uses newer synced messages without losing server rule metadata", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -105,17 +105,21 @@ describe("useMailThreads", () => {
       snippet: "synced",
     };
     syncedThread.messages[0]!.internalDate = "2026-08-23T00:00:00.000Z";
+    const remoteOlderThread = createThread("remote-older");
+    remoteOlderThread.messages[0]!.internalDate = "2026-08-10T00:00:00.000Z";
     mailbox.read
       .mockResolvedValueOnce({
         after: "2026-07-24T00:00:00.000Z",
         complete: true,
         syncedAt: 1,
+        truncated: false,
         threads: [syncedThread],
       })
       .mockResolvedValue({
         after: "2026-07-24T00:00:00.000Z",
         complete: true,
         syncedAt: Number.MAX_SAFE_INTEGER,
+        truncated: true,
         threads: [syncedThread],
       });
     const query = { type: "inbox" };
@@ -123,7 +127,7 @@ describe("useMailThreads", () => {
       () => useMailThreads({ emailAccountId: "account-merge", query }),
       {
         wrapper: createWrapper(() =>
-          Promise.resolve({ threads: [remoteThread] }),
+          Promise.resolve({ threads: [remoteThread, remoteOlderThread] }),
         ),
       },
     );
@@ -138,6 +142,10 @@ describe("useMailThreads", () => {
     await waitFor(() =>
       expect(result.current.threads[0]?.snippet).toBe("synced"),
     );
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "shared",
+      "remote-older",
+    ]);
     expect(result.current.threads[0]).toMatchObject({ plan, plans: [plan] });
   });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -120,11 +120,13 @@ export function useMailThreads({
     firstPage?: ThreadsListResponse;
     loadedAt: number;
   }>({ loadedAt: 0 });
+  const queryRef = useRef(query);
   // Auto-load can fire from the cursor and the bottom sentinel in the same
   // tick; two setSize(+1) calls would skip a page token.
   const loadMoreLock = useRef(false);
 
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
+  queryRef.current = query;
   if (data?.[0] && remoteSnapshot.current.firstPage !== data[0]) {
     remoteSnapshot.current = { firstPage: data[0], loadedAt: Date.now() };
   }
@@ -151,7 +153,10 @@ export function useMailThreads({
   useEffect(() => {
     let cancelled = false;
     const loadSyncedView = () => {
-      readSyncedMailboxThreads({ emailAccountId, query }).then((snapshot) => {
+      readSyncedMailboxThreads({
+        emailAccountId,
+        query: queryRef.current,
+      }).then((snapshot) => {
         if (cancelled || !snapshot) return;
         setSynced({
           identity: viewIdentity,
@@ -171,7 +176,7 @@ export function useMailThreads({
       cancelled = true;
       unsubscribe();
     };
-  }, [emailAccountId, query, viewIdentity]);
+  }, [emailAccountId, viewIdentity]);
 
   const hiddenThreadIds =
     hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_IDS;

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -64,6 +64,7 @@ type SyncedView = {
   complete: boolean;
   syncedAt: number;
   threads: ListThread[];
+  truncated: boolean;
 };
 
 export function useMailThreads({
@@ -164,6 +165,7 @@ export function useMailThreads({
           complete: snapshot.complete,
           syncedAt: snapshot.syncedAt,
           threads: snapshot.threads,
+          truncated: snapshot.truncated,
         });
       });
     };
@@ -201,6 +203,7 @@ export function useMailThreads({
             remoteThreads,
             syncedThreads,
             syncedAfter: synced.after,
+            syncedTruncated: synced.truncated,
           })
         : (remoteThreads ?? syncedThreads ?? persistentThreads),
     [
@@ -209,6 +212,7 @@ export function useMailThreads({
       synced?.after,
       synced?.complete,
       synced?.syncedAt,
+      synced?.truncated,
       syncedThreads,
     ],
   );
@@ -595,18 +599,31 @@ function mergeSyncedThreads({
   remoteThreads,
   syncedThreads,
   syncedAfter,
+  syncedTruncated,
 }: {
   remoteThreads: ListThread[];
   syncedThreads: ListThread[];
   syncedAfter: string;
+  syncedTruncated: boolean;
 }) {
   const syncedAfterTimestamp = new Date(syncedAfter).getTime();
+  const oldestSyncedTimestamp = Math.min(
+    ...syncedThreads.map(getThreadTimestamp),
+  );
+  const authoritativeCutoff = syncedTruncated
+    ? Math.max(syncedAfterTimestamp, oldestSyncedTimestamp)
+    : syncedAfterTimestamp;
   const remoteThreadsById = new Map(
     remoteThreads.map((thread) => [thread.id, thread]),
   );
   const threadsById = new Map(
     remoteThreads
-      .filter((thread) => getThreadTimestamp(thread) < syncedAfterTimestamp)
+      .filter((thread) => {
+        const timestamp = getThreadTimestamp(thread);
+        return syncedTruncated
+          ? timestamp <= authoritativeCutoff
+          : timestamp < authoritativeCutoff;
+      })
       .map((thread) => [thread.id, thread]),
   );
   for (const thread of syncedThreads) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -20,11 +20,16 @@ import {
   writeCachedThreadRows,
 } from "@/utils/email-cache/thread-lists";
 import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
+import { getThreadTimestamp } from "@/utils/threads/sort";
 import {
   EMAIL_CACHE_MEASURES,
   finishEmailCacheMeasure,
   startEmailCacheMeasure,
 } from "@/utils/email-cache/telemetry";
+import {
+  readSyncedMailboxThreads,
+  subscribeToMailboxStore,
+} from "@/utils/email-cache/mailbox";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { createSearchParams } from "@/utils/url";
 
@@ -50,6 +55,14 @@ type PersistentView = {
   identity: string;
   cachedAt: number;
   hasMore: boolean;
+  threads: ListThread[];
+};
+
+type SyncedView = {
+  identity: string;
+  after: string;
+  complete: boolean;
+  syncedAt: number;
   threads: ListThread[];
 };
 
@@ -92,6 +105,7 @@ export function useMailThreads({
       revalidateFirstPage: false,
     });
   const [persistent, setPersistent] = useState<PersistentView>();
+  const [synced, setSynced] = useState<SyncedView>();
   const [paginationRequestIdentity, setPaginationRequestIdentity] =
     useState<string>();
   const paginationRetryIdentity = useRef<string | undefined>(undefined);
@@ -102,11 +116,18 @@ export function useMailThreads({
   const pendingReconciliationWrites = useRef(0);
   const [, renderHiddenChanges] = useReducer((version) => version + 1, 0);
   const remoteIdentity = useRef<string | undefined>(undefined);
+  const remoteSnapshot = useRef<{
+    firstPage?: ThreadsListResponse;
+    loadedAt: number;
+  }>({ loadedAt: 0 });
   // Auto-load can fire from the cursor and the bottom sentinel in the same
   // tick; two setSize(+1) calls would skip a page token.
   const loadMoreLock = useRef(false);
 
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
+  if (data?.[0] && remoteSnapshot.current.firstPage !== data[0]) {
+    remoteSnapshot.current = { firstPage: data[0], loadedAt: Date.now() };
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -127,6 +148,31 @@ export function useMailThreads({
     };
   }, [emailAccountId, viewIdentity, viewKey]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const loadSyncedView = () => {
+      readSyncedMailboxThreads({ emailAccountId, query }).then((snapshot) => {
+        if (cancelled || !snapshot) return;
+        setSynced({
+          identity: viewIdentity,
+          after: snapshot.after,
+          complete: snapshot.complete,
+          syncedAt: snapshot.syncedAt,
+          threads: snapshot.threads,
+        });
+      });
+    };
+    const unsubscribe = subscribeToMailboxStore((changedAccountId) => {
+      if (changedAccountId === emailAccountId) loadSyncedView();
+    });
+    loadSyncedView();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [emailAccountId, query, viewIdentity]);
+
   const hiddenThreadIds =
     hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_IDS;
   const remoteThreads = useMemo(
@@ -135,7 +181,22 @@ export function useMailThreads({
   );
   const persistentThreads =
     persistent?.identity === viewIdentity ? persistent.threads : undefined;
-  const sourceThreads = remoteThreads ?? persistentThreads;
+  const syncedThreads =
+    synced?.identity === viewIdentity &&
+    (synced.complete || synced.threads.length > 0)
+      ? synced.threads
+      : undefined;
+  const sourceThreads =
+    remoteThreads &&
+    syncedThreads &&
+    synced?.complete &&
+    synced.syncedAt > remoteSnapshot.current.loadedAt
+      ? mergeSyncedThreads({
+          remoteThreads,
+          syncedThreads,
+          syncedAfter: synced.after,
+        })
+      : (remoteThreads ?? syncedThreads ?? persistentThreads);
   const threads = useMemo(
     () =>
       sourceThreads?.filter((thread) => !hiddenThreadIds.has(thread.id)) ?? [],
@@ -219,8 +280,8 @@ export function useMailThreads({
           }
         }
       } else {
-        const threadOrder = persistentThreads?.map((thread) => thread.id) ?? [];
-        for (const [index, thread] of (persistentThreads ?? []).entries()) {
+        const threadOrder = sourceThreads?.map((thread) => thread.id) ?? [];
+        for (const [index, thread] of (sourceThreads ?? []).entries()) {
           if (targets.has(thread.id) && !alreadyHidden.has(thread.id)) {
             entries.set(thread.id, {
               thread,
@@ -269,7 +330,7 @@ export function useMailThreads({
 
       return { viewIdentity, entries };
     },
-    [data, emailAccountId, mutate, persistentThreads, viewIdentity, viewKey],
+    [data, emailAccountId, mutate, sourceThreads, viewIdentity, viewKey],
   );
 
   const restoreThreads = useCallback(
@@ -293,6 +354,14 @@ export function useMailThreads({
       );
       renderHiddenChanges();
       setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? {
+              ...current,
+              threads: insertRestoredThreads(current.threads, restoring),
+            }
+          : current,
+      );
+      setSynced((current) =>
         current?.identity === viewIdentity
           ? {
               ...current,
@@ -385,6 +454,14 @@ export function useMailThreads({
               }
             : current,
         );
+        setSynced((current) =>
+          current?.identity === viewIdentity
+            ? {
+                ...current,
+                threads: replaceThreads(current.threads, updates),
+              }
+            : current,
+        );
         const localUpdate = mutate(
           (pages) =>
             pages?.map((page) => ({
@@ -449,7 +526,9 @@ export function useMailThreads({
 
   const hasMore = data
     ? Boolean(data.at(-1)?.nextPageToken)
-    : persistent?.identity === viewIdentity && persistent.hasMore;
+    : persistent?.identity === viewIdentity
+      ? persistent.hasMore
+      : Boolean(syncedThreads?.length);
 
   useEffect(() => {
     const loadedPageCount = data?.length ?? 0;
@@ -496,6 +575,37 @@ export function useMailThreads({
 }
 
 const EMPTY_THREAD_IDS = new Set<string>();
+
+function mergeSyncedThreads({
+  remoteThreads,
+  syncedThreads,
+  syncedAfter,
+}: {
+  remoteThreads: ListThread[];
+  syncedThreads: ListThread[];
+  syncedAfter: string;
+}) {
+  const syncedAfterTimestamp = new Date(syncedAfter).getTime();
+  const remoteThreadsById = new Map(
+    remoteThreads.map((thread) => [thread.id, thread]),
+  );
+  const threadsById = new Map(
+    remoteThreads
+      .filter((thread) => getThreadTimestamp(thread) < syncedAfterTimestamp)
+      .map((thread) => [thread.id, thread]),
+  );
+  for (const thread of syncedThreads) {
+    const remoteThread = remoteThreadsById.get(thread.id);
+    threadsById.set(thread.id, {
+      ...thread,
+      plan: remoteThread?.plan ?? thread.plan,
+      plans: remoteThread?.plans ?? thread.plans,
+    });
+  }
+  return [...threadsById.values()].sort(
+    (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
+  );
+}
 
 function replaceThreads(
   threads: ListThread[],

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -186,17 +186,27 @@ export function useMailThreads({
     (synced.complete || synced.threads.length > 0)
       ? synced.threads
       : undefined;
-  const sourceThreads =
-    remoteThreads &&
-    syncedThreads &&
-    synced?.complete &&
-    synced.syncedAt > remoteSnapshot.current.loadedAt
-      ? mergeSyncedThreads({
-          remoteThreads,
-          syncedThreads,
-          syncedAfter: synced.after,
-        })
-      : (remoteThreads ?? syncedThreads ?? persistentThreads);
+  const sourceThreads = useMemo(
+    () =>
+      remoteThreads &&
+      syncedThreads &&
+      synced?.complete &&
+      synced.syncedAt > remoteSnapshot.current.loadedAt
+        ? mergeSyncedThreads({
+            remoteThreads,
+            syncedThreads,
+            syncedAfter: synced.after,
+          })
+        : (remoteThreads ?? syncedThreads ?? persistentThreads),
+    [
+      persistentThreads,
+      remoteThreads,
+      synced?.after,
+      synced?.complete,
+      synced?.syncedAt,
+      syncedThreads,
+    ],
+  );
   const threads = useMemo(
     () =>
       sourceThreads?.filter((thread) => !hiddenThreadIds.has(thread.id)) ?? [],

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requestMailboxSync, useMailboxSync } from "./use-mailbox-sync";
+
+const mailboxSync = vi.hoisted(() => ({
+  fetchPage: vi.fn(),
+  syncPages: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/mailbox-sync", () => ({
+  fetchMailboxSyncPage: mailboxSync.fetchPage,
+  syncMailboxPages: mailboxSync.syncPages,
+}));
+
+const onlineDescriptor = Object.getOwnPropertyDescriptor(navigator, "onLine");
+const visibilityDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "visibilityState",
+);
+
+describe("useMailboxSync", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    setOnline(true);
+    setVisibility("visible");
+    mailboxSync.syncPages.mockResolvedValue({
+      hasMore: false,
+      pagesSynced: 1,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    restoreProperty(navigator, "onLine", onlineDescriptor);
+    restoreProperty(document, "visibilityState", visibilityDescriptor);
+  });
+
+  it("continues an incomplete sync quickly, then settles to polling", async () => {
+    mailboxSync.syncPages
+      .mockResolvedValueOnce({ hasMore: true, pagesSynced: 1 })
+      .mockResolvedValue({ hasMore: false, pagesSynced: 1 });
+
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    expect(mailboxSync.syncPages).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      fetchPage: expect.any(Function),
+      maxPages: 1,
+    });
+    await settlePromises();
+
+    await act(() => vi.advanceTimersByTimeAsync(9999));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+
+    await settlePromises();
+    await act(() => vi.advanceTimersByTimeAsync(59_999));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(3);
+  });
+
+  it("pauses offline or hidden work and resumes on browser events", async () => {
+    setOnline(false);
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    expect(mailboxSync.syncPages).not.toHaveBeenCalled();
+
+    await act(() => vi.advanceTimersByTimeAsync(60_000));
+    expect(mailboxSync.syncPages).not.toHaveBeenCalled();
+
+    setOnline(true);
+    act(() => window.dispatchEvent(new Event("online")));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await settlePromises();
+
+    setVisibility("hidden");
+    act(() => window.dispatchEvent(new Event("focus")));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates account syncs and queues one rerun requested in flight", async () => {
+    const pending = Promise.withResolvers<{
+      hasMore: boolean;
+      pagesSynced: number;
+    }>();
+    const rerun = Promise.withResolvers<{
+      hasMore: boolean;
+      pagesSynced: number;
+    }>();
+    mailboxSync.syncPages
+      .mockReturnValueOnce(pending.promise)
+      .mockReturnValueOnce(rerun.promise);
+
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+
+    act(() => requestMailboxSync("another-account"));
+    act(() => requestMailboxSync("account-1"));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+
+    pending.resolve({ hasMore: false, pagesSynced: 1 });
+    await settlePromises();
+    await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+
+    rerun.resolve({ hasMore: false, pagesSynced: 1 });
+    await settlePromises();
+  });
+
+  it("retries after a failed background sync", async () => {
+    mailboxSync.syncPages
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue({ hasMore: false, pagesSynced: 1 });
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    await settlePromises();
+
+    await act(() => vi.advanceTimersByTimeAsync(59_999));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+  });
+});
+
+async function settlePromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function setOnline(online: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value: online,
+  });
+}
+
+function setVisibility(visibilityState: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: visibilityState,
+  });
+}
+
+function restoreProperty(
+  target: object,
+  property: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+  } else {
+    Reflect.deleteProperty(target, property);
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  fetchMailboxSyncPage,
+  syncMailboxPages,
+} from "@/utils/email-cache/mailbox-sync";
+
+const COMPLETE_SYNC_INTERVAL_MS = 60_000;
+const CONTINUATION_DELAY_MS = 10_000;
+const inFlightSyncs = new Map<
+  string,
+  Promise<{ hasMore: boolean; pagesSynced: number }>
+>();
+const syncRequestListeners = new Set<(emailAccountId: string) => void>();
+
+export function useMailboxSync({
+  emailAccountId,
+  enabled,
+}: {
+  emailAccountId: string;
+  enabled: boolean;
+}) {
+  useEffect(() => {
+    if (!enabled || !emailAccountId) return;
+    let cancelled = false;
+    let running = false;
+    let rerunRequested = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = (delay: number) => {
+      clearTimeout(timeout);
+      if (!cancelled) timeout = setTimeout(run, delay);
+    };
+    const run = () => {
+      if (cancelled) return;
+      if (running) {
+        rerunRequested = true;
+        return;
+      }
+      if (document.visibilityState === "hidden" || navigator.onLine === false) {
+        schedule(COMPLETE_SYNC_INTERVAL_MS);
+        return;
+      }
+      running = true;
+      runSharedMailboxSync(emailAccountId)
+        .then(({ hasMore }) => {
+          if (!rerunRequested) {
+            schedule(
+              hasMore ? CONTINUATION_DELAY_MS : COMPLETE_SYNC_INTERVAL_MS,
+            );
+          }
+        })
+        .catch(() => {
+          if (!rerunRequested) schedule(COMPLETE_SYNC_INTERVAL_MS);
+        })
+        .finally(() => {
+          running = false;
+          if (rerunRequested) {
+            rerunRequested = false;
+            schedule(0);
+          }
+        });
+    };
+    const requestSync = (requestedAccountId: string) => {
+      if (requestedAccountId !== emailAccountId) return;
+      if (running) rerunRequested = true;
+      else schedule(0);
+    };
+    const onVisible = () => {
+      if (document.visibilityState === "visible") schedule(0);
+    };
+
+    syncRequestListeners.add(requestSync);
+    window.addEventListener("focus", run);
+    window.addEventListener("online", run);
+    document.addEventListener("visibilitychange", onVisible);
+    run();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+      syncRequestListeners.delete(requestSync);
+      window.removeEventListener("focus", run);
+      window.removeEventListener("online", run);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [emailAccountId, enabled]);
+}
+
+export function requestMailboxSync(emailAccountId: string) {
+  for (const listener of syncRequestListeners) listener(emailAccountId);
+}
+
+function runSharedMailboxSync(emailAccountId: string) {
+  const existing = inFlightSyncs.get(emailAccountId);
+  if (existing) return existing;
+
+  const sync = syncMailboxPages({
+    emailAccountId,
+    fetchPage: (input) => fetchMailboxSyncPage(emailAccountId, input),
+    maxPages: 1,
+  }).finally(() => {
+    if (inFlightSyncs.get(emailAccountId) === sync) {
+      inFlightSyncs.delete(emailAccountId);
+    }
+  });
+  inFlightSyncs.set(emailAccountId, sync);
+  return sync;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -17,6 +17,15 @@ const notifications = vi.hoisted(() => ({
 }));
 const markReadThreadAction = vi.hoisted(() => vi.fn());
 const snoozeThreadsAction = vi.hoisted(() => vi.fn());
+const mailboxCache = vi.hoisted(() => ({
+  markRead: vi.fn(),
+  remove: vi.fn(),
+}));
+const mailboxSync = vi.hoisted(() => ({ request: vi.fn() }));
+const reverseActions = vi.hoisted(() => ({
+  unarchive: vi.fn(),
+  untrash: vi.fn(),
+}));
 
 vi.mock("@/store/archive-queue", () => ({
   archiveEmails: queue.archive,
@@ -26,16 +35,27 @@ vi.mock("@/store/archive-queue", () => ({
 }));
 vi.mock("@/utils/actions/mail", () => ({
   markReadThreadAction,
-  unarchiveThreadAction: vi.fn(),
-  untrashThreadAction: vi.fn(),
+  unarchiveThreadAction: reverseActions.unarchive,
+  untrashThreadAction: reverseActions.untrash,
 }));
 vi.mock("@/utils/actions/snooze", () => ({ snoozeThreadsAction }));
+vi.mock("@/utils/email-cache/mailbox", () => ({
+  markSyncedMailboxThreadsRead: mailboxCache.markRead,
+  removeSyncedMailboxThreads: mailboxCache.remove,
+}));
+vi.mock("./use-mailbox-sync", () => ({
+  requestMailboxSync: mailboxSync.request,
+}));
 vi.mock("sonner", () => ({ toast: notifications }));
 
 describe("useThreadActions read state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     markReadThreadAction.mockResolvedValue({});
+    mailboxCache.markRead.mockResolvedValue(undefined);
+    mailboxCache.remove.mockResolvedValue(undefined);
+    reverseActions.unarchive.mockResolvedValue({});
+    reverseActions.untrash.mockResolvedValue({});
     snoozeThreadsAction.mockResolvedValue({
       data: { failedThreadIds: [], succeededThreadIds: ["thread"] },
     });
@@ -75,6 +95,11 @@ describe("useThreadActions read state", () => {
     const callbacks = queue.markRead.mock.calls[0]?.[0];
     callbacks.onSuccess("thread");
     expect(transaction.commit).toHaveBeenCalledWith("thread");
+    expect(mailboxCache.markRead).toHaveBeenCalledWith({
+      emailAccountId: "account",
+      read: true,
+      threadIds: ["thread"],
+    });
   });
 
   it("rolls back failed rows together after the batch settles", () => {
@@ -158,6 +183,11 @@ describe("useThreadActions read state", () => {
       read: false,
     });
     expect(transaction.commit).toHaveBeenCalledWith("thread");
+    expect(mailboxCache.markRead).toHaveBeenCalledWith({
+      emailAccountId: "account",
+      read: false,
+      threadIds: ["thread"],
+    });
   });
 
   it("rolls back a rejected read-state toggle", async () => {
@@ -211,6 +241,58 @@ describe("useThreadActions read state", () => {
       snoozedUntil: until,
     });
     expect(restoreThreads).toHaveBeenCalledWith(removal, ["thread-two"]);
+    expect(mailboxCache.remove).toHaveBeenCalledWith({
+      emailAccountId: "account",
+      threadIds: ["thread-one"],
+    });
+  });
+
+  it("reconciles successful archives into the mailbox store", async () => {
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads: vi.fn(() => ({
+          entries: new Map(),
+          viewIdentity: "view",
+        })),
+        restoreThreads: vi.fn(),
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.archive(["thread"]));
+    const callbacks = queue.archive.mock.calls[0]?.[0];
+    await act(async () => {
+      callbacks.onSuccess("thread");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mailboxCache.remove).toHaveBeenCalledWith({
+      emailAccountId: "account",
+      threadIds: ["thread"],
+    });
+    expect(mailboxSync.request).toHaveBeenCalledWith("account");
+  });
+
+  it("requests a fresh delta after undo restores a local row", async () => {
+    queue.cancel.mockReturnValue({ notCancelled: [] });
+    const removal = { entries: new Map(), viewIdentity: "view" };
+    const restoreThreads = vi.fn();
+    const { result } = renderHook(() =>
+      useThreadActions({
+        emailAccountId: "account",
+        removeThreads: vi.fn(() => removal),
+        restoreThreads,
+        optimisticallyUpdateThreads: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.archive(["thread"]));
+    await act(() => result.current.undo());
+
+    expect(restoreThreads).toHaveBeenCalledWith(removal, ["thread"]);
+    expect(mailboxSync.request).toHaveBeenCalledWith("account");
   });
 
   it("chunks snooze actions at the server validation limit", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -24,6 +24,11 @@ import type {
 import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
 import { snoozeThreadsAction } from "@/utils/actions/snooze";
 import { mapWithConcurrency } from "@/utils/async";
+import {
+  markSyncedMailboxThreadsRead,
+  removeSyncedMailboxThreads,
+} from "@/utils/email-cache/mailbox";
+import { requestMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 
 const THREAD_ACTION_CONCURRENCY = 10;
 const SNOOZE_ACTION_BATCH_CONCURRENCY = 2;
@@ -92,6 +97,7 @@ export function useThreadActions({
       const restored = batch.threadIds.filter((id) => !failed.includes(id));
 
       restoreThreads(batch.removal, restored);
+      if (restored.length) requestMailboxSync(emailAccountId);
 
       if (failed.length)
         toast.error(
@@ -123,7 +129,14 @@ export function useThreadActions({
       queue({
         threadIds,
         emailAccountId,
-        onSuccess: () => {},
+        onSuccess: (threadId) => {
+          removeSyncedMailboxThreads({
+            emailAccountId,
+            threadIds: [threadId],
+          })
+            .catch(() => {})
+            .finally(() => requestMailboxSync(emailAccountId));
+        },
         // The queue reports the specific thread that failed; the rest of the
         // batch archived fine and must stay gone.
         onError: (threadId) => {
@@ -165,7 +178,14 @@ export function useThreadActions({
       markReadThreads({
         threadIds: update.threadIds,
         emailAccountId,
-        onSuccess: update.commit,
+        onSuccess: (threadId) => {
+          update.commit(threadId);
+          markSyncedMailboxThreadsRead({
+            emailAccountId,
+            read: true,
+            threadIds: [threadId],
+          }).catch(() => {});
+        },
         onError: (threadId) => {
           failedThreadIds.push(threadId);
           toast.error("There was an error marking as read");
@@ -206,6 +226,14 @@ export function useThreadActions({
         if (!failedThreadIds.includes(threadId)) update.commit(threadId);
       }
       update.rollback(failedThreadIds);
+      const succeededThreadIds = update.threadIds.filter(
+        (threadId) => !failedThreadIds.includes(threadId),
+      );
+      await markSyncedMailboxThreadsRead({
+        emailAccountId,
+        read,
+        threadIds: succeededThreadIds,
+      }).catch(() => {});
 
       if (failedThreadIds.length) {
         toast.error(
@@ -253,6 +281,10 @@ export function useThreadActions({
       );
 
       restoreThreads(removal, failedThreadIds);
+      await removeSyncedMailboxThreads({
+        emailAccountId,
+        threadIds: succeededThreadIds,
+      }).catch(() => {});
 
       if (succeededThreadIds.length) {
         toast.success(

--- a/apps/web/utils/email-cache/cleanup.test.ts
+++ b/apps/web/utils/email-cache/cleanup.test.ts
@@ -5,6 +5,7 @@ import { waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scheduleEmailCacheCleanup } from "./cleanup";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
+import { EMAIL_CACHE_MAX_AGE_MS } from "./policy";
 
 const storageDescriptor = Object.getOwnPropertyDescriptor(navigator, "storage");
 const requestIdleCallbackDescriptor = Object.getOwnPropertyDescriptor(
@@ -54,6 +55,22 @@ describe("email cache cleanup", () => {
       lastAccessedAt: now - 1,
       byteSize: 8,
     });
+    await database?.put("mailboxMessages", {
+      emailAccountId: "account-1",
+      messageId: "expired-message",
+      threadId: "expired-thread",
+      data: getMessage("expired-message", "expired-thread"),
+      receivedAt: now - EMAIL_CACHE_MAX_AGE_MS - 1,
+      lastAccessedAt: now,
+    });
+    await database?.put("mailboxMessages", {
+      emailAccountId: "account-1",
+      messageId: "recent-message",
+      threadId: "recent-thread",
+      data: getMessage("recent-message", "recent-thread"),
+      receivedAt: now,
+      lastAccessedAt: now,
+    });
     await database?.put("threadDetails", {
       emailAccountId: "account-1",
       threadId: "newer",
@@ -74,8 +91,29 @@ describe("email cache cleanup", () => {
     await expect(
       database?.get("threadDetails", ["account-1", "newer", variant]),
     ).resolves.toBeDefined();
+    await expect(
+      database?.get("mailboxMessages", ["account-1", "expired-message"]),
+    ).resolves.toBeUndefined();
+    await expect(
+      database?.get("mailboxMessages", ["account-1", "recent-message"]),
+    ).resolves.toBeDefined();
   });
 });
+
+function getMessage(id: string, threadId: string) {
+  const date = new Date().toISOString();
+  return {
+    date,
+    headers: { date, from: "sender@example.com", subject: id, to: "me" },
+    historyId: "1",
+    id,
+    inline: [],
+    internalDate: date,
+    snippet: id,
+    subject: id,
+    threadId,
+  };
+}
 
 function restoreProperty(
   target: object,

--- a/apps/web/utils/email-cache/cleanup.test.ts
+++ b/apps/web/utils/email-cache/cleanup.test.ts
@@ -5,7 +5,10 @@ import { waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scheduleEmailCacheCleanup } from "./cleanup";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
-import { EMAIL_CACHE_MAX_AGE_MS } from "./policy";
+import {
+  EMAIL_CACHE_MAILBOX_MAX_AGE_MS,
+  EMAIL_CACHE_MAX_AGE_MS,
+} from "./policy";
 
 const storageDescriptor = Object.getOwnPropertyDescriptor(navigator, "storage");
 const requestIdleCallbackDescriptor = Object.getOwnPropertyDescriptor(
@@ -60,6 +63,14 @@ describe("email cache cleanup", () => {
       messageId: "expired-message",
       threadId: "expired-thread",
       data: getMessage("expired-message", "expired-thread"),
+      receivedAt: now - EMAIL_CACHE_MAILBOX_MAX_AGE_MS - 1,
+      lastAccessedAt: now,
+    });
+    await database?.put("mailboxMessages", {
+      emailAccountId: "account-1",
+      messageId: "refresh-margin-message",
+      threadId: "refresh-margin-thread",
+      data: getMessage("refresh-margin-message", "refresh-margin-thread"),
       receivedAt: now - EMAIL_CACHE_MAX_AGE_MS - 1,
       lastAccessedAt: now,
     });
@@ -96,6 +107,9 @@ describe("email cache cleanup", () => {
     ).resolves.toBeUndefined();
     await expect(
       database?.get("mailboxMessages", ["account-1", "recent-message"]),
+    ).resolves.toBeDefined();
+    await expect(
+      database?.get("mailboxMessages", ["account-1", "refresh-margin-message"]),
     ).resolves.toBeDefined();
   });
 });

--- a/apps/web/utils/email-cache/cleanup.ts
+++ b/apps/web/utils/email-cache/cleanup.ts
@@ -2,6 +2,7 @@ import { getEmailCacheDatabase } from "./database";
 import {
   EMAIL_CACHE_CLEANUP_INTERVAL_MS,
   EMAIL_CACHE_DEFAULT_DETAIL_BUDGET_BYTES,
+  EMAIL_CACHE_MAILBOX_MAX_AGE_MS,
   EMAIL_CACHE_MAX_AGE_MS,
   EMAIL_CACHE_MAX_DETAIL_BUDGET_BYTES,
   EMAIL_CACHE_MAX_VIEWS_PER_ACCOUNT,
@@ -106,7 +107,9 @@ async function cleanupEmailCache() {
 
     let mailboxMessageCursor = await mailboxMessagesStore
       .index("byReceivedAt")
-      .openCursor(IDBKeyRange.upperBound(now - EMAIL_CACHE_MAX_AGE_MS, true));
+      .openCursor(
+        IDBKeyRange.upperBound(now - EMAIL_CACHE_MAILBOX_MAX_AGE_MS, true),
+      );
     while (mailboxMessageCursor) {
       await mailboxMessageCursor.delete();
       mailboxMessageCursor = await mailboxMessageCursor.continue();

--- a/apps/web/utils/email-cache/cleanup.ts
+++ b/apps/web/utils/email-cache/cleanup.ts
@@ -46,12 +46,13 @@ async function cleanupEmailCache() {
         )
       : EMAIL_CACHE_DEFAULT_DETAIL_BUDGET_BYTES;
     const transaction = database.transaction(
-      ["threadRows", "threadViews", "threadDetails"],
+      ["threadRows", "threadViews", "threadDetails", "mailboxMessages"],
       "readwrite",
     );
     const detailsStore = transaction.objectStore("threadDetails");
     const viewsStore = transaction.objectStore("threadViews");
     const rowsStore = transaction.objectStore("threadRows");
+    const mailboxMessagesStore = transaction.objectStore("mailboxMessages");
     let retainedBytes = 0;
     let detailCursor = await detailsStore
       .index("byLastAccessed")
@@ -101,6 +102,14 @@ async function cleanupEmailCache() {
         await rowCursor.delete();
       }
       rowCursor = await rowCursor.continue();
+    }
+
+    let mailboxMessageCursor = await mailboxMessagesStore
+      .index("byReceivedAt")
+      .openCursor(IDBKeyRange.upperBound(now - EMAIL_CACHE_MAX_AGE_MS, true));
+    while (mailboxMessageCursor) {
+      await mailboxMessageCursor.delete();
+      mailboxMessageCursor = await mailboxMessageCursor.continue();
     }
 
     await transaction.done;

--- a/apps/web/utils/email-cache/database.ts
+++ b/apps/web/utils/email-cache/database.ts
@@ -1,7 +1,8 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import type { ParsedMessage } from "@/utils/types";
 
 const DATABASE_NAME = "inbox-zero-email-cache";
-const DATABASE_VERSION = 1;
+const DATABASE_VERSION = 2;
 
 export type CachedThreadRow = {
   emailAccountId: string;
@@ -30,7 +31,38 @@ export type CachedThreadDetail = {
   byteSize: number;
 };
 
+export type CachedMailboxMessage = {
+  emailAccountId: string;
+  messageId: string;
+  threadId: string;
+  data: ParsedMessage;
+  receivedAt: number;
+  lastAccessedAt: number;
+};
+
+export type CachedMailboxSyncState = {
+  emailAccountId: string;
+  cursor: string;
+  after: string;
+  hasMore: boolean;
+  lastSyncedAt: number;
+  completedAt?: number;
+};
+
 interface EmailCacheSchema extends DBSchema {
+  mailboxMessages: {
+    key: [emailAccountId: string, messageId: string];
+    value: CachedMailboxMessage;
+    indexes: {
+      byAccount: string;
+      byAccountThread: [emailAccountId: string, threadId: string];
+      byReceivedAt: number;
+    };
+  };
+  mailboxSyncStates: {
+    key: string;
+    value: CachedMailboxSyncState;
+  };
   threadDetails: {
     key: [emailAccountId: string, threadId: string, variant: string];
     value: CachedThreadDetail;
@@ -63,23 +95,38 @@ export function getEmailCacheDatabase() {
   if (databasePromise) return databasePromise;
 
   databasePromise = openDB<EmailCacheSchema>(DATABASE_NAME, DATABASE_VERSION, {
-    upgrade(database) {
-      const rows = database.createObjectStore("threadRows", {
-        keyPath: ["emailAccountId", "threadId"],
-      });
-      rows.createIndex("byAccount", "emailAccountId");
+    upgrade(database, oldVersion) {
+      if (oldVersion < 1) {
+        const rows = database.createObjectStore("threadRows", {
+          keyPath: ["emailAccountId", "threadId"],
+        });
+        rows.createIndex("byAccount", "emailAccountId");
 
-      const views = database.createObjectStore("threadViews", {
-        keyPath: ["emailAccountId", "viewKey"],
-      });
-      views.createIndex("byAccount", "emailAccountId");
-      views.createIndex("byLastAccessed", "lastAccessedAt");
+        const views = database.createObjectStore("threadViews", {
+          keyPath: ["emailAccountId", "viewKey"],
+        });
+        views.createIndex("byAccount", "emailAccountId");
+        views.createIndex("byLastAccessed", "lastAccessedAt");
 
-      const details = database.createObjectStore("threadDetails", {
-        keyPath: ["emailAccountId", "threadId", "variant"],
-      });
-      details.createIndex("byAccount", "emailAccountId");
-      details.createIndex("byLastAccessed", "lastAccessedAt");
+        const details = database.createObjectStore("threadDetails", {
+          keyPath: ["emailAccountId", "threadId", "variant"],
+        });
+        details.createIndex("byAccount", "emailAccountId");
+        details.createIndex("byLastAccessed", "lastAccessedAt");
+      }
+
+      if (oldVersion < 2) {
+        const messages = database.createObjectStore("mailboxMessages", {
+          keyPath: ["emailAccountId", "messageId"],
+        });
+        messages.createIndex("byAccount", "emailAccountId");
+        messages.createIndex("byAccountThread", ["emailAccountId", "threadId"]);
+        messages.createIndex("byReceivedAt", "receivedAt");
+
+        database.createObjectStore("mailboxSyncStates", {
+          keyPath: "emailAccountId",
+        });
+      }
     },
     blocking() {
       databasePromise?.then((database) => database?.close());
@@ -123,13 +170,21 @@ export async function clearEmailCache() {
     const database = await getEmailCacheDatabase();
     if (!database) return;
     const transaction = database.transaction(
-      ["threadRows", "threadViews", "threadDetails"],
+      [
+        "threadRows",
+        "threadViews",
+        "threadDetails",
+        "mailboxMessages",
+        "mailboxSyncStates",
+      ],
       "readwrite",
     );
     await Promise.all([
       transaction.objectStore("threadRows").clear(),
       transaction.objectStore("threadViews").clear(),
       transaction.objectStore("threadDetails").clear(),
+      transaction.objectStore("mailboxMessages").clear(),
+      transaction.objectStore("mailboxSyncStates").clear(),
       transaction.done,
     ]);
   } catch {
@@ -153,21 +208,31 @@ export async function clearEmailCacheForAccount(emailAccountId: string) {
     const database = await getEmailCacheDatabase();
     if (!database) return;
     const transaction = database.transaction(
-      ["threadRows", "threadViews", "threadDetails"],
+      [
+        "threadRows",
+        "threadViews",
+        "threadDetails",
+        "mailboxMessages",
+        "mailboxSyncStates",
+      ],
       "readwrite",
     );
     const rows = transaction.objectStore("threadRows");
     const views = transaction.objectStore("threadViews");
     const details = transaction.objectStore("threadDetails");
-    const [rowKeys, viewKeys, detailKeys] = await Promise.all([
+    const messages = transaction.objectStore("mailboxMessages");
+    const [rowKeys, viewKeys, detailKeys, messageKeys] = await Promise.all([
       rows.index("byAccount").getAllKeys(emailAccountId),
       views.index("byAccount").getAllKeys(emailAccountId),
       details.index("byAccount").getAllKeys(emailAccountId),
+      messages.index("byAccount").getAllKeys(emailAccountId),
     ]);
     await Promise.all([
       ...rowKeys.map((key) => rows.delete(key)),
       ...viewKeys.map((key) => views.delete(key)),
       ...detailKeys.map((key) => details.delete(key)),
+      ...messageKeys.map((key) => messages.delete(key)),
+      transaction.objectStore("mailboxSyncStates").delete(emailAccountId),
     ]);
     await transaction.done;
   } catch {

--- a/apps/web/utils/email-cache/database.ts
+++ b/apps/web/utils/email-cache/database.ts
@@ -2,7 +2,7 @@ import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import type { ParsedMessage } from "@/utils/types";
 
 const DATABASE_NAME = "inbox-zero-email-cache";
-const DATABASE_VERSION = 2;
+const DATABASE_VERSION = 3;
 
 export type CachedThreadRow = {
   emailAccountId: string;
@@ -55,6 +55,7 @@ interface EmailCacheSchema extends DBSchema {
     value: CachedMailboxMessage;
     indexes: {
       byAccount: string;
+      byAccountReceivedAt: [emailAccountId: string, receivedAt: number];
       byAccountThread: [emailAccountId: string, threadId: string];
       byReceivedAt: number;
     };
@@ -95,7 +96,7 @@ export function getEmailCacheDatabase() {
   if (databasePromise) return databasePromise;
 
   databasePromise = openDB<EmailCacheSchema>(DATABASE_NAME, DATABASE_VERSION, {
-    upgrade(database, oldVersion) {
+    upgrade(database, oldVersion, _newVersion, transaction) {
       if (oldVersion < 1) {
         const rows = database.createObjectStore("threadRows", {
           keyPath: ["emailAccountId", "threadId"],
@@ -120,12 +121,20 @@ export function getEmailCacheDatabase() {
           keyPath: ["emailAccountId", "messageId"],
         });
         messages.createIndex("byAccount", "emailAccountId");
+        messages.createIndex("byAccountReceivedAt", [
+          "emailAccountId",
+          "receivedAt",
+        ]);
         messages.createIndex("byAccountThread", ["emailAccountId", "threadId"]);
         messages.createIndex("byReceivedAt", "receivedAt");
 
         database.createObjectStore("mailboxSyncStates", {
           keyPath: "emailAccountId",
         });
+      } else if (oldVersion < 3) {
+        transaction
+          .objectStore("mailboxMessages")
+          .createIndex("byAccountReceivedAt", ["emailAccountId", "receivedAt"]);
       }
     },
     blocking() {

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -1,12 +1,16 @@
 import "fake-indexeddb/auto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
 import { readMailboxSyncState } from "./mailbox";
-import { syncMailboxPages } from "./mailbox-sync";
+import { fetchMailboxSyncPage, syncMailboxPages } from "./mailbox-sync";
 
 describe("mailbox sync coordinator", () => {
   beforeEach(async () => {
     await clearEmailCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("starts with a recent snapshot and follows cursors to completion", async () => {
@@ -212,5 +216,44 @@ describe("mailbox sync coordinator", () => {
 
     await expect(sync).resolves.toEqual({ hasMore: false, pagesSynced: 0 });
     await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
+  });
+
+  it("sends the account-scoped sync request through the app API", async () => {
+    const page = {
+      accountId: "account-1",
+      cursor: "cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: true,
+      upsertedMessages: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(page),
+      ok: true,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchMailboxSyncPage("account-1", { cursor: "before", limit: 100 }),
+    ).resolves.toEqual(page);
+    expect(fetchMock).toHaveBeenCalledWith("/api/mobile/mailbox-sync", {
+      body: JSON.stringify({ cursor: "before", limit: 100 }),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Email-Account-ID": "account-1",
+      },
+      method: "POST",
+    });
+  });
+
+  it("surfaces a failed app API response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(
+      fetchMailboxSyncPage("account-1", { limit: 100 }),
+    ).rejects.toThrow("Mailbox sync failed with status 503");
   });
 });

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { clearEmailCache } from "./database";
+import { clearEmailCache, getEmailCacheDatabase } from "./database";
 import { readMailboxSyncState } from "./mailbox";
 import { syncMailboxPages } from "./mailbox-sync";
 
@@ -122,6 +122,43 @@ describe("mailbox sync coordinator", () => {
     expect(await readMailboxSyncState("account-1")).toMatchObject({
       after: "2026-07-24T12:00:00.000Z",
       cursor: "new-cursor",
+    });
+  });
+
+  it.each([
+    {
+      after: "2026-08-01T12:00:00.000Z",
+      cursor: "",
+      state: "missing cursor",
+    },
+    { after: "invalid", cursor: "old-cursor", state: "invalid after date" },
+  ])("refreshes a persisted state with $state", async ({ after, cursor }) => {
+    const database = await getEmailCacheDatabase();
+    await database?.put("mailboxSyncStates", {
+      after,
+      cursor,
+      emailAccountId: "account-1",
+      hasMore: false,
+      lastSyncedAt: 1,
+    });
+    const fetchPage = vi.fn().mockResolvedValue({
+      accountId: "account-1",
+      cursor: "new-cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: true,
+      upsertedMessages: [],
+    });
+
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage,
+      now: new Date("2026-08-23T12:00:00.000Z"),
+    });
+
+    expect(fetchPage).toHaveBeenCalledWith({
+      after: "2026-07-24T12:00:00.000Z",
+      limit: 100,
     });
   });
 

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -6,6 +6,7 @@ import { fetchMailboxSyncPage, syncMailboxPages } from "./mailbox-sync";
 
 describe("mailbox sync coordinator", () => {
   beforeEach(async () => {
+    vi.clearAllMocks();
     await clearEmailCache();
   });
 

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -1,0 +1,179 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearEmailCache } from "./database";
+import { readMailboxSyncState } from "./mailbox";
+import { syncMailboxPages } from "./mailbox-sync";
+
+describe("mailbox sync coordinator", () => {
+  beforeEach(async () => {
+    await clearEmailCache();
+  });
+
+  it("starts with a recent snapshot and follows cursors to completion", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        accountId: "account-1",
+        cursor: "cursor-1",
+        deletedMessageIds: [],
+        hasMore: true,
+        reset: true,
+        upsertedMessages: [],
+      })
+      .mockResolvedValueOnce({
+        accountId: "account-1",
+        cursor: "cursor-2",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: false,
+        upsertedMessages: [],
+      });
+
+    await expect(
+      syncMailboxPages({
+        emailAccountId: "account-1",
+        fetchPage,
+        now: new Date("2026-08-23T12:00:00.000Z"),
+      }),
+    ).resolves.toEqual({ hasMore: false, pagesSynced: 2 });
+    expect(fetchPage).toHaveBeenNthCalledWith(1, {
+      after: "2026-07-24T12:00:00.000Z",
+      limit: 100,
+    });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, {
+      cursor: "cursor-1",
+      limit: 100,
+    });
+    expect(await readMailboxSyncState("account-1")).toMatchObject({
+      cursor: "cursor-2",
+      hasMore: false,
+    });
+  });
+
+  it("resumes from the persisted cursor and bounds work per run", async () => {
+    const initialFetch = vi.fn().mockResolvedValue({
+      accountId: "account-1",
+      cursor: "cursor-1",
+      deletedMessageIds: [],
+      hasMore: true,
+      reset: true,
+      upsertedMessages: [],
+    });
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: initialFetch,
+      maxPages: 1,
+      now: new Date("2026-08-23T12:00:00.000Z"),
+    });
+
+    const resumedFetch = vi.fn().mockResolvedValue({
+      accountId: "account-1",
+      cursor: "cursor-2",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: false,
+      upsertedMessages: [],
+    });
+    await expect(
+      syncMailboxPages({
+        emailAccountId: "account-1",
+        fetchPage: resumedFetch,
+        maxPages: 1,
+      }),
+    ).resolves.toEqual({ hasMore: false, pagesSynced: 1 });
+    expect(resumedFetch).toHaveBeenCalledWith({
+      cursor: "cursor-1",
+      limit: 100,
+    });
+  });
+
+  it("periodically refreshes the rolling mailbox window", async () => {
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: vi.fn().mockResolvedValue({
+        accountId: "account-1",
+        cursor: "old-cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [],
+      }),
+      now: new Date("2026-07-01T12:00:00.000Z"),
+    });
+
+    const refreshFetch = vi.fn().mockResolvedValue({
+      accountId: "account-1",
+      cursor: "new-cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: true,
+      upsertedMessages: [],
+    });
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: refreshFetch,
+      now: new Date("2026-08-23T12:00:00.000Z"),
+    });
+
+    expect(refreshFetch).toHaveBeenCalledWith({
+      after: "2026-07-24T12:00:00.000Z",
+      limit: 100,
+    });
+    expect(await readMailboxSyncState("account-1")).toMatchObject({
+      after: "2026-07-24T12:00:00.000Z",
+      cursor: "new-cursor",
+    });
+  });
+
+  it("rejects a response for a different account before persisting it", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      accountId: "account-2",
+      cursor: "cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: true,
+      upsertedMessages: [],
+    });
+
+    await expect(
+      syncMailboxPages({
+        emailAccountId: "account-1",
+        fetchPage,
+      }),
+    ).rejects.toThrow("Mailbox sync response account mismatch");
+    await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
+  });
+
+  it("does not repopulate an account cache cleared during a request", async () => {
+    const requestStarted = Promise.withResolvers<void>();
+    const pendingPage = Promise.withResolvers<{
+      accountId: string;
+      cursor: string;
+      deletedMessageIds: string[];
+      hasMore: boolean;
+      reset: boolean;
+      upsertedMessages: never[];
+    }>();
+    const sync = syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: () => {
+        requestStarted.resolve();
+        return pendingPage.promise;
+      },
+    });
+    await requestStarted.promise;
+
+    await clearEmailCache();
+    pendingPage.resolve({
+      accountId: "account-1",
+      cursor: "cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: true,
+      upsertedMessages: [],
+    });
+
+    await expect(sync).resolves.toEqual({ hasMore: false, pagesSynced: 0 });
+    await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/utils/email-cache/mailbox-sync.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.ts
@@ -37,18 +37,23 @@ export async function syncMailboxPages({
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
     return { hasMore: false, pagesSynced: 0 };
   }
-  const shouldRefreshWindow =
-    !state ||
-    new Date(state.after).getTime() <
+  const stateAfterTimestamp = state
+    ? new Date(state.after).getTime()
+    : Number.NaN;
+  const resumeCursor =
+    state?.cursor &&
+    Number.isFinite(stateAfterTimestamp) &&
+    stateAfterTimestamp >=
       syncStartedAt.getTime() -
-        (DEFAULT_SYNC_DAYS + SYNC_WINDOW_REFRESH_DAYS) * ONE_DAY_MS;
-  const initialAfter = shouldRefreshWindow
-    ? new Date(syncStartedAt.getTime() - DEFAULT_SYNC_DAYS * ONE_DAY_MS)
-    : undefined;
-  let input: MailboxSyncInput =
-    state?.cursor && !shouldRefreshWindow
-      ? { cursor: state.cursor, limit: DEFAULT_PAGE_LIMIT }
-      : { after: initialAfter!.toISOString(), limit: DEFAULT_PAGE_LIMIT };
+        (DEFAULT_SYNC_DAYS + SYNC_WINDOW_REFRESH_DAYS) * ONE_DAY_MS
+      ? state.cursor
+      : undefined;
+  const initialAfter = new Date(
+    syncStartedAt.getTime() - DEFAULT_SYNC_DAYS * ONE_DAY_MS,
+  );
+  let input: MailboxSyncInput = resumeCursor
+    ? { cursor: resumeCursor, limit: DEFAULT_PAGE_LIMIT }
+    : { after: initialAfter.toISOString(), limit: DEFAULT_PAGE_LIMIT };
   let hasMore = true;
   let pagesSynced = 0;
 
@@ -64,7 +69,7 @@ export async function syncMailboxPages({
     await applyMailboxSyncPage({
       emailAccountId,
       page,
-      after: initialAfter,
+      after: resumeCursor ? undefined : initialAfter,
       now: now?.getTime() ?? Date.now(),
     });
     pagesSynced += 1;

--- a/apps/web/utils/email-cache/mailbox-sync.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.ts
@@ -1,0 +1,94 @@
+import type { MailboxSyncResponse } from "@/app/api/mobile/mailbox-sync/route";
+import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
+import { ONE_DAY_MS } from "@/utils/date";
+import { captureEmailCacheEpoch, isEmailCacheEpochCurrent } from "./database";
+import { applyMailboxSyncPage, readMailboxSyncState } from "./mailbox";
+
+const DEFAULT_SYNC_DAYS = 30;
+const SYNC_WINDOW_REFRESH_DAYS = 7;
+const DEFAULT_PAGE_LIMIT = 100;
+const DEFAULT_MAX_PAGES = 10;
+
+export type MailboxSyncInput = {
+  after?: string;
+  cursor?: string;
+  limit: number;
+};
+
+export async function syncMailboxPages({
+  emailAccountId,
+  fetchPage,
+  now,
+  maxPages = DEFAULT_MAX_PAGES,
+}: {
+  emailAccountId: string;
+  fetchPage: (input: MailboxSyncInput) => Promise<MailboxSyncResponse>;
+  now?: Date;
+  maxPages?: number;
+}) {
+  if (!Number.isInteger(maxPages) || maxPages < 1) {
+    throw new Error("maxPages must be a positive integer");
+  }
+
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+  if (!epoch) return { hasMore: false, pagesSynced: 0 };
+  const syncStartedAt = now ?? new Date();
+  const state = await readMailboxSyncState(emailAccountId);
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
+    return { hasMore: false, pagesSynced: 0 };
+  }
+  const shouldRefreshWindow =
+    !state ||
+    new Date(state.after).getTime() <
+      syncStartedAt.getTime() -
+        (DEFAULT_SYNC_DAYS + SYNC_WINDOW_REFRESH_DAYS) * ONE_DAY_MS;
+  const initialAfter = shouldRefreshWindow
+    ? new Date(syncStartedAt.getTime() - DEFAULT_SYNC_DAYS * ONE_DAY_MS)
+    : undefined;
+  let input: MailboxSyncInput =
+    state?.cursor && !shouldRefreshWindow
+      ? { cursor: state.cursor, limit: DEFAULT_PAGE_LIMIT }
+      : { after: initialAfter!.toISOString(), limit: DEFAULT_PAGE_LIMIT };
+  let hasMore = true;
+  let pagesSynced = 0;
+
+  while (hasMore && pagesSynced < maxPages) {
+    const response = await fetchPage(input);
+    if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
+      return { hasMore: false, pagesSynced };
+    }
+    if (response.accountId !== emailAccountId) {
+      throw new Error("Mailbox sync response account mismatch");
+    }
+    const { accountId: _accountId, ...page } = response;
+    await applyMailboxSyncPage({
+      emailAccountId,
+      page,
+      after: initialAfter,
+      now: now?.getTime() ?? Date.now(),
+    });
+    pagesSynced += 1;
+    hasMore = page.hasMore;
+    input = { cursor: page.cursor, limit: DEFAULT_PAGE_LIMIT };
+  }
+
+  return { hasMore, pagesSynced };
+}
+
+export async function fetchMailboxSyncPage(
+  emailAccountId: string,
+  input: MailboxSyncInput,
+): Promise<MailboxSyncResponse> {
+  const response = await fetch("/api/mobile/mailbox-sync", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [EMAIL_ACCOUNT_HEADER]: emailAccountId,
+    },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    throw new Error(`Mailbox sync failed with status ${response.status}`);
+  }
+  return response.json();
+}

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -247,6 +247,16 @@ describe("synced mailbox cache", () => {
     expect(snapshot?.threads[0]?.messages.map((message) => message.id)).toEqual(
       ["earlier-message", "message-2", "message-3"],
     );
+
+    const limitedInbox = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: { type: "inbox" },
+      limit: 1,
+    });
+    expect(limitedInbox).toMatchObject({
+      truncated: true,
+      threads: [{ id: "thread-2" }],
+    });
   });
 
   it("supports unread, sender, label, folder, and date filters", async () => {

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "vitest";
-import { clearEmailCache } from "./database";
+import { clearEmailCache, getEmailCacheDatabase } from "./database";
 import {
   applyMailboxSyncPage,
   markSyncedMailboxThreadsRead,
@@ -105,6 +105,56 @@ describe("synced mailbox cache", () => {
       "new-thread",
     ]);
     expect(snapshot?.after).toBe("2026-07-25T00:00:00.000Z");
+  });
+
+  it("filters inbox rows and gives malformed dates a valid cleanup key", async () => {
+    const dateFallback = getMessage({
+      id: "date-fallback",
+      threadId: "valid-thread",
+    });
+    dateFallback.internalDate = "invalid";
+    dateFallback.date = "2026-08-22T10:00:00.000Z";
+    const nowFallback = getMessage({
+      id: "now-fallback",
+      threadId: "non-inbox-thread",
+      internalDate: "invalid",
+      labelIds: [],
+    });
+    nowFallback.date = "invalid";
+    const missingLabels = getMessage({
+      id: "missing-labels",
+      threadId: "missing-label-thread",
+    });
+    missingLabels.labelIds = undefined;
+
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      now: 500,
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [dateFallback, nowFallback, missingLabels],
+      },
+    });
+
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { type: "inbox" },
+      }),
+    ).resolves.toMatchObject({ threads: [{ id: "valid-thread" }] });
+    const database = await getEmailCacheDatabase();
+    await expect(
+      database?.get("mailboxMessages", ["account-1", "date-fallback"]),
+    ).resolves.toMatchObject({
+      receivedAt: new Date("2026-08-22T10:00:00.000Z").getTime(),
+    });
+    await expect(
+      database?.get("mailboxMessages", ["account-1", "now-fallback"]),
+    ).resolves.toMatchObject({ receivedAt: 500 });
   });
 
   it("derives sorted inbox and split views while preserving server plans", async () => {

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -18,6 +18,7 @@ import type { ParsedMessage } from "@/utils/types";
 
 describe("synced mailbox cache", () => {
   beforeEach(async () => {
+    vi.clearAllMocks();
     await clearEmailCache();
   });
 

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -1,0 +1,352 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearEmailCache } from "./database";
+import {
+  applyMailboxSyncPage,
+  markSyncedMailboxThreadsRead,
+  readMailboxSyncState,
+  readSyncedMailboxThreads,
+  removeSyncedMailboxThreads,
+} from "./mailbox";
+import { writeCachedThreadList } from "./thread-lists";
+import type { ParsedMessage } from "@/utils/types";
+
+describe("synced mailbox cache", () => {
+  beforeEach(async () => {
+    await clearEmailCache();
+  });
+
+  it("applies snapshots and deltas atomically with their cursor", async () => {
+    const first = getMessage({
+      id: "message-1",
+      threadId: "thread-1",
+      internalDate: "2026-08-20T10:00:00.000Z",
+    });
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      now: 100,
+      page: {
+        cursor: "cursor-1",
+        deletedMessageIds: [],
+        hasMore: true,
+        reset: true,
+        upsertedMessages: [first],
+      },
+    });
+
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      now: 200,
+      page: {
+        cursor: "cursor-2",
+        deletedMessageIds: [first.id],
+        hasMore: false,
+        reset: false,
+        upsertedMessages: [
+          getMessage({
+            id: "message-2",
+            threadId: "thread-2",
+            internalDate: "2026-08-21T10:00:00.000Z",
+          }),
+        ],
+      },
+    });
+
+    await expect(readMailboxSyncState("account-1")).resolves.toEqual({
+      after: "2026-07-24T00:00:00.000Z",
+      completedAt: 200,
+      cursor: "cursor-2",
+      emailAccountId: "account-1",
+      hasMore: false,
+      lastSyncedAt: 200,
+    });
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { type: "inbox" },
+      }),
+    ).resolves.toMatchObject({
+      complete: true,
+      syncedAt: 200,
+      threads: [{ id: "thread-2" }],
+    });
+  });
+
+  it("replaces account messages when the provider requests a reset", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "old",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [getMessage({ id: "old", threadId: "old-thread" })],
+      },
+    });
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-25T00:00:00.000Z"),
+      page: {
+        cursor: "new",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [getMessage({ id: "new", threadId: "new-thread" })],
+      },
+    });
+
+    const snapshot = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: { type: "inbox" },
+    });
+    expect(snapshot?.threads.map((thread) => thread.id)).toEqual([
+      "new-thread",
+    ]);
+    expect(snapshot?.after).toBe("2026-07-25T00:00:00.000Z");
+  });
+
+  it("derives sorted inbox and split views while preserving server plans", async () => {
+    const plan = { id: "execution-1", rule: { id: "rule-1" } };
+    await writeCachedThreadList({
+      emailAccountId: "account-1",
+      viewKey: "existing-view",
+      hasMore: false,
+      threads: [
+        {
+          id: "thread-2",
+          messages: [
+            {
+              date: "2026-08-19T10:00:00.000Z",
+              headers: {
+                date: "2026-08-19T10:00:00.000Z",
+                from: "Earlier <earlier@example.com>",
+                subject: "earlier subject",
+                to: "user@example.com",
+              },
+              id: "earlier-message",
+              internalDate: "2026-08-19T10:00:00.000Z",
+              snippet: "earlier snippet",
+              subject: "earlier subject",
+              threadId: "thread-2",
+            },
+          ],
+          plan,
+          plans: [plan],
+          snippet: "old",
+        },
+      ],
+    });
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      now: 300,
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "message-1",
+            threadId: "thread-1",
+            internalDate: "2026-08-20T10:00:00.000Z",
+            labelIds: ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+          }),
+          getMessage({
+            id: "message-2",
+            threadId: "thread-2",
+            internalDate: "2026-08-22T10:00:00.000Z",
+            labelIds: ["INBOX", "UNREAD", "CATEGORY_UPDATES"],
+          }),
+          getMessage({
+            id: "message-3",
+            threadId: "thread-2",
+            internalDate: "2026-08-23T10:00:00.000Z",
+            labelIds: ["INBOX", "CATEGORY_UPDATES"],
+          }),
+          getMessage({
+            id: "ignored-message",
+            threadId: "ignored-thread",
+            from: "Reminder <reminder@superhuman.com>",
+            internalDate: "2026-08-23T11:00:00.000Z",
+            labelIds: ["INBOX", "CATEGORY_UPDATES"],
+          }),
+        ],
+      },
+    });
+
+    const snapshot = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: { type: "CATEGORY_UPDATES" },
+      limit: 20,
+    });
+
+    expect(snapshot?.threads.map((thread) => thread.id)).toEqual([
+      "thread-2",
+      "thread-1",
+    ]);
+    expect(snapshot?.complete).toBe(false);
+    expect(snapshot?.threads[0]).toMatchObject({
+      id: "thread-2",
+      plan,
+      plans: [plan],
+      snippet: "message-3 snippet",
+    });
+    expect(snapshot?.threads[0]?.messages.map((message) => message.id)).toEqual(
+      ["earlier-message", "message-2", "message-3"],
+    );
+  });
+
+  it("supports unread, sender, label, folder, and date filters", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "match",
+            threadId: "matching-thread",
+            from: "Person <person@example.com>",
+            internalDate: "2026-08-22T10:00:00.000Z",
+            labelIds: ["INBOX", "UNREAD", "custom-label"],
+            parentFolderId: "folder-1",
+          }),
+          getMessage({
+            id: "miss",
+            threadId: "other-thread",
+            internalDate: "2026-08-19T10:00:00.000Z",
+            labelIds: ["INBOX"],
+            parentFolderId: "folder-2",
+          }),
+        ],
+      },
+    });
+
+    const snapshot = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: {
+        after: new Date("2026-08-21T00:00:00.000Z"),
+        before: new Date("2026-08-23T00:00:00.000Z"),
+        folderId: "folder-1",
+        fromEmail: "person@example.com",
+        isUnread: true,
+        labelId: "custom-label",
+      },
+    });
+
+    expect(snapshot?.threads.map((thread) => thread.id)).toEqual([
+      "matching-thread",
+    ]);
+  });
+
+  it("falls back for views the inbox snapshot cannot answer correctly", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [],
+      },
+    });
+
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { type: "sent" },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { inboxSection: "focused", type: "inbox" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reconciles read and removal mutations into the canonical store", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "message-1",
+            threadId: "thread-1",
+            labelIds: ["INBOX", "UNREAD"],
+          }),
+        ],
+      },
+    });
+
+    await markSyncedMailboxThreadsRead({
+      emailAccountId: "account-1",
+      read: true,
+      threadIds: ["thread-1"],
+    });
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { isUnread: true, type: "inbox" },
+      }),
+    ).resolves.toMatchObject({ threads: [] });
+
+    await removeSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      threadIds: ["thread-1"],
+    });
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { type: "inbox" },
+      }),
+    ).resolves.toMatchObject({ threads: [] });
+  });
+});
+
+function getMessage({
+  id,
+  threadId,
+  from = "Sender <sender@example.com>",
+  internalDate = "2026-08-23T10:00:00.000Z",
+  labelIds = ["INBOX"],
+  parentFolderId,
+}: {
+  id: string;
+  threadId: string;
+  from?: string;
+  internalDate?: string;
+  labelIds?: string[];
+  parentFolderId?: string;
+}): ParsedMessage {
+  return {
+    date: internalDate,
+    headers: {
+      date: internalDate,
+      from,
+      subject: `${id} subject`,
+      to: "user@example.com",
+    },
+    historyId: "history-id",
+    id,
+    inline: [],
+    internalDate,
+    labelIds,
+    parentFolderId,
+    snippet: `${id} snippet`,
+    subject: `${id} subject`,
+    threadId,
+  };
+}

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -1,12 +1,17 @@
 import "fake-indexeddb/auto";
-import { beforeEach, describe, expect, it } from "vitest";
-import { clearEmailCache, getEmailCacheDatabase } from "./database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearEmailCache,
+  clearEmailCacheForAccount,
+  getEmailCacheDatabase,
+} from "./database";
 import {
   applyMailboxSyncPage,
   markSyncedMailboxThreadsRead,
   readMailboxSyncState,
   readSyncedMailboxThreads,
   removeSyncedMailboxThreads,
+  subscribeToMailboxStore,
 } from "./mailbox";
 import { writeCachedThreadList } from "./thread-lists";
 import type { ParsedMessage } from "@/utils/types";
@@ -373,6 +378,73 @@ describe("synced mailbox cache", () => {
         query: { type: "inbox" },
       }),
     ).resolves.toMatchObject({ threads: [] });
+  });
+
+  it("clears mailbox data for one account without affecting another", async () => {
+    for (const emailAccountId of ["account-1", "account-2"]) {
+      await applyMailboxSyncPage({
+        emailAccountId,
+        after: new Date("2026-07-24T00:00:00.000Z"),
+        page: {
+          cursor: `${emailAccountId}-cursor`,
+          deletedMessageIds: [],
+          hasMore: false,
+          reset: true,
+          upsertedMessages: [
+            getMessage({
+              id: `${emailAccountId}-message`,
+              threadId: `${emailAccountId}-thread`,
+            }),
+          ],
+        },
+      });
+    }
+
+    await clearEmailCacheForAccount("account-1");
+
+    await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query: { type: "inbox" },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(readMailboxSyncState("account-2")).resolves.toMatchObject({
+      cursor: "account-2-cursor",
+    });
+    await expect(
+      readSyncedMailboxThreads({
+        emailAccountId: "account-2",
+        query: { type: "inbox" },
+      }),
+    ).resolves.toMatchObject({ threads: [{ id: "account-2-thread" }] });
+  });
+
+  it("notifies active subscribers after mailbox changes", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToMailboxStore(listener);
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({ id: "message-1", threadId: "thread-1" }),
+        ],
+      },
+    });
+    expect(listener).toHaveBeenCalledWith("account-1");
+
+    unsubscribe();
+    await markSyncedMailboxThreadsRead({
+      emailAccountId: "account-1",
+      read: true,
+      threadIds: ["thread-1"],
+    });
+    expect(listener).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -244,7 +244,7 @@ function toCachedMailboxMessage(
     messageId: message.id,
     threadId: message.threadId,
     data: message,
-    receivedAt: getMessageTimestamp(message),
+    receivedAt: getMessageTimestamp(message, now),
     lastAccessedAt: now,
   };
 }
@@ -284,6 +284,7 @@ function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {
   const requiredLabelIds = [
     ...(query.labelIds ?? []),
     ...(query.labelId ? [query.labelId] : []),
+    ...(query.type === "inbox" || query.type === "unread" ? ["INBOX"] : []),
     ...(query.type?.startsWith("CATEGORY_") ? [query.type] : []),
   ];
   if (
@@ -335,7 +336,8 @@ function toListThread(
     messagesById.set(message.id, toListMessage(message));
   }
   const listMessages = [...messagesById.values()].sort(sortByInternalDate());
-  const latest = listMessages.at(-1)!;
+  const latest = listMessages.at(-1);
+  if (!latest) throw new Error("Synced mailbox thread has no messages");
   return {
     id: threadId,
     snippet: latest.snippet,
@@ -363,10 +365,16 @@ function getCachedThread(value: unknown): ThreadListItem | undefined {
   return value as ThreadListItem;
 }
 
-function getMessageTimestamp(message: ParsedMessage | undefined) {
-  return internalDateToDate(message?.internalDate, {
+function getMessageTimestamp(message: ParsedMessage | undefined, fallback = 0) {
+  const internalTimestamp = internalDateToDate(message?.internalDate, {
     fallbackToNow: false,
   }).getTime();
+  if (Number.isFinite(internalTimestamp)) return internalTimestamp;
+
+  const dateTimestamp = internalDateToDate(message?.date, {
+    fallbackToNow: false,
+  }).getTime();
+  return Number.isFinite(dateTimestamp) ? dateTimestamp : fallback;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -121,10 +121,40 @@ export async function readSyncedMailboxThreads({
       return;
     }
 
-    const records = await transaction
-      .objectStore("mailboxMessages")
-      .index("byAccount")
-      .getAll(emailAccountId);
+    const messagesStore = transaction.objectStore("mailboxMessages");
+    let records: CachedMailboxMessage[];
+    if (isRecentInboxQuery(query)) {
+      const selectedThreadIds = new Set<string>();
+      let cursor = await messagesStore
+        .index("byAccountReceivedAt")
+        .openCursor(
+          IDBKeyRange.bound(
+            [emailAccountId, Number.MIN_SAFE_INTEGER],
+            [emailAccountId, Number.MAX_SAFE_INTEGER],
+          ),
+          "prev",
+        );
+      while (cursor && selectedThreadIds.size < limit) {
+        const message = cursor.value.data;
+        if (
+          message.labelIds?.includes("INBOX") &&
+          !isIgnoredSender(message.headers.from)
+        ) {
+          selectedThreadIds.add(message.threadId);
+        }
+        cursor = await cursor.continue();
+      }
+      const byThread = messagesStore.index("byAccountThread");
+      records = (
+        await Promise.all(
+          [...selectedThreadIds].map((threadId) =>
+            byThread.getAll([emailAccountId, threadId]),
+          ),
+        )
+      ).flat();
+    } else {
+      records = await messagesStore.index("byAccount").getAll(emailAccountId);
+    }
     const messagesByThread = groupMessagesByThread(
       records
         .map((record) => record.data)
@@ -278,6 +308,19 @@ function isSupportedMailboxQuery(query: ThreadsQuery) {
 
 function isCompleteMailboxQuery(query: ThreadsQuery) {
   return query.type === "inbox" || query.type === "unread";
+}
+
+function isRecentInboxQuery(query: ThreadsQuery) {
+  return (
+    query.type === "inbox" &&
+    !query.fromEmail &&
+    !query.folderId &&
+    !query.isUnread &&
+    !query.labelId &&
+    !query.labelIds?.length &&
+    !query.after &&
+    !query.before
+  );
 }
 
 function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -1,0 +1,374 @@
+import { internalDateToDate, sortByInternalDate } from "@/utils/date";
+import { canonicalizeEmailAddress } from "@/utils/email";
+import type { MailboxSyncPage } from "@/utils/email/types";
+import { isIgnoredSender } from "@/utils/filter-ignored-senders";
+import type { ThreadListItem } from "@/utils/threads/load";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+import type { ParsedMessage } from "@/utils/types";
+import { scheduleEmailCacheCleanup } from "./cleanup";
+import {
+  captureEmailCacheEpoch,
+  getEmailCacheDatabase,
+  isEmailCacheEpochCurrent,
+  type CachedMailboxMessage,
+} from "./database";
+
+const mailboxListeners = new Set<(emailAccountId: string) => void>();
+
+export type SyncedMailboxSnapshot = {
+  after: string;
+  complete: boolean;
+  syncedAt: number;
+  threads: ThreadListItem[];
+};
+
+export async function applyMailboxSyncPage({
+  emailAccountId,
+  page,
+  after,
+  now = Date.now(),
+}: {
+  emailAccountId: string;
+  page: MailboxSyncPage;
+  after?: Date;
+  now?: number;
+}) {
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+  const database = await getEmailCacheDatabase();
+  if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+
+  const transaction = database.transaction(
+    ["mailboxMessages", "mailboxSyncStates"],
+    "readwrite",
+  );
+  const messages = transaction.objectStore("mailboxMessages");
+  const states = transaction.objectStore("mailboxSyncStates");
+  const currentState = await states.get(emailAccountId);
+  const syncAfter = after?.toISOString() ?? currentState?.after;
+  if (!syncAfter) {
+    transaction.abort();
+    await transaction.done.catch(() => {});
+    throw new Error("Mailbox sync reset requires an after date");
+  }
+
+  if (page.reset) {
+    const messageKeys = await messages
+      .index("byAccount")
+      .getAllKeys(emailAccountId);
+    await Promise.all(messageKeys.map((key) => messages.delete(key)));
+  }
+
+  await Promise.all([
+    ...page.deletedMessageIds.map((messageId) =>
+      messages.delete([emailAccountId, messageId]),
+    ),
+    ...page.upsertedMessages.map((message) =>
+      messages.put(toCachedMailboxMessage(emailAccountId, message, now)),
+    ),
+    states.put({
+      emailAccountId,
+      cursor: page.cursor,
+      after: syncAfter,
+      hasMore: page.hasMore,
+      lastSyncedAt: now,
+      completedAt: page.hasMore ? currentState?.completedAt : now,
+    }),
+  ]);
+  await transaction.done;
+
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  scheduleEmailCacheCleanup();
+  notifyMailboxListeners(emailAccountId);
+}
+
+export async function readMailboxSyncState(emailAccountId: string) {
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+  try {
+    const database = await getEmailCacheDatabase();
+    if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+    const state = await database.get("mailboxSyncStates", emailAccountId);
+    if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+    return state;
+  } catch {
+    return;
+  }
+}
+
+export async function readSyncedMailboxThreads({
+  emailAccountId,
+  query,
+  limit = query.limit ?? 50,
+}: {
+  emailAccountId: string;
+  query: ThreadsQuery;
+  limit?: number;
+}): Promise<SyncedMailboxSnapshot | undefined> {
+  if (!isSupportedMailboxQuery(query)) return;
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+
+  try {
+    const database = await getEmailCacheDatabase();
+    if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+    const transaction = database.transaction(
+      ["mailboxMessages", "mailboxSyncStates", "threadRows"],
+      "readonly",
+    );
+    const state = await transaction
+      .objectStore("mailboxSyncStates")
+      .get(emailAccountId);
+    if (!state) {
+      await transaction.done;
+      return;
+    }
+
+    const records = await transaction
+      .objectStore("mailboxMessages")
+      .index("byAccount")
+      .getAll(emailAccountId);
+    const messagesByThread = groupMessagesByThread(
+      records
+        .map((record) => record.data)
+        .filter((message) => !isIgnoredSender(message.headers.from)),
+    );
+    const matchingThreads = [...messagesByThread.entries()]
+      .filter(([, messages]) => threadMatchesQuery(messages, query))
+      .sort(
+        ([, left], [, right]) =>
+          getMessageTimestamp(right.at(-1)) - getMessageTimestamp(left.at(-1)),
+      )
+      .slice(0, limit);
+
+    const rows = transaction.objectStore("threadRows");
+    const threads = await Promise.all(
+      matchingThreads.map(async ([threadId, messages]) => {
+        const cachedRow = await rows.get([emailAccountId, threadId]);
+        return toListThread(threadId, messages, cachedRow?.data);
+      }),
+    );
+    await transaction.done;
+    if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+
+    return {
+      after: state.after,
+      complete: Boolean(
+        state.completedAt && !state.hasMore && isCompleteMailboxQuery(query),
+      ),
+      syncedAt: state.lastSyncedAt,
+      threads,
+    };
+  } catch {
+    return;
+  }
+}
+
+export async function markSyncedMailboxThreadsRead({
+  emailAccountId,
+  threadIds,
+  read,
+}: {
+  emailAccountId: string;
+  threadIds: string[];
+  read: boolean;
+}) {
+  if (!threadIds.length) return;
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+  const database = await getEmailCacheDatabase();
+  if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  const transaction = database.transaction("mailboxMessages", "readwrite");
+  const store = transaction.objectStore("mailboxMessages");
+  const index = store.index("byAccountThread");
+
+  for (const threadId of new Set(threadIds)) {
+    const records = await index.getAll([emailAccountId, threadId]);
+    for (const record of records) {
+      const currentLabels = record.data.labelIds ?? [];
+      const labelIds = read
+        ? currentLabels.filter((labelId) => labelId !== "UNREAD")
+        : [...new Set([...currentLabels, "UNREAD"])];
+      await store.put({
+        ...record,
+        data: { ...record.data, labelIds },
+        lastAccessedAt: Date.now(),
+      });
+    }
+  }
+
+  await transaction.done;
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  notifyMailboxListeners(emailAccountId);
+}
+
+export async function removeSyncedMailboxThreads({
+  emailAccountId,
+  threadIds,
+}: {
+  emailAccountId: string;
+  threadIds: string[];
+}) {
+  if (!threadIds.length) return;
+  const epoch = captureEmailCacheEpoch(emailAccountId);
+  const database = await getEmailCacheDatabase();
+  if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  const transaction = database.transaction("mailboxMessages", "readwrite");
+  const store = transaction.objectStore("mailboxMessages");
+  const index = store.index("byAccountThread");
+
+  for (const threadId of new Set(threadIds)) {
+    const keys = await index.getAllKeys([emailAccountId, threadId]);
+    await Promise.all(keys.map((key) => store.delete(key)));
+  }
+
+  await transaction.done;
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  notifyMailboxListeners(emailAccountId);
+}
+
+export function subscribeToMailboxStore(
+  listener: (emailAccountId: string) => void,
+) {
+  mailboxListeners.add(listener);
+  return () => mailboxListeners.delete(listener);
+}
+
+function notifyMailboxListeners(emailAccountId: string) {
+  for (const listener of mailboxListeners) listener(emailAccountId);
+}
+
+function toCachedMailboxMessage(
+  emailAccountId: string,
+  message: ParsedMessage,
+  now: number,
+): CachedMailboxMessage {
+  return {
+    emailAccountId,
+    messageId: message.id,
+    threadId: message.threadId,
+    data: message,
+    receivedAt: getMessageTimestamp(message),
+    lastAccessedAt: now,
+  };
+}
+
+function groupMessagesByThread(messages: ParsedMessage[]) {
+  const messagesByThread = new Map<string, ParsedMessage[]>();
+  for (const message of messages) {
+    const threadMessages = messagesByThread.get(message.threadId) ?? [];
+    threadMessages.push(message);
+    messagesByThread.set(message.threadId, threadMessages);
+  }
+  for (const threadMessages of messagesByThread.values()) {
+    threadMessages.sort(sortByInternalDate());
+  }
+  return messagesByThread;
+}
+
+function isSupportedMailboxQuery(query: ThreadsQuery) {
+  if (
+    query.nextPageToken ||
+    query.inboxSection ||
+    query.excludeLabelNames?.length
+  ) {
+    return false;
+  }
+  if (!query.type || query.type === "inbox" || query.type === "unread") {
+    return true;
+  }
+  return query.type.startsWith("CATEGORY_");
+}
+
+function isCompleteMailboxQuery(query: ThreadsQuery) {
+  return query.type === "inbox" || query.type === "unread";
+}
+
+function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {
+  const requiredLabelIds = [
+    ...(query.labelIds ?? []),
+    ...(query.labelId ? [query.labelId] : []),
+    ...(query.type?.startsWith("CATEGORY_") ? [query.type] : []),
+  ];
+  if (
+    requiredLabelIds.length &&
+    !messages.some((message) =>
+      requiredLabelIds.every((labelId) => message.labelIds?.includes(labelId)),
+    )
+  ) {
+    return false;
+  }
+  if (
+    query.folderId &&
+    !messages.some((message) => message.parentFolderId === query.folderId)
+  ) {
+    return false;
+  }
+  if (
+    (query.isUnread || query.type === "unread") &&
+    !messages.some((message) => message.labelIds?.includes("UNREAD"))
+  ) {
+    return false;
+  }
+
+  return messages.some((message) => {
+    if (
+      query.fromEmail &&
+      canonicalizeEmailAddress(message.headers.from) !==
+        canonicalizeEmailAddress(query.fromEmail)
+    ) {
+      return false;
+    }
+    const timestamp = getMessageTimestamp(message);
+    if (query.after && timestamp <= query.after.getTime()) return false;
+    if (query.before && timestamp >= query.before.getTime()) return false;
+    return true;
+  });
+}
+
+function toListThread(
+  threadId: string,
+  messages: ParsedMessage[],
+  cachedRow: unknown,
+): ThreadListItem {
+  const cachedThread = getCachedThread(cachedRow);
+  const messagesById = new Map(
+    cachedThread?.messages.map((message) => [message.id, message]),
+  );
+  for (const message of messages) {
+    messagesById.set(message.id, toListMessage(message));
+  }
+  const listMessages = [...messagesById.values()].sort(sortByInternalDate());
+  const latest = listMessages.at(-1)!;
+  return {
+    id: threadId,
+    snippet: latest.snippet,
+    plan: cachedThread?.plan,
+    plans: cachedThread?.plans ?? [],
+    messages: listMessages,
+  };
+}
+
+function toListMessage(message: ParsedMessage) {
+  return {
+    id: message.id,
+    threadId: message.threadId,
+    snippet: message.snippet,
+    subject: message.subject,
+    date: message.date,
+    internalDate: message.internalDate,
+    labelIds: message.labelIds,
+    headers: message.headers,
+  };
+}
+
+function getCachedThread(value: unknown): ThreadListItem | undefined {
+  if (!isRecord(value) || !Array.isArray(value.messages)) return;
+  return value as ThreadListItem;
+}
+
+function getMessageTimestamp(message: ParsedMessage | undefined) {
+  return internalDateToDate(message?.internalDate, {
+    fallbackToNow: false,
+  }).getTime();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -20,6 +20,7 @@ export type SyncedMailboxSnapshot = {
   complete: boolean;
   syncedAt: number;
   threads: ThreadListItem[];
+  truncated: boolean;
 };
 
 export async function applyMailboxSyncPage({
@@ -134,7 +135,7 @@ export async function readSyncedMailboxThreads({
           ),
           "prev",
         );
-      while (cursor && selectedThreadIds.size < limit) {
+      while (cursor && selectedThreadIds.size < limit + 1) {
         const message = cursor.value.data;
         if (
           message.labelIds?.includes("INBOX") &&
@@ -165,12 +166,13 @@ export async function readSyncedMailboxThreads({
       .sort(
         ([, left], [, right]) =>
           getMessageTimestamp(right.at(-1)) - getMessageTimestamp(left.at(-1)),
-      )
-      .slice(0, limit);
+      );
+    const truncated = matchingThreads.length > limit;
+    const selectedThreads = matchingThreads.slice(0, limit);
 
     const rows = transaction.objectStore("threadRows");
     const threads = await Promise.all(
-      matchingThreads.map(async ([threadId, messages]) => {
+      selectedThreads.map(async ([threadId, messages]) => {
         const cachedRow = await rows.get([emailAccountId, threadId]);
         return toListThread(threadId, messages, cachedRow?.data);
       }),
@@ -185,6 +187,7 @@ export async function readSyncedMailboxThreads({
       ),
       syncedAt: state.lastSyncedAt,
       threads,
+      truncated,
     };
   } catch {
     return;

--- a/apps/web/utils/email-cache/policy.ts
+++ b/apps/web/utils/email-cache/policy.ts
@@ -1,5 +1,7 @@
 export const EMAIL_CACHE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 export const EMAIL_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+// Sync snapshots cover 30 days and roll every 7; one extra day prevents cleanup racing a refresh.
+export const EMAIL_CACHE_MAILBOX_MAX_AGE_MS = 38 * 24 * 60 * 60 * 1000;
 export const EMAIL_CACHE_MAX_VIEWS_PER_ACCOUNT = 50;
 export const EMAIL_CACHE_DEFAULT_DETAIL_BUDGET_BYTES = 100 * 1024 * 1024;
 export const EMAIL_CACHE_MAX_DETAIL_BUDGET_BYTES = 200 * 1024 * 1024;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260823-120438_pr-3359_55d2b740074c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- upgrade the email IndexedDB cache into a canonical, account-scoped mailbox message store with atomic provider cursor updates
- hydrate inbox and unread rows from local data immediately while existing server requests continue to reconcile rule metadata and older pages
- run the existing provider-neutral mailbox sync endpoint in the background, including bounded continuation, rolling 30-day refreshes, offline/visibility handling, corrupted-state recovery, and cache-clear race protection
- reconcile archive, trash, snooze, undo, and read-state actions into the local store so actions remain immediate before the first network page arrives

Provider access and OAuth tokens remain on the server; the desktop client does not call Gmail or Microsoft directly.

## Performance

Warm mail views can render from the canonical local store without waiting on the threads API. Background work is capped at one 100-message page per run, continues every 10 seconds during initial catch-up, and settles to 60-second delta polling. The store retains a rolling recent window and reuses cached server rows for full conversation metadata and rule plans. Merged local and server sources are memoized to preserve stable list identities.

## Testing

- focused local mailbox suite: 66 tests across 9 files, covering cache reads/writes, pagination, cleanup, browser scheduling, offline/visibility recovery, sync deduplication, API errors, and optimistic action reconciliation
- focused coverage: relevant mail hooks 92.87% line coverage; email-cache modules 89.37% line coverage; browser mailbox sync hook 92.85% line coverage
- full Node 24 unit suite: 736 files, 5,519 passed tests, 763 intentionally skipped, zero failures
- `pnpm lint` (2,731 files)
- pre-push gitleaks scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailboxes now synchronize automatically in the background and refresh when returning online, refocusing the app, or viewing an account.
  * Recent mailbox data remains available locally for faster loading and smoother offline experiences.
  * Optimistic archive, delete, restore, snooze, and read/unread actions stay consistent with synchronized mailbox data.
  * Newer messages are merged without losing associated thread details.

* **Bug Fixes**
  * Improved mailbox pagination, refresh handling, cache cleanup, and recovery from interrupted synchronization.
  * Preserved mailbox data more reliably during cache updates and account changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->