### PR TITLE
mail: Make All Accounts local-first

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -1,8 +1,12 @@
+import { randomUUID } from "node:crypto";
 import { expect, test, type Page } from "@playwright/test";
+import { Client } from "pg";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
 const MESSAGE_COUNT = 5000;
 const FIRST_LOCAL_SUBJECT = "Local mailbox load test 0";
+const PRIMARY_UNIFIED_SUBJECT = "Primary local unified conversation";
+const SECONDARY_UNIFIED_SUBJECT = "Secondary local unified conversation";
 
 test("renders a large local mailbox while server mail requests are unavailable", async ({
   page,
@@ -37,6 +41,52 @@ test("renders a large local mailbox while server mail requests are unavailable",
     body: await page.screenshot(),
     contentType: "image/png",
   });
+});
+
+test("renders and isolates two locally cached accounts without server mail requests", async ({
+  page,
+}, testInfo) => {
+  const { emailAccountId } = await openMail(page);
+  const secondAccount = await createSecondEmailAccount(emailAccountId);
+  const syncAccountIds = new Set<string>();
+
+  try {
+    await page.route("**/api/threads/all?**", (route) =>
+      route.abort("connectionfailed"),
+    );
+    await page.route("**/api/mobile/mailbox-sync", async (route) => {
+      const syncAccountId = await route
+        .request()
+        .headerValue("X-Email-Account-ID");
+      if (syncAccountId) syncAccountIds.add(syncAccountId);
+      await route.abort("connectionfailed");
+    });
+    await seedUnifiedMailbox(page, emailAccountId, secondAccount.id);
+
+    await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    const conversations = page.getByRole("listbox", {
+      name: "Conversations",
+    });
+    await expect(conversations).toBeVisible();
+    await expect(
+      conversationWithSubject(page, conversations, PRIMARY_UNIFIED_SUBJECT),
+    ).toBeVisible();
+    await expect(
+      conversationWithSubject(page, conversations, SECONDARY_UNIFIED_SUBJECT),
+    ).toBeVisible();
+    await expect(conversations.getByRole("option")).toHaveCount(2);
+    await expect(page.getByLabel(`Inbox: ${secondAccount.name}`)).toBeVisible();
+    await expect
+      .poll(() => [...syncAccountIds].sort())
+      .toEqual([emailAccountId, secondAccount.id].sort());
+
+    await testInfo.attach("local-unified-mailbox", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+  } finally {
+    await deleteSecondEmailAccount(secondAccount.accountId);
+  }
 });
 
 async function seedLargeMailbox(page: Page, emailAccountId: string) {
@@ -101,4 +151,140 @@ async function seedLargeMailbox(page: Page, emailAccountId: string) {
     },
     { accountId: emailAccountId, messageCount: MESSAGE_COUNT },
   );
+}
+
+async function seedUnifiedMailbox(
+  page: Page,
+  primaryAccountId: string,
+  secondaryAccountId: string,
+) {
+  await page.evaluate(
+    async ({ primaryAccountId, secondaryAccountId, subjects }) => {
+      await new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction(
+            ["mailboxMessages", "mailboxSyncStates"],
+            "readwrite",
+          );
+          transaction.onerror = () => reject(transaction.error);
+          transaction.oncomplete = () => {
+            database.close();
+            resolve();
+          };
+
+          const now = Date.now();
+          const accounts = [
+            {
+              emailAccountId: primaryAccountId,
+              receivedAt: now - 1000,
+              subject: subjects.primary,
+            },
+            {
+              emailAccountId: secondaryAccountId,
+              receivedAt: now,
+              subject: subjects.secondary,
+            },
+          ];
+          const messages = transaction.objectStore("mailboxMessages");
+          const states = transaction.objectStore("mailboxSyncStates");
+          for (const account of accounts) {
+            const internalDate = new Date(account.receivedAt).toISOString();
+            const messageId = `${account.emailAccountId}-shared-message`;
+            const threadId = "shared-thread";
+            messages.put({
+              data: {
+                date: internalDate,
+                headers: {
+                  date: internalDate,
+                  from: `Unified Sender <${account.emailAccountId}@example.com>`,
+                  subject: account.subject,
+                  to: "playwright-test@gmail.com",
+                },
+                id: messageId,
+                internalDate,
+                labelIds: ["INBOX", "UNREAD"],
+                snippet: `${account.subject} snippet`,
+                subject: account.subject,
+                threadId,
+              },
+              emailAccountId: account.emailAccountId,
+              lastAccessedAt: now,
+              messageId,
+              receivedAt: account.receivedAt,
+              threadId,
+            });
+            states.put({
+              after: new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString(),
+              completedAt: now,
+              cursor: `${account.emailAccountId}-cursor`,
+              emailAccountId: account.emailAccountId,
+              hasMore: false,
+              lastSyncedAt: now,
+            });
+          }
+        };
+      });
+    },
+    {
+      primaryAccountId,
+      secondaryAccountId,
+      subjects: {
+        primary: PRIMARY_UNIFIED_SUBJECT,
+        secondary: SECONDARY_UNIFIED_SUBJECT,
+      },
+    },
+  );
+}
+
+async function createSecondEmailAccount(primaryEmailAccountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  const suffix = randomUUID();
+  const accountId = `playwright-account-${suffix}`;
+  const id = `playwright-email-account-${suffix}`;
+  const email = `playwright-secondary-${suffix}@gmail.com`;
+  const name = "Playwright Secondary";
+
+  try {
+    await client.query("BEGIN");
+    const userResult = await client.query<{ userId: string }>(
+      `SELECT "userId" FROM "EmailAccount" WHERE id = $1`,
+      [primaryEmailAccountId],
+    );
+    const userId = userResult.rows[0]?.userId;
+    if (!userId) throw new Error("Could not find the Playwright account user");
+
+    await client.query(
+      `INSERT INTO "Account"
+        (id, "createdAt", "updatedAt", "userId", provider, type, "providerAccountId")
+       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, 'google', 'oidc', $3)`,
+      [accountId, userId, `playwright-provider-${suffix}`],
+    );
+    await client.query(
+      `INSERT INTO "EmailAccount"
+        (id, email, name, "createdAt", "updatedAt", "userId", "accountId")
+       VALUES ($1, $2, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $4, $5)`,
+      [id, email, name, userId, accountId],
+    );
+    await client.query("COMMIT");
+    return { accountId, email, id, name };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+async function deleteSecondEmailAccount(accountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(`DELETE FROM "Account" WHERE id = $1`, [accountId]);
+  } finally {
+    await client.end();
+  }
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -107,6 +107,7 @@ import { prefixPath } from "@/utils/path";
 import { LoadingContent } from "@/components/LoadingContent";
 import type { LabelCount } from "@/app/api/labels/counts/route";
 import type { ThreadsQuery } from "@/utils/threads/validation";
+import type { CombinedListThread } from "@/utils/threads/load-combined";
 import { getEmailTerminology } from "@/utils/terminology";
 import { createSearchParams } from "@/utils/url";
 import { redirectToSafeUrl } from "@/utils/redirect";
@@ -481,10 +482,10 @@ export function MailShell() {
       focusedThread ? getListThreadKey(focusedThread) : undefined,
     );
     const targetKeySet = new Set(targetKeys);
-    const targets: Array<{ id: string; account: { id: string } }> = [];
+    const targets: CombinedListThread[] = [];
     for (const thread of threads) {
       if ("account" in thread && targetKeySet.has(getListThreadKey(thread))) {
-        targets.push({ id: thread.id, account: { id: thread.account.id } });
+        targets.push(thread);
       }
     }
     return { targetKeys, targets };
@@ -512,9 +513,7 @@ export function MailShell() {
 
       const succeeded = new Set(succeededThreadKeys);
       const succeededByAccount = groupThreadIdsByAccount(
-        targets.filter((thread) =>
-          succeeded.has(`${thread.account.id}:${thread.id}`),
-        ),
+        targets.filter((thread) => succeeded.has(getListThreadKey(thread))),
       );
       await Promise.all(
         [...succeededByAccount].map(([accountId, threadIds]) =>
@@ -576,9 +575,7 @@ export function MailShell() {
 
       const succeeded = new Set(succeededThreadKeys);
       const succeededByAccount = groupThreadIdsByAccount(
-        targets.filter((thread) =>
-          succeeded.has(`${thread.account.id}:${thread.id}`),
-        ),
+        targets.filter((thread) => succeeded.has(getListThreadKey(thread))),
       );
       await Promise.all(
         [...succeededByAccount].map(([accountId, threadIds]) =>

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -46,14 +46,20 @@ import {
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
-import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
+import {
+  requestMailboxSync,
+  useMailboxSync,
+} from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
 import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
 import { useHoverThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
-import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
+import {
+  isThreadUnread,
+  withThreadReadState,
+} from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { Sidebar, useSidebar } from "@/components/ui/sidebar";
@@ -74,6 +80,7 @@ import { useLabelCounts } from "@/hooks/useLabelCounts";
 import { useSplitLabels } from "@/hooks/useLabels";
 import { useFolders } from "@/hooks/useFolders";
 import { useMailSettings } from "@/hooks/useMailSettings";
+import { useAccounts } from "@/hooks/useAccounts";
 import { useThread } from "@/hooks/useThread";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
@@ -86,6 +93,7 @@ import {
   archiveThreadAction,
   createLabelAction,
   deleteMailboxItemAction,
+  markReadThreadAction,
   removeThreadLabelAction,
   trashThreadAction,
   updateMailboxItemAction,
@@ -104,6 +112,10 @@ import { createSearchParams } from "@/utils/url";
 import { redirectToSafeUrl } from "@/utils/redirect";
 import { GMAIL_LABEL_COLORS } from "@/utils/gmail/label-colors";
 import { OUTLOOK_CATEGORY_COLORS } from "@/utils/outlook/category-colors";
+import {
+  markSyncedMailboxThreadsRead,
+  removeSyncedMailboxThreads,
+} from "@/utils/email-cache/mailbox";
 
 // Always present, never deletable. Everything else is a saved split. They carry
 // a kind so built-ins and saved splits resolve through one mapping.
@@ -124,6 +136,7 @@ const NO_COUNTS = new Map<string, LabelCount>();
 
 export function MailShell() {
   const { emailAccountId, userEmail, provider } = useAccount();
+  const { data: accountsData } = useAccounts();
   const isGoogle = isGoogleProvider(provider);
   const isOutlook = isMicrosoftProvider(provider);
   const categories = getMailCategories({ isGoogle, isOutlook });
@@ -159,7 +172,23 @@ export function MailShell() {
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   const isAllAccounts = accountScope === "all";
-  useMailboxSync({ emailAccountId, enabled: !isAllAccounts });
+  const combinedAccounts = useMemo(
+    () =>
+      (accountsData?.emailAccounts ?? []).map(({ id, email, name, image }) => ({
+        id,
+        email,
+        name,
+        image,
+      })),
+    [accountsData?.emailAccounts],
+  );
+  const mailboxSyncAccountIds = useMemo(
+    () =>
+      isAllAccounts && combinedAccounts.length
+        ? combinedAccounts.map((account) => account.id)
+        : [emailAccountId],
+    [combinedAccounts, emailAccountId, isAllAccounts],
+  );
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
   const layout = isAllAccounts ? "list" : accountLayout;
@@ -245,12 +274,14 @@ export function MailShell() {
     enabled: !isAllAccounts,
   });
   const combinedThreadState = useCombinedMailThreads({
+    accounts: combinedAccounts,
     emailAccountId,
     enabled: isAllAccounts,
     isUnread: activeSplitId === "unread",
   });
   const {
     labelsByAccount,
+    optimisticallyUpdateThreads: optimisticallyUpdateCombinedThreads,
     removeThreads: removeCombinedThreads,
     restoreThreads: restoreCombinedThreads,
   } = combinedThreadState;
@@ -445,6 +476,19 @@ export function MailShell() {
   );
 
   const openShortcuts = useCallback(() => setIsHelpOpen(true), []);
+  const getCombinedTargets = useCallback(() => {
+    const targetKeys = selection.targetIds(
+      focusedThread ? getListThreadKey(focusedThread) : undefined,
+    );
+    const targetKeySet = new Set(targetKeys);
+    const targets: Array<{ id: string; account: { id: string } }> = [];
+    for (const thread of threads) {
+      if ("account" in thread && targetKeySet.has(getListThreadKey(thread))) {
+        targets.push({ id: thread.id, account: { id: thread.account.id } });
+      }
+    }
+    return { targetKeys, targets };
+  }, [focusedThread, selection, threads]);
   const runCombinedAction = useCallback(
     async ({
       action,
@@ -457,19 +501,7 @@ export function MailShell() {
       actionVerb: string;
       failureDescription: string;
     }) => {
-      const targetKeys = selection.targetIds(
-        focusedThread ? getListThreadKey(focusedThread) : undefined,
-      );
-      const targets: Array<{ id: string; account: { id: string } }> = [];
-      for (const thread of threads) {
-        if (
-          !("account" in thread) ||
-          !targetKeys.includes(getListThreadKey(thread))
-        ) {
-          continue;
-        }
-        targets.push({ id: thread.id, account: { id: thread.account.id } });
-      }
+      const { targetKeys, targets } = getCombinedTargets();
       if (!targets.length) return;
 
       const removal = removeCombinedThreads(targetKeys);
@@ -477,6 +509,24 @@ export function MailShell() {
       const { failedThreadKeys, succeededThreadKeys } =
         await runCombinedThreadAction({ threads: targets, action });
       restoreCombinedThreads(removal, failedThreadKeys);
+
+      const succeeded = new Set(succeededThreadKeys);
+      const succeededByAccount = groupThreadIdsByAccount(
+        targets.filter((thread) =>
+          succeeded.has(`${thread.account.id}:${thread.id}`),
+        ),
+      );
+      await Promise.all(
+        [...succeededByAccount].map(([accountId, threadIds]) =>
+          removeSyncedMailboxThreads({
+            emailAccountId: accountId,
+            threadIds,
+          }).catch(() => {}),
+        ),
+      );
+      for (const accountId of succeededByAccount.keys()) {
+        requestMailboxSync(accountId);
+      }
 
       if (succeededThreadKeys.length) {
         toast.success(
@@ -492,11 +542,76 @@ export function MailShell() {
       }
     },
     [
-      focusedThread,
+      getCombinedTargets,
       removeCombinedThreads,
       restoreCombinedThreads,
       selection,
-      threads,
+    ],
+  );
+  const runCombinedReadAction = useCallback(
+    async (read: boolean) => {
+      const { targetKeys, targets } = getCombinedTargets();
+      if (!targets.length) return;
+
+      const removeFromUnread = read && activeSplitId === "unread";
+      const removal = removeFromUnread
+        ? removeCombinedThreads(targetKeys)
+        : undefined;
+      const update = removeFromUnread
+        ? undefined
+        : optimisticallyUpdateCombinedThreads(targetKeys, (thread) =>
+            withThreadReadState(thread, read),
+          );
+      selection.clear();
+
+      const { failedThreadKeys, succeededThreadKeys } =
+        await runCombinedThreadAction({
+          threads: targets,
+          action: (accountId, threadId) =>
+            markReadThreadAction(accountId, { threadId, read }),
+        });
+      if (removal) restoreCombinedThreads(removal, failedThreadKeys);
+      else update?.rollback(failedThreadKeys);
+      for (const threadKey of succeededThreadKeys) update?.commit(threadKey);
+
+      const succeeded = new Set(succeededThreadKeys);
+      const succeededByAccount = groupThreadIdsByAccount(
+        targets.filter((thread) =>
+          succeeded.has(`${thread.account.id}:${thread.id}`),
+        ),
+      );
+      await Promise.all(
+        [...succeededByAccount].map(([accountId, threadIds]) =>
+          markSyncedMailboxThreadsRead({
+            emailAccountId: accountId,
+            read,
+            threadIds,
+          }).catch(() => {}),
+        ),
+      );
+
+      if (succeededThreadKeys.length) {
+        toast.success(
+          succeededThreadKeys.length === 1
+            ? `Marked as ${read ? "read" : "unread"}`
+            : `Marked ${succeededThreadKeys.length} conversations as ${read ? "read" : "unread"}`,
+        );
+      }
+      if (failedThreadKeys.length) {
+        toast.error(
+          failedThreadKeys.length === targets.length
+            ? `Couldn't mark as ${read ? "read" : "unread"}`
+            : `Couldn't mark ${failedThreadKeys.length} of ${targets.length} conversations as ${read ? "read" : "unread"}`,
+        );
+      }
+    },
+    [
+      activeSplitId,
+      getCombinedTargets,
+      optimisticallyUpdateCombinedThreads,
+      removeCombinedThreads,
+      restoreCombinedThreads,
+      selection,
     ],
   );
   const archiveTargets = useCallback(async () => {
@@ -525,14 +640,14 @@ export function MailShell() {
       failureDescription: "deleting",
     });
   }, [isAllAccounts, runCombinedAction, runOn, trash]);
-  const markReadTargets = useCallback(
-    () => runOn(markRead, false),
-    [runOn, markRead],
-  );
-  const markUnreadTargets = useCallback(
-    () => runOn((ids) => setReadState(ids, false), false),
-    [runOn, setReadState],
-  );
+  const markReadTargets = useCallback(() => {
+    if (isAllAccounts) runCombinedReadAction(true);
+    else runOn(markRead, false);
+  }, [isAllAccounts, markRead, runCombinedReadAction, runOn]);
+  const markUnreadTargets = useCallback(() => {
+    if (isAllAccounts) runCombinedReadAction(false);
+    else runOn((ids) => setReadState(ids, false), false);
+  }, [isAllAccounts, runCombinedReadAction, runOn, setReadState]);
   const snoozeTargets = useCallback(
     (until: Date) => runOn((ids) => snooze(ids, until), true),
     [runOn, snooze],
@@ -550,15 +665,13 @@ export function MailShell() {
   }, [commandTargetIds, threads]);
   const mailCommandContext = useMemo(
     () => ({
-      actions: isAllAccounts
-        ? { archive: archiveTargets, trash: trashTargets }
-        : {
-            archive: archiveTargets,
-            markRead: markReadTargets,
-            markUnread: markUnreadTargets,
-            snooze: snoozeTargets,
-            trash: trashTargets,
-          },
+      actions: {
+        archive: archiveTargets,
+        markRead: markReadTargets,
+        markUnread: markUnreadTargets,
+        snooze: isAllAccounts ? undefined : snoozeTargets,
+        trash: trashTargets,
+      },
       hasRead: commandTargets.some(
         (thread) => !isThreadUnread(thread.messages),
       ),
@@ -842,6 +955,9 @@ export function MailShell() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
+      {mailboxSyncAccountIds.map((syncAccountId) => (
+        <MailboxSync emailAccountId={syncAccountId} key={syncAccountId} />
+      ))}
       <div className="flex min-h-0 flex-1">
         <div className="hidden [--sidebar-width:236px] lg:contents">
           <Sidebar name="left-sidebar" forceCollapsed={isFocusMode}>
@@ -1014,6 +1130,23 @@ export function MailShell() {
       <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
     </div>
   );
+}
+
+function MailboxSync({ emailAccountId }: { emailAccountId: string }) {
+  useMailboxSync({ emailAccountId, enabled: true });
+  return null;
+}
+
+function groupThreadIdsByAccount(
+  threads: Array<{ id: string; account: { id: string } }>,
+) {
+  const threadIdsByAccount = new Map<string, string[]>();
+  for (const thread of threads) {
+    const threadIds = threadIdsByAccount.get(thread.account.id) ?? [];
+    threadIds.push(thread.id);
+    threadIdsByAccount.set(thread.account.id, threadIds);
+  }
+  return threadIdsByAccount;
 }
 
 function summariseCombinedAction(verb: string, count: number) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
@@ -13,10 +13,10 @@ export function isThreadUnread(
 }
 
 /** Read state lives on every message, so marking a thread rewrites all of them. */
-export function withThreadReadState(
-  thread: ListThread,
+export function withThreadReadState<T extends ListThread>(
+  thread: T,
   read: boolean,
-): ListThread {
+): T {
   let changed = false;
   const messages = thread.messages.map((message) => {
     const labelIds = message.labelIds ?? [];
@@ -37,5 +37,5 @@ export function withThreadReadState(
   return {
     ...thread,
     messages,
-  };
+  } as T;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -337,6 +337,59 @@ describe("useCombinedMailThreads", () => {
     expect(mailbox.read).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores an older mailbox read that resolves after a newer one", async () => {
+    const staleRead = Promise.withResolvers<unknown>();
+    const newerRead = Promise.withResolvers<unknown>();
+    mailbox.read
+      .mockReturnValueOnce(staleRead.promise)
+      .mockReturnValueOnce(newerRead.promise);
+    const network = Promise.withResolvers<unknown>();
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() => expect(mailbox.read).toHaveBeenCalledOnce());
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("account-1");
+    });
+    await waitFor(() => expect(mailbox.read).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      newerRead.resolve({
+        accountStates: ACCOUNT_STATES,
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "newer")],
+        truncated: false,
+      });
+      await newerRead.promise;
+    });
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "newer",
+    ]);
+
+    await act(async () => {
+      staleRead.resolve({
+        accountStates: ACCOUNT_STATES,
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "stale")],
+        truncated: false,
+      });
+      await staleRead.promise;
+    });
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "newer",
+    ]);
+  });
+
   it("removes and restores same-id threads independently by account", async () => {
     const network = Promise.withResolvers<unknown>();
     mailbox.read.mockResolvedValue({

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -364,11 +364,13 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "local-fallback",
-      "remote",
-    ]);
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "local-fallback",
+        "remote",
+      ]);
+    });
   });
 
   it("rehydrates only when one of the displayed account stores changes", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -285,6 +285,53 @@ describe("useCombinedMailThreads", () => {
     });
   });
 
+  it("loads more synchronized rows while the server is unavailable", async () => {
+    const localThreads = Array.from({ length: 25 }, (_, index) =>
+      createThread(
+        index % 2 ? "account-1" : "account-2",
+        `local-${index}`,
+        new Date(Date.UTC(2026, 7, 23, 10, 0, index)).toISOString(),
+      ),
+    );
+    mailbox.read.mockImplementation(({ limit }: { limit: number }) =>
+      Promise.resolve({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
+        complete: true,
+        missingAccountIds: [],
+        threads: localThreads.slice(0, limit),
+        truncated: localThreads.length > limit,
+      }),
+    );
+    const network = Promise.withResolvers<unknown>();
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(20);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(25);
+      expect(result.current.hasMore).toBe(false);
+    });
+    expect(mailbox.read).toHaveBeenLastCalledWith({
+      accounts: ACCOUNTS,
+      limit: 40,
+      query: { type: "inbox" },
+    });
+  });
+
   it("reconciles freshness independently for each account", async () => {
     mailbox.read.mockResolvedValue({
       accountStates: {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCombinedMailThreads } from "./use-combined-mail-threads";
 
 const cache = vi.hoisted(() => ({
@@ -44,6 +44,10 @@ describe("useCombinedMailThreads", () => {
         return () => mailbox.listeners.delete(listener);
       },
     );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders a complete merged mailbox while the server revalidates", async () => {
@@ -130,6 +134,49 @@ describe("useCombinedMailThreads", () => {
       ]);
       expect(result.current.threads[0]?.snippet).toBe("remote");
     });
+  });
+
+  it("keeps a mailbox sync that completes while the server request is in flight", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(100);
+    const network = Promise.withResolvers<unknown>();
+    mailbox.read.mockResolvedValue({
+      accountStates: createAccountStates(200),
+      complete: true,
+      missingAccountIds: [],
+      threads: [createThread("account-1", "local-only")],
+      truncated: false,
+    });
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "local-only",
+      ]),
+    );
+
+    vi.mocked(Date.now).mockReturnValue(300);
+    await act(async () => {
+      network.resolve({
+        failedAccountIds: [],
+        labelsByAccount: {},
+        nextPageToken: null,
+        threads: [createThread("account-1", "server-only")],
+      });
+      await network.promise;
+    });
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "local-only",
+    ]);
   });
 
   it("keeps a complete canonical snapshot after it syncs more recently than the server page", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -12,6 +12,11 @@ const cache = vi.hoisted(() => ({
   restore: vi.fn(),
   write: vi.fn(),
 }));
+const mailbox = vi.hoisted(() => ({
+  listeners: new Set<(emailAccountId: string) => void>(),
+  read: vi.fn(),
+  subscribe: vi.fn(),
+}));
 
 vi.mock("@/utils/email-cache/thread-lists", () => ({
   readCachedThreadList: cache.read,
@@ -19,32 +24,43 @@ vi.mock("@/utils/email-cache/thread-lists", () => ({
   restoreCachedThreadsToView: cache.restore,
   writeCachedThreadList: cache.write,
 }));
+vi.mock("@/utils/email-cache/mailbox", () => ({
+  readCombinedSyncedMailboxThreads: mailbox.read,
+  subscribeToMailboxStore: mailbox.subscribe,
+}));
 
 describe("useCombinedMailThreads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cache.read.mockResolvedValue(undefined);
     cache.remove.mockResolvedValue(undefined);
     cache.restore.mockResolvedValue(undefined);
     cache.write.mockResolvedValue(undefined);
+    mailbox.listeners.clear();
+    mailbox.read.mockResolvedValue(undefined);
+    mailbox.subscribe.mockImplementation(
+      (listener: (emailAccountId: string) => void) => {
+        mailbox.listeners.add(listener);
+        return () => mailbox.listeners.delete(listener);
+      },
+    );
   });
 
-  it("shows a cached first page while all accounts revalidate", async () => {
+  it("renders a complete merged mailbox while the server revalidates", async () => {
     const network = Promise.withResolvers<unknown>();
-    const cachedThread = createThread("account-1", "cached");
-    cache.read.mockResolvedValue({
-      cachedAt: 100,
-      hasMore: true,
-      threads: [
-        {
-          id: "account-1:cached",
-          thread: cachedThread,
-        },
-      ],
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: 100,
+      threads: [createThread("account-2", "local")],
+      truncated: false,
     });
 
     const { result } = renderHook(
       () =>
         useCombinedMailThreads({
+          accounts: ACCOUNTS,
           emailAccountId: "account-1",
           enabled: true,
           isUnread: false,
@@ -53,22 +69,33 @@ describe("useCombinedMailThreads", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.threads).toEqual([cachedThread]);
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "local",
+      ]);
+      expect(result.current.hasMore).toBe(false);
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.hasMore).toBe(true);
     });
-    expect(cache.read).toHaveBeenCalledWith(
-      expect.objectContaining({ emailAccountId: "account-1" }),
-    );
+    expect(mailbox.read).toHaveBeenCalledWith({
+      accounts: ACCOUNTS,
+      limit: 20,
+      query: { type: "inbox" },
+    });
   });
 
-  it("persists and restores selected rows using their account-scoped keys", async () => {
-    cache.read.mockResolvedValue(undefined);
-    const first = createThread("account-1", "shared");
-    const second = createThread("account-2", "shared");
+  it("uses a newer server page when the persisted mailbox predates the request", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: 100,
+      threads: [createThread("account-1", "canonical")],
+      truncated: false,
+    });
+
     const { result } = renderHook(
       () =>
         useCombinedMailThreads({
+          accounts: ACCOUNTS,
           emailAccountId: "account-1",
           enabled: true,
           isUnread: false,
@@ -76,81 +103,357 @@ describe("useCombinedMailThreads", () => {
       {
         wrapper: createWrapper(() =>
           Promise.resolve({
-            threads: [first, second],
-            labelsByAccount: {},
             failedAccountIds: [],
+            labelsByAccount: {},
             nextPageToken: null,
+            threads: [
+              {
+                ...createThread("account-1", "canonical"),
+                snippet: "remote",
+              },
+              createThread("account-2", "stale-recent"),
+              createThread(
+                "account-2",
+                "older-than-local-window",
+                "2026-07-01T10:00:00.000Z",
+              ),
+            ],
           }),
         ),
       },
     );
-    await waitFor(() => expect(result.current.threads).toHaveLength(2));
-    await waitFor(() =>
-      expect(cache.write).toHaveBeenCalledWith(
-        expect.objectContaining({
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "canonical",
+      "stale-recent",
+      "older-than-local-window",
+    ]);
+    expect(result.current.threads[0]?.snippet).toBe("remote");
+  });
+
+  it("keeps a complete canonical snapshot after it syncs more recently than the server page", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: Number.MAX_SAFE_INTEGER,
+      threads: [createThread("account-1", "canonical")],
+      truncated: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
           emailAccountId: "account-1",
-          threads: [
-            { id: "account-1:shared", thread: first },
-            { id: "account-2:shared", thread: second },
-          ],
+          enabled: true,
+          isUnread: false,
         }),
-      ),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [
+              {
+                ...createThread("account-1", "canonical"),
+                snippet: "remote",
+              },
+              createThread("account-2", "stale-recent"),
+              createThread(
+                "account-2",
+                "older-than-local-window",
+                "2026-07-01T10:00:00.000Z",
+              ),
+            ],
+          }),
+        ),
+      },
     );
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "canonical",
+      "older-than-local-window",
+    ]);
+    expect(result.current.threads[0]?.snippet).toBe("canonical");
+  });
+
+  it("keeps valid next-page rows when the combined mailbox is truncated", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: Number.MAX_SAFE_INTEGER,
+      threads: [createThread("account-1", "canonical")],
+      truncated: true,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: "next-page",
+            threads: [
+              createThread(
+                "account-2",
+                "stale-recent",
+                "2026-08-23T10:01:00.000Z",
+              ),
+              createThread("account-1", "canonical"),
+              createThread(
+                "account-2",
+                "valid-next-page-row",
+                "2026-08-23T09:59:00.000Z",
+              ),
+            ],
+          }),
+        ),
+      },
+    );
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "canonical",
+      "valid-next-page-row",
+    ]);
+  });
+
+  it("rehydrates only when one of the displayed account stores changes", async () => {
+    mailbox.read
+      .mockResolvedValueOnce({
+        accountStates: { "account-1": ACCOUNT_STATES["account-1"] },
+        complete: false,
+        missingAccountIds: ["account-2"],
+        syncedAt: 100,
+        threads: [createThread("account-1", "one")],
+        truncated: false,
+      })
+      .mockResolvedValue({
+        accountStates: ACCOUNT_STATES,
+        complete: true,
+        missingAccountIds: [],
+        syncedAt: 200,
+        threads: [
+          createThread("account-2", "two"),
+          createThread("account-1", "one"),
+        ],
+        truncated: false,
+      });
+    const network = Promise.withResolvers<unknown>();
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("other-account");
+    });
+    expect(mailbox.read).toHaveBeenCalledOnce();
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("account-2");
+    });
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+    expect(mailbox.read).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes and restores same-id threads independently by account", async () => {
+    const network = Promise.withResolvers<unknown>();
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: 100,
+      threads: [
+        createThread("account-1", "shared"),
+        createThread("account-2", "shared"),
+      ],
+      truncated: false,
+    });
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
 
     let removal!: ReturnType<typeof result.current.removeThreads>;
     act(() => {
-      removal = result.current.removeThreads([
-        "account-1:shared",
-        "account-2:shared",
-      ]);
+      removal = result.current.removeThreads(["account-1:shared"]);
     });
