### PR TITLE
mail: Select all rows with modifier shortcut

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
+const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
+
 test("archives a selected conversation and restores it with undo", async ({
   page,
 }) => {
@@ -75,4 +77,28 @@ test("selects ranges and opens conversations with the keyboard", async ({
   await expect(page).toHaveURL(/thread-id=/);
   await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();
+});
+
+test("selects every conversation with Command A", async ({ page }) => {
+  const { conversations } = await openMail(page);
+  const options = conversations.getByRole("option");
+  const conversationCount = await options.count();
+  expect(conversationCount).toBeGreaterThan(1);
+
+  await options.nth(1).getByRole("checkbox").click();
+  await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
+
+  await page.keyboard.press(`${commandModifier}+KeyA`);
+
+  await expect(
+    page.getByText(`${conversationCount} selected`, { exact: true }),
+  ).toBeVisible();
+  await expect(options).toHaveCount(conversationCount);
+  await expect
+    .poll(() =>
+      options.evaluateAll((rows) =>
+        rows.every((row) => row.getAttribute("aria-selected") === "true"),
+      ),
+    )
+    .toBe(true);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
@@ -87,7 +87,8 @@ test("selects every conversation with Command A", async ({ page }) => {
 
   await page.getByRole("button", { name: /Search or jump/ }).click();
   const commandInput = page.getByPlaceholder("Type a command or search...");
-  await commandInput.fill("archive");
+  const query = "archive";
+  await commandInput.fill(query);
   await page.keyboard.press(`${commandModifier}+KeyA`);
 
   await expect
@@ -97,14 +98,8 @@ test("selects every conversation with Command A", async ({ page }) => {
         start: input.selectionStart,
       })),
     )
-    .toEqual({ end: "archive".length, start: 0 });
-  await expect
-    .poll(() =>
-      options.evaluateAll((rows) =>
-        rows.every((row) => row.getAttribute("aria-selected") === "false"),
-      ),
-    )
-    .toBe(true);
+    .toEqual({ end: query.length, start: 0 });
+  await expect.poll(() => allRowsAreSelected(options, false)).toBe(true);
   await page.keyboard.press("Escape");
   await expect(commandInput).toBeHidden();
 
@@ -117,11 +112,15 @@ test("selects every conversation with Command A", async ({ page }) => {
     page.getByText(`${conversationCount} selected`, { exact: true }),
   ).toBeVisible();
   await expect(options).toHaveCount(conversationCount);
-  await expect
-    .poll(() =>
-      options.evaluateAll((rows) =>
-        rows.every((row) => row.getAttribute("aria-selected") === "true"),
-      ),
-    )
-    .toBe(true);
+  await expect.poll(() => allRowsAreSelected(options, true)).toBe(true);
 });
+
+function allRowsAreSelected(rows: Locator, selected: boolean) {
+  return rows.evaluateAll(
+    (options, expected) =>
+      options.every(
+        (option) => option.getAttribute("aria-selected") === String(expected),
+      ),
+    selected,
+  );
+}

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -85,6 +85,29 @@ test("selects every conversation with Command A", async ({ page }) => {
   const conversationCount = await options.count();
   expect(conversationCount).toBeGreaterThan(1);
 
+  await page.getByRole("button", { name: /Search or jump/ }).click();
+  const commandInput = page.getByPlaceholder("Type a command or search...");
+  await commandInput.fill("archive");
+  await page.keyboard.press(`${commandModifier}+KeyA`);
+
+  await expect
+    .poll(() =>
+      commandInput.evaluate((input: HTMLInputElement) => ({
+        end: input.selectionEnd,
+        start: input.selectionStart,
+      })),
+    )
+    .toEqual({ end: "archive".length, start: 0 });
+  await expect
+    .poll(() =>
+      options.evaluateAll((rows) =>
+        rows.every((row) => row.getAttribute("aria-selected") === "false"),
+      ),
+    )
+    .toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(commandInput).toBeHidden();
+
   await options.nth(1).getByRole("checkbox").click();
   await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -609,6 +609,7 @@ export function MailShell() {
         if (next) setActiveSplitId(next.id);
       },
       select: () => selection.toggle(clampedIndex),
+      selectAll: selection.selectAll,
       // The cursor travels with the extension; without that, every repeat
       // re-extends from the same row and the range never grows.
       extendSelectionDown: () => extendSelection(1),

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.test.ts
@@ -21,6 +21,15 @@ describe("useThreadSelection", () => {
     expect(result.current.hasSelection).toBe(false);
   });
 
+  it("selects every row in the current mail view", () => {
+    const { result } = setup();
+
+    act(() => result.current.toggle(2));
+    act(() => result.current.selectAll());
+
+    expect([...result.current.selectedIds]).toEqual(IDS);
+  });
+
   it("shift-clicks a range from the last toggled row", () => {
     const { result } = setup();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-selection.ts
@@ -60,6 +60,20 @@ export function useThreadSelection(orderedIds: string[]) {
     [orderedIds, resetAnchor],
   );
 
+  const selectAll = useCallback(() => {
+    resetAnchor();
+    lastToggledIndex.current = null;
+    setSelectedIds((current) => {
+      if (
+        current.size === orderedIds.length &&
+        orderedIds.every((id) => current.has(id))
+      ) {
+        return current;
+      }
+      return new Set(orderedIds);
+    });
+  }, [orderedIds, resetAnchor]);
+
   // Shift+click: fill from the last individually toggled row to this one.
   const selectRangeTo = useCallback(
     (index: number) => {
@@ -109,12 +123,13 @@ export function useThreadSelection(orderedIds: string[]) {
       hasSelection: selectedIds.size > 0,
       isSelected: (id: string) => selectedIds.has(id),
       toggle,
+      selectAll,
       selectRangeTo,
       extendTo,
       clear,
       targetIds,
     }),
-    [selectedIds, toggle, selectRangeTo, extendTo, clear, targetIds],
+    [selectedIds, toggle, selectAll, selectRangeTo, extendTo, clear, targetIds],
   );
 }
 

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -43,6 +43,7 @@ describe("shortcut registry", () => {
   it("renders keys the way the help dialog and palette show them", () => {
     expect(formatShortcutKeys(getShortcut("next"))).toBe("J / ↓");
     expect(formatShortcutKeys(getShortcut("commandPalette"))).toBe("⌘K");
+    expect(formatShortcutKeys(getShortcut("selectAll"))).toBe("⌘A");
     expect(formatShortcutKeys(getShortcut("send"))).toBe("⌘↵");
     expect(formatShortcutKeys(getShortcut("backToApp"))).toBe("G A");
     expect(formatShortcutKeys(getShortcut("delete"))).toBe("#");

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -125,6 +125,13 @@ const SHORTCUT_DEFINITIONS = [
     label: "Select",
   },
   {
+    id: "selectAll",
+    keys: ["mod+a"],
+    scope: "mail",
+    group: "Triage",
+    label: "Select all",
+  },
+  {
     id: "extendSelectionDown",
     keys: ["shift+arrowdown", "shift+j"],
     scope: "mail",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260823-194325_pr-3369_afcced08faa2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds familiar select-all behavior to the mail list.

- registers the platform modifier shortcut and selects every loaded row in the active view
- preserves native select-all behavior while typing
- covers selection state, shortcut display, and the browser interaction

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Select All shortcut for mail conversations using Command+A on macOS and Control+A on other platforms.
  * Selecting all conversations updates the selection count while preserving the total conversation count.
  * Repeating the shortcut keeps all conversations selected.

* **Bug Fixes**
  * Improved selection behavior when selecting all from an existing partial selection.
  * Command/Control+A in the command search field now selects only its text, without selecting conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->