### PR TITLE
fix: warm mailbox sync from the app shell

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -1,5 +1,38 @@
 import { expect, test } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("starts mailbox warming from the app shell before mail opens", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  const syncAccountIds = new Set<string>();
+
+  await page.route("**/api/mobile/mailbox-sync", async (route) => {
+    const syncAccountId = await route
+      .request()
+      .headerValue("X-Email-Account-ID");
+    if (syncAccountId) syncAccountIds.add(syncAccountId);
+    await route.fulfill({
+      body: JSON.stringify({
+        accountId: syncAccountId ?? emailAccountId,
+        cursor: `${syncAccountId ?? emailAccountId}-cursor`,
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: false,
+        upsertedMessages: [],
+      }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+
+  await page.goto(`/${emailAccountId}/settings`);
+  await expect(
+    page.getByRole("heading", { name: "Settings", exact: true }),
+  ).toBeVisible();
+  await expect.poll(() => [...syncAccountIds]).toContain(emailAccountId);
+});
 
 test("opens a complete conversation and updates its read state", async ({
   page,

--- a/apps/web/app/(app)/MailboxSyncManager.test.tsx
+++ b/apps/web/app/(app)/MailboxSyncManager.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/hooks/useAccounts", () => ({ useAccounts: accounts.useAccounts }));
 vi.mock("@/providers/EmailAccountProvider", () => ({
   useAccount: () => activeAccount,
 }));
-vi.mock("./use-mailbox-sync", () => ({
+vi.mock("@/app/(app)/[emailAccountId]/mail/use-mailbox-sync", () => ({
   useMailboxSync: mailboxSync.useMailboxSync,
 }));
 
@@ -33,7 +33,7 @@ describe("MailboxSyncManager", () => {
     });
   });
 
-  it("synchronizes every connected account without retrying disconnected accounts", () => {
+  it("starts warming every connected account and prioritizes the active one", () => {
     render(<MailboxSyncManager />);
 
     expect(mailboxSync.useMailboxSync).toHaveBeenCalledTimes(2);

--- a/apps/web/app/(app)/MailboxSyncManager.tsx
+++ b/apps/web/app/(app)/MailboxSyncManager.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { useMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 
 export function MailboxSyncManager() {
   const { data } = useAccounts();

--- a/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
@@ -1,5 +1,4 @@
 import { MailThemeScope } from "@/app/(app)/[emailAccountId]/mail/MailThemeScope";
-import { MailboxSyncManager } from "@/app/(app)/[emailAccountId]/mail/MailboxSyncManager";
 import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
 
@@ -13,7 +12,6 @@ export default function MailLayout({
   return (
     <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
       <MailThemeScope />
-      <MailboxSyncManager />
       {children}
     </ShortcutsProvider>
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requestMailboxSync, useMailboxSync } from "./use-mailbox-sync";
 
+const desktop = vi.hoisted(() => ({ getApp: vi.fn() }));
 const mailboxSync = vi.hoisted(() => ({
   fetchPage: vi.fn(),
   syncPages: vi.fn(),
@@ -19,6 +20,9 @@ vi.mock("@/utils/email-cache/mailbox-sync", () => ({
 vi.mock("@/utils/email-cache/analytics", () => ({
   trackMailboxSyncResult: analytics.trackSyncResult,
 }));
+vi.mock("@/utils/desktop-app", () => ({
+  getInboxZeroDesktopApp: desktop.getApp,
+}));
 
 const onlineDescriptor = Object.getOwnPropertyDescriptor(navigator, "onLine");
 const visibilityDescriptor = Object.getOwnPropertyDescriptor(
@@ -32,6 +36,7 @@ describe("useMailboxSync", () => {
     vi.clearAllMocks();
     setOnline(true);
     setVisibility("visible");
+    desktop.getApp.mockReturnValue(undefined);
     vi.spyOn(Math, "random").mockReturnValue(0.5);
     mailboxSync.syncPages.mockResolvedValue({
       hasMore: false,
@@ -76,7 +81,7 @@ describe("useMailboxSync", () => {
     expect(mailboxSync.syncPages).toHaveBeenCalledTimes(3);
   });
 
-  it("pauses offline or hidden work and resumes on browser events", async () => {
+  it("pauses offline work and resumes on browser events", async () => {
     setOnline(false);
     renderHook(() =>
       useMailboxSync({ emailAccountId: "account-1", enabled: true }),
@@ -90,6 +95,14 @@ describe("useMailboxSync", () => {
     act(() => window.dispatchEvent(new Event("online")));
     expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
     await settlePromises();
+  });
+
+  it("pauses hidden polling in the web app until the tab is visible again", async () => {
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await settlePromises();
 
     setVisibility("hidden");
     act(() => window.dispatchEvent(new Event("focus")));
@@ -98,6 +111,24 @@ describe("useMailboxSync", () => {
     setVisibility("visible");
     act(() => document.dispatchEvent(new Event("visibilitychange")));
     await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues hidden polling in the desktop app", async () => {
+    desktop.getApp.mockReturnValue({
+      startAuth: vi.fn(),
+    });
+    setVisibility("hidden");
+
+    renderHook(() =>
+      useMailboxSync({ emailAccountId: "account-1", enabled: true }),
+    );
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await settlePromises();
+
+    await act(() => vi.advanceTimersByTimeAsync(59_999));
+    expect(mailboxSync.syncPages).toHaveBeenCalledOnce();
+    await act(() => vi.advanceTimersByTimeAsync(1));
     expect(mailboxSync.syncPages).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mailbox-sync.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
 import { trackMailboxSyncResult } from "@/utils/email-cache/analytics";
 import {
   fetchMailboxSyncPage,
@@ -48,6 +49,7 @@ export function useMailboxSync({
     let attempts = 0;
     let catchingUp = false;
     let consecutiveFailures = 0;
+    const desktop = getInboxZeroDesktopApp();
     let lastSteadyTelemetryAt = 0;
     let running = false;
     let rerunRequested = false;
@@ -63,7 +65,10 @@ export function useMailboxSync({
         rerunRequested = true;
         return;
       }
-      if (document.visibilityState === "hidden" || navigator.onLine === false) {
+      if (
+        navigator.onLine === false ||
+        (document.visibilityState === "hidden" && !desktop)
+      ) {
         schedule(COMPLETE_SYNC_INTERVAL_MS);
         return;
       }

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -14,6 +14,7 @@ import { AssessUser } from "@/app/(app)/[emailAccountId]/assess";
 import { SentryIdentify } from "@/app/(app)/sentry-identify";
 import { AiAutomationStatusBanner } from "@/app/(app)/AiAutomationStatusBanner";
 import { ErrorMessages } from "@/app/(app)/ErrorMessages";
+import { MailboxSyncManager } from "@/app/(app)/MailboxSyncManager";
 import { ProviderRateLimitBanner } from "@/app/(app)/ProviderRateLimitBanner";
 import { QueueInitializer } from "@/store/QueueInitializer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -90,6 +91,7 @@ export default async function AppLayout({
               !bypassPremiumChecks || Boolean(process.env.FEEDBACK_WEBHOOK_URL)
             }
           >
+            <MailboxSyncManager />
             <AiAutomationStatusBanner />
             <ErrorMessages />
             <ProviderRateLimitBanner />


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260824-073842_pr-3374_f61497bd251a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

mail: warm mailbox sync from the app shell

Start bounded mailbox warming from the authenticated app shell so connected accounts can begin syncing before /mail opens, while keeping the active account first and preserving the shared scheduler cap.

- move the mailbox sync manager from the mail route into the authenticated app shell
- keep hidden-tab polling paused on the web, but allow the desktop runtime to continue safe background sync
- add focused hook and manager tests plus an emulated Playwright check for shell-started warming

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mailbox synchronization now begins from the main app shell before opening mail.
  * The active connected account is synchronized first with priority, followed by other connected accounts.
  * Desktop app synchronization continues while the window is hidden.

* **Bug Fixes**
  * Disconnected accounts are excluded from mailbox warming.
  * Web synchronization pauses when the page is hidden or offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->