### PR TITLE
test: stabilize connected secondary mail fixture

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
@@ -15,19 +15,25 @@ export async function createSecondEmailAccount(
 
   try {
     await client.query("BEGIN");
-    const userResult = await client.query<{ userId: string }>(
-      `SELECT "userId" FROM "EmailAccount" WHERE id = $1`,
-      [primaryEmailAccountId],
-    );
-    const userId = userResult.rows[0]?.userId;
-    if (!userId) throw new Error("Could not find the Playwright account user");
-
-    await client.query(
+    const accountResult = await client.query<{ userId: string }>(
       `INSERT INTO "Account"
-        (id, "createdAt", "updatedAt", "userId", provider, type, "providerAccountId")
-       VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, 'google', 'oidc', $3)`,
-      [accountId, userId, `playwright-provider-${suffix}`],
+        (id, "createdAt", "updatedAt", "userId", provider, type,
+         "providerAccountId", refresh_token, "refreshTokenExpiresAt",
+         access_token, expires_at, token_type, scope)
+       SELECT $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, email_account."userId",
+         'google', 'oidc', $2, account.refresh_token,
+         account."refreshTokenExpiresAt", account.access_token,
+         account.expires_at, account.token_type, account.scope
+       FROM "EmailAccount" email_account
+       JOIN "Account" account ON account.id = email_account."accountId"
+       WHERE email_account.id = $3 AND account.refresh_token IS NOT NULL
+       RETURNING "userId"`,
+      [accountId, `playwright-provider-${suffix}`, primaryEmailAccountId],
     );
+    const userId = accountResult.rows[0]?.userId;
+    if (!userId)
+      throw new Error("Could not clone the Playwright account credentials");
+
     await client.query(
       `INSERT INTO "EmailAccount"
         (id, email, name, signature, "createdAt", "updatedAt", "userId", "accountId")

--- a/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-test-helpers.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Client } from "pg";
+import type { Account } from "@/generated/prisma/client";
 
 export async function createSecondEmailAccount(
   primaryEmailAccountId: string,
@@ -15,7 +16,7 @@ export async function createSecondEmailAccount(
 
   try {
     await client.query("BEGIN");
-    const accountResult = await client.query<{ userId: string }>(
+    const accountResult = await client.query<Pick<Account, "userId">>(
       `INSERT INTO "Account"
         (id, "createdAt", "updatedAt", "userId", provider, type,
          "providerAccountId", refresh_token, "refreshTokenExpiresAt",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260825-204619_pr-3391_43c95d95abca/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- clone the primary emulated Google account credentials when creating the synthetic second account
- fail fixture setup early if the primary account has no refresh token
- prevent background permission checks from treating the second account as disconnected and redirecting to consent

## Testing

- focused local-cache E2E repeated 3 times: 4 passed including auth setup
- sender selection and cached reader consumers: 3 passed including auth setup
- Ultracite check on the changed helper
- `git diff --check`

This fixes the mail E2E failure observed after #3390; no production code is changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email account setup in testing scenarios by preserving Google authentication credentials when creating an additional account.
  * Added validation to prevent account creation when required authentication details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->