### PR TITLE
mail: Keep All Accounts cache-first

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -46,10 +46,7 @@ import {
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threads";
-import {
-  requestMailboxSync,
-  useMailboxSync,
-} from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
+import { requestMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
 import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
@@ -182,13 +179,6 @@ export function MailShell() {
         image,
       })),
     [accountsData?.emailAccounts],
-  );
-  const mailboxSyncAccountIds = useMemo(
-    () =>
-      isAllAccounts && combinedAccounts.length
-        ? combinedAccounts.map((account) => account.id)
-        : [emailAccountId],
-    [combinedAccounts, emailAccountId, isAllAccounts],
   );
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
@@ -952,9 +942,6 @@ export function MailShell() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
-      {mailboxSyncAccountIds.map((syncAccountId) => (
-        <MailboxSync emailAccountId={syncAccountId} key={syncAccountId} />
-      ))}
       <div className="flex min-h-0 flex-1">
         <div className="hidden [--sidebar-width:236px] lg:contents">
           <Sidebar name="left-sidebar" forceCollapsed={isFocusMode}>
@@ -1127,11 +1114,6 @@ export function MailShell() {
       <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
     </div>
   );
-}
-
-function MailboxSync({ emailAccountId }: { emailAccountId: string }) {
-  useMailboxSync({ emailAccountId, enabled: true });
-  return null;
 }
 
 function groupThreadIdsByAccount(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
@@ -17,12 +17,19 @@ describe("MailboxSyncManager", () => {
     vi.clearAllMocks();
     accounts.useAccounts.mockReturnValue({
       data: {
-        emailAccounts: [{ id: "account-1" }, { id: "account-2" }],
+        emailAccounts: [
+          { account: { disconnectedAt: null }, id: "account-1" },
+          { account: { disconnectedAt: null }, id: "account-2" },
+          {
+            account: { disconnectedAt: "2026-08-23T10:00:00.000Z" },
+            id: "disconnected-account",
+          },
+        ],
       },
     });
   });
 
-  it("keeps every connected account synchronized", () => {
+  it("synchronizes every connected account without retrying disconnected accounts", () => {
     render(<MailboxSyncManager />);
 
     expect(mailboxSync.useMailboxSync).toHaveBeenCalledTimes(2);

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MailboxSyncManager } from "./MailboxSyncManager";
+
+const accounts = vi.hoisted(() => ({ useAccounts: vi.fn() }));
+const mailboxSync = vi.hoisted(() => ({ useMailboxSync: vi.fn() }));
+
+vi.mock("@/hooks/useAccounts", () => ({ useAccounts: accounts.useAccounts }));
+vi.mock("./use-mailbox-sync", () => ({
+  useMailboxSync: mailboxSync.useMailboxSync,
+}));
+
+describe("MailboxSyncManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accounts.useAccounts.mockReturnValue({
+      data: {
+        emailAccounts: [{ id: "account-1" }, { id: "account-2" }],
+      },
+    });
+  });
+
+  it("keeps every connected account synchronized", () => {
+    render(<MailboxSyncManager />);
+
+    expect(mailboxSync.useMailboxSync).toHaveBeenCalledTimes(2);
+    expect(mailboxSync.useMailboxSync).toHaveBeenNthCalledWith(1, {
+      emailAccountId: "account-1",
+      enabled: true,
+    });
+    expect(mailboxSync.useMailboxSync).toHaveBeenNthCalledWith(2, {
+      emailAccountId: "account-2",
+      enabled: true,
+    });
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
@@ -6,9 +6,11 @@ import { useAccounts } from "@/hooks/useAccounts";
 export function MailboxSyncManager() {
   const { data } = useAccounts();
 
-  return (data?.emailAccounts ?? []).map((account) => (
-    <MailboxSync emailAccountId={account.id} key={account.id} />
-  ));
+  return (data?.emailAccounts ?? [])
+    .filter((account) => !account.account.disconnectedAt)
+    .map((account) => (
+      <MailboxSync emailAccountId={account.id} key={account.id} />
+    ));
 }
 
 function MailboxSync({ emailAccountId }: { emailAccountId: string }) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
+import { useAccounts } from "@/hooks/useAccounts";
+
+export function MailboxSyncManager() {
+  const { data } = useAccounts();
+
+  return (data?.emailAccounts ?? []).map((account) => (
+    <MailboxSync emailAccountId={account.id} key={account.id} />
+  ));
+}
+
+function MailboxSync({ emailAccountId }: { emailAccountId: string }) {
+  useMailboxSync({ emailAccountId, enabled: true });
+  return null;
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
@@ -1,4 +1,5 @@
 import { MailThemeScope } from "@/app/(app)/[emailAccountId]/mail/MailThemeScope";
+import { MailboxSyncManager } from "@/app/(app)/[emailAccountId]/mail/MailboxSyncManager";
 import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
 
@@ -12,6 +13,7 @@ export default function MailLayout({
   return (
     <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
       <MailThemeScope />
+      <MailboxSyncManager />
       {children}
     </ShortcutsProvider>
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -136,6 +136,61 @@ describe("useCombinedMailThreads", () => {
     });
   });
 
+  it("keeps cached rows outside the first server page", async () => {
+    mailbox.read.mockResolvedValue({
+      accountStates: ACCOUNT_STATES,
+      complete: true,
+      missingAccountIds: [],
+      threads: [
+        createThread("account-1", "remote-row"),
+        createThread("account-2", "cached-only", "2026-08-23T09:59:00.000Z"),
+      ],
+      truncated: false,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      {
+        wrapper: createWrapper(() =>
+          Promise.resolve({
+            failedAccountIds: [],
+            labelsByAccount: {},
+            nextPageToken: "next-page",
+            threads: [
+              {
+                ...createThread("account-1", "remote-row"),
+                snippet: "remote",
+              },
+            ],
+          }),
+        ),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "remote-row",
+        "cached-only",
+      ]);
+      expect(result.current.threads[0]?.snippet).toBe("remote");
+      expect(cache.write).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasMore: true,
+          threads: expect.arrayContaining([
+            expect.objectContaining({ id: "account-1:remote-row" }),
+            expect.objectContaining({ id: "account-2:cached-only" }),
+          ]),
+        }),
+      );
+    });
+  });
+
   it("keeps a mailbox sync that completes while the server request is in flight", async () => {
     vi.spyOn(Date, "now").mockReturnValue(100);
     const network = Promise.withResolvers<unknown>();
@@ -173,7 +228,7 @@ describe("useCombinedMailThreads", () => {
       await network.promise;
     });
 
-    await waitFor(() => expect(cache.write).toHaveBeenCalledOnce());
+    await waitFor(() => expect(cache.write).toHaveBeenCalled());
     expect(result.current.threads.map((thread) => thread.id)).toEqual([
       "local-only",
     ]);
@@ -376,6 +431,77 @@ describe("useCombinedMailThreads", () => {
       accounts: ACCOUNTS,
       limit: 40,
       query: { type: "inbox" },
+    });
+  });
+
+  it("loads more synchronized rows before requesting another server page", async () => {
+    const localThreads = Array.from({ length: 25 }, (_, index) =>
+      createThread(
+        index % 2 ? "account-1" : "account-2",
+        `local-${index}`,
+        new Date(Date.UTC(2026, 7, 23, 10, 0, 25 - index)).toISOString(),
+      ),
+    );
+    mailbox.read.mockImplementation(({ limit }: { limit: number }) =>
+      Promise.resolve({
+        accountStates: createAccountStates(Number.MAX_SAFE_INTEGER),
+        complete: true,
+        missingAccountIds: [],
+        threads: localThreads.slice(0, limit),
+        truncated: localThreads.length > limit,
+      }),
+    );
+    const fetcher = vi.fn((key: string) =>
+      Promise.resolve(
+        key.includes("cursor=next-page")
+          ? {
+              failedAccountIds: [],
+              labelsByAccount: {},
+              nextPageToken: null,
+              threads: [createThread("account-1", "remote-page-two")],
+            }
+          : {
+              failedAccountIds: [],
+              labelsByAccount: {},
+              nextPageToken: "next-page",
+              threads: [localThreads[0]],
+            },
+      ),
+    );
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(20);
+      expect(result.current.hasMore).toBe(true);
+      expect(fetcher).toHaveBeenCalledOnce();
+    });
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(25);
+      expect(mailbox.read).toHaveBeenLastCalledWith({
+        accounts: ACCOUNTS,
+        limit: 40,
+        query: { type: "inbox" },
+      });
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      expect(result.current.hasMore).toBe(false);
     });
   });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -143,6 +143,7 @@ describe("useCombinedMailThreads", () => {
       missingAccountIds: [],
       threads: [
         createThread("account-1", "remote-row"),
+        createThread("account-2", "stale-recent", "2026-08-23T10:01:00.000Z"),
         createThread("account-2", "cached-only", "2026-08-23T09:59:00.000Z"),
       ],
       truncated: false,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -664,6 +664,10 @@ function mergeCombinedThreads({
   const remoteThreadsByKey = new Map(
     remoteThreads.map((thread) => [getListThreadKey(thread), thread]),
   );
+  const oldestRemoteTimestamp = remoteThreads.reduce(
+    (oldest, thread) => Math.min(oldest, getThreadTimestamp(thread)),
+    Number.POSITIVE_INFINITY,
+  );
   const threadsByKey = new Map(
     remoteThreads
       .filter((thread) => {
@@ -692,6 +696,12 @@ function mergeCombinedThreads({
     if (!locallyAuthoritative && !remoteHasMore) continue;
     const remoteThread = remoteThreadsByKey.get(getListThreadKey(thread));
     if (!locallyAuthoritative && remoteThread) continue;
+    if (
+      !locallyAuthoritative &&
+      getThreadTimestamp(thread) > oldestRemoteTimestamp
+    ) {
+      continue;
+    }
     threadsByKey.set(getListThreadKey(thread), {
       ...thread,
       plan: remoteThread?.plan ?? thread.plan,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -270,6 +270,7 @@ export function useCombinedMailThreads({
     () => data?.flatMap((page) => page.threads),
     [data],
   );
+  const remoteHasMore = Boolean(data?.at(-1)?.nextPageToken);
   const failedAccountIds = useMemo(
     () => [...new Set(data?.flatMap((page) => page.failedAccountIds) ?? [])],
     [data],
@@ -284,6 +285,7 @@ export function useCombinedMailThreads({
         ? mergeCombinedThreads({
             accountStates: syncedView.accountStates,
             failedAccountIds,
+            remoteHasMore,
             remoteLoadedAt: remoteSnapshot.current.loadedAt,
             remoteThreads,
             syncedThreads,
@@ -292,6 +294,7 @@ export function useCombinedMailThreads({
     [
       persistentThreads,
       failedAccountIds,
+      remoteHasMore,
       remoteThreads,
       syncedThreads,
       syncedView?.accountStates,
@@ -299,31 +302,25 @@ export function useCombinedMailThreads({
   );
   const hiddenThreadKeys =
     hiddenByView.current.get(viewIdentity) ?? EMPTY_THREAD_KEYS;
-  const remoteHasMore = Boolean(data?.at(-1)?.nextPageToken);
-  const visibleThreadLimit = Math.max(
-    COMBINED_PAGE_SIZE,
-    data && remoteHasMore
-      ? data.length * COMBINED_PAGE_SIZE
-      : (sourceThreads?.length ?? 0),
-  );
   const threads = useMemo(() => {
     const byKey = new Map<string, GetAllThreadsResponse["threads"][number]>();
     for (const thread of sourceThreads ?? []) {
       const threadKey = getListThreadKey(thread);
       if (!hiddenThreadKeys.has(threadKey)) byKey.set(threadKey, thread);
     }
-    return [...byKey.values()]
-      .sort(
-        (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
-      )
-      .slice(0, visibleThreadLimit);
-  }, [hiddenThreadKeys, sourceThreads, visibleThreadLimit]);
-  const hasMore = data
-    ? remoteHasMore
-    : syncedView
-      ? syncedView.truncated
-      : persistent?.identity === viewIdentity && persistent.hasMore;
-  const canLoadMoreLocally = !data && Boolean(syncedView?.truncated);
+    return [...byKey.values()].sort(
+      (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
+    );
+  }, [hiddenThreadKeys, sourceThreads]);
+  const hasMore = Boolean(
+    remoteHasMore ||
+      syncedView?.truncated ||
+      (!data &&
+        !syncedView &&
+        persistent?.identity === viewIdentity &&
+        persistent.hasMore),
+  );
+  const canLoadMoreLocally = Boolean(syncedView?.truncated);
   const isLoadingMore = size > 1 && !data?.[size - 1];
   const labelsByAccount = useMemo(() => {
     const merged: Record<string, EmailLabels> = {};
@@ -345,18 +342,14 @@ export function useCombinedMailThreads({
   }, [data]);
 
   useEffect(() => {
-    if (!enabled) return;
-    const firstPage = data?.[0];
-    if (!firstPage) return;
+    if (!enabled || (!data?.[0] && !syncedView)) return;
     writeCachedThreadList({
       emailAccountId,
       viewKey,
-      threads: firstPage.threads
-        .filter((thread) => !hiddenThreadKeys.has(getListThreadKey(thread)))
-        .map(toCachedCombinedThread),
-      hasMore: Boolean(firstPage.nextPageToken),
+      threads: threads.map(toCachedCombinedThread),
+      hasMore,
     }).catch(() => {});
-  }, [data, emailAccountId, enabled, hiddenThreadKeys, viewKey]);
+  }, [data, emailAccountId, enabled, hasMore, syncedView, threads, viewKey]);
 
   const removeThreads = useCallback(
     (threadKeys: string[]): CombinedThreadRemoval => {
@@ -639,12 +632,14 @@ const EMPTY_THREAD_KEYS = new Set<string>();
 function mergeCombinedThreads({
   accountStates,
   failedAccountIds,
+  remoteHasMore,
   remoteLoadedAt,
   remoteThreads,
   syncedThreads,
 }: {
   accountStates: SyncedCombinedMailboxSnapshot["accountStates"];
   failedAccountIds: string[];
+  remoteHasMore: boolean;
   remoteLoadedAt: number;
   remoteThreads: CombinedThread[];
   syncedThreads: CombinedThread[];
@@ -691,8 +686,12 @@ function mergeCombinedThreads({
       .map((thread) => [getListThreadKey(thread), thread]),
   );
   for (const thread of syncedThreads) {
-    if (!locallyAuthoritativeAccountIds.has(thread.account.id)) continue;
+    const locallyAuthoritative = locallyAuthoritativeAccountIds.has(
+      thread.account.id,
+    );
+    if (!locallyAuthoritative && !remoteHasMore) continue;
     const remoteThread = remoteThreadsByKey.get(getListThreadKey(thread));
+    if (!locallyAuthoritative && remoteThread) continue;
     threadsByKey.set(getListThreadKey(thread), {
       ...thread,
       plan: remoteThread?.plan ?? thread.plan,

--- a/apps/web/app/api/user/email-accounts/route.ts
+++ b/apps/web/app/api/user/email-accounts/route.ts
@@ -54,6 +54,10 @@ async function getEmailAccounts({ userId }: { userId: string }) {
 
       return {
         ...account,
+        account: {
+          ...account.account,
+          disconnectedAt: account.account.disconnectedAt?.toISOString() ?? null,
+        },
         providerRateLimit: providerRateLimit
           ? {
               provider: providerRateLimit.provider,

--- a/apps/web/app/api/user/email-accounts/route.ts
+++ b/apps/web/app/api/user/email-accounts/route.ts
@@ -29,6 +29,7 @@ async function getEmailAccounts({ userId }: { userId: string }) {
       image: true,
       account: {
         select: {
+          disconnectedAt: true,
           provider: true,
         },
       },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260823-200502_pr-3371_dea12a17fca8/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keep the merged All Accounts inbox visible and responsive while network pages refresh.

- preserve synchronized IndexedDB rows alongside partial server results
- exhaust local rows before requesting later server pages and persist the merged snapshot
- keep every connected mailbox synchronized on mail routes
- cover cache merging, pagination handoff, and multi-account syncing with focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail synchronization now runs across all connected email accounts in the mail area.
  * Combined mail views include synchronized threads beyond the initial server page.
  * Email account status information now identifies disconnected accounts.

* **Bug Fixes**
  * Improved merging of remote, cached, and synchronized threads to prevent duplicates and preserve available messages.
  * Improved pagination and loading when local or cached messages are available.
  * Disconnected accounts are excluded from synchronization.

* **Tests**
  * Added coverage for multi-account synchronization and cached-thread pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->