### PR TITLE
mail: allow sender selection in unified compose

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+
+export async function createSecondEmailAccount(
+  primaryEmailAccountId: string,
+  { signature }: { signature?: string } = {},
+) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  const suffix = randomUUID();
+  const accountId = `playwright-account-${suffix}`;
+  const id = `playwright-email-account-${suffix}`;
+  const email = `playwright-secondary-${suffix}@gmail.com`;
+  const name = "Playwright Secondary";
+
+  try {
+    await client.query("BEGIN");
+    const userResult = await client.query<{ userId: string }>(
+      `SELECT "userId" FROM "EmailAccount" WHERE id = $1`,
+      [primaryEmailAccountId],
+    );
+    const userId = userResult.rows[0]?.userId;
+    if (!userId) throw new Error("Could not find the Playwright account user");
+
+    await client.query(
+      `INSERT INTO "Account"
+        (id, "createdAt", "updatedAt", "userId", provider, type, "providerAccountId")
+       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, 'google', 'oidc', $3)`,
+      [accountId, userId, `playwright-provider-${suffix}`],
+    );
+    await client.query(
+      `INSERT INTO "EmailAccount"
+        (id, email, name, signature, "createdAt", "updatedAt", "userId", "accountId")
+       VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $5, $6)`,
+      [id, email, name, signature, userId, accountId],
+    );
+    await client.query("COMMIT");
+    return { accountId, email, id, name };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+export async function deleteSecondEmailAccount(accountId: string) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(`DELETE FROM "Account" WHERE id = $1`, [accountId]);
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -209,9 +209,11 @@ test("selects the sender when composing from all accounts", async ({
       .click();
 
     await expect(from).toContainText(secondAccount.email);
-    await expect(dialog.locator("[contenteditable='true']")).toContainText(
-      signature,
-    );
+    await expect(
+      dialog
+        .frameLocator('iframe[title="Signature preview"]')
+        .getByText(signature),
+    ).toBeVisible();
   } finally {
     await deleteSecondEmailAccount(secondAccount.accountId);
   }

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -179,6 +179,21 @@ test("composes, sends, and reads a new message from Sent", async ({
   });
 });
 
+test("selects the sender when composing from all accounts", async ({
+  page,
+}) => {
+  const { emailAccountId } = await openMail(page);
+
+  await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const from = dialog.getByRole("combobox", { name: "From" });
+  await expect(from).toBeVisible();
+  await from.click();
+  await expect(page.getByRole("option")).toHaveCount(1);
+});
+
 test("replies inside an existing conversation", async ({ page }, testInfo) => {
   const { conversations } = await openMail(page);
   const replyConversation = conversationWithSubject(

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Locator } from "@playwright/test";
+import {
+  createSecondEmailAccount,
+  deleteSecondEmailAccount,
+} from "./account-test-helpers";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
 test("keeps editing state stable across formatting, links, paste, and files", async ({
@@ -183,15 +187,34 @@ test("selects the sender when composing from all accounts", async ({
   page,
 }) => {
   const { emailAccountId } = await openMail(page);
+  const signature = "Secondary account signature";
+  const secondAccount = await createSecondEmailAccount(emailAccountId, {
+    signature,
+  });
 
-  await page.goto(`/${emailAccountId}/mail?accountScope=all`);
-  await page.getByRole("button", { name: /^Compose/ }).click();
+  try {
+    await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    await page.getByRole("button", { name: /^Compose/ }).click();
 
-  const dialog = page.getByRole("dialog", { name: "New Message" });
-  const from = dialog.getByRole("combobox", { name: "From" });
-  await expect(from).toBeVisible();
-  await from.click();
-  await expect(page.getByRole("option")).toHaveCount(1);
+    const dialog = page.getByRole("dialog", { name: "New Message" });
+    const from = dialog.getByRole("combobox", { name: "From" });
+    await expect(from).toBeVisible();
+    await from.click();
+    await expect(page.getByRole("option")).toHaveCount(2);
+    await page
+      .getByRole("option", {
+        name: `${secondAccount.name} (${secondAccount.email})`,
+        exact: true,
+      })
+      .click();
+
+    await expect(from).toContainText(secondAccount.email);
+    await expect(dialog.locator("[contenteditable='true']")).toContainText(
+      signature,
+    );
+  } finally {
+    await deleteSecondEmailAccount(secondAccount.accountId);
+  }
 });
 
 test("replies inside an existing conversation", async ({ page }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -1,6 +1,8 @@
-import { randomUUID } from "node:crypto";
 import { expect, test, type Page } from "@playwright/test";
-import { Client } from "pg";
+import {
+  createSecondEmailAccount,
+  deleteSecondEmailAccount,
+} from "./account-test-helpers";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
 const MESSAGE_COUNT = 5000;
@@ -507,54 +509,4 @@ function readerBody(page: Page, text: string) {
   return page
     .locator("pre")
     .filter({ hasText: new RegExp(`^${escapeRegExp(text)}$`) });
-}
-
-async function createSecondEmailAccount(primaryEmailAccountId: string) {
-  const client = new Client({ connectionString: process.env.DATABASE_URL });
-  await client.connect();
-  const suffix = randomUUID();
-  const accountId = `playwright-account-${suffix}`;
-  const id = `playwright-email-account-${suffix}`;
-  const email = `playwright-secondary-${suffix}@gmail.com`;
-  const name = "Playwright Secondary";
-
-  try {
-    await client.query("BEGIN");
-    const userResult = await client.query<{ userId: string }>(
-      `SELECT "userId" FROM "EmailAccount" WHERE id = $1`,
-      [primaryEmailAccountId],
-    );
-    const userId = userResult.rows[0]?.userId;
-    if (!userId) throw new Error("Could not find the Playwright account user");
-
-    await client.query(
-      `INSERT INTO "Account"
-        (id, "createdAt", "updatedAt", "userId", provider, type, "providerAccountId")
-       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, 'google', 'oidc', $3)`,
-      [accountId, userId, `playwright-provider-${suffix}`],
-    );
-    await client.query(
-      `INSERT INTO "EmailAccount"
-        (id, email, name, "createdAt", "updatedAt", "userId", "accountId")
-       VALUES ($1, $2, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $4, $5)`,
-      [id, email, name, userId, accountId],
-    );
-    await client.query("COMMIT");
-    return { accountId, email, id, name };
-  } catch (error) {
-    await client.query("ROLLBACK");
-    throw error;
-  } finally {
-    await client.end();
-  }
-}
-
-async function deleteSecondEmailAccount(accountId: string) {
-  const client = new Client({ connectionString: process.env.DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(`DELETE FROM "Account" WHERE id = $1`, [accountId]);
-  } finally {
-    await client.end();
-  }
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -515,12 +515,7 @@ function ComposeEmailFormContent({
               isComposeWindow && "min-h-11 border-b",
             )}
           >
-            <label
-              className="shrink-0 text-sm font-medium text-foreground"
-              htmlFor="from-account"
-            >
-              From
-            </label>
+            <ComposeFieldLabel htmlFor="from-account" label="From" />
             <Select
               value={selectedEmailAccountId}
               onValueChange={onSelectEmailAccount}
@@ -570,14 +565,7 @@ function ComposeEmailFormContent({
                 isComposeWindow && "min-h-11 items-center border-b",
               )}
             >
-              {isComposeWindow && (
-                <label
-                  className="shrink-0 text-sm font-medium text-foreground"
-                  htmlFor="to"
-                >
-                  To
-                </label>
-              )}
+              {isComposeWindow && <ComposeFieldLabel htmlFor="to" label="To" />}
               <div className="min-w-0 flex-1">
                 {env.NEXT_PUBLIC_CONTACTS_ENABLED ? (
                   <div className="flex space-x-2">
@@ -968,6 +956,23 @@ function readFileAsBase64(file: File) {
 
 function revokePreview(attachment: ComposeAttachment) {
   if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+}
+
+function ComposeFieldLabel({
+  htmlFor,
+  label,
+}: {
+  htmlFor: string;
+  label: string;
+}) {
+  return (
+    <label
+      className="shrink-0 text-sm font-medium text-foreground"
+      htmlFor={htmlFor}
+    >
+      {label}
+    </label>
+  );
 }
 
 function formatFileSize(size: number) {

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -40,6 +40,7 @@ import { type SubmitHandler, useForm } from "react-hook-form";
 import { useHotkeys } from "react-hotkeys-hook";
 import useSWR from "swr";
 import type { ContactsResponse } from "@/app/api/google/contacts/route";
+import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
 import { Input, Label } from "@/components/Input";
 import { ButtonLoader } from "@/components/Loading";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -48,6 +49,13 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CommandShortcut } from "@/components/ui/command";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { env } from "@/env";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useModifierKey } from "@/hooks/useModifierKey";
@@ -78,6 +86,7 @@ export type ReplyingToEmail = {
 };
 
 type ComposeEmailFormProps = {
+  fromAccounts?: GetEmailAccountsResponse["emailAccounts"];
   layout?: "default" | "window";
   replyingToEmail?: ReplyingToEmail;
   refetch?: () => void;
@@ -92,7 +101,18 @@ type ComposeAttachment = EmailComposerAttachment & {
 type ComposeFormValues = Omit<SendEmailBody, "attachments" | "messageHtml">;
 
 export function ComposeEmailForm(props: ComposeEmailFormProps) {
-  const { data: emailAccount, error, isLoading } = useEmailAccountFull();
+  const { emailAccountId } = useAccount();
+  const [selectedEmailAccountId, setSelectedEmailAccountId] =
+    useState(emailAccountId);
+  const selectedAccountOverride =
+    selectedEmailAccountId === emailAccountId
+      ? undefined
+      : selectedEmailAccountId;
+  const {
+    data: emailAccount,
+    error,
+    isLoading,
+  } = useEmailAccountFull(selectedAccountOverride);
 
   return (
     <LoadingContent error={error} loading={isLoading}>
@@ -100,6 +120,9 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
         <ComposeEmailFormContent
           {...props}
           accountSignatureHtml={emailAccount.signature ?? ""}
+          key={selectedEmailAccountId}
+          onSelectEmailAccount={setSelectedEmailAccountId}
+          selectedEmailAccountId={selectedEmailAccountId}
         />
       )}
     </LoadingContent>
@@ -109,13 +132,19 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
 function ComposeEmailFormContent({
   layout = "default",
   replyingToEmail,
+  fromAccounts,
   accountSignatureHtml,
+  selectedEmailAccountId,
+  onSelectEmailAccount,
   refetch,
   onSuccess,
   onDiscard,
-}: ComposeEmailFormProps & { accountSignatureHtml: string }) {
+}: ComposeEmailFormProps & {
+  accountSignatureHtml: string;
+  selectedEmailAccountId: string;
+  onSelectEmailAccount: (emailAccountId: string) => void;
+}) {
   const isComposeWindow = layout === "window";
-  const { emailAccountId } = useAccount();
   const [initialComposer] = useState(() => {
     const draft = prepareEmailDraft({
       html: replyingToEmail?.draftHtml ?? "",
@@ -386,7 +415,10 @@ function ComposeEmailFormContent({
       }
 
       try {
-        const result = await sendEmailAction(emailAccountId, enrichedData);
+        const result = await sendEmailAction(
+          selectedEmailAccountId,
+          enrichedData,
+        );
         if (result?.data) {
           toastSuccess({ description: "Email sent!" });
           onSuccess?.(result.data.messageId ?? "", result.data.threadId ?? "");
@@ -405,12 +437,12 @@ function ComposeEmailFormContent({
       refetch?.();
     },
     [
-      emailAccountId,
       initialDraft,
       onSuccess,
       preservedBlocks,
       refetch,
       searchQuery,
+      selectedEmailAccountId,
     ],
   );
 
@@ -476,6 +508,46 @@ function ComposeEmailFormContent({
       )}
     >
       <div className={cn(isComposeWindow ? "shrink-0 px-4" : "contents")}>
+        {!!fromAccounts?.length && !replyingToEmail && (
+          <div
+            className={cn(
+              "flex items-center gap-2",
+              isComposeWindow && "min-h-11 border-b",
+            )}
+          >
+            <label
+              className="shrink-0 text-sm font-medium text-foreground"
+              htmlFor="from-account"
+            >
+              From
+            </label>
+            <Select
+              value={selectedEmailAccountId}
+              onValueChange={onSelectEmailAccount}
+            >
+              <SelectTrigger
+                aria-label="From"
+                className="h-10 min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 shadow-none focus:ring-0 focus:ring-offset-0"
+                id="from-account"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {fromAccounts.map((account) => (
+                  <SelectItem
+                    disabled={Boolean(account.account.disconnectedAt)}
+                    key={account.id}
+                    value={account.id}
+                  >
+                    {account.name
+                      ? `${account.name} (${account.email})`
+                      : account.email}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
         {replyingToEmail?.to && !editReply ? (
           <button
             type="button"

--- a/apps/web/hooks/useAccounts.ts
+++ b/apps/web/hooks/useAccounts.ts
@@ -1,8 +1,11 @@
 import useSWR from "swr";
 import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
 
-export function useAccounts() {
-  return useSWR<GetEmailAccountsResponse>("/api/user/email-accounts", {
-    revalidateOnFocus: false,
-  });
+export function useAccounts(enabled = true) {
+  return useSWR<GetEmailAccountsResponse>(
+    enabled ? "/api/user/email-accounts" : null,
+    {
+      revalidateOnFocus: false,
+    },
+  );
 }

--- a/apps/web/hooks/useEmailAccountFull.ts
+++ b/apps/web/hooks/useEmailAccountFull.ts
@@ -1,10 +1,10 @@
 import useSWR from "swr";
 import type { EmailAccountFullResponse } from "@/app/api/user/email-account/route";
-import { processSWRResponse } from "@/utils/swr"; // Import the generic helper
+import { getAccountScopedKey, processSWRResponse } from "@/utils/swr";
 
-export function useEmailAccountFull() {
+export function useEmailAccountFull(emailAccountId?: string) {
   const swrResult = useSWR<EmailAccountFullResponse | { error: string }>(
-    "/api/user/email-account",
+    getAccountScopedKey("/api/user/email-account", emailAccountId),
   );
   return processSWRResponse<EmailAccountFullResponse>(swrResult);
 }

--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -2,7 +2,9 @@
 
 import { createContext, useCallback, useContext, useState } from "react";
 import { Maximize2Icon, Minimize2Icon, XIcon } from "lucide-react";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useModal } from "@/hooks/useModal";
+import { useAccounts } from "@/hooks/useAccounts";
 import { ComposeEmailFormLazy } from "@/app/(app)/[emailAccountId]/compose/ComposeEmailFormLazy";
 import {
   Dialog,
@@ -24,8 +26,13 @@ const ComposeModalContext = createContext<Context>({
 export const useComposeModal = () => useContext(ComposeModalContext);
 
 export function ComposeModalProvider(props: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [isExpanded, setIsExpanded] = useState(false);
+  const isAllAccountsMailView =
+    pathname.endsWith("/mail") && searchParams.get("accountScope") === "all";
+  const { data: accountsData } = useAccounts(isAllAccountsMailView);
   const openCompose = useCallback(() => {
     setIsExpanded(false);
     openModal();
@@ -120,6 +127,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
               )}
             >
               <ComposeEmailFormLazy
+                fromAccounts={accountsData?.emailAccounts}
                 layout="window"
                 onDiscard={closeCompose}
                 onSuccess={closeCompose}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260824-203414_pr-3382_55c3067ed39c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a From account selector when composing a new message from the unified mail view.

The selected account controls sending and signature loading, while replies remain tied to their existing account. An emulated browser regression covers sender selection. Validation: app lint and Playwright test discovery passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a sender selector to the compose window when viewing all accounts.
  - Choose which connected email account to send from.
  - The selected account’s signature is applied to the message.
  - Messages are sent through the selected account.
  - Disconnected accounts appear unavailable for selection.

- **Tests**
  - Added coverage for sender selection, account-specific signatures, From-field validation, and available account options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->