### PR TITLE
mail: Align sidebar toggle on reader page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -53,35 +53,43 @@ export function ReaderNavigation({
   showSidebarToggle = false,
 }: ReaderNavigationProps) {
   return (
-    <div className="sticky top-0 z-10 mt-5 mb-4 flex items-center bg-card">
-      {showSidebarToggle ? (
-        <div className="flex w-10 shrink-0 justify-end">
-          <SidebarTrigger
-            name="left-sidebar"
-            className="hidden lg:inline-flex"
-          />
-        </div>
-      ) : null}
+    <>
+      <div className="h-5" />
+      <div className="sticky top-0 z-10 mb-4 flex items-center bg-card">
+        {showSidebarToggle ? (
+          <div className="flex w-10 shrink-0 justify-end">
+            <SidebarTrigger
+              name="left-sidebar"
+              className="hidden lg:inline-flex"
+            />
+          </div>
+        ) : null}
 
-      <div className="min-w-0 flex-1">
-        <div className="mx-auto w-full max-w-[54rem] px-6">
-          <div className="-mx-1 flex items-center gap-3 px-1 py-2">
-            <Button onClick={onBack} size="xs-2" variant="outline">
-              <ArrowLeftIcon className="mr-1.5 size-3.5" />
-              Back
-              <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
-            </Button>
-            {position ? (
-              <span className="font-mono text-muted-foreground text-xs">
-                {`${position.index} of ${position.total}`}
-              </span>
-            ) : null}
+        <div className="min-w-0 flex-1">
+          <div className="mx-auto w-full max-w-[54rem] px-6">
+            <div className="-mx-1 flex items-center gap-3 px-1 py-2">
+              <Button
+                onClick={onBack}
+                size="xs-2"
+                type="button"
+                variant="outline"
+              >
+                <ArrowLeftIcon className="mr-1.5 size-3.5" />
+                Back
+                <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
+              </Button>
+              {position ? (
+                <span className="font-mono text-muted-foreground text-xs">
+                  {`${position.index} of ${position.total}`}
+                </span>
+              ) : null}
+            </div>
           </div>
         </div>
-      </div>
 
-      {showSidebarToggle ? <div className="w-10 shrink-0" /> : null}
-    </div>
+        {showSidebarToggle ? <div className="w-10 shrink-0" /> : null}
+      </div>
+    </>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -11,14 +11,13 @@ import {
   UserRoundSearchIcon,
 } from "lucide-react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
-import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { Kbd } from "@/components/Kbd";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 
-export type ReaderToolbarProps = {
+type ReaderToolbarProps = {
   subject: string;
   /** Display name of the other party. Falls back to the address when absent. */
   senderName: string;
@@ -31,25 +30,63 @@ export type ReaderToolbarProps = {
    */
   labelHref: (labelId: string) => string;
   onRemoveLabel?: (labelId: string) => void;
-  layout: MailLayoutMode;
   isFocusMode: boolean;
-  /** 1-based position of the open thread in the list, for the "N of M" readout. */
-  position?: { index: number; total: number };
-  onBack: () => void;
   onArchive: () => void;
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
   onOpenSenderContext?: () => void;
-  showSidebarToggle?: boolean;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
 
+type ReaderNavigationProps = {
+  /** 1-based position of the open thread in the list, for the "N of M" readout. */
+  position?: { index: number; total: number };
+  onBack: () => void;
+  showSidebarToggle?: boolean;
+};
+
+export function ReaderNavigation({
+  position,
+  onBack,
+  showSidebarToggle = false,
+}: ReaderNavigationProps) {
+  return (
+    <div className="sticky top-0 z-10 mt-5 mb-4 flex items-center bg-card">
+      {showSidebarToggle ? (
+        <div className="flex w-10 shrink-0 justify-end">
+          <SidebarTrigger
+            name="left-sidebar"
+            className="hidden lg:inline-flex"
+          />
+        </div>
+      ) : null}
+
+      <div className="min-w-0 flex-1">
+        <div className="mx-auto w-full max-w-[54rem] px-6">
+          <div className="-mx-1 flex items-center gap-3 px-1 py-2">
+            <Button onClick={onBack} size="xs-2" variant="outline">
+              <ArrowLeftIcon className="mr-1.5 size-3.5" />
+              Back
+              <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
+            </Button>
+            {position ? (
+              <span className="font-mono text-muted-foreground text-xs">
+                {`${position.index} of ${position.total}`}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {showSidebarToggle ? <div className="w-10 shrink-0" /> : null}
+    </div>
+  );
+}
+
 /**
  * The reader's header: what the thread is, and what you can do to it.
- * In `list` layout the list is hidden behind the reader, so it also carries the
- * way back and the position in the list.
  */
 export function ReaderToolbar({
   subject,
@@ -58,44 +95,18 @@ export function ReaderToolbar({
   labels,
   labelHref,
   onRemoveLabel,
-  layout,
   isFocusMode,
-  position,
-  onBack,
   onArchive,
   onReply,
   onDelete,
   onToggleFocusMode,
   onOpenSenderContext,
-  showSidebarToggle = false,
   menu,
 }: ReaderToolbarProps) {
-  const showBackBar = layout === "list" && !isFocusMode;
   const FocusIcon = isFocusMode ? MinimizeIcon : MaximizeIcon;
 
   return (
     <div>
-      {showBackBar ? (
-        <div className="-mx-1 sticky top-0 z-10 mb-4 flex items-center gap-3 bg-card px-1 py-2">
-          {showSidebarToggle ? (
-            <SidebarTrigger
-              name="left-sidebar"
-              className="hidden lg:inline-flex"
-            />
-          ) : null}
-          <Button onClick={onBack} size="xs-2" variant="outline">
-            <ArrowLeftIcon className="mr-1.5 size-3.5" />
-            Back
-            <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
-          </Button>
-          {position ? (
-            <span className="font-mono text-muted-foreground text-xs">
-              {`${position.index} of ${position.total}`}
-            </span>
-          ) : null}
-        </div>
-      ) : null}
-
       <div className="flex flex-wrap items-start gap-x-4 gap-y-3 border-border border-b pb-4">
         <div className="min-w-56 flex-1">
           <h1 className="font-title font-medium text-2xl text-foreground leading-tight tracking-tight">

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -3,7 +3,10 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { Loader2Icon, MailIcon } from "lucide-react";
-import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
+import {
+  ReaderNavigation,
+  ReaderToolbar,
+} from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
 import type {
   ListThread,
   MailLayoutMode,
@@ -133,15 +136,21 @@ export function ThreadReader({
       {/* White, unlike the list: the reader is its own surface, and it has to
       match `EmailThread` below or the toolbar reads as a separate band. */}
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-card">
+        {layout === "list" && !isFocusMode ? (
+          <ReaderNavigation
+            onBack={onBack}
+            position={position}
+            showSidebarToggle={showSidebarToggle}
+          />
+        ) : null}
+
         <div className={readerMeasure({ layout, isFocusMode })}>
           <ReaderToolbar
             isFocusMode={isFocusMode}
             labelHref={labelHref}
             labels={labels}
-            layout={layout}
             menu={menu}
             onArchive={onArchive}
-            onBack={onBack}
             onDelete={onDelete}
             onOpenSenderContext={
               canResearchSender
@@ -151,10 +160,8 @@ export function ThreadReader({
             onRemoveLabel={onRemoveLabel}
             onReply={onReply}
             onToggleFocusMode={onToggleFocusMode}
-            position={position}
             senderEmail={senderEmail}
             senderName={senderName}
-            showSidebarToggle={showSidebarToggle}
             subject={headerMessage.headers.subject}
           />
 
@@ -196,5 +203,5 @@ function readerMeasure({
   // ~860px: the mock's measure, and about as wide as an email body stays legible.
   if (isFocusMode) return "mx-auto w-full max-w-[54rem] px-10 py-10";
   if (layout === "split") return "px-6 py-5";
-  return "mx-auto w-full max-w-[54rem] px-6 py-5";
+  return "mx-auto w-full max-w-[54rem] px-6 pb-5";
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260823-195937_pr-3370_bc8dcc3965a1/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Aligns the collapsed sidebar control with the page edge while preserving the reader content measure.

- separate reader navigation from constrained message content
- keep navigation content centered with balanced edge spacing
- validate the updated components with Ultracite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved thread reader navigation by separating back, position, and sidebar controls from the reader toolbar.
  * Navigation controls now appear appropriately in list-based reading layouts.
  * Adjusted reader spacing for a more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->