-    expect(result.current.threads).toEqual([]);
-    expect(cache.remove).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadIds: ["account-1:shared", "account-2:shared"],
-      }),
-    );
+    expect(result.current.threads.map((thread) => thread.account.id)).toEqual([
+      "account-2",
+    ]);
 
-    act(() => {
-      result.current.restoreThreads(removal, ["account-2:shared"]);
-    });
-    expect(result.current.threads).toEqual([second]);
-    expect(cache.restore).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entries: [
-          expect.objectContaining({
-            thread: { id: "account-2:shared", thread: second },
-          }),
-        ],
-      }),
+    act(() => result.current.restoreThreads(removal, ["account-1:shared"]));
+    expect(result.current.threads.map((thread) => thread.account.id)).toEqual([
+      "account-1",
+      "account-2",
+    ]);
+  });
+
+  it("does not restore a failed page-two action into the first-page cache", async () => {
+    const fetcher = vi.fn((key: string) =>
+      Promise.resolve(
+        key.includes("cursor=next-page")
+          ? {
+              failedAccountIds: [],
+              labelsByAccount: {},
+              nextPageToken: null,
+              threads: [createThread("account-2", "page-two")],
+            }
+          : {
+              failedAccountIds: [],
+              labelsByAccount: {},
+              nextPageToken: "next-page",
+              threads: [createThread("account-1", "page-one")],
+            },
+      ),
     );
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    let removal!: ReturnType<typeof result.current.removeThreads>;
+    act(() => {
+      removal = result.current.removeThreads(["account-2:page-two"]);
+      result.current.restoreThreads(removal, ["account-2:page-two"]);
+    });
+
+    await waitFor(() => expect(cache.restore).toHaveBeenCalledOnce());
+    expect(cache.restore).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      entries: [],
+      viewKey: expect.any(String),
+    });
+  });
+
+  it("updates and rolls back one account without touching a same-id thread", async () => {
+    const network = Promise.withResolvers<unknown>();
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: 100,
+      threads: [
+        createThread("account-1", "shared"),
+        createThread("account-2", "shared"),
+      ],
+      truncated: false,
+    });
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(2));
+
+    let update!: ReturnType<typeof result.current.optimisticallyUpdateThreads>;
+    act(() => {
+      update = result.current.optimisticallyUpdateThreads(
+        ["account-1:shared"],
+        (thread) => ({ ...thread, snippet: "updated" }),
+      );
+    });
+    expect(
+      result.current.threads.map((thread) => [
+        thread.account.id,
+        thread.snippet,
+      ]),
+    ).toEqual([
+      ["account-1", "updated"],
+      ["account-2", "shared"],
+    ]);
+
+    act(() => update.rollback(["account-1:shared"]));
+    expect(result.current.threads.map((thread) => thread.snippet)).toEqual([
+      "shared",
+      "shared",
+    ]);
   });
 });
 
