### PR TITLE
mail: coordinate predictive thread prefetch

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -116,9 +116,10 @@ test("opening a prefetched conversation reuses the in-flight detail request", as
   await expect(
     page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
   ).toBeVisible();
-  // Keep the prefetch pending while React's deferred reader selection settles
-  // and joins the shared request; otherwise slow runners can release it first.
-  await page.waitForTimeout(500);
+  await expect(page.getByTestId("thread-reader")).toHaveAttribute(
+    "data-detail-selection-settled",
+    "true",
+  );
   expect(threadDetailRequestCount).toBe(1);
   releaseFirstRequest.resolve();
 

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -113,6 +113,13 @@ test("opening a prefetched conversation reuses the in-flight detail request", as
   await expect.poll(() => threadDetailRequestCount).toBe(1);
 
   await readerConversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+  ).toBeVisible();
+  // Keep the prefetch pending while React's deferred reader selection settles
+  // and joins the shared request; otherwise slow runners can release it first.
+  await page.waitForTimeout(500);
+  expect(threadDetailRequestCount).toBe(1);
   releaseFirstRequest.resolve();
 
   await expect(

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -87,7 +87,6 @@ test("opens a complete conversation and updates its read state", async ({
 test("opening a prefetched conversation reuses the in-flight detail request", async ({
   page,
 }) => {
-  const { conversations } = await openMail(page);
   let threadDetailRequestCount = 0;
   const releaseFirstRequest = Promise.withResolvers<void>();
 
@@ -103,6 +102,7 @@ test("opening a prefetched conversation reuses the in-flight detail request", as
       await route.fulfill({ response });
     },
   );
+  const { conversations } = await openMail(page);
 
   const readerConversation = conversationWithSubject(
     page,
@@ -113,8 +113,6 @@ test("opening a prefetched conversation reuses the in-flight detail request", as
   await expect.poll(() => threadDetailRequestCount).toBe(1);
 
   await readerConversation.click();
-  await expect.poll(() => threadDetailRequestCount).toBe(1);
-
   releaseFirstRequest.resolve();
 
   await expect(
@@ -123,6 +121,7 @@ test("opening a prefetched conversation reuses the in-flight detail request", as
   await expect(
     page.getByText("First message in the reader conversation."),
   ).toBeVisible();
+  expect(threadDetailRequestCount).toBe(1);
 });
 
 test("filters the mail list by state, category, and label", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -84,6 +84,47 @@ test("opens a complete conversation and updates its read state", async ({
   await expect(page).not.toHaveURL(/thread-id=/);
 });
 
+test("opening a prefetched conversation reuses the in-flight detail request", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+  let threadDetailRequestCount = 0;
+  const releaseFirstRequest = Promise.withResolvers<void>();
+
+  await page.route(
+    "**/api/threads/thr_playwright_reader?includeDrafts=true",
+    async (route) => {
+      threadDetailRequestCount += 1;
+      const responsePromise = route.fetch();
+      if (threadDetailRequestCount === 1) {
+        await releaseFirstRequest.promise;
+      }
+      const response = await responsePromise;
+      await route.fulfill({ response });
+    },
+  );
+
+  const readerConversation = conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Navigation Message",
+  );
+  await readerConversation.hover();
+  await expect.poll(() => threadDetailRequestCount).toBe(1);
+
+  await readerConversation.click();
+  await expect.poll(() => threadDetailRequestCount).toBe(1);
+
+  releaseFirstRequest.resolve();
+
+  await expect(
+    page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("First message in the reader conversation."),
+  ).toBeVisible();
+});
+
 test("filters the mail list by state, category, and label", async ({
   page,
 }) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1077,6 +1077,7 @@ export function MailShell() {
             key={openThreadId ?? "empty"}
             thread={openThread ?? null}
             threadId={openThreadId}
+            detailSelectionSettled={readerThreadId === openThreadId}
             loading={
               Boolean(openThreadId) &&
               (readerThreadId !== openThreadId || isOpenThreadLoading)

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -51,6 +51,8 @@ import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-co
 import { runCombinedThreadAction } from "@/app/(app)/[emailAccountId]/mail/combined-thread-actions";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
 import { useHoverThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch";
+import { useThreadPrefetchCoordinator } from "@/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator";
+import { usePredictiveThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import {
@@ -329,13 +331,28 @@ export function MailShell() {
   // Deferred so holding J/K in split view doesn't fire a full-thread provider
   // fetch for every row the cursor passes over — only the row you settle on.
   const readerThreadId = useDeferredValue(isAllAccounts ? null : openThreadId);
+  const threadPrefetchCoordinator = useThreadPrefetchCoordinator();
+  const listPrefetchScopeKey = `list:${emailAccountId}:${isAllAccounts ? `all-accounts:${activeSplitId}` : JSON.stringify(query)}`;
+  const adjacentPrefetchScopeKey = `adjacent:${emailAccountId}:${readerThreadId ?? "none"}`;
   useAdjacentThreadPrefetch({
+    coordinator: threadPrefetchCoordinator,
     currentThreadId: readerThreadId,
     emailAccountId,
+    scopeKey: adjacentPrefetchScopeKey,
     threadIds: isAllAccounts ? [] : orderedIds,
   });
-  const { schedulePrefetch, cancelPrefetch } = useHoverThreadPrefetch({
+  usePredictiveThreadPrefetch({
+    coordinator: threadPrefetchCoordinator,
     emailAccountId,
+    enabled: !isAllAccounts && layout === "list" && !openThreadId,
+    focusedIndex: clampedIndex,
+    scopeKey: listPrefetchScopeKey,
+    threads,
+  });
+  const { schedulePrefetch, cancelPrefetch } = useHoverThreadPrefetch({
+    coordinator: threadPrefetchCoordinator,
+    emailAccountId,
+    scopeKey: listPrefetchScopeKey,
   });
   const prefetchThreadAt = useCallback(
     (index: number) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -332,7 +332,9 @@ export function MailShell() {
   // fetch for every row the cursor passes over — only the row you settle on.
   const readerThreadId = useDeferredValue(isAllAccounts ? null : openThreadId);
   const threadPrefetchCoordinator = useThreadPrefetchCoordinator();
-  const listPrefetchScopeKey = `list:${emailAccountId}:${isAllAccounts ? `all-accounts:${activeSplitId}` : JSON.stringify(query)}`;
+  const listPrefetchScopeIdentity = `${emailAccountId}:${isAllAccounts ? `all-accounts:${activeSplitId}` : JSON.stringify(query)}`;
+  const predictivePrefetchScopeKey = `predictive:${listPrefetchScopeIdentity}`;
+  const hoverPrefetchScopeKey = `hover:${listPrefetchScopeIdentity}`;
   const adjacentPrefetchScopeKey = `adjacent:${emailAccountId}:${readerThreadId ?? "none"}`;
   useAdjacentThreadPrefetch({
     coordinator: threadPrefetchCoordinator,
@@ -346,13 +348,13 @@ export function MailShell() {
     emailAccountId,
     enabled: !isAllAccounts && layout === "list" && !openThreadId,
     focusedIndex: clampedIndex,
-    scopeKey: listPrefetchScopeKey,
+    scopeKey: predictivePrefetchScopeKey,
     threads,
   });
   const { schedulePrefetch, cancelPrefetch } = useHoverThreadPrefetch({
     coordinator: threadPrefetchCoordinator,
     emailAccountId,
-    scopeKey: listPrefetchScopeKey,
+    scopeKey: hoverPrefetchScopeKey,
   });
   const prefetchThreadAt = useCallback(
     (index: number) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -36,6 +36,8 @@ export type ThreadReaderProps = {
   thread: ListThread | null;
   /** The selected thread, including while its row and messages are loading. */
   threadId: string | null;
+  /** Whether the deferred detail selection has caught up to the open row. */
+  detailSelectionSettled: boolean;
   loading: boolean;
   error?: ComponentProps<typeof LoadingContent>["error"];
   /**
@@ -71,6 +73,7 @@ export type ThreadReaderProps = {
 export function ThreadReader({
   thread,
   threadId,
+  detailSelectionSettled,
   loading,
   error,
   messages,
@@ -98,7 +101,11 @@ export function ThreadReader({
 
   if (error || !headerMessage) {
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+      <div
+        className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-2 px-6 py-16 text-center"
+        data-detail-selection-settled={detailSelectionSettled}
+        data-testid="thread-reader"
+      >
         <LoadingContent
           error={error}
           loading={loading}
@@ -135,7 +142,11 @@ export function ThreadReader({
     <>
       {/* White, unlike the list: the reader is its own surface, and it has to
       match `EmailThread` below or the toolbar reads as a separate band. */}
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-card">
+      <div
+        className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-card"
+        data-detail-selection-settled={detailSelectionSettled}
+        data-testid="thread-reader"
+      >
         {layout === "list" && !isFocusMode ? (
           <ReaderNavigation
             onBack={onBack}

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { unstable_serialize } from "swr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
+import {
+  createThreadRequest,
+  fetchThreadRequest,
+} from "@/utils/email-cache/thread-request";
+
+const threadPrefetch = vi.hoisted(() => ({
+  prefetch: vi.fn(),
+  shouldPrefetch: vi.fn(),
+}));
+
+vi.mock("./thread-prefetch", () => ({
+  prefetchThreadDetail: threadPrefetch.prefetch,
+  shouldPrefetchThreads: threadPrefetch.shouldPrefetch,
+}));
+
+describe("createThreadPrefetchCoordinator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    threadPrefetch.shouldPrefetch.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs at most two prefetches at a time", async () => {
+    const resolvers = new Map<string, () => void>();
+    threadPrefetch.prefetch.mockImplementation(
+      ({ threadId }: { threadId: string }) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(threadId, resolve);
+        }),
+    );
+    const coordinator = createCoordinator();
+
+    coordinator.scheduleMany([
+      job("thread-1"),
+      job("thread-2"),
+      job("thread-3"),
+    ]);
+
+    expect(getCalledThreadIds()).toEqual(["thread-1", "thread-2"]);
+
+    resolvers.get("thread-1")?.();
+    await vi.waitFor(() =>
+      expect(getCalledThreadIds()).toEqual([
+        "thread-1",
+        "thread-2",
+        "thread-3",
+      ]),
+    );
+  });
+
+  it("dedupes by cache identity and upgrades a queued thread to the higher priority", async () => {
+    const resolvers = new Map<string, () => void>();
+    threadPrefetch.prefetch.mockImplementation(
+      ({ threadId }: { threadId: string }) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(threadId, resolve);
+        }),
+    );
+    const coordinator = createCoordinator();
+
+    coordinator.schedule(job("thread-1", "focused"));
+    coordinator.schedule(job("thread-2", "focused"));
+    coordinator.schedule(job("thread-3", "nearby"));
+    coordinator.schedule(job("thread-4", "focused"));
+    coordinator.schedule(job("thread-3", "hover"));
+
+    expect(getCalledThreadIds()).toEqual(["thread-1", "thread-2"]);
+
+    resolvers.get("thread-1")?.();
+    await vi.waitFor(() =>
+      expect(getCalledThreadIds()).toEqual([
+        "thread-1",
+        "thread-2",
+        "thread-3",
+      ]),
+    );
+    expect(
+      getCalledThreadIds().filter((threadId) => threadId === "thread-3"),
+    ).toHaveLength(1);
+  });
+
+  it("drops queued jobs and marks active jobs stale when their scope is cancelled", async () => {
+    const activeJobs: Array<{ isCancelled?: () => boolean; threadId: string }> =
+      [];
+    const resolvers = new Map<string, () => void>();
+    threadPrefetch.prefetch.mockImplementation(
+      (input: { isCancelled?: () => boolean; threadId: string }) =>
+        new Promise<void>((resolve) => {
+          activeJobs.push(input);
+          resolvers.set(input.threadId, resolve);
+        }),
+    );
+    const coordinator = createCoordinator();
+
+    coordinator.scheduleMany([
+      job("thread-1"),
+      job("thread-2"),
+      job("thread-3"),
+    ]);
+    coordinator.cancelScope("scope-a");
+
+    expect(activeJobs.every((job) => job.isCancelled?.())).toBe(true);
+
+    resolvers.get("thread-1")?.();
+    await Promise.resolve();
+    expect(getCalledThreadIds()).toEqual(["thread-1", "thread-2"]);
+  });
+
+  it("skips prefetch when the thread is already in SWR cache", () => {
+    const request = createThreadRequest({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      options: { includeDrafts: true },
+    });
+    const cache = new Map([
+      [
+        unstable_serialize(request.key),
+        { data: { thread: { id: "thread-1" } } },
+      ],
+    ]);
+    const coordinator = createCoordinator({ cache });
+
+    coordinator.schedule(job("thread-1"));
+
+    expect(threadPrefetch.prefetch).not.toHaveBeenCalled();
+  });
+
+  it("skips prefetch when the same thread request is already in flight", () => {
+    const request = createThreadRequest({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      options: { includeDrafts: true },
+    });
+    const release = Promise.withResolvers<void>();
+    fetchThreadRequest(request, () => release.promise);
+    const coordinator = createCoordinator();
+
+    coordinator.schedule(job("thread-1"));
+
+    expect(threadPrefetch.prefetch).not.toHaveBeenCalled();
+    release.resolve();
+  });
+
+  it("respects the shared network gate", () => {
+    threadPrefetch.shouldPrefetch.mockReturnValue(false);
+    const coordinator = createCoordinator();
+
+    coordinator.schedule(job("thread-1"));
+
+    expect(threadPrefetch.prefetch).not.toHaveBeenCalled();
+  });
+});
+
+function createCoordinator({
+  cache = new Map(),
+}: {
+  cache?: Map<string, unknown>;
+} = {}) {
+  return createThreadPrefetchCoordinator({
+    cache,
+    fetcher: vi.fn(),
+    mutate: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function getCalledThreadIds() {
+  return threadPrefetch.prefetch.mock.calls.map(
+    ([input]: [{ threadId: string }]) => input.threadId,
+  );
+}
+
+function job(threadId: string, priority = "focused") {
+  return {
+    emailAccountId: "account-1",
+    priority: priority as "adjacent" | "focused" | "hover" | "nearby",
+    scopeKey: "scope-a",
+    threadId,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
@@ -114,6 +114,40 @@ describe("createThreadPrefetchCoordinator", () => {
     expect(getCalledThreadIds()).toEqual(["thread-1", "thread-2"]);
   });
 
+  it("cancels one producer scope without disturbing work from another", async () => {
+    const activeJobs: Array<{ isCancelled?: () => boolean; threadId: string }> =
+      [];
+    const resolvers = new Map<string, () => void>();
+    threadPrefetch.prefetch.mockImplementation(
+      (input: { isCancelled?: () => boolean; threadId: string }) =>
+        new Promise<void>((resolve) => {
+          activeJobs.push(input);
+          resolvers.set(input.threadId, resolve);
+        }),
+    );
+    const coordinator = createCoordinator();
+
+    coordinator.scheduleMany([
+      { ...job("hover-active"), scopeKey: "hover-scope" },
+      { ...job("predictive-active"), scopeKey: "predictive-scope" },
+      { ...job("hover-queued"), scopeKey: "hover-scope" },
+      { ...job("predictive-queued"), scopeKey: "predictive-scope" },
+    ]);
+    coordinator.cancelScope("predictive-scope");
+
+    expect(activeJobs[0]?.isCancelled?.()).toBe(false);
+    expect(activeJobs[1]?.isCancelled?.()).toBe(true);
+
+    resolvers.get("hover-active")?.();
+    await vi.waitFor(() =>
+      expect(getCalledThreadIds()).toEqual([
+        "hover-active",
+        "predictive-active",
+        "hover-queued",
+      ]),
+    );
+  });
+
   it("skips prefetch when the thread is already in SWR cache", () => {
     const request = createThreadRequest({
       emailAccountId: "account-1",

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts
@@ -157,6 +157,23 @@ describe("createThreadPrefetchCoordinator", () => {
 
     expect(threadPrefetch.prefetch).not.toHaveBeenCalled();
   });
+
+  it("reactivates after lifecycle cleanup without reviving stale jobs", () => {
+    threadPrefetch.prefetch.mockImplementation(() => new Promise(() => {}));
+    const coordinator = createCoordinator();
+
+    coordinator.schedule(job("thread-1"));
+    const firstJob = threadPrefetch.prefetch.mock.calls[0]?.[0] as {
+      isCancelled?: () => boolean;
+    };
+
+    coordinator.dispose();
+    coordinator.activate();
+    coordinator.schedule(job("thread-2"));
+
+    expect(firstJob.isCancelled?.()).toBe(true);
+    expect(getCalledThreadIds()).toEqual(["thread-1", "thread-2"]);
+  });
 });
 
 function createCoordinator({

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.ts
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import type { Cache, ScopedMutator } from "swr";
+import { unstable_serialize, useSWRConfig } from "swr";
+import { prefetchThreadDetail, shouldPrefetchThreads } from "./thread-prefetch";
+import {
+  createThreadRequest,
+  isThreadRequestInFlight,
+} from "@/utils/email-cache/thread-request";
+
+export const MAX_CONCURRENT_THREAD_PREFETCHES = 2;
+export const MAX_QUEUED_THREAD_PREFETCHES = 6;
+
+const PRIORITY_ORDER = {
+  nearby: 0,
+  focused: 1,
+  adjacent: 2,
+  hover: 3,
+} as const;
+
+export type ThreadPrefetchPriority = keyof typeof PRIORITY_ORDER;
+
+export type ThreadPrefetchJob = {
+  emailAccountId: string;
+  threadId: string;
+  priority: ThreadPrefetchPriority;
+  scopeKey: string;
+};
+
+type ScheduledPrefetchJob = ThreadPrefetchJob & {
+  cacheIdentity: string;
+  enqueuedAt: number;
+  requestKey: ReturnType<typeof unstable_serialize>;
+  scopeVersion: number;
+};
+
+type ThreadPrefetchQueueEntry = {
+  job: ScheduledPrefetchJob;
+  status: "active" | "queued";
+};
+
+export type ThreadPrefetchCoordinator = {
+  cancelScope: (scopeKey: string) => void;
+  dispose: () => void;
+  schedule: (job: ThreadPrefetchJob) => void;
+  scheduleMany: (jobs: ThreadPrefetchJob[]) => void;
+};
+
+export function createThreadPrefetchCoordinator({
+  cache,
+  fetcher,
+  mutate,
+}: {
+  cache: Cache<unknown>;
+  fetcher: ((key: [string, string]) => unknown) | null | undefined;
+  mutate: ScopedMutator;
+}): ThreadPrefetchCoordinator {
+  let activeCount = 0;
+  let disposed = false;
+  let sequence = 0;
+  const jobsByIdentity = new Map<string, ThreadPrefetchQueueEntry>();
+  const scopeVersions = new Map<string, number>();
+
+  const getScopeVersion = (scopeKey: string) =>
+    scopeVersions.get(scopeKey) ?? 0;
+
+  const shouldSkipJob = (
+    job: Pick<ScheduledPrefetchJob, "cacheIdentity" | "requestKey">,
+  ) =>
+    cache.get(job.requestKey)?.data !== undefined ||
+    isThreadRequestInFlight({ cacheIdentity: job.cacheIdentity });
+
+  const isCancelled = (
+    job: Pick<ScheduledPrefetchJob, "scopeKey" | "scopeVersion">,
+  ) => disposed || getScopeVersion(job.scopeKey) !== job.scopeVersion;
+
+  const dropQueuedOverflow = () => {
+    const queued = [...jobsByIdentity.values()]
+      .filter((entry) => entry.status === "queued")
+      .sort(compareQueuedEntries);
+    while (queued.length > MAX_QUEUED_THREAD_PREFETCHES) {
+      const entry = queued.shift();
+      if (!entry) break;
+      jobsByIdentity.delete(entry.job.cacheIdentity);
+    }
+  };
+
+  const pumpQueue = () => {
+    if (
+      disposed ||
+      activeCount >= MAX_CONCURRENT_THREAD_PREFETCHES ||
+      !fetcher ||
+      !shouldPrefetchThreads()
+    ) {
+      return;
+    }
+
+    const next = [...jobsByIdentity.values()]
+      .filter((entry) => entry.status === "queued")
+      .sort(compareQueuedEntries)
+      .at(-1);
+    if (!next) return;
+    if (shouldSkipJob(next.job) || isCancelled(next.job)) {
+      jobsByIdentity.delete(next.job.cacheIdentity);
+      pumpQueue();
+      return;
+    }
+
+    next.status = "active";
+    activeCount += 1;
+    prefetchThreadDetail({
+      emailAccountId: next.job.emailAccountId,
+      threadId: next.job.threadId,
+      fetcher,
+      mutate,
+      isCancelled: () => isCancelled(next.job),
+    })
+      .catch(() => {
+        // Prefetch failures are intentionally silent; opening still retries normally.
+      })
+      .finally(() => {
+        activeCount -= 1;
+        const current = jobsByIdentity.get(next.job.cacheIdentity);
+        if (current === next) jobsByIdentity.delete(next.job.cacheIdentity);
+        pumpQueue();
+      });
+
+    if (activeCount < MAX_CONCURRENT_THREAD_PREFETCHES) {
+      pumpQueue();
+    }
+  };
+
+  const schedule = (job: ThreadPrefetchJob) => {
+    if (disposed || !fetcher || !shouldPrefetchThreads()) return;
+
+    const request = createThreadRequest({
+      emailAccountId: job.emailAccountId,
+      threadId: job.threadId,
+      options: { includeDrafts: true },
+    });
+    const scheduledJob: ScheduledPrefetchJob = {
+      ...job,
+      cacheIdentity: request.cacheIdentity,
+      enqueuedAt: sequence,
+      requestKey: unstable_serialize(request.key),
+      scopeVersion: getScopeVersion(job.scopeKey),
+    };
+    sequence += 1;
+
+    if (shouldSkipJob(scheduledJob)) return;
+
+    const existing = jobsByIdentity.get(request.cacheIdentity);
+    if (existing) {
+      if (existing.status === "queued") {
+        existing.job = mergeQueuedJobs(existing.job, scheduledJob);
+        dropQueuedOverflow();
+        pumpQueue();
+      }
+      return;
+    }
+
+    jobsByIdentity.set(request.cacheIdentity, {
+      job: scheduledJob,
+      status: "queued",
+    });
+    dropQueuedOverflow();
+    pumpQueue();
+  };
+
+  const scheduleMany = (jobs: ThreadPrefetchJob[]) => {
+    for (const job of jobs) {
+      schedule(job);
+    }
+  };
+
+  const cancelScope = (scopeKey: string) => {
+    scopeVersions.set(scopeKey, getScopeVersion(scopeKey) + 1);
+    for (const [cacheIdentity, entry] of jobsByIdentity.entries()) {
+      if (entry.status === "queued" && entry.job.scopeKey === scopeKey) {
+        jobsByIdentity.delete(cacheIdentity);
+      }
+    }
+  };
+
+  const dispose = () => {
+    disposed = true;
+    jobsByIdentity.clear();
+    scopeVersions.clear();
+  };
+
+  return {
+    cancelScope,
+    dispose,
+    schedule,
+    scheduleMany,
+  };
+}
+
+export function useThreadPrefetchCoordinator() {
+  const { cache, fetcher, mutate } = useSWRConfig();
+  const coordinator = useMemo(
+    () => createThreadPrefetchCoordinator({ cache, fetcher, mutate }),
+    [cache, fetcher, mutate],
+  );
+
+  useEffect(() => () => coordinator.dispose(), [coordinator]);
+
+  return coordinator;
+}
+
+function compareQueuedEntries(
+  left: ThreadPrefetchQueueEntry,
+  right: ThreadPrefetchQueueEntry,
+) {
+  return (
+    PRIORITY_ORDER[left.job.priority] - PRIORITY_ORDER[right.job.priority] ||
+    right.job.enqueuedAt - left.job.enqueuedAt
+  );
+}
+
+function mergeQueuedJobs(
+  existing: ScheduledPrefetchJob,
+  incoming: ScheduledPrefetchJob,
+): ScheduledPrefetchJob {
+  if (PRIORITY_ORDER[incoming.priority] > PRIORITY_ORDER[existing.priority]) {
+    return incoming;
+  }
+
+  return {
+    ...incoming,
+    priority: existing.priority,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.ts
@@ -30,6 +30,7 @@ export type ThreadPrefetchJob = {
 
 type ScheduledPrefetchJob = ThreadPrefetchJob & {
   cacheIdentity: string;
+  coordinatorGeneration: number;
   enqueuedAt: number;
   requestKey: ReturnType<typeof unstable_serialize>;
   scopeVersion: number;
@@ -41,6 +42,7 @@ type ThreadPrefetchQueueEntry = {
 };
 
 export type ThreadPrefetchCoordinator = {
+  activate: () => void;
   cancelScope: (scopeKey: string) => void;
   dispose: () => void;
   schedule: (job: ThreadPrefetchJob) => void;
@@ -57,6 +59,7 @@ export function createThreadPrefetchCoordinator({
   mutate: ScopedMutator;
 }): ThreadPrefetchCoordinator {
   let activeCount = 0;
+  let coordinatorGeneration = 0;
   let disposed = false;
   let sequence = 0;
   const jobsByIdentity = new Map<string, ThreadPrefetchQueueEntry>();
@@ -72,8 +75,14 @@ export function createThreadPrefetchCoordinator({
     isThreadRequestInFlight({ cacheIdentity: job.cacheIdentity });
 
   const isCancelled = (
-    job: Pick<ScheduledPrefetchJob, "scopeKey" | "scopeVersion">,
-  ) => disposed || getScopeVersion(job.scopeKey) !== job.scopeVersion;
+    job: Pick<
+      ScheduledPrefetchJob,
+      "coordinatorGeneration" | "scopeKey" | "scopeVersion"
+    >,
+  ) =>
+    disposed ||
+    job.coordinatorGeneration !== coordinatorGeneration ||
+    getScopeVersion(job.scopeKey) !== job.scopeVersion;
 
   const dropQueuedOverflow = () => {
     const queued = [...jobsByIdentity.values()]
@@ -142,6 +151,7 @@ export function createThreadPrefetchCoordinator({
     const scheduledJob: ScheduledPrefetchJob = {
       ...job,
       cacheIdentity: request.cacheIdentity,
+      coordinatorGeneration,
       enqueuedAt: sequence,
       requestKey: unstable_serialize(request.key),
       scopeVersion: getScopeVersion(job.scopeKey),
@@ -149,7 +159,6 @@ export function createThreadPrefetchCoordinator({
     sequence += 1;
 
     if (shouldSkipJob(scheduledJob)) return;
-
     const existing = jobsByIdentity.get(request.cacheIdentity);
     if (existing) {
       if (existing.status === "queued") {
@@ -183,13 +192,19 @@ export function createThreadPrefetchCoordinator({
     }
   };
 
+  const activate = () => {
+    disposed = false;
+  };
+
   const dispose = () => {
     disposed = true;
+    coordinatorGeneration += 1;
     jobsByIdentity.clear();
     scopeVersions.clear();
   };
 
   return {
+    activate,
     cancelScope,
     dispose,
     schedule,
@@ -204,7 +219,10 @@ export function useThreadPrefetchCoordinator() {
     [cache, fetcher, mutate],
   );
 
-  useEffect(() => () => coordinator.dispose(), [coordinator]);
+  useEffect(() => {
+    coordinator.activate();
+    return () => coordinator.dispose();
+  }, [coordinator]);
 
   return coordinator;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prefetchThreadDetail } from "./thread-prefetch";
+
+const threadCache = vi.hoisted(() => ({
+  read: vi.fn(),
+  write: vi.fn(),
+}));
+const emailHtml = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/threads", () => ({
+  readCachedThreadDetail: threadCache.read,
+  writeCachedThreadDetail: threadCache.write,
+}));
+
+vi.mock("@/utils/email/prepare-html.client", () => ({
+  prepareEmailHtml: emailHtml.prepare,
+}));
+
+describe("prefetchThreadDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    threadCache.write.mockResolvedValue(undefined);
+    emailHtml.prepare.mockResolvedValue(undefined);
+  });
+
+  it("hydrates SWR from disk and prepares the latest visible html without a request", async () => {
+    threadCache.read.mockResolvedValue({
+      data: {
+        thread: {
+          id: "thread-1",
+          messages: [
+            {
+              id: "thread-1-older",
+              labelIds: [],
+              textHtml: "<p>older</p>",
+            },
+            {
+              id: "thread-1-draft",
+              labelIds: ["DRAFT"],
+              textHtml: "<p>draft</p>",
+            },
+            {
+              id: "thread-1-latest",
+              labelIds: [],
+              textHtml: "<p>latest</p>",
+            },
+          ],
+        },
+      },
+    });
+    const fetcher = vi.fn();
+    const mutate = vi.fn().mockResolvedValue(undefined);
+
+    await prefetchThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      fetcher,
+      mutate,
+    });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(threadCache.write).not.toHaveBeenCalled();
+    expect(emailHtml.prepare).toHaveBeenCalledWith({
+      html: "<p>latest</p>",
+      messageId: "thread-1-latest",
+    });
+  });
+
+  it("writes fetched thread details and prepares visible html", async () => {
+    threadCache.read.mockResolvedValue(undefined);
+    const fetcher = vi.fn().mockResolvedValue({
+      thread: {
+        id: "thread-2",
+        messages: [
+          {
+            id: "thread-2-message",
+            labelIds: [],
+            textHtml: "<p>network</p>",
+          },
+        ],
+      },
+    });
+    const mutate = vi.fn().mockResolvedValue(undefined);
+
+    await prefetchThreadDetail({
+      emailAccountId: "account-2",
+      threadId: "thread-2",
+      fetcher,
+      mutate,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(threadCache.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          thread: expect.objectContaining({ id: "thread-2" }),
+        }),
+        emailAccountId: "account-2",
+        threadId: "thread-2",
+      }),
+    );
+    expect(emailHtml.prepare).toHaveBeenCalledWith({
+      html: "<p>network</p>",
+      messageId: "thread-2-message",
+    });
+  });
+
+  it("skips html preparation when cancellation happens after hydrating from disk", async () => {
+    let cancelled = false;
+    threadCache.read.mockResolvedValue({
+      data: {
+        thread: {
+          id: "thread-3",
+          messages: [
+            {
+              id: "thread-3-message",
+              labelIds: [],
+              textHtml: "<p>x</p>",
+            },
+          ],
+        },
+      },
+    });
+    const mutate = vi.fn().mockImplementation(async () => {
+      cancelled = true;
+    });
+
+    await prefetchThreadDetail({
+      emailAccountId: "account-3",
+      threadId: "thread-3",
+      fetcher: vi.fn(),
+      isCancelled: () => cancelled,
+      mutate,
+    });
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(emailHtml.prepare).not.toHaveBeenCalled();
+  });
+
+  it("skips mutate and persistence when the scope goes stale before the network returns", async () => {
+    threadCache.read.mockResolvedValue(undefined);
+    let cancelled = false;
+    const response = Promise.withResolvers<unknown>();
+    const fetcher = vi.fn(() => response.promise);
+    const mutate = vi.fn().mockResolvedValue(undefined);
+
+    const prefetch = prefetchThreadDetail({
+      emailAccountId: "account-4",
+      threadId: "thread-4",
+      fetcher,
+      isCancelled: () => cancelled,
+      mutate,
+    });
+
+    cancelled = true;
+    response.resolve({
+      thread: {
+        id: "thread-4",
+        messages: [
+          {
+            id: "thread-4-message",
+            labelIds: [],
+            textHtml: "<p>late</p>",
+          },
+        ],
+      },
+    });
+    await prefetch;
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(threadCache.write).not.toHaveBeenCalled();
+    expect(emailHtml.prepare).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
@@ -48,6 +48,7 @@ export async function prefetchThreadDetail({
         revalidate: false,
       },
     );
+    if (isCancelled?.()) return;
     await prepareVisibleMessageHtml(cached.data);
     return;
   }
@@ -56,11 +57,12 @@ export async function prefetchThreadDetail({
     request,
     async () => (await fetcher(request.key)) as ThreadResponse | undefined,
   );
-  if (!data) return;
+  if (!data || isCancelled?.()) return;
   await mutate(request.key, data, {
     populateCache: true,
     revalidate: false,
   });
+  if (isCancelled?.()) return;
   await Promise.all([
     writeCachedThreadDetail({
       emailAccountId,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
@@ -1,34 +1,11 @@
 // @vitest-environment jsdom
 
-import type { ReactNode } from "react";
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAdjacentThreadPrefetch } from "./use-adjacent-thread-prefetch";
-
-const cache = vi.hoisted(() => ({
-  read: vi.fn(),
-  write: vi.fn(),
-}));
-const emailHtml = vi.hoisted(() => ({
-  prepare: vi.fn(),
-}));
-
-vi.mock("@/utils/email-cache/threads", () => ({
-  readCachedThreadDetail: cache.read,
-  writeCachedThreadDetail: cache.write,
-}));
-
-vi.mock("@/utils/email/prepare-html.client", () => ({
-  prepareEmailHtml: emailHtml.prepare,
-}));
-
 describe("useAdjacentThreadPrefetch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    cache.read.mockResolvedValue(undefined);
-    cache.write.mockResolvedValue(undefined);
-    emailHtml.prepare.mockResolvedValue(undefined);
     Object.defineProperty(window, "requestIdleCallback", {
       configurable: true,
       value: (callback: IdleRequestCallback) => {
@@ -42,108 +19,75 @@ describe("useAdjacentThreadPrefetch", () => {
     });
   });
 
-  it("prefetches only the previous and next conversations", async () => {
-    const fetcher = vi.fn((key: [string, string]) =>
-      Promise.resolve({ thread: { id: key[0], messages: [] } }),
+  it("schedules only the previous and next thread ids", () => {
+    const coordinator = createCoordinator();
+
+    renderHook(() =>
+      useAdjacentThreadPrefetch({
+        coordinator,
+        currentThreadId: "thread-2",
+        emailAccountId: "account-1",
+        scopeKey: "scope-adjacent",
+        threadIds: ["thread-1", "thread-2", "thread-3", "thread-4"],
+      }),
     );
 
-    renderHook(
-      () =>
-        useAdjacentThreadPrefetch({
-          currentThreadId: "thread-2",
-          emailAccountId: "account-1",
-          threadIds: ["thread-1", "thread-2", "thread-3", "thread-4"],
-        }),
-      { wrapper: createWrapper(fetcher) },
-    );
-
-    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
-    expect(fetcher.mock.calls.map(([key]) => key[0])).toEqual([
-      "/api/threads/thread-1?includeDrafts=true",
-      "/api/threads/thread-3?includeDrafts=true",
+    expect(coordinator.scheduleMany).toHaveBeenCalledWith([
+      {
+        emailAccountId: "account-1",
+        priority: "adjacent",
+        scopeKey: "scope-adjacent",
+        threadId: "thread-1",
+      },
+      {
+        emailAccountId: "account-1",
+        priority: "adjacent",
+        scopeKey: "scope-adjacent",
+        threadId: "thread-3",
+      },
     ]);
   });
 
-  it("hydrates adjacent SWR entries from disk without a request", async () => {
-    cache.read.mockResolvedValue({
-      data: { thread: { id: "cached", messages: [] } },
-    });
-    const fetcher = vi.fn();
+  it("does nothing when the current thread is missing from the list", () => {
+    const coordinator = createCoordinator();
 
-    renderHook(
-      () =>
-        useAdjacentThreadPrefetch({
-          currentThreadId: "thread-2",
-          emailAccountId: "account-1",
-          threadIds: ["thread-1", "thread-2", "thread-3"],
-        }),
-      { wrapper: createWrapper(fetcher) },
+    renderHook(() =>
+      useAdjacentThreadPrefetch({
+        coordinator,
+        currentThreadId: "missing",
+        emailAccountId: "account-1",
+        scopeKey: "scope-missing",
+        threadIds: ["thread-1", "thread-2", "thread-3"],
+      }),
     );
 
-    await waitFor(() => expect(cache.read).toHaveBeenCalledTimes(2));
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(fetcher).not.toHaveBeenCalled();
+    expect(coordinator.scheduleMany).not.toHaveBeenCalled();
   });
 
-  it("prepares the visible message html while prefetching a conversation", async () => {
-    const fetcher = vi.fn((key: [string, string]) => {
-      const threadId = key[0].includes("thread-1") ? "thread-1" : "thread-3";
-      return Promise.resolve({
-        thread: {
-          id: threadId,
-          messages: [
-            {
-              id: `${threadId}-older`,
-              labelIds: [],
-              textHtml: `<p>${threadId} older</p>`,
-            },
-            {
-              id: `${threadId}-draft`,
-              labelIds: ["DRAFT"],
-              textHtml: `<p>${threadId} draft</p>`,
-            },
-            {
-              id: `${threadId}-latest`,
-              labelIds: [],
-              textHtml: `<p>${threadId} latest</p>`,
-            },
-          ],
-        },
-      });
-    });
-
-    renderHook(
-      () =>
-        useAdjacentThreadPrefetch({
-          currentThreadId: "thread-2",
-          emailAccountId: "account-1",
-          threadIds: ["thread-1", "thread-2", "thread-3"],
-        }),
-      { wrapper: createWrapper(fetcher) },
+  it("cancels the adjacent scope on cleanup", () => {
+    const coordinator = createCoordinator();
+    const { unmount } = renderHook(() =>
+      useAdjacentThreadPrefetch({
+        coordinator,
+        currentThreadId: "thread-2",
+        emailAccountId: "account-1",
+        scopeKey: "scope-cleanup",
+        threadIds: ["thread-1", "thread-2", "thread-3"],
+      }),
     );
 
-    await waitFor(() => expect(emailHtml.prepare).toHaveBeenCalledTimes(2));
-    expect(emailHtml.prepare.mock.calls.map(([input]) => input)).toEqual([
-      {
-        messageId: "thread-1-latest",
-        html: "<p>thread-1 latest</p>",
-      },
-      {
-        messageId: "thread-3-latest",
-        html: "<p>thread-3 latest</p>",
-      },
-    ]);
+    unmount();
+
+    expect(coordinator.cancelScope).toHaveBeenCalledWith("scope-cleanup");
+    expect(coordinator.cancelScope).toHaveBeenCalledTimes(2);
   });
 });
 
-function createWrapper(fetcher: (key: [string, string]) => unknown) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <SWRConfig value={{ fetcher, provider: () => new Map() }}>
-        {children}
-      </SWRConfig>
-    );
+function createCoordinator() {
+  return {
+    cancelScope: vi.fn(),
+    dispose: vi.fn(),
+    schedule: vi.fn(),
+    scheduleMany: vi.fn(),
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx
@@ -2,6 +2,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
 import { useAdjacentThreadPrefetch } from "./use-adjacent-thread-prefetch";
 describe("useAdjacentThreadPrefetch", () => {
   beforeEach(() => {
@@ -83,8 +84,9 @@ describe("useAdjacentThreadPrefetch", () => {
   });
 });
 
-function createCoordinator() {
+function createCoordinator(): ThreadPrefetchCoordinator {
   return {
+    activate: vi.fn(),
     cancelScope: vi.fn(),
     dispose: vi.fn(),
     schedule: vi.fn(),

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.ts
@@ -1,22 +1,21 @@
 "use client";
 
 import { useEffect, useMemo } from "react";
-import { useSWRConfig } from "swr";
-import {
-  prefetchThreadDetail,
-  shouldPrefetchThreads,
-} from "@/app/(app)/[emailAccountId]/mail/thread-prefetch";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
 
 export function useAdjacentThreadPrefetch({
+  coordinator,
   currentThreadId,
   emailAccountId,
+  scopeKey,
   threadIds,
 }: {
+  coordinator: ThreadPrefetchCoordinator;
   currentThreadId: string | null;
   emailAccountId: string;
+  scopeKey: string;
   threadIds: string[];
 }) {
-  const { fetcher, mutate } = useSWRConfig();
   const adjacentThreadIds = useMemo(() => {
     const currentIndex = currentThreadId
       ? threadIds.indexOf(currentThreadId)
@@ -28,22 +27,18 @@ export function useAdjacentThreadPrefetch({
   }, [currentThreadId, threadIds]);
 
   useEffect(() => {
-    if (!fetcher || !shouldPrefetchThreads() || !adjacentThreadIds.length)
-      return;
-    let cancelled = false;
+    coordinator.cancelScope(scopeKey);
+    if (!adjacentThreadIds.length) return;
 
     const prefetch = () => {
-      for (const threadId of adjacentThreadIds) {
-        prefetchThreadDetail({
+      coordinator.scheduleMany(
+        adjacentThreadIds.map((threadId) => ({
           emailAccountId,
+          priority: "adjacent" as const,
+          scopeKey,
           threadId,
-          fetcher,
-          mutate,
-          isCancelled: () => cancelled,
-        }).catch(() => {
-          // Prefetch failures are intentionally silent; opening still retries normally.
-        });
-      }
+        })),
+      );
     };
 
     const idleCallback = window.requestIdleCallback?.(prefetch, {
@@ -53,9 +48,9 @@ export function useAdjacentThreadPrefetch({
       idleCallback === undefined ? window.setTimeout(prefetch, 150) : undefined;
 
     return () => {
-      cancelled = true;
+      coordinator.cancelScope(scopeKey);
       if (idleCallback !== undefined) window.cancelIdleCallback(idleCallback);
       if (timeout !== undefined) window.clearTimeout(timeout);
     };
-  }, [adjacentThreadIds, emailAccountId, fetcher, mutate]);
+  }, [adjacentThreadIds, coordinator, emailAccountId, scopeKey]);
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
@@ -2,6 +2,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
 import {
   HOVER_PREFETCH_DELAY_MS,
   useHoverThreadPrefetch,
@@ -99,8 +100,9 @@ describe("useHoverThreadPrefetch", () => {
   });
 });
 
-function createCoordinator() {
+function createCoordinator(): ThreadPrefetchCoordinator {
   return {
+    activate: vi.fn(),
     cancelScope: vi.fn(),
     dispose: vi.fn(),
     schedule: vi.fn(),

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx
@@ -1,71 +1,52 @@
 // @vitest-environment jsdom
 
-import type { ReactNode } from "react";
 import { renderHook } from "@testing-library/react";
-import { SWRConfig, unstable_serialize } from "swr";
-import type { Cache, State } from "swr";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOVER_PREFETCH_DELAY_MS,
   useHoverThreadPrefetch,
 } from "./use-hover-thread-prefetch";
-
-const cache = vi.hoisted(() => ({
-  read: vi.fn(),
-  write: vi.fn(),
-}));
-const emailHtml = vi.hoisted(() => ({
-  prepare: vi.fn(),
-}));
-
-vi.mock("@/utils/email-cache/threads", () => ({
-  readCachedThreadDetail: cache.read,
-  writeCachedThreadDetail: cache.write,
-}));
-
-vi.mock("@/utils/email/prepare-html.client", () => ({
-  prepareEmailHtml: emailHtml.prepare,
-}));
-
 describe("useHoverThreadPrefetch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    cache.read.mockResolvedValue(undefined);
-    cache.write.mockResolvedValue(undefined);
-    emailHtml.prepare.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("prefetches a hovered conversation only after the dwell delay", async () => {
-    const fetcher = vi.fn((key: [string, string]) =>
-      Promise.resolve({ thread: { id: key[0], messages: [] } }),
-    );
-    const { result } = renderHook(
-      () => useHoverThreadPrefetch({ emailAccountId: "account-dwell" }),
-      { wrapper: createWrapper(fetcher) },
+  it("schedules a hover prefetch only after the dwell delay", async () => {
+    const coordinator = createCoordinator();
+    const { result } = renderHook(() =>
+      useHoverThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-dwell",
+        scopeKey: "scope-dwell",
+      }),
     );
 
     result.current.schedulePrefetch("thread-1");
     await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS - 1);
-    expect(fetcher).not.toHaveBeenCalled();
+    expect(coordinator.schedule).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);
-    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
-    expect(fetcher.mock.calls[0]?.[0]).toEqual([
-      "/api/threads/thread-1?includeDrafts=true",
-      "account-dwell",
-    ]);
+    expect(coordinator.schedule).toHaveBeenCalledWith({
+      emailAccountId: "account-dwell",
+      priority: "hover",
+      scopeKey: "scope-dwell",
+      threadId: "thread-1",
+    });
   });
 
-  it("does not prefetch when the pointer leaves before the delay", async () => {
-    const fetcher = vi.fn();
-    const { result } = renderHook(
-      () => useHoverThreadPrefetch({ emailAccountId: "account-leave" }),
-      { wrapper: createWrapper(fetcher) },
+  it("does not schedule when the pointer leaves before the delay", async () => {
+    const coordinator = createCoordinator();
+    const { result } = renderHook(() =>
+      useHoverThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-leave",
+        scopeKey: "scope-leave",
+      }),
     );
 
     result.current.schedulePrefetch("thread-1");
@@ -73,17 +54,17 @@ describe("useHoverThreadPrefetch", () => {
     result.current.cancelPrefetch();
     await vi.advanceTimersByTimeAsync(1000);
 
-    expect(fetcher).not.toHaveBeenCalled();
-    expect(cache.read).not.toHaveBeenCalled();
+    expect(coordinator.schedule).not.toHaveBeenCalled();
   });
 
-  it("sweeping across rows fetches only the row the pointer settles on", async () => {
-    const fetcher = vi.fn((key: [string, string]) =>
-      Promise.resolve({ thread: { id: key[0], messages: [] } }),
-    );
-    const { result } = renderHook(
-      () => useHoverThreadPrefetch({ emailAccountId: "account-sweep" }),
-      { wrapper: createWrapper(fetcher) },
+  it("keeps only the latest hover intent while sweeping rows", async () => {
+    const coordinator = createCoordinator();
+    const { result } = renderHook(() =>
+      useHoverThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-sweep",
+        scopeKey: "scope-sweep",
+      }),
     );
 
     result.current.schedulePrefetch("thread-1");
@@ -91,82 +72,38 @@ describe("useHoverThreadPrefetch", () => {
     result.current.schedulePrefetch("thread-2");
     await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
 
-    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
-    expect(fetcher.mock.calls[0]?.[0]).toEqual([
-      "/api/threads/thread-2?includeDrafts=true",
-      "account-sweep",
-    ]);
+    expect(coordinator.schedule).toHaveBeenCalledTimes(1);
+    expect(coordinator.schedule).toHaveBeenCalledWith({
+      emailAccountId: "account-sweep",
+      priority: "hover",
+      scopeKey: "scope-sweep",
+      threadId: "thread-2",
+    });
   });
 
-  it("skips conversations already in the SWR cache", async () => {
-    const fetcher = vi.fn();
-    const seeded = new Map<string, State>([
-      [
-        unstable_serialize([
-          "/api/threads/thread-1?includeDrafts=true",
-          "account-cached",
-        ]),
-        { data: { thread: { id: "thread-1", messages: [] } } },
-      ],
-    ]);
-    const { result } = renderHook(
-      () => useHoverThreadPrefetch({ emailAccountId: "account-cached" }),
-      { wrapper: createWrapper(fetcher, () => seeded) },
+  it("cancels the scope on cleanup", () => {
+    const coordinator = createCoordinator();
+    const { result, unmount } = renderHook(() =>
+      useHoverThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-cleanup",
+        scopeKey: "scope-cleanup",
+      }),
     );
 
     result.current.schedulePrefetch("thread-1");
-    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS * 2);
+    unmount();
 
-    expect(fetcher).not.toHaveBeenCalled();
-    expect(cache.read).not.toHaveBeenCalled();
-  });
-
-  it("runs one prefetch at a time and keeps only the latest intent", async () => {
-    const resolvers = new Map<string, (value: unknown) => void>();
-    const fetcher = vi.fn(
-      (key: [string, string]) =>
-        new Promise((resolve) => {
-          resolvers.set(key[0], resolve);
-        }),
-    );
-    const { result } = renderHook(
-      () => useHoverThreadPrefetch({ emailAccountId: "account-flight" }),
-      { wrapper: createWrapper(fetcher) },
-    );
-
-    result.current.schedulePrefetch("thread-1");
-    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
-    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
-
-    // Two more dwells while thread-1 is still in flight: only the newest runs.
-    result.current.schedulePrefetch("thread-2");
-    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
-    result.current.schedulePrefetch("thread-3");
-    await vi.advanceTimersByTimeAsync(HOVER_PREFETCH_DELAY_MS);
-    expect(fetcher).toHaveBeenCalledTimes(1);
-
-    resolvers.get("/api/threads/thread-1?includeDrafts=true")?.({
-      thread: { id: "thread-1", messages: [] },
-    });
-    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
-    expect(fetcher.mock.calls.map(([key]) => key[0])).toEqual([
-      "/api/threads/thread-1?includeDrafts=true",
-      "/api/threads/thread-3?includeDrafts=true",
-    ]);
-
-    // Settle the remaining request so shared in-flight state doesn't leak.
-    resolvers.get("/api/threads/thread-3?includeDrafts=true")?.({
-      thread: { id: "thread-3", messages: [] },
-    });
-    await vi.advanceTimersByTimeAsync(0);
+    expect(coordinator.cancelScope).toHaveBeenCalledWith("scope-cleanup");
+    expect(coordinator.schedule).not.toHaveBeenCalled();
   });
 });
 
-function createWrapper(
-  fetcher: (key: [string, string]) => unknown,
-  provider: () => Cache = () => new Map(),
-) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <SWRConfig value={{ fetcher, provider }}>{children}</SWRConfig>;
+function createCoordinator() {
+  return {
+    cancelScope: vi.fn(),
+    dispose: vi.fn(),
+    schedule: vi.fn(),
+    scheduleMany: vi.fn(),
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.ts
@@ -1,15 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { unstable_serialize, useSWRConfig } from "swr";
-import {
-  prefetchThreadDetail,
-  shouldPrefetchThreads,
-} from "@/app/(app)/[emailAccountId]/mail/thread-prefetch";
-import {
-  createThreadRequest,
-  isThreadRequestInFlight,
-} from "@/utils/email-cache/thread-request";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
 
 export const HOVER_PREFETCH_DELAY_MS = 90;
 
@@ -18,54 +10,21 @@ export const HOVER_PREFETCH_DELAY_MS = 90;
  * dwell, focus, or the J/K cursor settling on it), so opening feels instant.
  */
 export function useHoverThreadPrefetch({
+  coordinator,
   emailAccountId,
+  scopeKey,
 }: {
+  coordinator: ThreadPrefetchCoordinator;
   emailAccountId: string;
+  scopeKey: string;
 }) {
-  const { cache, fetcher, mutate } = useSWRConfig();
   const timerRef = useRef<number | undefined>(undefined);
-  const isPrefetchingRef = useRef(false);
-  const queuedThreadIdRef = useRef<string | null>(null);
-
-  const runPrefetch = useCallback(
-    function run(threadId: string) {
-      if (isPrefetchingRef.current) {
-        // One hover prefetch at a time; only the newest intent survives.
-        queuedThreadIdRef.current = threadId;
-        return;
-      }
-      if (!fetcher || !shouldPrefetchThreads()) return;
-      const request = createThreadRequest({
-        emailAccountId,
-        threadId,
-        options: { includeDrafts: true },
-      });
-      const alreadyCached =
-        cache.get(unstable_serialize(request.key))?.data !== undefined;
-      if (alreadyCached || isThreadRequestInFlight(request)) return;
-
-      isPrefetchingRef.current = true;
-      const finish = () => {
-        isPrefetchingRef.current = false;
-        const queued = queuedThreadIdRef.current;
-        queuedThreadIdRef.current = null;
-        if (queued) run(queued);
-      };
-      // Prefetch failures are intentionally silent; opening still retries normally.
-      prefetchThreadDetail({ emailAccountId, threadId, fetcher, mutate }).then(
-        finish,
-        finish,
-      );
-    },
-    [cache, emailAccountId, fetcher, mutate],
-  );
 
   const cancelPrefetch = useCallback(() => {
     if (timerRef.current !== undefined) {
       window.clearTimeout(timerRef.current);
       timerRef.current = undefined;
     }
-    queuedThreadIdRef.current = null;
   }, []);
 
   const schedulePrefetch = useCallback(
@@ -75,13 +34,24 @@ export function useHoverThreadPrefetch({
       // rows from firing a fetch per row.
       timerRef.current = window.setTimeout(() => {
         timerRef.current = undefined;
-        runPrefetch(threadId);
+        coordinator.schedule({
+          emailAccountId,
+          priority: "hover",
+          scopeKey,
+          threadId,
+        });
       }, HOVER_PREFETCH_DELAY_MS);
     },
-    [cancelPrefetch, runPrefetch],
+    [cancelPrefetch, coordinator, emailAccountId, scopeKey],
   );
 
-  useEffect(() => cancelPrefetch, [cancelPrefetch]);
+  useEffect(
+    () => () => {
+      cancelPrefetch();
+      coordinator.cancelScope(scopeKey);
+    },
+    [cancelPrefetch, coordinator, scopeKey],
+  );
 
   return { schedulePrefetch, cancelPrefetch };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.test.tsx
@@ -2,6 +2,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
 import { usePredictiveThreadPrefetch } from "./use-predictive-thread-prefetch";
 import type { ListThread } from "./types";
 
@@ -133,8 +134,9 @@ function createCombinedThread(accountId: string, id: string): ListThread {
   };
 }
 
-function createCoordinator() {
+function createCoordinator(): ThreadPrefetchCoordinator {
   return {
+    activate: vi.fn(),
     cancelScope: vi.fn(),
     dispose: vi.fn(),
     schedule: vi.fn(),

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePredictiveThreadPrefetch } from "./use-predictive-thread-prefetch";
+import type { ListThread } from "./types";
+
+describe("usePredictiveThreadPrefetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: (callback: IdleRequestCallback) => {
+        callback({ didTimeout: false, timeRemaining: () => 50 });
+        return 1;
+      },
+    });
+    Object.defineProperty(window, "cancelIdleCallback", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("schedules the focused row first and a tiny nearby window in list mode", () => {
+    const coordinator = createCoordinator();
+
+    renderHook(() =>
+      usePredictiveThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-1",
+        enabled: true,
+        focusedIndex: 1,
+        scopeKey: "scope-predictive",
+        threads: [
+          createThread("thread-1"),
+          createThread("thread-2"),
+          createThread("thread-3"),
+        ],
+      }),
+    );
+
+    expect(coordinator.scheduleMany).toHaveBeenCalledWith([
+      {
+        emailAccountId: "account-1",
+        priority: "nearby",
+        scopeKey: "scope-predictive",
+        threadId: "thread-1",
+      },
+      {
+        emailAccountId: "account-1",
+        priority: "focused",
+        scopeKey: "scope-predictive",
+        threadId: "thread-2",
+      },
+      {
+        emailAccountId: "account-1",
+        priority: "nearby",
+        scopeKey: "scope-predictive",
+        threadId: "thread-3",
+      },
+    ]);
+  });
+
+  it("skips combined-account rows and disabled list states", () => {
+    const coordinator = createCoordinator();
+
+    renderHook(() =>
+      usePredictiveThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-1",
+        enabled: false,
+        focusedIndex: 0,
+        scopeKey: "scope-disabled",
+        threads: [
+          createCombinedThread("account-2", "thread-1"),
+          createThread("thread-2"),
+        ],
+      }),
+    );
+
+    expect(coordinator.scheduleMany).not.toHaveBeenCalled();
+  });
+
+  it("cancels the predictive scope on cleanup", () => {
+    const coordinator = createCoordinator();
+    const { unmount } = renderHook(() =>
+      usePredictiveThreadPrefetch({
+        coordinator,
+        emailAccountId: "account-1",
+        enabled: true,
+        focusedIndex: 0,
+        scopeKey: "scope-cleanup",
+        threads: [createThread("thread-1")],
+      }),
+    );
+
+    unmount();
+
+    expect(coordinator.cancelScope).toHaveBeenCalledWith("scope-cleanup");
+  });
+});
+
+function createThread(id: string): ListThread {
+  return {
+    id,
+    messages: [
+      {
+        date: "2026-08-20T10:00:00.000Z",
+        headers: { from: "Sender <sender@example.com>", subject: id },
+        id: `${id}-message`,
+        internalDate: "2026-08-20T10:00:00.000Z",
+        labelIds: ["INBOX"],
+        snippet: id,
+        subject: id,
+        threadId: id,
+      },
+    ],
+    plan: undefined,
+    plans: [],
+    snippet: id,
+  };
+}
+
+function createCombinedThread(accountId: string, id: string): ListThread {
+  return {
+    ...createThread(id),
+    account: {
+      email: `${accountId}@example.com`,
+      id: accountId,
+      image: null,
+      name: accountId,
+    },
+  };
+}
+
+function createCoordinator() {
+  return {
+    cancelScope: vi.fn(),
+    dispose: vi.fn(),
+    schedule: vi.fn(),
+    scheduleMany: vi.fn(),
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import type { ListThread } from "./types";
+import type { ThreadPrefetchCoordinator } from "./thread-prefetch-coordinator";
+
+export const PREDICTIVE_THREAD_PREFETCH_DELAY_MS = 120;
+export const PREDICTIVE_THREAD_PREFETCH_NEARBY_WINDOW = 1;
+
+export function usePredictiveThreadPrefetch({
+  coordinator,
+  emailAccountId,
+  enabled,
+  focusedIndex,
+  scopeKey,
+  threads,
+}: {
+  coordinator: ThreadPrefetchCoordinator;
+  emailAccountId: string;
+  enabled: boolean;
+  focusedIndex: number;
+  scopeKey: string;
+  threads: ListThread[];
+}) {
+  const jobs = useMemo(() => {
+    if (!enabled) return [];
+
+    const ids = new Set<string>();
+    const scheduled: Array<{
+      priority: "focused" | "nearby";
+      threadId: string;
+    }> = [];
+    for (
+      let index = focusedIndex - PREDICTIVE_THREAD_PREFETCH_NEARBY_WINDOW;
+      index <= focusedIndex + PREDICTIVE_THREAD_PREFETCH_NEARBY_WINDOW;
+      index += 1
+    ) {
+      const thread = threads[index];
+      if (!thread || "account" in thread || ids.has(thread.id)) continue;
+      ids.add(thread.id);
+      scheduled.push({
+        priority: index === focusedIndex ? "focused" : "nearby",
+        threadId: thread.id,
+      });
+    }
+
+    return scheduled;
+  }, [enabled, focusedIndex, threads]);
+
+  useEffect(() => {
+    coordinator.cancelScope(scopeKey);
+    if (!jobs.length) return;
+
+    const schedule = () => {
+      coordinator.scheduleMany(
+        jobs.map((job) => ({
+          emailAccountId,
+          priority: job.priority,
+          scopeKey,
+          threadId: job.threadId,
+        })),
+      );
+    };
+
+    const idleCallback = window.requestIdleCallback?.(schedule, {
+      timeout: 800,
+    });
+    const timeout =
+      idleCallback === undefined
+        ? window.setTimeout(schedule, PREDICTIVE_THREAD_PREFETCH_DELAY_MS)
+        : undefined;
+
+    return () => {
+      coordinator.cancelScope(scopeKey);
+      if (idleCallback !== undefined) window.cancelIdleCallback(idleCallback);
+      if (timeout !== undefined) window.clearTimeout(timeout);
+    };
+  }, [coordinator, emailAccountId, jobs, scopeKey]);
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260824-083643_pr-3376_37ec512f2eb6/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary
- add a shared bounded thread-prefetch coordinator with cache/in-flight/network gating, scope cancellation, dedupe, and priority upgrades
- route hover, adjacent-reader, and focused nearby list prefetching through the coordinator while preserving combined-account exclusions
- add focused unit/hook coverage plus an emulated Playwright proof for reusing the in-flight detail request when opening a prefetched thread
- keep coordinator cleanup safe under React Strict Mode without reviving stale work

## Testing
- pnpm test --run 'app/(app)/[emailAccountId]/mail/thread-prefetch.test.ts' 'app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator.test.ts' 'app/(app)/[emailAccountId]/mail/use-hover-thread-prefetch.test.tsx' 'app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch.test.tsx' 'app/(app)/[emailAccountId]/mail/use-predictive-thread-prefetch.test.tsx'
- pnpm check
- pnpm dev-setup init --db empty --auth emulate --url localhost --port 3041
- pnpm dev-setup exec --skip-init -- env GOOGLE_CLIENT_ID=client_id GOOGLE_CLIENT_SECRET=client_secret pnpm --dir apps/web exec playwright test __tests__/playwright/emulated/mail/navigation-and-views.spec.ts --grep "opening a prefetched conversation reuses the in-flight detail request" *(passed locally)*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added predictive loading for nearby email conversations during idle time.
  * Hovering over a conversation now begins loading its details before selection.
  * Adjacent, hover, and predictive loading now share a coordinated queue that prioritizes active interactions and avoids duplicate requests.
* **Bug Fixes**
  * Canceled preloads no longer update stale conversation content.
  * Selecting a conversation while its preview loads now reuses the existing request.
  * Improved loading behavior when switching accounts or mail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->