### PR TITLE
mail: Open reply composer with Enter

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -222,6 +222,18 @@ test("selects the sender when composing from all accounts", async ({
 test("opens and sends a reply from the reader with Enter", async ({
   page,
 }, testInfo) => {
+  const releaseThreadRequest = Promise.withResolvers<void>();
+  let threadRequestStarted = false;
+  await page.route(
+    "**/api/threads/thr_playwright_reply?includeDrafts=true",
+    async (route) => {
+      threadRequestStarted = true;
+      const responsePromise = route.fetch();
+      await releaseThreadRequest.promise;
+      const response = await responsePromise;
+      await route.fulfill({ response });
+    },
+  );
   const { conversations } = await openMail(page);
   const replyConversation = conversationWithSubject(
     page,
@@ -229,13 +241,16 @@ test("opens and sends a reply from the reader with Enter", async ({
     "Reply Workflow Message",
   );
   await replyConversation.click();
+  await expect.poll(() => threadRequestStarted).toBe(true);
+  await page.keyboard.press("Enter");
+  releaseThreadRequest.resolve();
+
   await expect(
     page.getByText("Please reply to this seeded conversation."),
   ).toBeVisible();
   const sentByMe = page.getByText("Me", { exact: true });
   const initialSentByMeCount = await sentByMe.count();
 
-  await page.keyboard.press("Enter");
   const replyEditor = page.locator("[contenteditable='true']");
   await expect(replyEditor).toBeVisible();
   await expect(replyEditor).toHaveCount(1);

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -219,7 +219,9 @@ test("selects the sender when composing from all accounts", async ({
   }
 });
 
-test("replies inside an existing conversation", async ({ page }, testInfo) => {
+test("opens and sends a reply from the reader with Enter", async ({
+  page,
+}, testInfo) => {
   const { conversations } = await openMail(page);
   const replyConversation = conversationWithSubject(
     page,
@@ -233,7 +235,7 @@ test("replies inside an existing conversation", async ({ page }, testInfo) => {
   const sentByMe = page.getByText("Me", { exact: true });
   const initialSentByMeCount = await sentByMe.count();
 
-  await page.getByRole("button", { name: /^Reply R$/ }).click();
+  await page.keyboard.press("Enter");
   const replyEditor = page.locator("[contenteditable='true']");
   await expect(replyEditor).toBeVisible();
   await expect(replyEditor).toHaveCount(1);

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -616,7 +616,9 @@ export function MailShell() {
     return {
       next: () => move(1),
       previous: () => move(-1),
-      open: () => openAt(clampedIndex),
+      open: openThreadId
+        ? () => setReplyToMessageId(openMessages.at(-1)?.id)
+        : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
         : () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -167,6 +167,7 @@ export function MailShell() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
+  const pendingReplyThreadKey = useRef<string | null>(null);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   const isAllAccounts = accountScope === "all";
@@ -386,6 +387,31 @@ export function MailShell() {
   const openMessages = readerSelectionSettled
     ? (openThreadData?.thread.messages ?? NO_MESSAGES)
     : NO_MESSAGES;
+  const requestReaderReply = useCallback(() => {
+    const messageId = openMessages.at(-1)?.id;
+    if (messageId) {
+      pendingReplyThreadKey.current = null;
+      setReplyToMessageId(messageId);
+      return;
+    }
+
+    pendingReplyThreadKey.current = openReaderThreadKey;
+  }, [openMessages, openReaderThreadKey]);
+
+  useEffect(() => {
+    const pendingThreadKey = pendingReplyThreadKey.current;
+    if (!pendingThreadKey) return;
+    if (pendingThreadKey !== openReaderThreadKey) {
+      pendingReplyThreadKey.current = null;
+      return;
+    }
+
+    const messageId = openMessages.at(-1)?.id;
+    if (!readerSelectionSettled || !messageId) return;
+
+    pendingReplyThreadKey.current = null;
+    setReplyToMessageId(messageId);
+  }, [openMessages, openReaderThreadKey, readerSelectionSettled]);
 
   // The row, not the fetched thread: marking read patches the row optimistically,
   // so it is the copy that stays in step. The fetch only stands in for a link
@@ -616,9 +642,7 @@ export function MailShell() {
     return {
       next: () => move(1),
       previous: () => move(-1),
-      open: openThreadId
-        ? () => setReplyToMessageId(openMessages.at(-1)?.id)
-        : () => openAt(clampedIndex),
+      open: openThreadId ? requestReaderReply : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
         : () => {
@@ -1020,7 +1044,7 @@ export function MailShell() {
               }}
               onArchive={archiveTargets}
               onDelete={trashTargets}
-              onReply={() => setReplyToMessageId(openMessages.at(-1)?.id)}
+              onReply={requestReaderReply}
               onToggleFocusMode={() => setIsFocusMode((on) => !on)}
               showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260826-095414_pr-3395_70e136a95f13/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates the Enter shortcut to open the reply composer when the email reader is active while preserving list navigation.

- Reuses the existing reader reply flow.
- Covers the behavior in the emulated browser reply workflow.
- Validation: 31 shortcut tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressing **Enter** while viewing an open conversation now starts a reply to the latest message after the conversation finishes loading.
  * The reader’s reply action uses the same reliable flow, and existing shortcut behavior for opening a focused conversation remains unchanged.

* **Bug Fixes**
  * Improved reply handling when navigating between conversations to prevent actions from applying to outdated threads.

* **Tests**
  * Expanded coverage for keyboard-initiated replies and sending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->