### PR TITLE
fix(desktop): prevent sidebar titlebar overlap

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -29,12 +29,8 @@ export function ListToolbar({
 
   return (
     <div
-      className={cn(
-        "flex shrink-0 items-center gap-2 px-3 pt-3 pb-3",
-        // Mac traffic lights hang past the collapsed 3rem sidebar.
-        showSidebarToggle &&
-          "lg:pl-[max(0.75rem,calc(var(--desktop-traffic-lights-width,0px)-3rem))]",
-      )}
+      data-desktop-mac-titlebar-spacer={showSidebarToggle || undefined}
+      className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3"
     >
       {showSidebarToggle ? (
         <SidebarTrigger name="left-sidebar" className="hidden lg:inline-flex" />

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -287,7 +287,7 @@ export function SideNav({
             <SidebarTrigger name="left-sidebar" className="ml-auto" />
           </div>
         ) : (
-          <div className="pb-2 pt-[var(--desktop-traffic-lights-height,0px)]">
+          <div data-desktop-mac-titlebar-spacer className="pb-2">
             <SidebarTrigger name="left-sidebar" />
           </div>
         )}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -273,8 +273,11 @@
 /* Mac desktop shell: leave the traffic-light row empty. Set by a
    before-hydration script when window.inboxZeroDesktop is present. */
 html[data-mac-desktop] {
-  --desktop-traffic-lights-width: 78px;
   --desktop-traffic-lights-height: 52px;
+}
+
+html[data-mac-desktop] [data-desktop-mac-titlebar-spacer] {
+  padding-top: var(--desktop-traffic-lights-height);
 }
 
 html[data-mac-desktop] [data-hide-on-desktop-mac] {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260823-101710_pr-3362_529f471d417e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- Reuse shared desktop titlebar spacing for collapsed sidebars.
- Keep toolbar controls clear of native window controls.

## Validation

- `pnpm exec ultracite check apps/web/styles/globals.css apps/web/components/SideNav.tsx apps/web/app/\(app\)/\[emailAccountId\]/mail/ListToolbar.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop Mac title-bar spacing in the mail toolbar and collapsed sidebar.
  - Ensured content consistently clears the Mac traffic-light controls.
  - Simplified spacing behavior for a more stable desktop layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->