-function createThread(accountId: string, threadId: string) {
+const ACCOUNTS = [createAccount("account-1"), createAccount("account-2")];
+const ACCOUNT_STATES = {
+  "account-1": {
+    after: "2026-07-24T00:00:00.000Z",
+    syncedAt: 100,
+    truncated: false,
+  },
+  "account-2": {
+    after: "2026-07-24T00:00:00.000Z",
+    syncedAt: 100,
+    truncated: false,
+  },
+};
+
+function createAccount(id: string) {
+  return { email: `${id}@example.com`, id, image: null, name: id };
+}
+
+function createThread(
+  accountId: string,
+  id: string,
+  internalDate = "2026-08-23T10:00:00.000Z",
+) {
   return {
-    id: threadId,
+    account: createAccount(accountId),
+    id,
     messages: [
       {
-        id: `${threadId}-message`,
-        threadId,
-        snippet: threadId,
-        subject: threadId,
-        date: "0",
-        internalDate: "0",
+        date: internalDate,
+        headers: { subject: id },
+        id: `${id}-message`,
+        internalDate,
         labelIds: ["INBOX"],
-        headers: { subject: threadId },
+        snippet: id,
+        subject: id,
+        threadId: id,
       },
     ],
     plan: undefined,
     plans: [],
-    snippet: threadId,
-    account: {
-      id: accountId,
-      email: `${accountId}@example.com`,
-      name: null,
-      image: null,
-    },
+    snippet: id,
   };
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -293,6 +293,44 @@ describe("useCombinedMailThreads", () => {
     ]);
   });
 
