### PR TITLE
auth: Use configured origin for callback redirects

### DIFF
--- a/apps/web/utils/oauth/auth-callback-deduplication.test.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.test.ts
@@ -27,6 +27,10 @@ vi.mock("@/utils/redis/oauth-code", () => ({
   setOAuthCodeResult: mockSetOAuthCodeResult,
 }));
 
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_BASE_URL: "https://example.com" },
+}));
+
 import { deduplicateOAuthCallback } from "./auth-callback-deduplication";
 
 const logger = createScopedLogger("test/auth-callback-deduplication");
@@ -160,6 +164,31 @@ describe("deduplicateOAuthCallback", () => {
     expect(handleRequest).not.toHaveBeenCalled();
   });
 
+  it("resolves relative cached redirects against the configured public URL", async () => {
+    mockClaimOAuthCodeAndWait.mockResolvedValue({
+      result: {
+        params: {
+          redirect: "/welcome-redirect",
+          status: "302",
+        },
+        requestFingerprint: REQUEST_FINGERPRINT,
+        status: "success",
+      },
+      status: "success",
+      waited: true,
+    });
+
+    const response = await deduplicateOAuthCallback({
+      request: createGoogleCallbackRequest("https://0.0.0.0:3000"),
+      handleRequest: vi.fn(),
+      logger,
+    });
+
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/welcome-redirect",
+    );
+  });
+
   it("does not replay session cookies to a different OAuth state", async () => {
     mockClaimOAuthCodeAndWait.mockResolvedValue({
       result: {
@@ -251,9 +280,9 @@ describe("deduplicateOAuthCallback", () => {
   });
 });
 
-function createGoogleCallbackRequest() {
+function createGoogleCallbackRequest(origin = "https://example.com") {
   return new Request(
-    "https://example.com/api/auth/callback/google?code=oauth-code&state=oauth-state",
+    `${origin}/api/auth/callback/google?code=oauth-code&state=oauth-state`,
     { headers: { cookie: OAUTH_STATE_COOKIE } },
   );
 }

--- a/apps/web/utils/oauth/auth-callback-deduplication.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.ts
@@ -8,6 +8,7 @@ import {
   setOAuthCodeResult,
 } from "@/utils/redis/oauth-code";
 import { WELCOME_PATH } from "@/utils/config";
+import { env } from "@/env";
 
 const CALLBACK_PATH_REGEX = /\/api\/auth\/(?:oauth2\/)?callback\/([^/]+)\/?$/;
 const CALLBACK_RESULT_TTL_SECONDS = 600;
@@ -47,7 +48,7 @@ export async function deduplicateOAuthCallback({
       error: claim.error,
       provider,
     });
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(getPublicRedirectUrl(), 302);
   }
 
   if (claim.status === "success") {
@@ -58,7 +59,6 @@ export async function deduplicateOAuthCallback({
       { provider },
     );
     return createCachedRedirect({
-      request,
       requestFingerprint,
       result: claim.result,
     });
@@ -66,7 +66,7 @@ export async function deduplicateOAuthCallback({
 
   if (claim.status === "timeout") {
     logger.warn("OAuth callback wait timed out", { provider });
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(getPublicRedirectUrl(), 302);
   }
 
   try {
@@ -125,11 +125,9 @@ function getOAuthCallback(request: Request) {
 }
 
 function createCachedRedirect({
-  request,
   requestFingerprint,
   result,
 }: {
-  request: Request;
   requestFingerprint?: string;
   result: OAuthCodeResult;
 }) {
@@ -138,10 +136,10 @@ function createCachedRedirect({
   const status = Number(params.status);
 
   if (!redirect) {
-    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+    return Response.redirect(getPublicRedirectUrl(), 302);
   }
 
-  const redirectUrl = new URL(redirect, request.url);
+  const redirectUrl = getPublicRedirectUrl(redirect);
   const redirectStatus = REDIRECT_STATUSES.has(status) ? status : 302;
   const headers = new Headers({ location: redirectUrl.toString() });
 
@@ -193,4 +191,8 @@ function parseSetCookies(value: string) {
   } catch {
     return [];
   }
+}
+
+function getPublicRedirectUrl(path = WELCOME_PATH) {
+  return new URL(path, env.NEXT_PUBLIC_BASE_URL);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260823-130948_pr-3363_6012d95b7840/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensure OAuth callback deduplication sends relative redirects to the configured public application origin.

- Resolve cached and fallback redirects against the canonical base URL
- Add regression coverage for internal request origins
- Validate the focused callback deduplication test suite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback redirect handling by consistently using the configured public application URL.
  * Fixed fallback and cached redirects when callback requests originate from different or unexpected URLs.
  * Preserved request validation checks for cached OAuth redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->