### PR TITLE
mail: Hide archived messages from saved splits

### DIFF
--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -23,18 +23,18 @@ describe("mailSplitToThreadsQuery", () => {
     });
   });
 
-  it("queries by label id, not by label name", () => {
+  it("limits label splits to matching inbox mail", () => {
     expect(
       mailSplitToThreadsQuery(split(MailSplitKind.LABEL, "Label_42")),
-    ).toEqual({ labelId: "Label_42" });
+    ).toEqual({ labelIds: ["Label_42", "INBOX"] });
   });
 
-  it("passes a provider category through as the type", () => {
+  it("limits provider category splits to matching inbox mail", () => {
     expect(
       mailSplitToThreadsQuery(
         split(MailSplitKind.CATEGORY, "CATEGORY_PERSONAL"),
       ),
-    ).toEqual({ type: "CATEGORY_PERSONAL" });
+    ).toEqual({ labelIds: ["CATEGORY_PERSONAL", "INBOX"] });
   });
 
   it.each([

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -21,11 +21,14 @@ export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
       return { type: "inbox", isUnread: true };
     case MailSplitKind.LABEL:
       if (!split.value) throw new Error(`Split "${split.name}" has no label`);
-      return { labelId: split.value };
+      return { labelIds: [split.value, "INBOX"] };
     case MailSplitKind.CATEGORY:
       if (!split.value)
         throw new Error(`Split "${split.name}" has no category`);
-      return mailTypeToThreadsQuery(split.value);
+      if (isOutlookInboxSection(split.value)) {
+        return mailTypeToThreadsQuery(split.value);
+      }
+      return { labelIds: [split.value, "INBOX"] };
   }
 }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260824-212411_pr-3384_6c011a76bd8e/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Scope saved label and category splits to matching inbox messages while preserving provider-specific inbox sections.

Validated with focused split-query, provider, and mailbox-cache tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mail filtering for label-based searches so results are limited to matching messages in the Inbox.
  * Updated category filtering to correctly handle Inbox sections and preserve expected results for other categories.
  * Refined query behavior to provide more consistent filtering across supported mail providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->