+  it("uses an available local snapshot when that account fails remotely", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: { "account-1": ACCOUNT_STATES["account-1"] },
+      complete: false,
+      missingAccountIds: ["account-2"],
+      threads: [
+        createThread("account-1", "local-fallback", "2026-08-23T10:01:00.000Z"),
+      ],
+      truncated: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: ["account-1"],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [createThread("account-2", "remote")],
+          }),
+        ),
+      },
+    );
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "local-fallback",
+      "remote",
+    ]);
+  });
+
   it("rehydrates only when one of the displayed account stores changes", async () => {
     mailbox.read
       .mockResolvedValueOnce({

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -237,6 +237,46 @@ describe("useCombinedMailThreads", () => {
     ]);
   });
 
+  it("does not hide authoritative local rows when the server is exhausted", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
+      complete: true,
+      missingAccountIds: [],
+      threads: Array.from({ length: 21 }, (_, index) =>
+        createThread(
+          index % 2 ? "account-1" : "account-2",
+          `local-${index}`,
+          new Date(Date.UTC(2026, 7, 23, 10, 0, index)).toISOString(),
+        ),
+      ),
+      truncated: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [],
+          }),
+        ),
+      },
+    );
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads).toHaveLength(21);
+    expect(result.current.hasMore).toBe(false);
+  });
+
   it("reconciles freshness independently for each account", async () => {
     mailbox.read.mockResolvedValue({
       accountStates: {
@@ -532,6 +572,102 @@ describe("useCombinedMailThreads", () => {
     );
   });
 
+  it("keeps a removed thread hidden until a newer sync confirms absence", async () => {
+    mailbox.read
+      .mockResolvedValueOnce({
+        accountStates: ACCOUNT_STATES,
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "provider-stale")],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({
+        accountStates: ACCOUNT_STATES,
+        complete: true,
+        missingAccountIds: [],
+        threads: [],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER - 2, false),
+        complete: false,
+        missingAccountIds: [],
+        threads: [],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER - 1),
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "provider-stale")],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
+        complete: true,
+        missingAccountIds: [],
+        threads: [],
+        truncated: false,
+      })
+      .mockResolvedValue({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "provider-stale")],
+        truncated: false,
+      });
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [createThread("account-1", "provider-stale")],
+          }),
+        ),
+      },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    act(() => result.current.removeThreads(["account-1:provider-stale"]));
+    expect(result.current.threads).toHaveLength(0);
+
+    for (const expectedReadCount of [2, 3, 4]) {
+      await act(async () => {
+        for (const listener of mailbox.listeners) listener("account-1");
+        await Promise.resolve();
+      });
+      await waitFor(() =>
+        expect(mailbox.read).toHaveBeenCalledTimes(expectedReadCount),
+      );
+    }
+    expect(result.current.threads).toHaveLength(0);
+
+    await act(async () => {
+      for (const listener of mailbox.listeners) listener("account-1");
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(mailbox.read).toHaveBeenCalledTimes(5));
+
+    await act(async () => {
+      for (const listener of mailbox.listeners) listener("account-1");
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "provider-stale",
+      ]),
+    );
+  });
+
   it("does not restore a failed page-two action into the first-page cache", async () => {
     const fetcher = vi.fn((key: string) =>
       Promise.resolve(
@@ -631,15 +767,17 @@ describe("useCombinedMailThreads", () => {
 const ACCOUNTS = [createAccount("account-1"), createAccount("account-2")];
 const ACCOUNT_STATES = createAccountStates(100);
 
-function createAccountStates(syncedAt: number) {
+function createAccountStates(syncedAt: number, complete = true) {
   return {
     "account-1": {
       after: "2026-07-24T00:00:00.000Z",
+      complete,
       syncedAt,
       truncated: false,
     },
     "account-2": {
       after: "2026-07-24T00:00:00.000Z",
+      complete,
       syncedAt,
       truncated: false,
     },

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -52,7 +52,6 @@ describe("useCombinedMailThreads", () => {
       accountStates: ACCOUNT_STATES,
       complete: true,
       missingAccountIds: [],
-      syncedAt: 100,
       threads: [createThread("account-2", "local")],
       truncated: false,
     });
@@ -87,7 +86,6 @@ describe("useCombinedMailThreads", () => {
       accountStates: ACCOUNT_STATES,
       complete: true,
       missingAccountIds: [],
-      syncedAt: 100,
       threads: [createThread("account-1", "canonical")],
       truncated: false,
     });
@@ -134,10 +132,9 @@ describe("useCombinedMailThreads", () => {
 
   it("keeps a complete canonical snapshot after it syncs more recently than the server page", async () => {
     mailbox.read.mockResolvedValue({
-      accountStates: ACCOUNT_STATES,
+      accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
       complete: true,
       missingAccountIds: [],
-      syncedAt: Number.MAX_SAFE_INTEGER,
       threads: [createThread("account-1", "canonical")],
       truncated: false,
     });
@@ -181,13 +178,22 @@ describe("useCombinedMailThreads", () => {
     expect(result.current.threads[0]?.snippet).toBe("canonical");
   });
 
-  it("keeps valid next-page rows when the combined mailbox is truncated", async () => {
+  it("keeps valid next-page rows when an account mailbox is truncated", async () => {
     mailbox.read.mockResolvedValue({
-      accountStates: ACCOUNT_STATES,
+      accountStates: {
+        ...createAccountStates(Number.MAX_SAFE_INTEGER),
+        "account-2": {
+          ...ACCOUNT_STATES["account-2"],
+          syncedAt: Number.MAX_SAFE_INTEGER,
+          truncated: true,
+        },
+      },
       complete: true,
       missingAccountIds: [],
-      syncedAt: Number.MAX_SAFE_INTEGER,
-      threads: [createThread("account-1", "canonical")],
+      threads: [
+        createThread("account-1", "canonical"),
+        createThread("account-2", "boundary"),
+      ],
       truncated: true,
     });
 
@@ -226,7 +232,64 @@ describe("useCombinedMailThreads", () => {
     await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
     expect(result.current.threads.map((thread) => thread.id)).toEqual([
       "canonical",
+      "boundary",
       "valid-next-page-row",
+    ]);
+  });
+
+  it("reconciles freshness independently for each account", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: {
+        "account-1": {
+          ...ACCOUNT_STATES["account-1"],
+          syncedAt: Number.MAX_SAFE_INTEGER,
+        },
+        "account-2": ACCOUNT_STATES["account-2"],
+      },
+      complete: true,
+      missingAccountIds: [],
+      threads: [
+        createThread("account-1", "fresh-local", "2026-08-23T10:02:00.000Z"),
+        createThread("account-2", "stale-local", "2026-08-23T09:00:00.000Z"),
+      ],
+      truncated: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [
+              createThread(
+                "account-1",
+                "stale-server",
+                "2026-08-23T10:01:00.000Z",
+              ),
+              createThread(
+                "account-2",
+                "fresh-server",
+                "2026-08-23T10:00:00.000Z",
+              ),
+            ],
+          }),
+        ),
+      },
+    );
+
+    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "fresh-local",
+      "fresh-server",
     ]);
   });
 
@@ -236,7 +299,6 @@ describe("useCombinedMailThreads", () => {
         accountStates: { "account-1": ACCOUNT_STATES["account-1"] },
         complete: false,
         missingAccountIds: ["account-2"],
-        syncedAt: 100,
         threads: [createThread("account-1", "one")],
         truncated: false,
       })
@@ -244,7 +306,6 @@ describe("useCombinedMailThreads", () => {
         accountStates: ACCOUNT_STATES,
         complete: true,
         missingAccountIds: [],
-        syncedAt: 200,
         threads: [
           createThread("account-2", "two"),
           createThread("account-1", "one"),
@@ -282,7 +343,6 @@ describe("useCombinedMailThreads", () => {
       accountStates: ACCOUNT_STATES,
       complete: true,
       missingAccountIds: [],
-      syncedAt: 100,
       threads: [
         createThread("account-1", "shared"),
         createThread("account-2", "shared"),
@@ -314,6 +374,71 @@ describe("useCombinedMailThreads", () => {
       "account-1",
       "account-2",
     ]);
+  });
+
+  it("shows a thread again after its removal is confirmed and new mail arrives", async () => {
+    const freshAccountStates = createAccountStates(Number.MAX_SAFE_INTEGER);
+    mailbox.read
+      .mockResolvedValueOnce({
+        accountStates: freshAccountStates,
+        complete: true,
+        missingAccountIds: [],
+        threads: [createThread("account-1", "returning")],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({
+        accountStates: freshAccountStates,
+        complete: true,
+        missingAccountIds: [],
+        threads: [],
+        truncated: false,
+      })
+      .mockResolvedValue({
+        accountStates: freshAccountStates,
+        complete: true,
+        missingAccountIds: [],
+        threads: [
+          createThread("account-1", "returning", "2026-08-23T11:00:00.000Z"),
+        ],
+        truncated: false,
+      });
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: null,
+            threads: [createThread("account-1", "returning")],
+          }),
+        ),
+      },
+    );
+    await waitFor(() => expect(result.current.threads).toHaveLength(1));
+
+    act(() => result.current.removeThreads(["account-1:returning"]));
+    expect(result.current.threads).toHaveLength(0);
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("account-1");
+    });
+    await waitFor(() => expect(mailbox.read).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      for (const listener of mailbox.listeners) listener("account-1");
+    });
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "returning",
+      ]),
+    );
   });
 
   it("does not restore a failed page-two action into the first-page cache", async () => {
@@ -369,7 +494,6 @@ describe("useCombinedMailThreads", () => {
       accountStates: ACCOUNT_STATES,
       complete: true,
       missingAccountIds: [],
-      syncedAt: 100,
       threads: [
         createThread("account-1", "shared"),
         createThread("account-2", "shared"),
@@ -414,18 +538,22 @@ describe("useCombinedMailThreads", () => {
 });
 
 const ACCOUNTS = [createAccount("account-1"), createAccount("account-2")];
-const ACCOUNT_STATES = {
-  "account-1": {
-    after: "2026-07-24T00:00:00.000Z",
-    syncedAt: 100,
-    truncated: false,
-  },
-  "account-2": {
-    after: "2026-07-24T00:00:00.000Z",
-    syncedAt: 100,
-    truncated: false,
-  },
-};
+const ACCOUNT_STATES = createAccountStates(100);
+
+function createAccountStates(syncedAt: number) {
+  return {
+    "account-1": {
+      after: "2026-07-24T00:00:00.000Z",
+      syncedAt,
+      truncated: false,
+    },
+    "account-2": {
+      after: "2026-07-24T00:00:00.000Z",
+      syncedAt,
+      truncated: false,
+    },
+  };
+}
 
 function createAccount(id: string) {
   return { email: `${id}@example.com`, id, image: null, name: id };

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -121,13 +121,15 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "canonical",
-      "stale-recent",
-      "older-than-local-window",
-    ]);
-    expect(result.current.threads[0]?.snippet).toBe("remote");
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "canonical",
+        "stale-recent",
+        "older-than-local-window",
+      ]);
+      expect(result.current.threads[0]?.snippet).toBe("remote");
+    });
   });
 
   it("keeps a complete canonical snapshot after it syncs more recently than the server page", async () => {
@@ -170,12 +172,14 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "canonical",
-      "older-than-local-window",
-    ]);
-    expect(result.current.threads[0]?.snippet).toBe("canonical");
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "canonical",
+        "older-than-local-window",
+      ]);
+      expect(result.current.threads[0]?.snippet).toBe("canonical");
+    });
   });
 
   it("keeps valid next-page rows when an account mailbox is truncated", async () => {
@@ -229,12 +233,14 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "canonical",
-      "boundary",
-      "valid-next-page-row",
-    ]);
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "canonical",
+        "boundary",
+        "valid-next-page-row",
+      ]);
+    });
   });
 
   it("does not hide authoritative local rows when the server is exhausted", async () => {
@@ -272,9 +278,11 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads).toHaveLength(21);
-    expect(result.current.hasMore).toBe(false);
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads).toHaveLength(21);
+      expect(result.current.hasMore).toBe(false);
+    });
   });
 
   it("reconciles freshness independently for each account", async () => {
@@ -326,11 +334,13 @@ describe("useCombinedMailThreads", () => {
       },
     );
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "fresh-local",
-      "fresh-server",
-    ]);
+    await waitFor(() => {
+      expect(cache.write).toHaveBeenCalledOnce();
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "fresh-local",
+        "fresh-server",
+      ]);
+    });
   });
 
   it("uses an available local snapshot when that account fails remotely", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -119,6 +119,11 @@ export function useCombinedMailThreads({
     });
   const [persistent, setPersistent] = useState<PersistentCombinedView>();
   const [synced, setSynced] = useState<SyncedCombinedView>();
+  const [localPagination, setLocalPagination] = useState({
+    identity: viewIdentity,
+    limit: COMBINED_PAGE_SIZE,
+  });
+  const [isLoadingMoreLocally, setIsLoadingMoreLocally] = useState(false);
   const accountsRef = useRef(accounts);
   const hiddenByView = useRef(new Map<string, Set<string>>());
   const hiddenConfirmationsByView = useRef(
@@ -132,6 +137,10 @@ export function useCombinedMailThreads({
     loadedAt: number;
   }>({ loadedAt: 0 });
   const loadMoreLock = useRef(false);
+  const localSnapshotLimit =
+    localPagination.identity === viewIdentity
+      ? localPagination.limit
+      : COMBINED_PAGE_SIZE;
 
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
   accountsRef.current = accounts;
@@ -175,10 +184,12 @@ export function useCombinedMailThreads({
       const generation = ++readGeneration;
       readCombinedSyncedMailboxThreads({
         accounts: accountsRef.current,
-        limit: COMBINED_PAGE_SIZE,
+        limit: localSnapshotLimit,
         query: { type: isUnread ? "unread" : "inbox" },
       }).then((snapshot) => {
-        if (cancelled || generation !== readGeneration || !snapshot) return;
+        if (cancelled || generation !== readGeneration) return;
+        setIsLoadingMoreLocally(false);
+        if (!snapshot) return;
         const hidden = hiddenByView.current.get(viewIdentity);
         if (hidden?.size) {
           const snapshotThreadKeys = new Set(
@@ -220,7 +231,7 @@ export function useCombinedMailThreads({
       cancelled = true;
       unsubscribe();
     };
-  }, [accountIdentity, enabled, isUnread, viewIdentity]);
+  }, [accountIdentity, enabled, isUnread, localSnapshotLimit, viewIdentity]);
 
   const remoteThreads = useMemo(
     () => data?.flatMap((page) => page.threads),
@@ -276,9 +287,10 @@ export function useCombinedMailThreads({
   }, [hiddenThreadKeys, sourceThreads, visibleThreadLimit]);
   const hasMore = data
     ? remoteHasMore
-    : persistent?.identity === viewIdentity
-      ? persistent.hasMore
-      : Boolean(syncedView?.truncated);
+    : syncedView
+      ? syncedView.truncated
+      : persistent?.identity === viewIdentity && persistent.hasMore;
+  const canLoadMoreLocally = !data && Boolean(syncedView?.truncated);
   const isLoadingMore = size > 1 && !data?.[size - 1];
   const labelsByAccount = useMemo(() => {
     const merged: Record<string, EmailLabels> = {};
@@ -551,7 +563,7 @@ export function useCombinedMailThreads({
     isLoading: isLoading && sourceThreads === undefined,
     error: sourceThreads !== undefined ? undefined : error,
     hasMore: Boolean(hasMore),
-    isLoadingMore,
+    isLoadingMore: isLoadingMore || isLoadingMoreLocally,
     failedAccountIds,
     labelsByAccount,
     removeThreads,
@@ -559,11 +571,29 @@ export function useCombinedMailThreads({
     optimisticallyUpdateThreads,
     loadMore: useCallback(() => {
       if (loadMoreLock.current || !hasMore) return;
+      if (canLoadMoreLocally) {
+        if (isLoadingMoreLocally) return;
+        setIsLoadingMoreLocally(true);
+        setLocalPagination((current) => ({
+          identity: viewIdentity,
+          limit:
+            (current.identity === viewIdentity
+              ? current.limit
+              : COMBINED_PAGE_SIZE) + COMBINED_PAGE_SIZE,
+        }));
+        return;
+      }
       loadMoreLock.current = true;
       setSize((current) => current + 1).catch(() => {
         loadMoreLock.current = false;
       });
-    }, [hasMore, setSize]),
+    }, [
+      canLoadMoreLocally,
+      hasMore,
+      isLoadingMoreLocally,
+      setSize,
+      viewIdentity,
+    ]),
   };
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useSWRConfig } from "swr";
 import useSWRInfinite from "swr/infinite";
 import type { GetAllThreadsResponse } from "@/app/api/threads/all/route";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
@@ -97,10 +98,10 @@ export function useCombinedMailThreads({
     [isUnread],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
+  const { fetcher } = useSWRConfig();
   const remoteRequest = useRef({
     identity: viewIdentity,
     startedAt: Date.now(),
-    validating: false,
   });
   const getKey = useCallback(
     (pageIndex: number, previousPageData: GetAllThreadsResponse | null) => {
@@ -116,12 +117,30 @@ export function useCombinedMailThreads({
     },
     [enabled, isUnread],
   );
-  const { data, error, isLoading, isValidating, size, setSize, mutate } =
-    useSWRInfinite<GetAllThreadsResponse>(getKey, {
-      keepPreviousData: false,
-      revalidateFirstPage: false,
-      revalidateOnFocus: false,
-    });
+  const fetchCombinedPage = useCallback(
+    async (key: string) => {
+      if (!fetcher) throw new Error("SWR fetcher is unavailable");
+      const query = new URLSearchParams(key.split("?")[1]);
+      if (!query.has("cursor")) {
+        remoteRequest.current = {
+          identity: viewIdentity,
+          startedAt: Date.now(),
+        };
+      }
+      return (await fetcher(key)) as GetAllThreadsResponse;
+    },
+    [fetcher, viewIdentity],
+  );
+  const { data, error, isLoading, size, setSize, mutate } =
+    useSWRInfinite<GetAllThreadsResponse>(
+      getKey,
+      fetcher ? fetchCombinedPage : null,
+      {
+        keepPreviousData: false,
+        revalidateFirstPage: false,
+        revalidateOnFocus: false,
+      },
+    );
   const [persistent, setPersistent] = useState<PersistentCombinedView>();
   const [synced, setSynced] = useState<SyncedCombinedView>();
   const [localPagination, setLocalPagination] = useState({
@@ -151,13 +170,8 @@ export function useCombinedMailThreads({
     remoteRequest.current = {
       identity: viewIdentity,
       startedAt: Date.now(),
-      validating: false,
     };
   }
-  if (isValidating && !remoteRequest.current.validating) {
-    remoteRequest.current.startedAt = Date.now();
-  }
-  remoteRequest.current.validating = isValidating;
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
   accountsRef.current = accounts;
   if (data?.[0] && remoteSnapshot.current.firstPage !== data[0]) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -54,6 +54,11 @@ type CombinedThreadRemoval = {
   entries: Map<string, RemovedCombinedThread>;
 };
 
+type HiddenThreadConfirmation = {
+  accountId: string;
+  after: number;
+};
+
 type PersistentCombinedView = {
   identity: string;
   hasMore: boolean;
@@ -116,6 +121,9 @@ export function useCombinedMailThreads({
   const [synced, setSynced] = useState<SyncedCombinedView>();
   const accountsRef = useRef(accounts);
   const hiddenByView = useRef(new Map<string, Set<string>>());
+  const hiddenConfirmationsByView = useRef(
+    new Map<string, Map<string, HiddenThreadConfirmation>>(),
+  );
   const optimisticUpdateTokens = useRef(new Map<string, symbol>());
   const [, renderHiddenChanges] = useReducer((version) => version + 1, 0);
   const remoteIdentity = useRef<string | undefined>(undefined);
@@ -176,10 +184,24 @@ export function useCombinedMailThreads({
           const snapshotThreadKeys = new Set(
             snapshot.threads.map(getListThreadKey),
           );
+          const confirmations =
+            hiddenConfirmationsByView.current.get(viewIdentity);
           const unconfirmed = new Set(
-            [...hidden].filter((threadKey) =>
-              snapshotThreadKeys.has(threadKey),
-            ),
+            [...hidden].filter((threadKey) => {
+              if (snapshotThreadKeys.has(threadKey)) return true;
+              const confirmation = confirmations?.get(threadKey);
+              if (!confirmation) return true;
+              const accountState =
+                snapshot.accountStates[confirmation.accountId];
+              if (
+                !accountState?.complete ||
+                accountState.syncedAt <= confirmation.after
+              ) {
+                return true;
+              }
+              confirmations.delete(threadKey);
+              return false;
+            }),
           );
           if (unconfirmed.size !== hidden.size) {
             hiddenByView.current.set(viewIdentity, unconfirmed);
@@ -233,9 +255,12 @@ export function useCombinedMailThreads({
   );
   const hiddenThreadKeys =
     hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS;
+  const remoteHasMore = Boolean(data?.at(-1)?.nextPageToken);
   const visibleThreadLimit = Math.max(
     COMBINED_PAGE_SIZE,
-    (data?.length ?? 1) * COMBINED_PAGE_SIZE,
+    data && remoteHasMore
+      ? data.length * COMBINED_PAGE_SIZE
+      : (sourceThreads?.length ?? 0),
   );
   const threads = useMemo(() => {
     const byKey = new Map<string, GetAllThreadsResponse["threads"][number]>();
@@ -250,7 +275,7 @@ export function useCombinedMailThreads({
       .slice(0, visibleThreadLimit);
   }, [hiddenThreadKeys, sourceThreads, visibleThreadLimit]);
   const hasMore = data
-    ? Boolean(data.at(-1)?.nextPageToken)
+    ? remoteHasMore
     : persistent?.identity === viewIdentity
       ? persistent.hasMore
       : Boolean(syncedView?.truncated);
@@ -315,6 +340,17 @@ export function useCombinedMailThreads({
         viewIdentity,
         new Set([...alreadyHidden, ...removedKeys]),
       );
+      const confirmations = new Map(
+        hiddenConfirmationsByView.current.get(viewIdentity),
+      );
+      const after = Date.now();
+      for (const [threadKey, entry] of entries) {
+        confirmations.set(threadKey, {
+          accountId: entry.thread.account.id,
+          after,
+        });
+      }
+      hiddenConfirmationsByView.current.set(viewIdentity, confirmations);
       renderHiddenChanges();
       const removed = new Set(removedKeys);
       setPersistent((current) =>
@@ -373,6 +409,10 @@ export function useCombinedMailThreads({
         hidden.delete(getListThreadKey(entry.thread));
       }
       hiddenByView.current.set(viewIdentity, hidden);
+      const confirmations = hiddenConfirmationsByView.current.get(viewIdentity);
+      for (const entry of restoring) {
+        confirmations?.delete(getListThreadKey(entry.thread));
+      }
       renderHiddenChanges();
       const firstPageEntries = restoring.filter(
         (entry) => entry.pageIndex === 0,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -214,7 +214,7 @@ export function useCombinedMailThreads({
   const syncedThreads = syncedView?.threads;
   const sourceThreads = useMemo(
     () =>
-      remoteThreads && syncedThreads && syncedView?.complete
+      remoteThreads && syncedThreads
         ? mergeCombinedThreads({
             accountStates: syncedView.accountStates,
             failedAccountIds,
@@ -229,7 +229,6 @@ export function useCombinedMailThreads({
       remoteThreads,
       syncedThreads,
       syncedView?.accountStates,
-      syncedView?.complete,
     ],
   );
   const hiddenThreadKeys =

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -24,6 +24,7 @@ import {
   restoreCachedThreadsToView,
   writeCachedThreadList,
 } from "@/utils/email-cache/thread-lists";
+import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
 import {
   EMAIL_CACHE_MEASURES,
   finishEmailCacheMeasure,
@@ -33,6 +34,8 @@ import { getThreadTimestamp } from "@/utils/threads/sort";
 import { createSearchParams } from "@/utils/url";
 
 type CombinedThread = GetAllThreadsResponse["threads"][number];
+
+const COMBINED_PAGE_SIZE = 20;
 
 type CachedCombinedThread = {
   id: string;
@@ -95,7 +98,7 @@ export function useCombinedMailThreads({
         return null;
       }
       const params = createSearchParams({
-        limit: 20,
+        limit: COMBINED_PAGE_SIZE,
         isUnread: isUnread || undefined,
         cursor: pageIndex > 0 ? previousPageData?.nextPageToken : undefined,
       });
@@ -162,10 +165,25 @@ export function useCombinedMailThreads({
     const loadSyncedView = () => {
       readCombinedSyncedMailboxThreads({
         accounts: accountsRef.current,
-        limit: 20,
+        limit: COMBINED_PAGE_SIZE,
         query: { type: isUnread ? "unread" : "inbox" },
       }).then((snapshot) => {
         if (cancelled || !snapshot) return;
+        const hidden = hiddenByView.current.get(viewIdentity);
+        if (hidden?.size) {
+          const snapshotThreadKeys = new Set(
+            snapshot.threads.map(getListThreadKey),
+          );
+          const unconfirmed = new Set(
+            [...hidden].filter((threadKey) =>
+              snapshotThreadKeys.has(threadKey),
+            ),
+          );
+          if (unconfirmed.size !== hidden.size) {
+            hiddenByView.current.set(viewIdentity, unconfirmed);
+            renderHiddenChanges();
+          }
+        }
         setSynced({ identity: viewIdentity, ...snapshot });
       });
     };
@@ -184,45 +202,52 @@ export function useCombinedMailThreads({
     () => data?.flatMap((page) => page.threads),
     [data],
   );
+  const failedAccountIds = useMemo(
+    () => [...new Set(data?.flatMap((page) => page.failedAccountIds) ?? [])],
+    [data],
+  );
   const persistentThreads =
     persistent?.identity === viewIdentity ? persistent.threads : undefined;
   const syncedView = synced?.identity === viewIdentity ? synced : undefined;
   const syncedThreads = syncedView?.threads;
   const sourceThreads = useMemo(
     () =>
-      remoteThreads &&
-      syncedThreads &&
-      syncedView?.complete &&
-      syncedView.syncedAt > remoteSnapshot.current.loadedAt
+      remoteThreads && syncedThreads && syncedView?.complete
         ? mergeCombinedThreads({
             accountStates: syncedView.accountStates,
+            failedAccountIds,
+            remoteLoadedAt: remoteSnapshot.current.loadedAt,
             remoteThreads,
             syncedThreads,
-            syncedTruncated: syncedView.truncated,
           })
         : (remoteThreads ?? syncedThreads ?? persistentThreads),
     [
       persistentThreads,
+      failedAccountIds,
       remoteThreads,
       syncedThreads,
       syncedView?.accountStates,
       syncedView?.complete,
-      syncedView?.syncedAt,
-      syncedView?.truncated,
     ],
   );
   const hiddenThreadKeys =
     hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS;
+  const visibleThreadLimit = Math.max(
+    COMBINED_PAGE_SIZE,
+    (data?.length ?? 1) * COMBINED_PAGE_SIZE,
+  );
   const threads = useMemo(() => {
     const byKey = new Map<string, GetAllThreadsResponse["threads"][number]>();
     for (const thread of sourceThreads ?? []) {
       const threadKey = getListThreadKey(thread);
       if (!hiddenThreadKeys.has(threadKey)) byKey.set(threadKey, thread);
     }
-    return [...byKey.values()].sort(
-      (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
-    );
-  }, [hiddenThreadKeys, sourceThreads]);
+    return [...byKey.values()]
+      .sort(
+        (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
+      )
+      .slice(0, visibleThreadLimit);
+  }, [hiddenThreadKeys, sourceThreads, visibleThreadLimit]);
   const hasMore = data
     ? Boolean(data.at(-1)?.nextPageToken)
     : persistent?.identity === viewIdentity
@@ -290,6 +315,27 @@ export function useCombinedMailThreads({
         new Set([...alreadyHidden, ...removedKeys]),
       );
       renderHiddenChanges();
+      const removed = new Set(removedKeys);
+      setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? {
+              ...current,
+              threads: current.threads.filter(
+                (thread) => !removed.has(getListThreadKey(thread)),
+              ),
+            }
+          : current,
+      );
+      mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            threads: page.threads.filter(
+              (thread) => !removed.has(getListThreadKey(thread)),
+            ),
+          })),
+        { populateCache: true, revalidate: false },
+      ).catch(() => {});
       removeCachedThreadsFromView({
         emailAccountId,
         viewKey,
@@ -300,6 +346,7 @@ export function useCombinedMailThreads({
     },
     [
       emailAccountId,
+      mutate,
       pageIndexByThreadKey,
       sourceThreads,
       viewIdentity,
@@ -326,19 +373,42 @@ export function useCombinedMailThreads({
       }
       hiddenByView.current.set(viewIdentity, hidden);
       renderHiddenChanges();
+      const firstPageEntries = restoring.filter(
+        (entry) => entry.pageIndex === 0,
+      );
+      setPersistent((current) =>
+        current?.identity === viewIdentity
+          ? {
+              ...current,
+              threads: insertRestoredCombinedThreads(
+                current.threads,
+                firstPageEntries,
+              ),
+            }
+          : current,
+      );
+      mutate(
+        (pages) =>
+          pages?.map((page, pageIndex) => ({
+            ...page,
+            threads: insertRestoredCombinedThreads(
+              page.threads,
+              restoring.filter((entry) => entry.pageIndex === pageIndex),
+            ),
+          })),
+        { populateCache: true, revalidate: false },
+      ).catch(() => {});
       restoreCachedThreadsToView({
         emailAccountId,
         viewKey,
-        entries: restoring
-          .filter((entry) => entry.pageIndex === 0)
-          .map(({ thread, index, threadOrder }) => ({
-            thread: toCachedCombinedThread(thread),
-            index,
-            threadOrder,
-          })),
+        entries: firstPageEntries.map(({ thread, index, threadOrder }) => ({
+          thread: toCachedCombinedThread(thread),
+          index,
+          threadOrder,
+        })),
       }).catch(() => {});
     },
-    [emailAccountId, viewIdentity, viewKey],
+    [emailAccountId, mutate, viewIdentity, viewKey],
   );
 
   const optimisticallyUpdateThreads = useCallback(
@@ -441,9 +511,7 @@ export function useCombinedMailThreads({
     error: sourceThreads !== undefined ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore,
-    failedAccountIds: [
-      ...new Set(data?.flatMap((page) => page.failedAccountIds) ?? []),
-    ],
+    failedAccountIds,
     labelsByAccount,
     removeThreads,
     restoreThreads,
@@ -466,18 +534,34 @@ const EMPTY_THREAD_KEYS = new Set<string>();
 
 function mergeCombinedThreads({
   accountStates,
+  failedAccountIds,
+  remoteLoadedAt,
   remoteThreads,
   syncedThreads,
-  syncedTruncated,
 }: {
   accountStates: SyncedCombinedMailboxSnapshot["accountStates"];
+  failedAccountIds: string[];
+  remoteLoadedAt: number;
   remoteThreads: CombinedThread[];
   syncedThreads: CombinedThread[];
-  syncedTruncated: boolean;
 }) {
-  const oldestSyncedTimestamp = Math.min(
-    ...syncedThreads.map(getThreadTimestamp),
+  const locallyAuthoritativeAccountIds = new Set(
+    Object.entries(accountStates)
+      .filter(
+        ([accountId, state]) =>
+          failedAccountIds.includes(accountId) ||
+          state.syncedAt > remoteLoadedAt,
+      )
+      .map(([accountId]) => accountId),
   );
+  const oldestSyncedTimestampByAccount = new Map<string, number>();
+  for (const thread of syncedThreads) {
+    const timestamp = getThreadTimestamp(thread);
+    const current = oldestSyncedTimestampByAccount.get(thread.account.id);
+    if (current === undefined || timestamp < current) {
+      oldestSyncedTimestampByAccount.set(thread.account.id, timestamp);
+    }
+  }
   const remoteThreadsByKey = new Map(
     remoteThreads.map((thread) => [getListThreadKey(thread), thread]),
   );
@@ -485,19 +569,25 @@ function mergeCombinedThreads({
     remoteThreads
       .filter((thread) => {
         const state = accountStates[thread.account.id];
-        if (!state) return true;
+        if (!state || !locallyAuthoritativeAccountIds.has(thread.account.id)) {
+          return true;
+        }
         const afterTimestamp = new Date(state.after).getTime();
-        const authoritativeCutoff = syncedTruncated
+        const oldestSyncedTimestamp =
+          oldestSyncedTimestampByAccount.get(thread.account.id) ??
+          afterTimestamp;
+        const authoritativeCutoff = state.truncated
           ? Math.max(afterTimestamp, oldestSyncedTimestamp)
           : afterTimestamp;
         const timestamp = getThreadTimestamp(thread);
-        return syncedTruncated
+        return state.truncated
           ? timestamp <= authoritativeCutoff
           : timestamp < authoritativeCutoff;
       })
       .map((thread) => [getListThreadKey(thread), thread]),
   );
   for (const thread of syncedThreads) {
+    if (!locallyAuthoritativeAccountIds.has(thread.account.id)) continue;
     const remoteThread = remoteThreadsByKey.get(getListThreadKey(thread));
     threadsByKey.set(getListThreadKey(thread), {
       ...thread,
@@ -508,6 +598,29 @@ function mergeCombinedThreads({
   return [...threadsByKey.values()].sort(
     (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
   );
+}
+
+function insertRestoredCombinedThreads(
+  threads: CombinedThread[],
+  restoring: RemovedCombinedThread[],
+) {
+  if (!restoring.length) return threads;
+  const threadsByKey = new Map(
+    [...threads, ...restoring.map((entry) => entry.thread)].map((thread) => [
+      getListThreadKey(thread),
+      thread,
+    ]),
+  );
+  return restoreThreadOrder(
+    threads.map(getListThreadKey),
+    restoring.map(({ thread, index, threadOrder }) => ({
+      threadId: getListThreadKey(thread),
+      index,
+      threadOrder,
+    })),
+  )
+    .map((threadKey) => threadsByKey.get(threadKey))
+    .filter((thread): thread is CombinedThread => thread !== undefined);
 }
 
 function replaceCombinedThreads(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -1,10 +1,22 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import useSWRInfinite from "swr/infinite";
 import type { GetAllThreadsResponse } from "@/app/api/threads/all/route";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { EmailLabels } from "@/providers/email-label-types";
+import {
+  readCombinedSyncedMailboxThreads,
+  subscribeToMailboxStore,
+  type SyncedCombinedMailboxSnapshot,
+} from "@/utils/email-cache/mailbox";
 import { createThreadListCacheKey } from "@/utils/email-cache/keys";
 import {
   readCachedThreadList,
@@ -12,7 +24,6 @@ import {
   restoreCachedThreadsToView,
   writeCachedThreadList,
 } from "@/utils/email-cache/thread-lists";
-import { restoreThreadOrder } from "@/utils/email-cache/thread-order";
 import {
   EMAIL_CACHE_MEASURES,
   finishEmailCacheMeasure,
@@ -42,20 +53,33 @@ type CombinedThreadRemoval = {
 
 type PersistentCombinedView = {
   identity: string;
-  cachedAt: number;
   hasMore: boolean;
   threads: CombinedThread[];
 };
 
+type SyncedCombinedView = SyncedCombinedMailboxSnapshot & {
+  identity: string;
+};
+
 export function useCombinedMailThreads({
+  accounts,
   emailAccountId,
   enabled,
   isUnread,
 }: {
+  accounts: CombinedThread["account"][];
   emailAccountId: string;
   enabled: boolean;
   isUnread: boolean;
 }) {
+  const accountIdentity = useMemo(
+    () =>
+      accounts
+        .map((account) => account.id)
+        .sort()
+        .join(":"),
+    [accounts],
+  );
   const viewKey = useMemo(
     () =>
       createThreadListCacheKey({
@@ -64,7 +88,7 @@ export function useCombinedMailThreads({
       }),
     [isUnread],
   );
-  const viewIdentity = `${emailAccountId}:${viewKey}`;
+  const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
   const getKey = useCallback(
     (pageIndex: number, previousPageData: GetAllThreadsResponse | null) => {
       if (!enabled || (previousPageData && !previousPageData.nextPageToken)) {
@@ -86,10 +110,23 @@ export function useCombinedMailThreads({
       revalidateOnFocus: false,
     });
   const [persistent, setPersistent] = useState<PersistentCombinedView>();
+  const [synced, setSynced] = useState<SyncedCombinedView>();
+  const accountsRef = useRef(accounts);
+  const hiddenByView = useRef(new Map<string, Set<string>>());
+  const optimisticUpdateTokens = useRef(new Map<string, symbol>());
+  const [, renderHiddenChanges] = useReducer((version) => version + 1, 0);
   const remoteIdentity = useRef<string | undefined>(undefined);
+  const remoteSnapshot = useRef<{
+    firstPage?: GetAllThreadsResponse;
+    loadedAt: number;
+  }>({ loadedAt: 0 });
   const loadMoreLock = useRef(false);
 
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
+  accountsRef.current = accounts;
+  if (data?.[0] && remoteSnapshot.current.firstPage !== data[0]) {
+    remoteSnapshot.current = { firstPage: data[0], loadedAt: Date.now() };
+  }
 
   useEffect(() => {
     if (!enabled) return;
@@ -106,7 +143,6 @@ export function useCombinedMailThreads({
       }
       setPersistent({
         identity: viewIdentity,
-        cachedAt: cached.cachedAt,
         hasMore: cached.hasMore,
         threads: cached.threads.map((entry) => entry.thread),
       });
@@ -117,25 +153,81 @@ export function useCombinedMailThreads({
     };
   }, [emailAccountId, enabled, viewIdentity, viewKey]);
 
+  useEffect(() => {
+    if (!enabled || !accountIdentity) return;
+    let cancelled = false;
+    const accountIds = new Set(
+      accountsRef.current.map((account) => account.id),
+    );
+    const loadSyncedView = () => {
+      readCombinedSyncedMailboxThreads({
+        accounts: accountsRef.current,
+        limit: 20,
+        query: { type: isUnread ? "unread" : "inbox" },
+      }).then((snapshot) => {
+        if (cancelled || !snapshot) return;
+        setSynced({ identity: viewIdentity, ...snapshot });
+      });
+    };
+    const unsubscribe = subscribeToMailboxStore((changedAccountId) => {
+      if (accountIds.has(changedAccountId)) loadSyncedView();
+    });
+    loadSyncedView();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [accountIdentity, enabled, isUnread, viewIdentity]);
+
   const remoteThreads = useMemo(
     () => data?.flatMap((page) => page.threads),
     [data],
   );
   const persistentThreads =
     persistent?.identity === viewIdentity ? persistent.threads : undefined;
-  const sourceThreads = remoteThreads ?? persistentThreads;
+  const syncedView = synced?.identity === viewIdentity ? synced : undefined;
+  const syncedThreads = syncedView?.threads;
+  const sourceThreads = useMemo(
+    () =>
+      remoteThreads &&
+      syncedThreads &&
+      syncedView?.complete &&
+      syncedView.syncedAt > remoteSnapshot.current.loadedAt
+        ? mergeCombinedThreads({
+            accountStates: syncedView.accountStates,
+            remoteThreads,
+            syncedThreads,
+            syncedTruncated: syncedView.truncated,
+          })
+        : (remoteThreads ?? syncedThreads ?? persistentThreads),
+    [
+      persistentThreads,
+      remoteThreads,
+      syncedThreads,
+      syncedView?.accountStates,
+      syncedView?.complete,
+      syncedView?.syncedAt,
+      syncedView?.truncated,
+    ],
+  );
+  const hiddenThreadKeys =
+    hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS;
   const threads = useMemo(() => {
     const byKey = new Map<string, GetAllThreadsResponse["threads"][number]>();
     for (const thread of sourceThreads ?? []) {
-      byKey.set(getListThreadKey(thread), thread);
+      const threadKey = getListThreadKey(thread);
+      if (!hiddenThreadKeys.has(threadKey)) byKey.set(threadKey, thread);
     }
     return [...byKey.values()].sort(
       (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
     );
-  }, [sourceThreads]);
+  }, [hiddenThreadKeys, sourceThreads]);
   const hasMore = data
     ? Boolean(data.at(-1)?.nextPageToken)
-    : persistent?.identity === viewIdentity && persistent.hasMore;
+    : persistent?.identity === viewIdentity
+      ? persistent.hasMore
+      : Boolean(syncedView?.truncated);
   const isLoadingMore = size > 1 && !data?.[size - 1];
   const labelsByAccount = useMemo(() => {
     const merged: Record<string, EmailLabels> = {};
@@ -146,6 +238,15 @@ export function useCombinedMailThreads({
     }
     return merged;
   }, [data]);
+  const pageIndexByThreadKey = useMemo(() => {
+    const pageIndexes = new Map<string, number>();
+    for (const [pageIndex, page] of (data ?? []).entries()) {
+      for (const thread of page.threads) {
+        pageIndexes.set(getListThreadKey(thread), pageIndex);
+      }
+    }
+    return pageIndexes;
+  }, [data]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -154,10 +255,12 @@ export function useCombinedMailThreads({
     writeCachedThreadList({
       emailAccountId,
       viewKey,
-      threads: firstPage.threads.map(toCachedCombinedThread),
+      threads: firstPage.threads
+        .filter((thread) => !hiddenThreadKeys.has(getListThreadKey(thread)))
+        .map(toCachedCombinedThread),
       hasMore: Boolean(firstPage.nextPageToken),
     }).catch(() => {});
-  }, [data, emailAccountId, enabled, viewKey]);
+  }, [data, emailAccountId, enabled, hiddenThreadKeys, viewKey]);
 
   const removeThreads = useCallback(
     (threadKeys: string[]): CombinedThreadRemoval => {
@@ -165,60 +268,28 @@ export function useCombinedMailThreads({
       if (!threadKeys.length) return { viewIdentity, entries };
       const targets = new Set(threadKeys);
 
-      if (data) {
-        for (const [pageIndex, page] of data.entries()) {
-          const threadOrder = page.threads.map(getListThreadKey);
-          for (const [index, thread] of page.threads.entries()) {
-            const threadKey = getListThreadKey(thread);
-            if (targets.has(threadKey)) {
-              entries.set(threadKey, {
-                thread,
-                pageIndex,
-                index,
-                threadOrder,
-              });
-            }
-          }
-        }
-      } else {
-        const threadOrder = (persistentThreads ?? []).map(getListThreadKey);
-        for (const [index, thread] of (persistentThreads ?? []).entries()) {
-          const threadKey = getListThreadKey(thread);
-          if (targets.has(threadKey)) {
-            entries.set(threadKey, {
-              thread,
-              pageIndex: 0,
-              index,
-              threadOrder,
-            });
-          }
+      const alreadyHidden =
+        hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS;
+      const threadOrder = (sourceThreads ?? []).map(getListThreadKey);
+      for (const [index, thread] of (sourceThreads ?? []).entries()) {
+        const threadKey = getListThreadKey(thread);
+        if (targets.has(threadKey) && !alreadyHidden.has(threadKey)) {
+          entries.set(threadKey, {
+            thread,
+            pageIndex: pageIndexByThreadKey.get(threadKey) ?? 0,
+            index,
+            threadOrder,
+          });
         }
       }
 
       const removedKeys = [...entries.keys()];
       if (!removedKeys.length) return { viewIdentity, entries };
-      const removed = new Set(removedKeys);
-
-      setPersistent((current) =>
-        current?.identity === viewIdentity
-          ? {
-              ...current,
-              threads: current.threads.filter(
-                (thread) => !removed.has(getListThreadKey(thread)),
-              ),
-            }
-          : current,
+      hiddenByView.current.set(
+        viewIdentity,
+        new Set([...alreadyHidden, ...removedKeys]),
       );
-      mutate(
-        (pages) =>
-          pages?.map((page) => ({
-            ...page,
-            threads: page.threads.filter(
-              (thread) => !removed.has(getListThreadKey(thread)),
-            ),
-          })),
-        { populateCache: true, revalidate: false },
-      ).catch(() => {});
+      renderHiddenChanges();
       removeCachedThreadsFromView({
         emailAccountId,
         viewKey,
@@ -227,7 +298,13 @@ export function useCombinedMailThreads({
 
       return { viewIdentity, entries };
     },
-    [data, emailAccountId, mutate, persistentThreads, viewIdentity, viewKey],
+    [
+      emailAccountId,
+      pageIndexByThreadKey,
+      sourceThreads,
+      viewIdentity,
+      viewKey,
+    ],
   );
 
   const restoreThreads = useCallback(
@@ -241,27 +318,14 @@ export function useCombinedMailThreads({
       for (const entry of restoring) {
         removal.entries.delete(getListThreadKey(entry.thread));
       }
-      setPersistent((current) =>
-        current?.identity === viewIdentity
-          ? {
-              ...current,
-              threads: insertRestoredThreads(current.threads, restoring),
-            }
-          : current,
+      const hidden = new Set(
+        hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS,
       );
-      mutate(
-        (pages) =>
-          pages?.map((page, pageIndex) => {
-            const pageEntries = restoring.filter(
-              (entry) => entry.pageIndex === pageIndex,
-            );
-            return {
-              ...page,
-              threads: insertRestoredThreads(page.threads, pageEntries),
-            };
-          }),
-        { populateCache: true, revalidate: false },
-      ).catch(() => {});
+      for (const entry of restoring) {
+        hidden.delete(getListThreadKey(entry.thread));
+      }
+      hiddenByView.current.set(viewIdentity, hidden);
+      renderHiddenChanges();
       restoreCachedThreadsToView({
         emailAccountId,
         viewKey,
@@ -274,7 +338,91 @@ export function useCombinedMailThreads({
           })),
       }).catch(() => {});
     },
-    [emailAccountId, mutate, viewIdentity, viewKey],
+    [emailAccountId, viewIdentity, viewKey],
+  );
+
+  const optimisticallyUpdateThreads = useCallback(
+    (
+      threadKeys: string[],
+      updater: (thread: CombinedThread) => CombinedThread,
+    ) => {
+      const targets = new Set(threadKeys);
+      const previousByKey = new Map<string, CombinedThread>();
+      const updatedByKey = new Map<string, CombinedThread>();
+      const updateToken = Symbol("combined-thread-update");
+
+      for (const thread of sourceThreads ?? []) {
+        const threadKey = getListThreadKey(thread);
+        if (!targets.has(threadKey)) continue;
+        const updated = updater(thread);
+        if (updated === thread) continue;
+        previousByKey.set(threadKey, thread);
+        updatedByKey.set(threadKey, updated);
+        optimisticUpdateTokens.current.set(threadKey, updateToken);
+      }
+
+      const applyUpdates = (
+        replacements: ReadonlyMap<string, CombinedThread>,
+      ) => {
+        if (!replacements.size) return;
+        setSynced((current) => {
+          if (current?.identity !== viewIdentity) return current;
+          const threads = replaceCombinedThreads(current.threads, replacements);
+          return threads === current.threads
+            ? current
+            : { ...current, threads };
+        });
+        setPersistent((current) => {
+          if (current?.identity !== viewIdentity) return current;
+          const threads = replaceCombinedThreads(current.threads, replacements);
+          return threads === current.threads
+            ? current
+            : { ...current, threads };
+        });
+        mutate(
+          (pages) => {
+            if (!pages) return pages;
+            let changed = false;
+            const updatedPages = pages.map((page) => {
+              const threads = replaceCombinedThreads(
+                page.threads,
+                replacements,
+              );
+              if (threads === page.threads) return page;
+              changed = true;
+              return { ...page, threads };
+            });
+            return changed ? updatedPages : pages;
+          },
+          { populateCache: true, revalidate: false },
+        ).catch(() => {});
+      };
+
+      applyUpdates(updatedByKey);
+      const changedThreadKeys = [...updatedByKey.keys()];
+      const isLatestUpdate = (threadKey: string) =>
+        optimisticUpdateTokens.current.get(threadKey) === updateToken;
+
+      return {
+        threadKeys: changedThreadKeys,
+        commit: (threadKey: string) => {
+          if (isLatestUpdate(threadKey)) {
+            optimisticUpdateTokens.current.delete(threadKey);
+          }
+        },
+        rollback: (failedThreadKeys: string[]) => {
+          const restoring = new Map<string, CombinedThread>();
+          for (const threadKey of failedThreadKeys) {
+            if (!isLatestUpdate(threadKey)) continue;
+            optimisticUpdateTokens.current.delete(threadKey);
+            const previous = previousByKey.get(threadKey);
+            if (previous) restoring.set(threadKey, previous);
+          }
+          applyUpdates(restoring);
+        },
+      };
+    },
+    [mutate, sourceThreads, viewIdentity],
   );
 
   useEffect(() => {
@@ -289,8 +437,8 @@ export function useCombinedMailThreads({
 
   return {
     threads,
-    isLoading: isLoading && !sourceThreads,
-    error: sourceThreads ? undefined : error,
+    isLoading: isLoading && sourceThreads === undefined,
+    error: sourceThreads !== undefined ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore,
     failedAccountIds: [
@@ -299,6 +447,7 @@ export function useCombinedMailThreads({
     labelsByAccount,
     removeThreads,
     restoreThreads,
+    optimisticallyUpdateThreads,
     loadMore: useCallback(() => {
       if (loadMoreLock.current || !hasMore) return;
       loadMoreLock.current = true;
@@ -313,25 +462,64 @@ function toCachedCombinedThread(thread: CombinedThread): CachedCombinedThread {
   return { id: getListThreadKey(thread), thread };
 }
 
-function insertRestoredThreads(
-  threads: CombinedThread[],
-  restoring: RemovedCombinedThread[],
-) {
-  if (!restoring.length) return threads;
-  const threadsByKey = new Map(
-    [...threads, ...restoring.map((entry) => entry.thread)].map((thread) => [
-      getListThreadKey(thread),
-      thread,
-    ]),
+const EMPTY_THREAD_KEYS = new Set<string>();
+
+function mergeCombinedThreads({
+  accountStates,
+  remoteThreads,
+  syncedThreads,
+  syncedTruncated,
+}: {
+  accountStates: SyncedCombinedMailboxSnapshot["accountStates"];
+  remoteThreads: CombinedThread[];
+  syncedThreads: CombinedThread[];
+  syncedTruncated: boolean;
+}) {
+  const oldestSyncedTimestamp = Math.min(
+    ...syncedThreads.map(getThreadTimestamp),
   );
-  return restoreThreadOrder(
-    threads.map(getListThreadKey),
-    restoring.map(({ thread, index, threadOrder }) => ({
-      threadId: getListThreadKey(thread),
-      index,
-      threadOrder,
-    })),
-  )
-    .map((threadKey) => threadsByKey.get(threadKey))
-    .filter((thread): thread is CombinedThread => thread !== undefined);
+  const remoteThreadsByKey = new Map(
+    remoteThreads.map((thread) => [getListThreadKey(thread), thread]),
+  );
+  const threadsByKey = new Map(
+    remoteThreads
+      .filter((thread) => {
+        const state = accountStates[thread.account.id];
+        if (!state) return true;
+        const afterTimestamp = new Date(state.after).getTime();
+        const authoritativeCutoff = syncedTruncated
+          ? Math.max(afterTimestamp, oldestSyncedTimestamp)
+          : afterTimestamp;
+        const timestamp = getThreadTimestamp(thread);
+        return syncedTruncated
+          ? timestamp <= authoritativeCutoff
+          : timestamp < authoritativeCutoff;
+      })
+      .map((thread) => [getListThreadKey(thread), thread]),
+  );
+  for (const thread of syncedThreads) {
+    const remoteThread = remoteThreadsByKey.get(getListThreadKey(thread));
+    threadsByKey.set(getListThreadKey(thread), {
+      ...thread,
+      plan: remoteThread?.plan ?? thread.plan,
+      plans: remoteThread?.plans ?? thread.plans,
+    });
+  }
+  return [...threadsByKey.values()].sort(
+    (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
+  );
+}
+
+function replaceCombinedThreads(
+  threads: CombinedThread[],
+  replacements: ReadonlyMap<string, CombinedThread>,
+) {
+  let changed = false;
+  const updatedThreads = threads.map((thread) => {
+    const replacement = replacements.get(getListThreadKey(thread));
+    if (!replacement || replacement === thread) return thread;
+    changed = true;
+    return replacement;
+  });
+  return changed ? updatedThreads : threads;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -199,7 +199,7 @@ export function useCombinedMailThreads({
               ) {
                 return true;
               }
-              confirmations.delete(threadKey);
+              confirmations?.delete(threadKey);
               return false;
             }),
           );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -162,13 +162,15 @@ export function useCombinedMailThreads({
     const accountIds = new Set(
       accountsRef.current.map((account) => account.id),
     );
+    let readGeneration = 0;
     const loadSyncedView = () => {
+      const generation = ++readGeneration;
       readCombinedSyncedMailboxThreads({
         accounts: accountsRef.current,
         limit: COMBINED_PAGE_SIZE,
         query: { type: isUnread ? "unread" : "inbox" },
       }).then((snapshot) => {
-        if (cancelled || !snapshot) return;
+        if (cancelled || generation !== readGeneration || !snapshot) return;
         const hidden = hiddenByView.current.get(viewIdentity);
         if (hidden?.size) {
           const snapshotThreadKeys = new Set(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -97,6 +97,11 @@ export function useCombinedMailThreads({
     [isUnread],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
+  const remoteRequest = useRef({
+    identity: viewIdentity,
+    startedAt: Date.now(),
+    validating: false,
+  });
   const getKey = useCallback(
     (pageIndex: number, previousPageData: GetAllThreadsResponse | null) => {
       if (!enabled || (previousPageData && !previousPageData.nextPageToken)) {
@@ -111,7 +116,7 @@ export function useCombinedMailThreads({
     },
     [enabled, isUnread],
   );
-  const { data, error, isLoading, size, setSize, mutate } =
+  const { data, error, isLoading, isValidating, size, setSize, mutate } =
     useSWRInfinite<GetAllThreadsResponse>(getKey, {
       keepPreviousData: false,
       revalidateFirstPage: false,
@@ -142,10 +147,24 @@ export function useCombinedMailThreads({
       ? localPagination.limit
       : COMBINED_PAGE_SIZE;
 
+  if (remoteRequest.current.identity !== viewIdentity) {
+    remoteRequest.current = {
+      identity: viewIdentity,
+      startedAt: Date.now(),
+      validating: false,
+    };
+  }
+  if (isValidating && !remoteRequest.current.validating) {
+    remoteRequest.current.startedAt = Date.now();
+  }
+  remoteRequest.current.validating = isValidating;
   remoteIdentity.current = data?.[0] ? viewIdentity : undefined;
   accountsRef.current = accounts;
   if (data?.[0] && remoteSnapshot.current.firstPage !== data[0]) {
-    remoteSnapshot.current = { firstPage: data[0], loadedAt: Date.now() };
+    remoteSnapshot.current = {
+      firstPage: data[0],
+      loadedAt: remoteRequest.current.startedAt,
+    };
   }
 
   useEffect(() => {

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -523,7 +523,6 @@ describe("synced mailbox cache", () => {
       },
       complete: true,
       missingAccountIds: [],
-      syncedAt: 100,
       truncated: false,
     });
     expect(
@@ -532,6 +531,19 @@ describe("synced mailbox cache", () => {
       ["account-2", "shared-thread"],
       ["account-1", "shared-thread"],
     ]);
+
+    const truncatedSnapshot = await readCombinedSyncedMailboxThreads({
+      accounts: [getAccount("account-1"), getAccount("account-2")],
+      query: { type: "inbox" },
+      limit: 1,
+    });
+    expect(truncatedSnapshot).toMatchObject({
+      truncated: true,
+      threads: [
+        { account: { id: "account-2" }, id: "shared-thread" },
+        { account: { id: "account-1" }, id: "shared-thread" },
+      ],
+    });
   });
 
   it("returns available unread rows while another account is not cached", async () => {

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -514,10 +514,12 @@ describe("synced mailbox cache", () => {
       accountStates: {
         "account-1": {
           after: "2026-07-24T00:00:00.000Z",
+          complete: true,
           truncated: false,
         },
         "account-2": {
           after: "2026-07-24T00:00:00.000Z",
+          complete: true,
           truncated: false,
         },
       },
@@ -578,6 +580,7 @@ describe("synced mailbox cache", () => {
     });
 
     expect(snapshot).toMatchObject({
+      accountStates: { "account-1": { complete: true } },
       complete: false,
       missingAccountIds: ["account-2"],
       truncated: false,

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   applyMailboxSyncPage,
   markSyncedMailboxThreadsRead,
+  readCombinedSyncedMailboxThreads,
   readMailboxSyncState,
   readSyncedMailboxThreads,
   removeSyncedMailboxThreads,
@@ -465,6 +466,115 @@ describe("synced mailbox cache", () => {
     ).resolves.toMatchObject({ threads: [{ id: "account-2-thread" }] });
   });
 
+  it("merges account snapshots by composite thread key and global recency", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      now: 100,
+      page: {
+        cursor: "account-1-cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "account-1-message",
+            threadId: "shared-thread",
+            internalDate: "2026-08-22T10:00:00.000Z",
+          }),
+        ],
+      },
+    });
+    await applyMailboxSyncPage({
+      emailAccountId: "account-2",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      now: 200,
+      page: {
+        cursor: "account-2-cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "account-2-message",
+            threadId: "shared-thread",
+            internalDate: "2026-08-23T10:00:00.000Z",
+          }),
+        ],
+      },
+    });
+
+    const snapshot = await readCombinedSyncedMailboxThreads({
+      accounts: [getAccount("account-1"), getAccount("account-2")],
+      query: { type: "inbox" },
+      limit: 20,
+    });
+
+    expect(snapshot).toMatchObject({
+      accountStates: {
+        "account-1": {
+          after: "2026-07-24T00:00:00.000Z",
+          truncated: false,
+        },
+        "account-2": {
+          after: "2026-07-24T00:00:00.000Z",
+          truncated: false,
+        },
+      },
+      complete: true,
+      missingAccountIds: [],
+      syncedAt: 100,
+      truncated: false,
+    });
+    expect(
+      snapshot?.threads.map((thread) => [thread.account.id, thread.id]),
+    ).toEqual([
+      ["account-2", "shared-thread"],
+      ["account-1", "shared-thread"],
+    ]);
+  });
+
+  it("returns available unread rows while another account is not cached", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "account-1-cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "read-message",
+            threadId: "read-thread",
+            internalDate: "2026-08-23T11:00:00.000Z",
+          }),
+          getMessage({
+            id: "unread-message",
+            threadId: "unread-thread",
+            internalDate: "2026-08-23T10:00:00.000Z",
+            labelIds: ["INBOX", "UNREAD"],
+          }),
+        ],
+      },
+    });
+
+    const snapshot = await readCombinedSyncedMailboxThreads({
+      accounts: [getAccount("account-1"), getAccount("account-2")],
+      query: { type: "unread" },
+      limit: 20,
+    });
+
+    expect(snapshot).toMatchObject({
+      complete: false,
+      missingAccountIds: ["account-2"],
+      truncated: false,
+    });
+    expect(snapshot?.threads).toMatchObject([
+      { account: { id: "account-1" }, id: "unread-thread" },
+    ]);
+  });
+
   it("notifies active subscribers after mailbox changes", async () => {
     const listener = vi.fn();
     const unsubscribe = subscribeToMailboxStore(listener);
@@ -525,5 +635,14 @@ function getMessage({
     snippet: `${id} snippet`,
     subject: `${id} subject`,
     threadId,
+  };
+}
+
+function getAccount(id: string) {
+  return {
+    email: `${id}@example.com`,
+    id,
+    image: null,
+    name: id,
   };
 }

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -28,10 +28,12 @@ export type SyncedMailboxSnapshot = {
 };
 
 export type SyncedCombinedMailboxSnapshot = {
-  accountStates: Record<string, { after: string; truncated: boolean }>;
+  accountStates: Record<
+    string,
+    { after: string; syncedAt: number; truncated: boolean }
+  >;
   complete: boolean;
   missingAccountIds: string[];
-  syncedAt: number;
   threads: CombinedListThread[];
   truncated: boolean;
 };
@@ -321,6 +323,7 @@ export async function readCombinedSyncedMailboxThreads({
         account.id,
         {
           after: snapshot.after,
+          syncedAt: snapshot.syncedAt,
           truncated: snapshot.truncated,
         },
       ]),
@@ -331,8 +334,7 @@ export async function readCombinedSyncedMailboxThreads({
     missingAccountIds: accounts
       .map((account) => account.id)
       .filter((accountId) => !availableAccountIds.has(accountId)),
-    syncedAt: Math.min(...available.map(({ snapshot }) => snapshot.syncedAt)),
-    threads: threads.slice(0, limit),
+    threads,
     truncated:
       threads.length > limit ||
       available.some(({ snapshot }) => snapshot.truncated),

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -2,7 +2,9 @@ import { internalDateToDate, sortByInternalDate } from "@/utils/date";
 import { canonicalizeEmailAddress } from "@/utils/email";
 import type { MailboxSyncPage } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
+import type { CombinedListThread } from "@/utils/threads/load-combined";
 import type { ThreadListItem } from "@/utils/threads/load";
+import { getThreadTimestamp } from "@/utils/threads/sort";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import type { ParsedMessage } from "@/utils/types";
 import { scheduleEmailCacheCleanup } from "./cleanup";
@@ -22,6 +24,15 @@ export type SyncedMailboxSnapshot = {
   complete: boolean;
   syncedAt: number;
   threads: ThreadListItem[];
+  truncated: boolean;
+};
+
+export type SyncedCombinedMailboxSnapshot = {
+  accountStates: Record<string, { after: string; truncated: boolean }>;
+  complete: boolean;
+  missingAccountIds: string[];
+  syncedAt: number;
+  threads: CombinedListThread[];
   truncated: boolean;
 };
 
@@ -260,6 +271,72 @@ export async function readSyncedMailboxThreads({
   } catch {
     return;
   }
+}
+
+export async function readCombinedSyncedMailboxThreads({
+  accounts,
+  query,
+  limit = query.limit ?? 50,
+}: {
+  accounts: CombinedListThread["account"][];
+  query: ThreadsQuery;
+  limit?: number;
+}): Promise<SyncedCombinedMailboxSnapshot | undefined> {
+  if (!accounts.length) return;
+
+  const accountSnapshots = await Promise.all(
+    accounts.map(async (account) => ({
+      account,
+      snapshot: await readSyncedMailboxThreads({
+        emailAccountId: account.id,
+        query,
+        limit,
+      }),
+    })),
+  );
+  const available = accountSnapshots.filter(
+    (
+      result,
+    ): result is {
+      account: CombinedListThread["account"];
+      snapshot: SyncedMailboxSnapshot;
+    } => result.snapshot !== undefined,
+  );
+  if (!available.length) return;
+
+  const threads = available
+    .flatMap(({ account, snapshot }) =>
+      snapshot.threads.map((thread) => ({ ...thread, account })),
+    )
+    .sort(
+      (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
+    );
+  const availableAccountIds = new Set(
+    available.map(({ account }) => account.id),
+  );
+
+  return {
+    accountStates: Object.fromEntries(
+      available.map(({ account, snapshot }) => [
+        account.id,
+        {
+          after: snapshot.after,
+          truncated: snapshot.truncated,
+        },
+      ]),
+    ),
+    complete:
+      available.length === accounts.length &&
+      available.every(({ snapshot }) => snapshot.complete),
+    missingAccountIds: accounts
+      .map((account) => account.id)
+      .filter((accountId) => !availableAccountIds.has(accountId)),
+    syncedAt: Math.min(...available.map(({ snapshot }) => snapshot.syncedAt)),
+    threads: threads.slice(0, limit),
+    truncated:
+      threads.length > limit ||
+      available.some(({ snapshot }) => snapshot.truncated),
+  };
 }
 
 export async function markSyncedMailboxThreadsRead({

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -30,7 +30,7 @@ export type SyncedMailboxSnapshot = {
 export type SyncedCombinedMailboxSnapshot = {
   accountStates: Record<
     string,
-    { after: string; syncedAt: number; truncated: boolean }
+    { after: string; complete: boolean; syncedAt: number; truncated: boolean }
   >;
   complete: boolean;
   missingAccountIds: string[];
@@ -323,6 +323,7 @@ export async function readCombinedSyncedMailboxThreads({
         account.id,
         {
           after: snapshot.after,
+          complete: snapshot.complete,
           syncedAt: snapshot.syncedAt,
           truncated: snapshot.truncated,
         },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260823-192449_pr-3368_bc21768cdbbc/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Make the All Accounts inbox read from the canonical per-account desktop mailbox cache while the server revalidates, with account-safe merging and actions.

- sync every connected account and merge IndexedDB snapshots by account plus thread identity
- route archive, trash, read, and unread actions through each owning account with optimistic rollback and cache reconciliation
- cover freshness, pagination, cross-account isolation, offline rendering, and a 5,000-message local mailbox

Validation: 5,559 unit tests passed, lint passed, and the local Playwright mailbox suite passed 3/3.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified mail views combine conversations across multiple email accounts.
  - Cached mail remains available when mailbox servers are temporarily unavailable.
  - Conversations are sorted by recent activity while remaining isolated by account.
  - Mailbox synchronization supports individual accounts and combined views.
  - Read/unread actions work across combined views with immediate updates and recovery if synchronization fails.

- **Bug Fixes**
  - Improved account-specific cache freshness, partial results, pagination, and conversation changes.
  - Prevented stale synchronization results from overwriting newer mailbox state.
  - Removed conversations no longer present in synchronized mailbox data while preserving newly restored mail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->