### PR TITLE
mail: Bound multi-account mailbox synchronization

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.test.tsx
@@ -5,9 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MailboxSyncManager } from "./MailboxSyncManager";
 
 const accounts = vi.hoisted(() => ({ useAccounts: vi.fn() }));
+const activeAccount = vi.hoisted(() => ({ emailAccountId: "account-2" }));
 const mailboxSync = vi.hoisted(() => ({ useMailboxSync: vi.fn() }));
 
 vi.mock("@/hooks/useAccounts", () => ({ useAccounts: accounts.useAccounts }));
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => activeAccount,
+}));
 vi.mock("./use-mailbox-sync", () => ({
   useMailboxSync: mailboxSync.useMailboxSync,
 }));
@@ -34,12 +38,14 @@ describe("MailboxSyncManager", () => {
 
     expect(mailboxSync.useMailboxSync).toHaveBeenCalledTimes(2);
     expect(mailboxSync.useMailboxSync).toHaveBeenNthCalledWith(1, {
-      emailAccountId: "account-1",
-      enabled: true,
-    });
-    expect(mailboxSync.useMailboxSync).toHaveBeenNthCalledWith(2, {
       emailAccountId: "account-2",
       enabled: true,
+      priority: true,
+    });
+    expect(mailboxSync.useMailboxSync).toHaveBeenNthCalledWith(2, {
+      emailAccountId: "account-1",
+      enabled: true,
+      priority: false,
     });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxSyncManager.tsx
@@ -2,18 +2,35 @@
 
 import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useAccounts } from "@/hooks/useAccounts";
+import { useAccount } from "@/providers/EmailAccountProvider";
 
 export function MailboxSyncManager() {
   const { data } = useAccounts();
+  const { emailAccountId: activeEmailAccountId } = useAccount();
 
   return (data?.emailAccounts ?? [])
     .filter((account) => !account.account.disconnectedAt)
+    .sort(
+      (left, right) =>
+        Number(right.id === activeEmailAccountId) -
+        Number(left.id === activeEmailAccountId),
+    )
     .map((account) => (
-      <MailboxSync emailAccountId={account.id} key={account.id} />
+      <MailboxSync
+        emailAccountId={account.id}
+        key={account.id}
+        priority={account.id === activeEmailAccountId}
+      />
     ));
 }
 
-function MailboxSync({ emailAccountId }: { emailAccountId: string }) {
-  useMailboxSync({ emailAccountId, enabled: true });
+function MailboxSync({
+  emailAccountId,
+  priority,
+}: {
+  emailAccountId: string;
+  priority: boolean;
+}) {
+  useMailboxSync({ emailAccountId, enabled: true, priority });
   return null;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
@@ -27,7 +27,8 @@ describe("mailbox sync scheduler", () => {
     const first = scheduler.run({ emailAccountId: "account-1" });
     const second = scheduler.run({ emailAccountId: "account-2" });
     const third = scheduler.run({ emailAccountId: "account-3" });
-    const priority = scheduler.run({
+    const priority = scheduler.run({ emailAccountId: "active-account" });
+    scheduler.setPriority({
       emailAccountId: "active-account",
       priority: true,
     });

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
@@ -84,6 +84,40 @@ describe("mailbox sync scheduler", () => {
     await Promise.all([blocker, first, duplicate]);
   });
 
+  it("reprioritizes queued work when the active account changes", async () => {
+    const pending = new Map<
+      string,
+      ReturnType<typeof Promise.withResolvers<typeof SYNC_RESULT>>
+    >();
+    const started: string[] = [];
+    const sync = vi.fn((emailAccountId: string) => {
+      started.push(emailAccountId);
+      const result = Promise.withResolvers<typeof SYNC_RESULT>();
+      pending.set(emailAccountId, result);
+      return result.promise;
+    });
+    const scheduler = createMailboxSyncScheduler({ maxConcurrent: 1, sync });
+
+    const blocker = scheduler.run({ emailAccountId: "blocker" });
+    const oldActive = scheduler.run({
+      emailAccountId: "old-active",
+      priority: true,
+    });
+    const newActive = scheduler.run({ emailAccountId: "new-active" });
+
+    scheduler.setPriority({ emailAccountId: "old-active", priority: false });
+    scheduler.setPriority({ emailAccountId: "new-active", priority: true });
+
+    pending.get("blocker")?.resolve(SYNC_RESULT);
+    await settlePromises();
+    expect(started).toEqual(["blocker", "new-active"]);
+
+    pending.get("new-active")?.resolve(SYNC_RESULT);
+    await settlePromises();
+    pending.get("old-active")?.resolve(SYNC_RESULT);
+    await Promise.all([blocker, oldActive, newActive]);
+  });
+
   it("releases capacity after a failure", async () => {
     const first = Promise.withResolvers<typeof SYNC_RESULT>();
     const second = Promise.withResolvers<typeof SYNC_RESULT>();

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
@@ -141,7 +141,10 @@ describe("mailbox sync scheduler", () => {
   });
 });
 
-function settlePromises(iterations = 10): Promise<void> {
-  if (iterations === 0) return Promise.resolve();
-  return Promise.resolve().then(() => settlePromises(iterations - 1));
+function settlePromises() {
+  let promise = Promise.resolve();
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    promise = promise.then(() => undefined);
+  }
+  return promise;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMailboxSyncScheduler } from "./mailbox-sync-scheduler";
+
+const SYNC_RESULT = { hasMore: false, pagesSynced: 1 };
+
+describe("mailbox sync scheduler", () => {
+  it("caps concurrency and runs a queued priority account first", async () => {
+    const pending = new Map<
+      string,
+      ReturnType<typeof Promise.withResolvers<typeof SYNC_RESULT>>
+    >();
+    const started: string[] = [];
+    let active = 0;
+    let peakActive = 0;
+    const sync = vi.fn((emailAccountId: string) => {
+      started.push(emailAccountId);
+      active += 1;
+      peakActive = Math.max(peakActive, active);
+      const result = Promise.withResolvers<typeof SYNC_RESULT>();
+      pending.set(emailAccountId, result);
+      return result.promise.finally(() => {
+        active -= 1;
+      });
+    });
+    const scheduler = createMailboxSyncScheduler({ maxConcurrent: 2, sync });
+
+    const first = scheduler.run({ emailAccountId: "account-1" });
+    const second = scheduler.run({ emailAccountId: "account-2" });
+    const third = scheduler.run({ emailAccountId: "account-3" });
+    const priority = scheduler.run({
+      emailAccountId: "active-account",
+      priority: true,
+    });
+
+    expect(started).toEqual(["account-1", "account-2"]);
+
+    pending.get("account-1")?.resolve(SYNC_RESULT);
+    await settlePromises();
+    expect(started).toEqual(["account-1", "account-2", "active-account"]);
+
+    pending.get("account-2")?.resolve(SYNC_RESULT);
+    await settlePromises();
+    expect(started).toEqual([
+      "account-1",
+      "account-2",
+      "active-account",
+      "account-3",
+    ]);
+
+    pending.get("active-account")?.resolve(SYNC_RESULT);
+    pending.get("account-3")?.resolve(SYNC_RESULT);
+    await Promise.all([first, second, third, priority]);
+    expect(peakActive).toBe(2);
+  });
+
+  it("deduplicates queued and running work by account", async () => {
+    const pending = new Map<
+      string,
+      ReturnType<typeof Promise.withResolvers<typeof SYNC_RESULT>>
+    >();
+    const sync = vi.fn((emailAccountId: string) => {
+      const result = Promise.withResolvers<typeof SYNC_RESULT>();
+      pending.set(emailAccountId, result);
+      return result.promise;
+    });
+    const scheduler = createMailboxSyncScheduler({ maxConcurrent: 1, sync });
+
+    const blocker = scheduler.run({ emailAccountId: "blocker" });
+    const first = scheduler.run({ emailAccountId: "account-1" });
+    const duplicate = scheduler.run({
+      emailAccountId: "account-1",
+      priority: true,
+    });
+
+    expect(duplicate).toBe(first);
+    expect(sync).toHaveBeenCalledOnce();
+
+    pending.get("blocker")?.resolve(SYNC_RESULT);
+    await settlePromises();
+    expect(sync).toHaveBeenCalledTimes(2);
+
+    pending.get("account-1")?.resolve(SYNC_RESULT);
+    await Promise.all([blocker, first, duplicate]);
+  });
+
+  it("releases capacity after a failure", async () => {
+    const first = Promise.withResolvers<typeof SYNC_RESULT>();
+    const second = Promise.withResolvers<typeof SYNC_RESULT>();
+    const sync = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const scheduler = createMailboxSyncScheduler({ maxConcurrent: 1, sync });
+
+    const failed = scheduler.run({ emailAccountId: "account-1" });
+    const next = scheduler.run({ emailAccountId: "account-2" });
+    expect(sync).toHaveBeenCalledOnce();
+
+    first.reject(new Error("offline"));
+    await expect(failed).rejects.toThrow("offline");
+    await settlePromises();
+    expect(sync).toHaveBeenCalledTimes(2);
+
+    second.resolve(SYNC_RESULT);
+    await expect(next).resolves.toEqual(SYNC_RESULT);
+  });
+});
+
+async function settlePromises() {
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    await Promise.resolve();
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.test.ts
@@ -141,8 +141,7 @@ describe("mailbox sync scheduler", () => {
   });
 });
 
-async function settlePromises() {
-  for (let iteration = 0; iteration < 10; iteration += 1) {
-    await Promise.resolve();
-  }
+function settlePromises(iterations = 10): Promise<void> {
+  if (iterations === 0) return Promise.resolve();
+  return Promise.resolve().then(() => settlePromises(iterations - 1));
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.ts
@@ -1,0 +1,93 @@
+type MailboxSyncResult = { hasMore: boolean; pagesSynced: number };
+
+type ScheduledSync = {
+  emailAccountId: string;
+  priority: boolean;
+  queued: boolean;
+  result: ReturnType<typeof Promise.withResolvers<MailboxSyncResult>>;
+};
+
+export function createMailboxSyncScheduler({
+  maxConcurrent,
+  sync,
+}: {
+  maxConcurrent: number;
+  sync: (emailAccountId: string) => Promise<MailboxSyncResult>;
+}) {
+  if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
+    throw new Error("maxConcurrent must be a positive integer");
+  }
+
+  const requests = new Map<string, ScheduledSync>();
+  const queue: ScheduledSync[] = [];
+  let activeCount = 0;
+
+  const enqueue = (request: ScheduledSync) => {
+    if (!request.priority) {
+      queue.push(request);
+      return;
+    }
+
+    const firstStandardRequest = queue.findIndex((queued) => !queued.priority);
+    if (firstStandardRequest === -1) queue.push(request);
+    else queue.splice(firstStandardRequest, 0, request);
+  };
+
+  const drain = () => {
+    while (activeCount < maxConcurrent) {
+      const request = queue.shift();
+      if (!request) return;
+      request.queued = false;
+      activeCount += 1;
+
+      let syncResult: Promise<MailboxSyncResult>;
+      try {
+        syncResult = sync(request.emailAccountId);
+      } catch (error) {
+        syncResult = Promise.reject(error);
+      }
+
+      syncResult
+        .then(request.result.resolve, request.result.reject)
+        .then(() => {
+          activeCount -= 1;
+          if (requests.get(request.emailAccountId) === request) {
+            requests.delete(request.emailAccountId);
+          }
+          drain();
+        });
+    }
+  };
+
+  return {
+    run({
+      emailAccountId,
+      priority = false,
+    }: {
+      emailAccountId: string;
+      priority?: boolean;
+    }) {
+      const existing = requests.get(emailAccountId);
+      if (existing) {
+        if (priority && !existing.priority && existing.queued) {
+          existing.priority = true;
+          const queueIndex = queue.indexOf(existing);
+          if (queueIndex >= 0) queue.splice(queueIndex, 1);
+          enqueue(existing);
+        }
+        return existing.result.promise;
+      }
+
+      const request: ScheduledSync = {
+        emailAccountId,
+        priority,
+        queued: true,
+        result: Promise.withResolvers<MailboxSyncResult>(),
+      };
+      requests.set(emailAccountId, request);
+      enqueue(request);
+      drain();
+      return request.result.promise;
+    },
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mailbox-sync-scheduler.ts
@@ -33,6 +33,16 @@ export function createMailboxSyncScheduler({
     else queue.splice(firstStandardRequest, 0, request);
   };
 
+  const setQueuedPriority = (request: ScheduledSync, priority: boolean) => {
+    if (!request.queued || request.priority === priority) return;
+
+    request.priority = priority;
+    const queueIndex = queue.indexOf(request);
+    if (queueIndex < 0) return;
+    queue.splice(queueIndex, 1);
+    enqueue(request);
+  };
+
   const drain = () => {
     while (activeCount < maxConcurrent) {
       const request = queue.shift();
@@ -69,12 +79,7 @@ export function createMailboxSyncScheduler({
     }) {
       const existing = requests.get(emailAccountId);
       if (existing) {
-        if (priority && !existing.priority && existing.queued) {
-          existing.priority = true;
-          const queueIndex = queue.indexOf(existing);
-          if (queueIndex >= 0) queue.splice(queueIndex, 1);
-          enqueue(existing);
-        }
+        if (priority) setQueuedPriority(existing, true);
         return existing.result.promise;
       }
 
@@ -88,6 +93,16 @@ export function createMailboxSyncScheduler({
       enqueue(request);
       drain();
       return request.result.promise;
+    },
+    setPriority({
+      emailAccountId,
+      priority,
+    }: {
+      emailAccountId: string;
+      priority: boolean;
+    }) {
+      const request = requests.get(emailAccountId);
+      if (request) setQueuedPriority(request, priority);
     },
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
@@ -168,6 +168,31 @@ describe("useMailboxSync", () => {
     expect(mailboxSync.syncPages).toHaveBeenCalledTimes(5);
   });
 
+  it("keeps retry backoff when account priority changes", async () => {
+    mailboxSync.syncPages
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue({ hasMore: false, pagesSynced: 1 });
+    const { rerender } = renderHook(
+      ({ priority }) =>
+        useMailboxSync({
+          emailAccountId: "account-1",
+          enabled: true,
+          priority,
+        }),
+      { initialProps: { priority: false } },
+    );
+    await settlePromises();
+
+    rerender({ priority: true });
+    await settlePromises();
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+
+    await act(() => vi.advanceTimersByTimeAsync(59_999));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+  });
+
   it("jitters retry schedules to avoid synchronized clients", async () => {
     vi.mocked(Math.random).mockReturnValue(0);
     mailboxSync.syncPages

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { trackMailboxSyncResult } from "@/utils/email-cache/analytics";
 import {
   fetchMailboxSyncPage,
@@ -34,6 +34,14 @@ export function useMailboxSync({
   enabled: boolean;
   priority?: boolean;
 }) {
+  const priorityRef = useRef(priority);
+
+  useEffect(() => {
+    if (!enabled || !emailAccountId) return;
+    priorityRef.current = priority;
+    mailboxSyncScheduler.setPriority({ emailAccountId, priority });
+  }, [emailAccountId, enabled, priority]);
+
   useEffect(() => {
     if (!enabled || !emailAccountId) return;
     let cancelled = false;
@@ -64,7 +72,7 @@ export function useMailboxSync({
       const startedAt = performance.now();
       attempts += 1;
       mailboxSyncScheduler
-        .run({ emailAccountId, priority })
+        .run({ emailAccountId, priority: priorityRef.current })
         .then(({ hasMore, pagesSynced }) => {
           const catchUpCompleted = catchingUp && !hasMore;
           const shouldTrackSteadySync =
@@ -139,7 +147,7 @@ export function useMailboxSync({
       window.removeEventListener("online", run);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [emailAccountId, enabled, priority]);
+  }, [emailAccountId, enabled]);
 }
 
 export function requestMailboxSync(emailAccountId: string) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
@@ -6,24 +6,33 @@ import {
   fetchMailboxSyncPage,
   syncMailboxPages,
 } from "@/utils/email-cache/mailbox-sync";
+import { createMailboxSyncScheduler } from "./mailbox-sync-scheduler";
 
 const COMPLETE_SYNC_INTERVAL_MS = 60_000;
 const CONTINUATION_DELAY_MS = 10_000;
+const MAX_CONCURRENT_MAILBOX_SYNCS = 2;
 const MAX_RETRY_DELAY_MS = 15 * 60_000;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const STEADY_SYNC_TELEMETRY_INTERVAL_MS = 15 * 60_000;
-const inFlightSyncs = new Map<
-  string,
-  Promise<{ hasMore: boolean; pagesSynced: number }>
->();
 const syncRequestListeners = new Set<(emailAccountId: string) => void>();
+const mailboxSyncScheduler = createMailboxSyncScheduler({
+  maxConcurrent: MAX_CONCURRENT_MAILBOX_SYNCS,
+  sync: (emailAccountId) =>
+    syncMailboxPages({
+      emailAccountId,
+      fetchPage: (input) => fetchMailboxSyncPage(emailAccountId, input),
+      maxPages: 1,
+    }),
+});
 
 export function useMailboxSync({
   emailAccountId,
   enabled,
+  priority = false,
 }: {
   emailAccountId: string;
   enabled: boolean;
+  priority?: boolean;
 }) {
   useEffect(() => {
     if (!enabled || !emailAccountId) return;
@@ -54,7 +63,8 @@ export function useMailboxSync({
       const initial = attempts === 0;
       const startedAt = performance.now();
       attempts += 1;
-      runSharedMailboxSync(emailAccountId)
+      mailboxSyncScheduler
+        .run({ emailAccountId, priority })
         .then(({ hasMore, pagesSynced }) => {
           const catchUpCompleted = catchingUp && !hasMore;
           const shouldTrackSteadySync =
@@ -129,28 +139,11 @@ export function useMailboxSync({
       window.removeEventListener("online", run);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [emailAccountId, enabled]);
+  }, [emailAccountId, enabled, priority]);
 }
 
 export function requestMailboxSync(emailAccountId: string) {
   for (const listener of syncRequestListeners) listener(emailAccountId);
-}
-
-function runSharedMailboxSync(emailAccountId: string) {
-  const existing = inFlightSyncs.get(emailAccountId);
-  if (existing) return existing;
-
-  const sync = syncMailboxPages({
-    emailAccountId,
-    fetchPage: (input) => fetchMailboxSyncPage(emailAccountId, input),
-    maxPages: 1,
-  }).finally(() => {
-    if (inFlightSyncs.get(emailAccountId) === sync) {
-      inFlightSyncs.delete(emailAccountId);
-    }
-  });
-  inFlightSyncs.set(emailAccountId, sync);
-  return sync;
 }
 
 function getRetryDelay(consecutiveFailures: number, retryAfterMs?: number) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260823-215744_pr-3372_8c07105ba951/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Coordinate background mailbox synchronization across connected accounts so the active mailbox stays responsive without unbounded request bursts.

- prioritize the active account and cap concurrent mailbox syncs at two
- deduplicate queued and running work per account while preserving existing retries
- cover concurrency, priority, deduplication, failures, and manager orchestration

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mailbox synchronization by prioritizing the active account.
  - Limited simultaneous mailbox syncs to two for improved stability.
  - Prevented duplicate synchronization requests while work is queued or running.
  - Reordered queued synchronization when account priority changes.
  - Improved recovery after synchronization failures so later work can continue.

- **Bug Fixes**
  - Disconnected accounts are excluded from synchronization.
  - Changing account priority no longer resets existing retry delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->