### PR TITLE
Harden thread detail cache coverage

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -7,6 +7,10 @@ const MESSAGE_COUNT = 5000;
 const FIRST_LOCAL_SUBJECT = "Local mailbox load test 0";
 const PRIMARY_UNIFIED_SUBJECT = "Primary local unified conversation";
 const SECONDARY_UNIFIED_SUBJECT = "Secondary local unified conversation";
+const THREAD_DETAIL_VARIANT = "drafts:1|replies:0";
+const WARM_READER_BODY = "Cached reader body from IndexedDB";
+const COLD_READER_BODY = "Network reader body after cache miss";
+const REFRESHED_READER_BODY = "Fresh reader body after revalidation";
 
 test("renders a large local mailbox while server mail requests are unavailable", async ({
   page,
@@ -86,6 +90,91 @@ test("renders and isolates two locally cached accounts without server mail reque
   } finally {
     await deleteSecondEmailAccount(secondAccount.accountId);
   }
+});
+
+test("renders a cached thread body when the reader request is offline", async ({
+  page,
+}, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const threadId = await openFirstThread(page, conversations);
+  await seedThreadDetail(page, {
+    emailAccountId,
+    textPlain: WARM_READER_BODY,
+    threadId,
+  });
+
+  await page.route(threadDetailRoute(threadId), (route) =>
+    route.abort("connectionfailed"),
+  );
+  await page.reload();
+
+  await expect(readerBody(page, WARM_READER_BODY)).toBeVisible();
+  await testInfo.attach("cached-thread-reader", {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
+});
+
+test("falls back to the network for an uncached thread body and persists it", async ({
+  page,
+}) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const threadId = await openFirstThread(page, conversations);
+  await clearThreadDetail(page, { emailAccountId, threadId });
+
+  await page.route(threadDetailRoute(threadId), async (route) => {
+    await route.fulfill({
+      body: JSON.stringify(
+        getThreadDetailResponse({
+          textPlain: COLD_READER_BODY,
+          threadId,
+        }),
+      ),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+  await page.reload();
+
+  await expect(readerBody(page, COLD_READER_BODY)).toBeVisible();
+  await expect
+    .poll(() => readThreadDetailTextPlain(page, { emailAccountId, threadId }))
+    .toBe(COLD_READER_BODY);
+});
+
+test("shows cached reader content immediately and refreshes it from the network", async ({
+  page,
+}) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const threadId = await openFirstThread(page, conversations);
+  const network = Promise.withResolvers<void>();
+
+  await seedThreadDetail(page, {
+    emailAccountId,
+    textPlain: WARM_READER_BODY,
+    threadId,
+  });
+  await page.route(threadDetailRoute(threadId), async (route) => {
+    await network.promise;
+    await route.fulfill({
+      body: JSON.stringify(
+        getThreadDetailResponse({
+          textPlain: REFRESHED_READER_BODY,
+          threadId,
+        }),
+      ),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+  await page.reload();
+
+  await expect(readerBody(page, WARM_READER_BODY)).toBeVisible();
+  network.resolve();
+  await expect(readerBody(page, REFRESHED_READER_BODY)).toBeVisible();
+  await expect
+    .poll(() => readThreadDetailTextPlain(page, { emailAccountId, threadId }))
+    .toBe(REFRESHED_READER_BODY);
 });
 
 async function seedLargeMailbox(page: Page, emailAccountId: string) {
@@ -236,6 +325,188 @@ async function seedUnifiedMailbox(
       },
     },
   );
+}
+
+async function openFirstThread(
+  page: Page,
+  conversations: ReturnType<Page["getByRole"]>,
+) {
+  await conversations.getByRole("option").first().click();
+  const threadId = new URL(page.url()).searchParams.get("thread-id");
+  if (!threadId) throw new Error("Expected an open thread id");
+  return threadId;
+}
+
+async function seedThreadDetail(
+  page: Page,
+  {
+    emailAccountId,
+    threadId,
+    textPlain,
+  }: {
+    emailAccountId: string;
+    threadId: string;
+    textPlain: string;
+  },
+) {
+  const data = getThreadDetailResponse({ textPlain, threadId });
+  await page.evaluate(
+    async ({ byteSize, data, emailAccountId, threadId, variant }) => {
+      await new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction(
+            "threadDetails",
+            "readwrite",
+          );
+          transaction.onerror = () => reject(transaction.error);
+          transaction.oncomplete = () => {
+            database.close();
+            resolve();
+          };
+          const now = Date.now();
+          transaction.objectStore("threadDetails").put({
+            byteSize,
+            data,
+            emailAccountId,
+            fetchedAt: now,
+            lastAccessedAt: now,
+            threadId,
+            variant,
+          });
+        };
+      });
+    },
+    {
+      byteSize: JSON.stringify(data).length,
+      data,
+      emailAccountId,
+      threadId,
+      variant: THREAD_DETAIL_VARIANT,
+    },
+  );
+}
+
+async function clearThreadDetail(
+  page: Page,
+  {
+    emailAccountId,
+    threadId,
+  }: {
+    emailAccountId: string;
+    threadId: string;
+  },
+) {
+  await page.evaluate(
+    async ({ emailAccountId, threadId, variant }) => {
+      await new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction(
+            "threadDetails",
+            "readwrite",
+          );
+          transaction.onerror = () => reject(transaction.error);
+          transaction.oncomplete = () => {
+            database.close();
+            resolve();
+          };
+          transaction
+            .objectStore("threadDetails")
+            .delete([emailAccountId, threadId, variant]);
+        };
+      });
+    },
+    { emailAccountId, threadId, variant: THREAD_DETAIL_VARIANT },
+  );
+}
+
+async function readThreadDetailTextPlain(
+  page: Page,
+  {
+    emailAccountId,
+    threadId,
+  }: {
+    emailAccountId: string;
+    threadId: string;
+  },
+) {
+  return page.evaluate(
+    async ({ emailAccountId, threadId, variant }) =>
+      await new Promise<string | undefined>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction("threadDetails", "readonly");
+          transaction.onerror = () => reject(transaction.error);
+          const request = transaction
+            .objectStore("threadDetails")
+            .get([emailAccountId, threadId, variant]);
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            database.close();
+            resolve(request.result?.data?.thread?.messages?.[0]?.textPlain);
+          };
+        };
+      }),
+    { emailAccountId, threadId, variant: THREAD_DETAIL_VARIANT },
+  );
+}
+
+function getThreadDetailResponse({
+  threadId,
+  textPlain,
+}: {
+  threadId: string;
+  textPlain: string;
+}) {
+  const date = "2026-08-23T10:00:00.000Z";
+  return {
+    thread: {
+      historyId: "history-1",
+      id: threadId,
+      messages: [
+        {
+          date,
+          headers: {
+            date,
+            from: "reader-cache@example.com",
+            subject: textPlain,
+            to: "playwright-test@gmail.com",
+          },
+          historyId: "history-1",
+          id: `${threadId}-message`,
+          inline: [],
+          snippet: textPlain,
+          subject: textPlain,
+          textPlain,
+          threadId,
+        },
+      ],
+      snippet: textPlain,
+    },
+  };
+}
+
+function threadDetailRoute(threadId: string) {
+  return new RegExp(
+    `/api/threads/${escapeRegExp(encodeURIComponent(threadId))}(?:\\?.*)?$`,
+  );
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readerBody(page: Page, text: string) {
+  return page
+    .locator("pre")
+    .filter({ hasText: new RegExp(`^${escapeRegExp(text)}$`) });
 }
 
 async function createSecondEmailAccount(primaryEmailAccountId: string) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
@@ -5,8 +5,8 @@ import {
   fetchThreadRequest,
 } from "@/utils/email-cache/thread-request";
 import {
-  readCachedThread,
-  writeCachedThread,
+  readCachedThreadDetail,
+  writeCachedThreadDetail,
 } from "@/utils/email-cache/threads";
 import { prepareEmailHtml } from "@/utils/email/prepare-html.client";
 
@@ -33,7 +33,7 @@ export async function prefetchThreadDetail({
     threadId,
     options: { includeDrafts: true },
   });
-  const cached = await readCachedThread<ThreadResponse>({
+  const cached = await readCachedThreadDetail({
     emailAccountId,
     threadId,
     variant: request.variant,
@@ -62,7 +62,7 @@ export async function prefetchThreadDetail({
     revalidate: false,
   });
   await Promise.all([
-    writeCachedThread({
+    writeCachedThreadDetail({
       emailAccountId,
       threadId,
       variant: request.variant,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
@@ -15,8 +15,8 @@ const emailHtml = vi.hoisted(() => ({
 }));
 
 vi.mock("@/utils/email-cache/threads", () => ({
-  readCachedThread: cache.read,
-  writeCachedThread: cache.write,
+  readCachedThreadDetail: cache.read,
+  writeCachedThreadDetail: cache.write,
 }));
 
 vi.mock("@/utils/email/prepare-html.client", () => ({

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
@@ -19,8 +19,8 @@ const emailHtml = vi.hoisted(() => ({
 }));
 
 vi.mock("@/utils/email-cache/threads", () => ({
-  readCachedThread: cache.read,
-  writeCachedThread: cache.write,
+  readCachedThreadDetail: cache.read,
+  writeCachedThreadDetail: cache.write,
 }));
 
 vi.mock("@/utils/email/prepare-html.client", () => ({

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -16,8 +16,8 @@ vi.mock("@/providers/EmailAccountProvider", () => ({
 }));
 
 vi.mock("@/utils/email-cache/threads", () => ({
-  readCachedThread: cache.read,
-  writeCachedThread: cache.write,
+  readCachedThreadDetail: cache.read,
+  writeCachedThreadDetail: cache.write,
 }));
 
 describe("useThread", () => {
@@ -61,7 +61,41 @@ describe("useThread", () => {
     network.resolve({
       thread: { id: "thread-1", messages: [{ id: "network" }] },
     });
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages[0]?.id).toBe("network"),
+    );
     await waitFor(() => expect(cache.write).toHaveBeenCalled());
+  });
+
+  it("falls back to the network when no cached detail exists", async () => {
+    const network = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi.fn(() => network.promise);
+
+    const { result } = renderHook(() => useThread({ id: "thread-1" }), {
+      wrapper: createWrapper(fetcher),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+
+    network.resolve({
+      thread: { id: "thread-1", messages: [{ id: "network-only" }] },
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages[0]?.id).toBe("network-only"),
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(cache.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          thread: { id: "thread-1", messages: [{ id: "network-only" }] },
+        },
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+      }),
+    );
   });
 
   it("never lets a late disk read overwrite fresher network data", async () => {

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -3,8 +3,8 @@ import useSWR, { useSWRConfig } from "swr";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
-  readCachedThread,
-  writeCachedThread,
+  readCachedThreadDetail,
+  writeCachedThreadDetail,
 } from "@/utils/email-cache/threads";
 import {
   createThreadRequest,
@@ -64,7 +64,7 @@ export function useThread(
     let cancelled = false;
     const startedAt = startEmailCacheMeasure();
 
-    readCachedThread<ThreadResponse>({
+    readCachedThreadDetail({
       emailAccountId,
       threadId: id,
       variant: request.variant,
@@ -87,7 +87,7 @@ export function useThread(
 
   useEffect(() => {
     if (!remoteData || !request || !id) return;
-    writeCachedThread({
+    writeCachedThreadDetail({
       emailAccountId,
       threadId: id,
       variant: request.variant,

--- a/apps/web/utils/email-cache/threads.test.ts
+++ b/apps/web/utils/email-cache/threads.test.ts
@@ -1,9 +1,8 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "vitest";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { clearEmailCache, clearEmailCacheForAccount } from "./database";
-import { readCachedThread, writeCachedThread } from "./threads";
-
-type TestThreadResponse = { thread: { id: string; body: string } };
+import { readCachedThreadDetail, writeCachedThreadDetail } from "./threads";
 
 describe("cached thread details", () => {
   beforeEach(async () => {
@@ -11,15 +10,15 @@ describe("cached thread details", () => {
   });
 
   it("isolates thread response variants", async () => {
-    await writeCachedThread({
+    await writeCachedThreadDetail({
       emailAccountId: "account-1",
       threadId: "thread-1",
       variant: "drafts:0|replies:0",
-      data: { thread: { id: "thread-1", body: "without drafts" } },
+      data: getThreadResponse({ textPlain: "without drafts" }),
     });
 
     await expect(
-      readCachedThread<TestThreadResponse>({
+      readCachedThreadDetail({
         emailAccountId: "account-1",
         threadId: "thread-1",
         variant: "drafts:1|replies:0",
@@ -29,47 +28,47 @@ describe("cached thread details", () => {
 
   it("clears one account without affecting another", async () => {
     for (const emailAccountId of ["account-1", "account-2"]) {
-      await writeCachedThread({
+      await writeCachedThreadDetail({
         emailAccountId,
         threadId: "thread-1",
         variant: "drafts:0|replies:0",
-        data: { thread: { id: "thread-1", body: emailAccountId } },
+        data: getThreadResponse({ textPlain: emailAccountId }),
       });
     }
 
     await clearEmailCacheForAccount("account-1");
 
     await expect(
-      readCachedThread<TestThreadResponse>({
+      readCachedThreadDetail({
         emailAccountId: "account-1",
         threadId: "thread-1",
         variant: "drafts:0|replies:0",
       }),
     ).resolves.toBeUndefined();
     await expect(
-      readCachedThread<TestThreadResponse>({
+      readCachedThreadDetail({
         emailAccountId: "account-2",
         threadId: "thread-1",
         variant: "drafts:0|replies:0",
       }),
     ).resolves.toMatchObject({
-      data: { thread: { body: "account-2" } },
+      data: { thread: { messages: [{ textPlain: "account-2" }] } },
     });
   });
 
   it("rejects writes started while an account clear is in progress", async () => {
     const clearing = clearEmailCacheForAccount("account-1");
-    const writing = writeCachedThread({
+    const writing = writeCachedThreadDetail({
       emailAccountId: "account-1",
       threadId: "thread-1",
       variant: "drafts:0|replies:0",
-      data: { thread: { id: "thread-1", body: "late response" } },
+      data: getThreadResponse({ textPlain: "late response" }),
     });
 
     await Promise.all([clearing, writing]);
 
     await expect(
-      readCachedThread<TestThreadResponse>({
+      readCachedThreadDetail({
         emailAccountId: "account-1",
         threadId: "thread-1",
         variant: "drafts:0|replies:0",
@@ -78,20 +77,186 @@ describe("cached thread details", () => {
   });
 
   it("does not return expired thread details", async () => {
-    await writeCachedThread({
+    await writeCachedThreadDetail({
       emailAccountId: "account-1",
       threadId: "thread-1",
       variant: "drafts:0|replies:0",
-      data: { thread: { id: "thread-1", body: "Expired" } },
+      data: getThreadResponse({ textPlain: "Expired" }),
       now: Date.now() - 31 * 24 * 60 * 60 * 1000,
     });
 
     await expect(
-      readCachedThread<TestThreadResponse>({
+      readCachedThreadDetail({
         emailAccountId: "account-1",
         threadId: "thread-1",
         variant: "drafts:0|replies:0",
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("stores only the reader fields and attachment metadata", async () => {
+    await writeCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+      data: getThreadResponseWithExtraFields(),
+    });
+
+    const cached = await readCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(cached).toMatchObject({
+      data: {
+        thread: {
+          historyId: "history-1",
+          id: "thread-1",
+          messages: [
+            {
+              attachments: [
+                {
+                  attachmentId: "attachment-1",
+                  filename: "report.pdf",
+                  mimeType: "application/pdf",
+                  size: 10,
+                },
+              ],
+              headers: {
+                date: "2026-08-23T10:00:00.000Z",
+                from: "sender@example.com",
+                subject: "Subject",
+                to: "me@example.com",
+              },
+              id: "message-1",
+              inline: [
+                {
+                  attachmentId: "inline-1",
+                  filename: "inline.png",
+                  mimeType: "image/png",
+                  size: 12,
+                },
+              ],
+              textPlain: "Body",
+            },
+          ],
+          snippet: "snippet",
+        },
+      },
+    });
+    expect(
+      (cached?.data.thread as Record<string, unknown>).providerOnlyField,
+    ).toBeUndefined();
+    expect(
+      (cached?.data.thread.messages[0] as Record<string, unknown>)
+        .extraMessageField,
+    ).toBeUndefined();
+    expect(
+      (
+        cached?.data.thread.messages[0]?.attachments?.[0] as Record<
+          string,
+          unknown
+        >
+      ).content,
+    ).toBeUndefined();
+  });
 });
+
+function getThreadResponse({
+  textPlain,
+}: {
+  textPlain: string;
+}): ThreadResponse {
+  const date = "2026-08-23T10:00:00.000Z";
+  return {
+    thread: {
+      historyId: "history-1",
+      id: "thread-1",
+      messages: [
+        {
+          date,
+          headers: {
+            date,
+            from: "sender@example.com",
+            subject: "Subject",
+            to: "me@example.com",
+          },
+          historyId: "history-1",
+          id: "message-1",
+          inline: [],
+          snippet: textPlain,
+          subject: "Subject",
+          textPlain,
+          threadId: "thread-1",
+        },
+      ],
+      snippet: textPlain,
+    },
+  };
+}
+
+function getThreadResponseWithExtraFields(): ThreadResponse {
+  const date = "2026-08-23T10:00:00.000Z";
+  return {
+    thread: {
+      historyId: "history-1",
+      id: "thread-1",
+      messages: [
+        {
+          attachments: [
+            {
+              attachmentId: "attachment-1",
+              content: "base64-payload",
+              filename: "report.pdf",
+              headers: {
+                "content-description": "report",
+                "content-disposition": "attachment",
+                "content-id": "attachment-content-id",
+                "content-transfer-encoding": "base64",
+                "content-type": "application/pdf",
+                ignored: "value",
+              },
+              mimeType: "application/pdf",
+              size: 10,
+            },
+          ],
+          date,
+          extraMessageField: "remove-me",
+          headers: {
+            date,
+            from: "sender@example.com",
+            subject: "Subject",
+            to: "me@example.com",
+            unknown: "value",
+          },
+          historyId: "history-1",
+          id: "message-1",
+          inline: [
+            {
+              attachmentId: "inline-1",
+              data: "inline-payload",
+              filename: "inline.png",
+              headers: {
+                "content-description": "inline",
+                "content-id": "inline-content-id",
+                "content-transfer-encoding": "base64",
+                "content-type": "image/png",
+                ignored: "value",
+              },
+              mimeType: "image/png",
+              size: 12,
+            },
+          ],
+          labelIds: ["INBOX"],
+          snippet: "snippet",
+          subject: "Subject",
+          textPlain: "Body",
+          threadId: "thread-1",
+        },
+      ],
+      providerOnlyField: "remove-me",
+      snippet: "snippet",
+    },
+  } as ThreadResponse;
+}

--- a/apps/web/utils/email-cache/threads.test.ts
+++ b/apps/web/utils/email-cache/threads.test.ts
@@ -1,7 +1,11 @@
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
-import { clearEmailCache, clearEmailCacheForAccount } from "./database";
+import {
+  clearEmailCache,
+  clearEmailCacheForAccount,
+  getEmailCacheDatabase,
+} from "./database";
 import { readCachedThreadDetail, writeCachedThreadDetail } from "./threads";
 
 describe("cached thread details", () => {
@@ -161,6 +165,57 @@ describe("cached thread details", () => {
       ).content,
     ).toBeUndefined();
   });
+
+  it("rewrites legacy thread detail records with sanitized data and byte size", async () => {
+    const legacy = getThreadResponseWithExtraFields();
+    const expected = getSanitizedThreadResponse();
+
+    await seedLegacyThreadDetailRecord({
+      byteSize: JSON.stringify(legacy).length,
+      data: legacy,
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    const cached = await readCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(cached).toMatchObject({
+      byteSize: JSON.stringify(expected).length,
+      data: expected,
+    });
+
+    const persisted = await getPersistedThreadDetailRecord({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(persisted).toMatchObject({
+      byteSize: JSON.stringify(expected).length,
+      data: expected,
+    });
+    expect(
+      (
+        persisted?.data as {
+          thread?: Record<string, unknown>;
+        }
+      ).thread?.providerOnlyField,
+    ).toBeUndefined();
+    expect(
+      (
+        (
+          persisted?.data as {
+            thread?: { messages?: Array<Record<string, unknown>> };
+          }
+        ).thread?.messages?.[0]?.attachments?.[0] as Record<string, unknown>
+      ).content,
+    ).toBeUndefined();
+  });
 });
 
 function getThreadResponse({
@@ -259,4 +314,104 @@ function getThreadResponseWithExtraFields(): ThreadResponse {
       snippet: "snippet",
     },
   } as ThreadResponse;
+}
+
+function getSanitizedThreadResponse(): ThreadResponse {
+  return {
+    thread: {
+      historyId: "history-1",
+      id: "thread-1",
+      messages: [
+        {
+          attachments: [
+            {
+              attachmentId: "attachment-1",
+              filename: "report.pdf",
+              headers: {
+                "content-description": "report",
+                "content-disposition": "attachment",
+                "content-id": "attachment-content-id",
+                "content-transfer-encoding": "base64",
+                "content-type": "application/pdf",
+              },
+              mimeType: "application/pdf",
+              size: 10,
+            },
+          ],
+          date: "2026-08-23T10:00:00.000Z",
+          headers: {
+            date: "2026-08-23T10:00:00.000Z",
+            from: "sender@example.com",
+            subject: "Subject",
+            to: "me@example.com",
+          },
+          historyId: "history-1",
+          id: "message-1",
+          inline: [
+            {
+              attachmentId: "inline-1",
+              filename: "inline.png",
+              headers: {
+                "content-description": "inline",
+                "content-id": "inline-content-id",
+                "content-transfer-encoding": "base64",
+                "content-type": "image/png",
+              },
+              mimeType: "image/png",
+              size: 12,
+            },
+          ],
+          labelIds: ["INBOX"],
+          snippet: "snippet",
+          subject: "Subject",
+          textPlain: "Body",
+          threadId: "thread-1",
+        },
+      ],
+      snippet: "snippet",
+    },
+  };
+}
+
+async function seedLegacyThreadDetailRecord({
+  byteSize,
+  data,
+  emailAccountId,
+  threadId,
+  variant,
+}: {
+  byteSize: number;
+  data: ThreadResponse;
+  emailAccountId: string;
+  threadId: string;
+  variant: string;
+}) {
+  const database = await getEmailCacheDatabase();
+  if (!database) throw new Error("Expected email cache database");
+  const now = Date.now();
+
+  await database.put("threadDetails", {
+    byteSize,
+    data,
+    emailAccountId,
+    fetchedAt: now,
+    lastAccessedAt: now,
+    threadId,
+    variant,
+  });
+}
+
+async function getPersistedThreadDetailRecord({
+  emailAccountId,
+  threadId,
+  variant,
+}: {
+  emailAccountId: string;
+  threadId: string;
+  variant: string;
+}) {
+  const database = await getEmailCacheDatabase();
+  if (!database) throw new Error("Expected email cache database");
+
+  return database.get("threadDetails", [emailAccountId, threadId, variant]);
 }

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -1,3 +1,9 @@
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
+import type {
+  Attachment,
+  ParsedMessage,
+  ParsedMessageHeaders,
+} from "@/utils/types";
 import { scheduleEmailCacheCleanup } from "./cleanup";
 import {
   captureEmailCacheEpoch,
@@ -6,7 +12,13 @@ import {
 } from "./database";
 import { EMAIL_CACHE_MAX_AGE_MS } from "./policy";
 
-export async function writeCachedThread<T>({
+export type CachedThreadDetail = {
+  byteSize: number;
+  cachedAt: number;
+  data: ThreadResponse;
+};
+
+export async function writeCachedThreadDetail({
   emailAccountId,
   threadId,
   variant,
@@ -16,10 +28,11 @@ export async function writeCachedThread<T>({
   emailAccountId: string;
   threadId: string;
   variant: string;
-  data: T;
+  data: ThreadResponse;
   now?: number;
 }) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
+  const sanitized = sanitizeThreadResponse(data);
 
   try {
     const database = await getEmailCacheDatabase();
@@ -28,10 +41,10 @@ export async function writeCachedThread<T>({
       emailAccountId,
       threadId,
       variant,
-      data,
+      data: sanitized,
       fetchedAt: now,
       lastAccessedAt: now,
-      byteSize: new Blob([JSON.stringify(data)]).size,
+      byteSize: new Blob([JSON.stringify(sanitized)]).size,
     });
     scheduleEmailCacheCleanup();
   } catch {
@@ -40,7 +53,7 @@ export async function writeCachedThread<T>({
   }
 }
 
-export async function readCachedThread<T>({
+export async function readCachedThreadDetail({
   emailAccountId,
   threadId,
   variant,
@@ -48,7 +61,7 @@ export async function readCachedThread<T>({
   emailAccountId: string;
   threadId: string;
   variant: string;
-}) {
+}): Promise<CachedThreadDetail | undefined> {
   const epoch = captureEmailCacheEpoch(emailAccountId);
 
   try {
@@ -72,11 +85,96 @@ export async function readCachedThread<T>({
     if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
     scheduleEmailCacheCleanup();
     return {
-      data: record.data as T,
+      data: sanitizeThreadResponse(record.data as ThreadResponse),
       cachedAt: record.fetchedAt,
       byteSize: record.byteSize,
     };
   } catch {
     return;
   }
+}
+
+function sanitizeThreadResponse(data: ThreadResponse): ThreadResponse {
+  return {
+    thread: {
+      historyId: data.thread.historyId,
+      id: data.thread.id,
+      messages: data.thread.messages.map(sanitizeMessage),
+      snippet: data.thread.snippet,
+    },
+  };
+}
+
+function sanitizeMessage(message: ParsedMessage): ParsedMessage {
+  return {
+    attachments: message.attachments?.map(sanitizeAttachment),
+    bodyContentType: message.bodyContentType,
+    conversationIndex: message.conversationIndex,
+    date: message.date,
+    externalUrl: message.externalUrl,
+    headers: sanitizeHeaders(message.headers),
+    historyId: message.historyId,
+    id: message.id,
+    inline: message.inline.map(sanitizeInlineAttachment),
+    internalDate: message.internalDate,
+    labelIds: message.labelIds ? [...message.labelIds] : undefined,
+    parentFolderId: message.parentFolderId,
+    rawRecipients: message.rawRecipients,
+    snippet: message.snippet,
+    subject: message.subject,
+    textHtml: message.textHtml,
+    textPlain: message.textPlain,
+    threadId: message.threadId,
+  };
+}
+
+function sanitizeAttachment(attachment: Attachment): Attachment {
+  return {
+    attachmentId: attachment.attachmentId,
+    filename: attachment.filename,
+    headers: {
+      "content-description": attachment.headers["content-description"],
+      "content-disposition": attachment.headers["content-disposition"],
+      "content-id": attachment.headers["content-id"],
+      "content-transfer-encoding":
+        attachment.headers["content-transfer-encoding"],
+      "content-type": attachment.headers["content-type"],
+    },
+    mimeType: attachment.mimeType,
+    size: attachment.size,
+  };
+}
+
+function sanitizeInlineAttachment(
+  attachment: ParsedMessage["inline"][number],
+): ParsedMessage["inline"][number] {
+  return {
+    attachmentId: attachment.attachmentId,
+    filename: attachment.filename,
+    headers: {
+      "content-description": attachment.headers["content-description"],
+      "content-id": attachment.headers["content-id"],
+      "content-transfer-encoding":
+        attachment.headers["content-transfer-encoding"],
+      "content-type": attachment.headers["content-type"],
+    },
+    mimeType: attachment.mimeType,
+    size: attachment.size,
+  };
+}
+
+function sanitizeHeaders(headers: ParsedMessageHeaders): ParsedMessageHeaders {
+  return {
+    bcc: headers.bcc,
+    cc: headers.cc,
+    date: headers.date,
+    from: headers.from,
+    "in-reply-to": headers["in-reply-to"],
+    "list-unsubscribe": headers["list-unsubscribe"],
+    "message-id": headers["message-id"],
+    references: headers.references,
+    "reply-to": headers["reply-to"],
+    subject: headers.subject,
+    to: headers.to,
+  };
 }

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -33,6 +33,7 @@ export async function writeCachedThreadDetail({
 }) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
   const sanitized = sanitizeThreadResponse(data);
+  const byteSize = getThreadResponseByteSize(sanitized);
 
   try {
     const database = await getEmailCacheDatabase();
@@ -44,7 +45,7 @@ export async function writeCachedThreadDetail({
       data: sanitized,
       fetchedAt: now,
       lastAccessedAt: now,
-      byteSize: new Blob([JSON.stringify(sanitized)]).size,
+      byteSize,
     });
     scheduleEmailCacheCleanup();
   } catch {
@@ -80,14 +81,23 @@ export async function readCachedThreadDetail({
       return;
     }
 
-    await store.put({ ...record, lastAccessedAt: Date.now() });
+    const now = Date.now();
+    const sanitized = sanitizeThreadResponse(record.data as ThreadResponse);
+    const byteSize = getThreadResponseByteSize(sanitized);
+
+    await store.put({
+      ...record,
+      data: sanitized,
+      lastAccessedAt: now,
+      byteSize,
+    });
     await transaction.done;
     if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
     scheduleEmailCacheCleanup();
     return {
-      data: sanitizeThreadResponse(record.data as ThreadResponse),
+      data: sanitized,
       cachedAt: record.fetchedAt,
-      byteSize: record.byteSize,
+      byteSize,
     };
   } catch {
     return;
@@ -177,4 +187,8 @@ function sanitizeHeaders(headers: ParsedMessageHeaders): ParsedMessageHeaders {
     subject: headers.subject,
     to: headers.to,
   };
+}
+
+function getThreadResponseByteSize(data: ThreadResponse) {
+  return new Blob([JSON.stringify(data)]).size;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260824-074326_pr-3375_a8ec15a37d76/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- harden the existing IndexedDB thread-detail cache around a typed, sanitized reader payload
- keep `useThread` and `thread-prefetch` on the same cache path while adding stronger warm/cold/revalidate coverage
- add reader-focused Playwright coverage for cached offline render, cache miss persistence, and stale-while-revalidate refresh

## Testing
- pnpm test utils/email-cache/threads.test.ts hooks/useThread.test.tsx "app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx" "app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx"
- DATABASE_URL="postgresql://postgres:password@localhost:5433/inboxzero?schema=public" DIRECT_URL="postgresql://postgres:password@localhost:5433/inboxzero?schema=public" pnpm test:playwright --project=emulated __tests__/playwright/emulated/mail/local-cache.spec.ts
- pnpm check *(still reports pre-existing repo issues outside this change: Biome schema version mismatch plus existing warnings in `apps/desktop/src/auto-update.ts` and `scripts/dev-setup.ts`)*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Thread details now load from local cache when available, including while offline.
  - Cached thread content appears immediately and refreshes automatically with the latest network data.
  - Threads without cached content fall back to the network and are saved for faster future access.
  - Cached thread data now preserves reader content and attachment metadata while excluding unnecessary details.

- **Bug Fixes**
  - Improved consistency for thread prefetching, loading, and cache updates.
  - Improved handling and cleanup of cached thread data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->