### PR TITLE
Track exact AI discovery prompts during onboarding

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepHowYouHeard.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepHowYouHeard.tsx
@@ -86,16 +86,30 @@ const SOURCES = [
 export function StepHowYouHeard({ onNext }: { onNext: () => void }) {
   const { executeAsync: saveSource } = useAction(saveOnboardingAnswersAction);
   const [showOtherInput, setShowOtherInput] = useState(false);
+  const [showAiPromptInput, setShowAiPromptInput] = useState(false);
   const [customSource, setCustomSource] = useState("");
+  const [aiDiscoveryPrompt, setAiDiscoveryPrompt] = useState("");
 
   const submitSource = useCallback(
-    (source: string) => {
+    (source: string, discoveryPrompt?: string) => {
+      const trimmedDiscoveryPrompt = discoveryPrompt?.trim();
+
       onNext();
 
       saveSource({
         surveyId: "onboarding",
-        questions: [{ key: "source", type: "single_choice" }],
-        answers: { $survey_response: source },
+        questions: [
+          { key: "source", type: "single_choice" },
+          ...(trimmedDiscoveryPrompt
+            ? [{ key: "ai_discovery_prompt", type: "open" }]
+            : []),
+        ],
+        answers: {
+          $survey_response: source,
+          ...(trimmedDiscoveryPrompt
+            ? { $survey_response_1: trimmedDiscoveryPrompt }
+            : {}),
+        },
       })
         .then((result) => {
           if (result?.serverError || result?.validationErrors) {
@@ -137,9 +151,17 @@ export function StepHowYouHeard({ onNext }: { onNext: () => void }) {
   const onSelectSource = useCallback(
     (value: string) => {
       if (value === OTHER_VALUE) {
+        setShowAiPromptInput(false);
         setShowOtherInput(true);
         return;
       }
+      if (value === "llm") {
+        setShowOtherInput(false);
+        setShowAiPromptInput(true);
+        return;
+      }
+      setShowAiPromptInput(false);
+      setShowOtherInput(false);
       submitSource(value);
     },
     [submitSource],
@@ -194,6 +216,36 @@ export function StepHowYouHeard({ onNext }: { onNext: () => void }) {
               className="w-full"
               disabled={!customSource.trim()}
             >
+              Continue
+              <ArrowRightIcon className="size-4 ml-2" />
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {showAiPromptInput && (
+        <form
+          className="mt-4 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submitSource("llm", aiDiscoveryPrompt);
+          }}
+        >
+          <Input
+            name="aiDiscoveryPrompt"
+            type="text"
+            label="What did you ask the AI? (optional)"
+            placeholder="Paste the prompt that led you to Inbox Zero"
+            registerProps={{
+              value: aiDiscoveryPrompt,
+              maxLength: 500,
+              onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+                setAiDiscoveryPrompt(event.target.value),
+              autoFocus: true,
+            }}
+          />
+          <div className="flex w-full max-w-xs mx-auto">
+            <Button type="submit" className="w-full">
               Continue
               <ArrowRightIcon className="size-4 ml-2" />
             </Button>

--- a/apps/web/utils/actions/onboarding.test.ts
+++ b/apps/web/utils/actions/onboarding.test.ts
@@ -75,6 +75,28 @@ describe("saveOnboardingAnswersAction", () => {
     expect(trackOnboardingAnswerMock).toHaveBeenCalled();
   });
 
+  it("tracks the discovery prompt for AI-referred signups", async () => {
+    prisma.user.update.mockResolvedValue({ id: "user-1" } as any);
+
+    const result = await saveOnboardingAnswersAction({
+      surveyId: "onboarding",
+      questions: [
+        { key: "source", type: "single_choice" },
+        { key: "ai_discovery_prompt", type: "open" },
+      ],
+      answers: {
+        $survey_response: "llm",
+        $survey_response_1: "best open source AI email assistant",
+      },
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(trackOnboardingAnswerMock).toHaveBeenCalledWith("user@example.com", {
+      surveySource: "llm",
+      surveyAiDiscoveryPrompt: "best open source AI email assistant",
+    });
+  });
+
   it("does not schedule side effects when the DB update fails", async () => {
     prisma.user.update.mockRejectedValue(new Error("db down"));
 

--- a/apps/web/utils/actions/onboarding.ts
+++ b/apps/web/utils/actions/onboarding.ts
@@ -36,6 +36,7 @@ export const saveOnboardingAnswersAction = actionClientUser
           surveyGoal?: string;
           surveyCompanySize?: number;
           surveySource?: string;
+          surveyAiDiscoveryPrompt?: string;
           surveyImprovements?: string;
         } = {};
 
@@ -99,6 +100,14 @@ export const saveOnboardingAnswersAction = actionClientUser
         const sourceAnswer = getAnswerByKey("source");
         if (sourceAnswer && sourceAnswer !== "undefined") {
           result.surveySource = sourceAnswer;
+        }
+
+        const aiDiscoveryPromptAnswer = getAnswerByKey("ai_discovery_prompt");
+        if (
+          aiDiscoveryPromptAnswer &&
+          aiDiscoveryPromptAnswer !== "undefined"
+        ) {
+          result.surveyAiDiscoveryPrompt = aiDiscoveryPromptAnswer;
         }
 
         const improvementsAnswer = getAnswerByKey("improvements");

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -478,6 +478,7 @@ export async function trackOnboardingAnswer(
     surveyGoal?: string;
     surveyCompanySize?: number;
     surveySource?: string;
+    surveyAiDiscoveryPrompt?: string;
     surveyImprovements?: string;
   },
 ) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260823-153008_pr-3367_ed497691b564/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- keep the existing `ChatGPT, Claude, or other AI` acquisition source
- ask AI-referred signups for the exact discovery prompt as an optional follow-up
- persist the answer with onboarding data and expose `surveyAiDiscoveryPrompt` in PostHog

## Why
This tests the strongest low-risk idea from [Jake Ward's X bookmark](https://x.com/jakezward/status/2090060494858014873): exact prompts reveal which AI-search intents are actually producing registrations. Tally's broader growth claims are not assumed to be causal; this PR only adds first-party attribution for Inbox Zero.

## Verification
- `pnpm test utils/actions/onboarding.test.ts` — 5 tests passed
- `pnpm exec biome check 'apps/web/app/(app)/[emailAccountId]/onboarding/StepHowYouHeard.tsx' apps/web/utils/actions/onboarding.ts apps/web/utils/actions/onboarding.test.ts apps/web/utils/posthog.ts` — passed
- `git diff --check` — passed

## Expected signal
After release, review after 30 AI-attributed signups or 2026-09-23, whichever comes first:
- completion rate for `surveyAiDiscoveryPrompt` among `surveySource = llm`
- repeated prompts/intents that can be mapped to existing or missing landing/comparison content
- onboarding continuation rate from the acquisition-source step versus the pre-release baseline

Keep the prompt only if it yields usable intent clusters without a material continuation-rate drop; otherwise remove or revise it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional prompt for users who indicate they discovered the app through ChatGPT, Claude, or another AI tool.
  * AI discovery responses are included in onboarding survey submissions and analytics.
  * AI discovery and custom-source inputs remain mutually exclusive.

* **Tests**
  * Added coverage for saving and tracking AI-related onboarding responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->