### PR TITLE
mail: Hide support chat

### DIFF
--- a/apps/web/components/CrispChat.tsx
+++ b/apps/web/components/CrispChat.tsx
@@ -2,15 +2,18 @@
 
 import { useEffect, useState } from "react";
 import { Crisp } from "crisp-sdk-web";
+import { usePathname } from "next/navigation";
 import { env } from "@/env";
 import { useSidebar } from "@/components/ui/sidebar";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
 const CrispChat = () => {
   const { state } = useSidebar();
+  const pathname = usePathname();
 
   const [isConfigured, setIsConfigured] = useState(false);
   const isChatOpen = state.includes("chat-sidebar");
+  const isMailRoute = pathname?.includes("/mail");
 
   useEffect(() => {
     if (!env.NEXT_PUBLIC_CRISP_WEBSITE_ID) return;
@@ -31,12 +34,12 @@ const CrispChat = () => {
   useEffect(() => {
     if (!env.NEXT_PUBLIC_CRISP_WEBSITE_ID || !isConfigured) return;
 
-    if (isChatOpen) {
+    if (isChatOpen || isMailRoute) {
       Crisp.chat.hide();
     } else {
       Crisp.chat.show();
     }
-  }, [isConfigured, isChatOpen]);
+  }, [isConfigured, isChatOpen, isMailRoute]);
 
   return null;
 };


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260824-201052_pr-3381_2bd27cc23393/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Hide the support chat while users view the mail screen.

- Restore chat visibility after navigating away from mail
- Validate the updated component with Ultracite and whitespace checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Crisp chat is now hidden on mail pages.
  - Chat visibility updates correctly when navigating between routes.
  - Crisp chat remains hidden while the chat sidebar is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->