### PR TITLE
mail: Fix initial thread list loading state

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1058,7 +1058,6 @@ export function MailShell() {
                 onArchiveSelected={archiveTargets}
                 onDeleteSelected={trashTargets}
                 onClearSelection={selection.clear}
-                emptyTitle="Nothing in this view"
                 showLoadMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMore}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -38,7 +38,6 @@ export type ThreadListProps = {
   onArchiveSelected: () => void;
   onDeleteSelected: () => void;
   onClearSelection: () => void;
-  emptyTitle: string;
   showLoadMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
@@ -64,7 +63,6 @@ export function ThreadList({
   onArchiveSelected,
   onDeleteSelected,
   onClearSelection,
-  emptyTitle,
   showLoadMore,
   isLoadingMore,
   onLoadMore,
@@ -145,22 +143,8 @@ export function ThreadList({
         ref={setScrollRoot}
       >
         {threads.length === 0 ? (
-          <div className="px-6 py-12 text-center">
-            <div className="text-foreground text-sm">{emptyTitle}</div>
-            <div className="mt-1.5 text-muted-foreground text-xs">
-              Nothing here right now.
-            </div>
-            {showLoadMore ? (
-              <Button
-                className="mt-4"
-                disabled={isLoadingMore}
-                onClick={onLoadMore}
-                size="sm"
-                variant="outline"
-              >
-                {isLoadingMore ? "Loading more" : "Load more"}
-              </Button>
-            ) : null}
+          <div className="px-6 py-12 text-center text-muted-foreground text-sm">
+            No emails in this view
           </div>
         ) : (
           <>

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -85,6 +85,29 @@ describe("useCombinedMailThreads", () => {
     });
   });
 
+  it("keeps loading when an empty cached page is awaiting server rows", async () => {
+    const network = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue({
+      hasMore: true,
+      threads: [],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
   it("uses a newer server page when the persisted mailbox predates the request", async () => {
     mailbox.read.mockResolvedValue({
       accountStates: ACCOUNT_STATES,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -586,7 +586,7 @@ export function useCombinedMailThreads({
 
   return {
     threads,
-    isLoading: isLoading && sourceThreads === undefined,
+    isLoading: isLoading && !sourceThreads?.length,
     error: sourceThreads !== undefined ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore: isLoadingMore || isLoadingMoreLocally,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -587,7 +587,7 @@ export function useCombinedMailThreads({
   return {
     threads,
     isLoading: isLoading && !sourceThreads?.length,
-    error: sourceThreads !== undefined ? undefined : error,
+    error: sourceThreads?.length ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore: isLoadingMore || isLoadingMoreLocally,
     failedAccountIds,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -207,6 +207,32 @@ describe("useMailThreads", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("surfaces an initial request failure when the cache has no rows", async () => {
+    const requestError = new Error("request failed");
+    const pendingRetry = Promise.withResolvers<unknown>();
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(requestError)
+      .mockReturnValue(pendingRetry.promise);
+    cache.read.mockResolvedValue({
+      cachedAt: 100,
+      hasMore: true,
+      threads: [],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useMailThreads({
+          emailAccountId: "account-empty-cache-error",
+          query: { type: "inbox" },
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    expect(result.current.threads).toEqual([]);
+    await waitFor(() => expect(result.current.error).toBe(requestError));
+  });
+
   it("keeps network rows when the disk read finishes later", async () => {
     const disk = Promise.withResolvers<unknown>();
     const network = Promise.withResolvers<unknown>();

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx
@@ -185,6 +185,28 @@ describe("useMailThreads", () => {
     );
   });
 
+  it("keeps loading when an empty cached page is awaiting server rows", async () => {
+    const network = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue({
+      cachedAt: 100,
+      hasMore: true,
+      threads: [],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useMailThreads({
+          emailAccountId: "account-empty-cache",
+          query: { type: "inbox" },
+        }),
+      { wrapper: createWrapper(() => network.promise) },
+    );
+
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
   it("keeps network rows when the disk read finishes later", async () => {
     const disk = Promise.withResolvers<unknown>();
     const network = Promise.withResolvers<unknown>();

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -593,7 +593,7 @@ export function useMailThreads({
   return {
     threads,
     isLoading: isLoading && !sourceThreads?.length,
-    error: sourceThreads ? undefined : error,
+    error: sourceThreads?.length ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore:
       paginationRequestIdentity === viewIdentity ||

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -592,7 +592,7 @@ export function useMailThreads({
 
   return {
     threads,
-    isLoading: isLoading && !sourceThreads,
+    isLoading: isLoading && !sourceThreads?.length,
     error: sourceThreads ? undefined : error,
     hasMore: Boolean(hasMore),
     isLoadingMore:


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260825-092710_pr-3386_9bd6a4115884/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes mail lists so empty local cache entries do not replace the initial loading state while server results are pending.

- Simplifies the true empty state and removes its invalid pagination action.
- Covers single-account and combined-account loading behavior with focused tests.

Validation: 37 focused tests passed; formatting checks completed with pre-existing repository warnings only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indicators when an email view starts empty but more messages are available.
  * Preserved error messages when an initial email request fails.
  * Prevented empty states from displaying unnecessary explanatory text or load-more controls.
  * Standardized empty mailbox messaging to “No emails in this view.”

* **Tests**
  * Added regression coverage for loading and error behavior while awaiting messages from the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->