### PR TITLE
Fix send shortcut line break in email editor

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -143,6 +143,20 @@ test("keeps editing state stable across formatting, links, paste, and files", as
   await expect(dialog).toHaveAttribute("data-compose-expanded", "false");
 });
 
+test("does not add a line break for the send shortcut", async ({ page }) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const editor = dialog.locator("[contenteditable='true']");
+  await editor.pressSequentially("Draft body");
+  const initialHtml = await editor.innerHTML();
+
+  await editor.press("ControlOrMeta+Enter");
+
+  await expect(editor).toHaveJSProperty("innerHTML", initialHtml);
+});
+
 test("composes, sends, and reads a new message from Sent", async ({
   page,
 }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -143,18 +143,39 @@ test("keeps editing state stable across formatting, links, paste, and files", as
   await expect(dialog).toHaveAttribute("data-compose-expanded", "false");
 });
 
-test("does not add a line break for the send shortcut", async ({ page }) => {
-  await openMail(page);
+test("does not add a line break for the send shortcut", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  const subject = `Shortcut Message ${testInfo.retry}`;
   await page.getByRole("button", { name: /^Compose/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
   const editor = dialog.locator("[contenteditable='true']");
+  await dialog
+    .getByRole("textbox", { name: "To" })
+    .fill("recipient@example.com");
+  await dialog.getByPlaceholder("Subject").fill(subject);
   await editor.pressSequentially("Draft body");
-  const initialHtml = await editor.innerHTML();
 
   await editor.press("ControlOrMeta+Enter");
 
-  await expect(editor).toHaveJSProperty("innerHTML", initialHtml);
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
+  await page.getByRole("link", { name: /^Sent/ }).click();
+  const sentConversation = conversationWithSubject(
+    page,
+    conversations,
+    subject,
+  );
+  await sentConversation.click();
+  const sentBody = page
+    .frameLocator('iframe[title="Email content preview"]')
+    .locator("body");
+  await expect(sentBody).toHaveText("Draft body");
+  expect(await sentBody.evaluate((element) => element.innerText)).toBe(
+    "Draft body",
+  );
 });
 
 test("composes, sends, and reads a new message from Sent", async ({

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -515,6 +515,7 @@ function ComposeEmailFormContent({
     {
       enableOnFormTags: true,
       enableOnContentEditable: true,
+      eventListenerOptions: { capture: true },
       preventDefault: true,
     },
   );


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260826-100315_pr-3394_d28e0ef213aa/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents the modified Enter send shortcut from adding a line break to an email draft.

- Handles the existing shortcut before editor input processing.
- Adds emulated browser regression coverage for unchanged draft content.
- Validation: targeted Biome checks and Playwright test discovery.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the compose keyboard shortcut so `Control+Enter` or `Command+Enter` sends emails reliably.
  - Prevented the shortcut from inserting an unintended line break or changing the message content.
  - Improved shortcut handling when recipient and subject fields are completed, with sent messages now preserving the exact draft body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->