### PR TITLE
mail: Render inline images after sending

### DIFF
--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -622,6 +622,7 @@ function EmailPreview({
   compact?: boolean;
   showDetails?: boolean;
 }) {
+  const { emailAccountId } = useAccount();
   const { data, isLoading, error } = useThread({ id: threadId });
 
   if (isLoading) {
@@ -653,7 +654,12 @@ function EmailPreview({
   const body = (
     <>
       {lastMessage.textHtml ? (
-        <HtmlEmail html={lastMessage.textHtml} messageId={lastMessage.id} />
+        <HtmlEmail
+          emailAccountId={emailAccountId}
+          html={lastMessage.textHtml}
+          inlineAttachments={lastMessage.inline}
+          messageId={lastMessage.id}
+        />
       ) : (
         <PlainEmail
           text={

--- a/apps/web/components/email-list/EmailAttachments.tsx
+++ b/apps/web/components/email-list/EmailAttachments.tsx
@@ -7,7 +7,10 @@ import type { ThreadMessage } from "@/components/email-list/types";
 import { CardBasic } from "@/components/ui/card";
 import { toastError } from "@/components/Toast";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { fetchAttachment } from "@/utils/attachments/download";
+import {
+  fetchAttachment,
+  getAttachmentUrl,
+} from "@/utils/attachments/download";
 
 export function EmailAttachments({ message }: { message: ThreadMessage }) {
   const { emailAccountId } = useAccount();
@@ -45,14 +48,12 @@ export function EmailAttachments({ message }: { message: ThreadMessage }) {
   return (
     <div className="mt-4 grid grid-cols-2 gap-2 xl:grid-cols-3">
       {message.attachments?.map((attachment) => {
-        const searchParams = new URLSearchParams({
+        const url = getAttachmentUrl({
           messageId: message.id,
           attachmentId: attachment.attachmentId,
           mimeType: attachment.mimeType,
           filename: attachment.filename,
         });
-
-        const url = `/api/messages/attachment?${searchParams.toString()}`;
 
         return (
           <CardBasic key={attachment.attachmentId} className="p-4">

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -34,6 +34,7 @@ describe("HtmlEmail", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -106,6 +107,63 @@ describe("HtmlEmail", () => {
         "img-src data: https://app.example.com;",
       );
     });
+  });
+
+  it("resolves authenticated cid images to temporary local URLs", async () => {
+    const html = '<img src="cid:screenshot@inboxzero.local" />';
+    const objectUrl = "blob:https://app.example.com/inline-image";
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue(objectUrl);
+    const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (input: string) =>
+        input === "/api/email/render-html"
+          ? {
+              ok: true,
+              json: async () => ({ html }),
+            }
+          : {
+              ok: true,
+              blob: async () => new Blob(["image"], { type: "image/png" }),
+            },
+      ),
+    );
+
+    const { getByTitle, unmount } = render(
+      <HtmlEmail
+        emailAccountId="account-1"
+        html={html}
+        inlineAttachments={[
+          {
+            attachmentId: "attachment-1",
+            filename: "screenshot.png",
+            headers: {
+              "content-description": "",
+              "content-id": "<screenshot@inboxzero.local>",
+              "content-transfer-encoding": "base64",
+              "content-type": "image/png",
+            },
+            mimeType: "image/png",
+            size: 5,
+          },
+        ]}
+        messageId="message-inline"
+      />,
+    );
+
+    const iframe = getByTitle("Email content preview");
+    await waitFor(() => {
+      expect(iframe.getAttribute("srcdoc")).toContain(`src="${objectUrl}"`);
+      expect(iframe.getAttribute("srcdoc")).toContain(
+        "img-src data: blob: https:;",
+      );
+    });
+    expect(createObjectUrl).toHaveBeenCalledOnce();
+
+    unmount();
+    expect(revokeObjectUrl).toHaveBeenCalledWith(objectUrl);
   });
 });
 

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -337,15 +337,18 @@ async function loadInlineImageSources({
   html: string;
   inlineAttachments: ParsedMessage["inline"];
   messageId: string;
-}) {
+}): Promise<Record<string, string>> {
   if (!emailAccountId || !inlineAttachments.length) return {};
 
-  const attachmentByContentId = new Map(
-    inlineAttachments.flatMap((attachment) => {
-      const contentId = normalizeContentId(attachment.headers["content-id"]);
-      return contentId ? [[contentId, attachment] as const] : [];
-    }),
-  );
+  const attachmentByContentId = new Map<
+    string,
+    ParsedMessage["inline"][number]
+  >();
+  for (const attachment of inlineAttachments) {
+    const contentId = normalizeContentId(attachment.headers["content-id"]);
+    if (contentId) attachmentByContentId.set(contentId, attachment);
+  }
+
   const entries = await Promise.all(
     getInlineImageContentIds(html).map(async (contentId) => {
       const attachment = attachmentByContentId.get(contentId);

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -8,8 +8,19 @@ import {
   prepareSanitizedEmailHtml,
   sanitizeEmailHtml,
 } from "@/utils/email/prepare-html.client";
+import type { ParsedMessage } from "@/utils/types";
+import {
+  getInlineImageContentIds,
+  normalizeContentId,
+  rewriteInlineImageSources,
+} from "@/utils/email/inline-images";
+import {
+  fetchAttachment,
+  getAttachmentUrl,
+} from "@/utils/attachments/download";
 
 const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
+const NO_INLINE_ATTACHMENTS: ParsedMessage["inline"] = [];
 /**
  * Reading size for a message body that brought no styling of its own. Shared by
  * both paths: Tailwind classes can't reach inside the iframe, so plain text has
@@ -20,9 +31,13 @@ const BODY_TYPE = { fontSize: "14.5px", lineHeight: 1.65 } as const;
 export function HtmlEmail({
   html,
   messageId,
+  emailAccountId,
+  inlineAttachments = NO_INLINE_ATTACHMENTS,
 }: {
   html: string;
   messageId: string;
+  emailAccountId?: string;
+  inlineAttachments?: ParsedMessage["inline"];
 }) {
   const sanitizedHtml = useMemo(() => sanitizeEmailHtml(html), [html]);
   const [showReplies, setShowReplies] = useState(false);
@@ -37,15 +52,33 @@ export function HtmlEmail({
 
   useEffect(() => {
     let cancelled = false;
+    const objectUrls: string[] = [];
     setRenderHtml(
       getPreparedEmailHtml({ messageId, sourceHtml: sanitizedHtml }) ??
         sanitizedHtml,
     );
 
-    prepareSanitizedEmailHtml({ messageId, sourceHtml: sanitizedHtml }).then(
-      (rewrittenHtml) => {
-        if (cancelled) return;
-        startTransition(() => setRenderHtml(rewrittenHtml));
+    Promise.all([
+      prepareSanitizedEmailHtml({ messageId, sourceHtml: sanitizedHtml }),
+      loadInlineImageSources({
+        emailAccountId,
+        html: sanitizedHtml,
+        inlineAttachments,
+        messageId,
+      }),
+    ]).then(
+      ([rewrittenHtml, inlineImages]) => {
+        const loadedObjectUrls = Object.values(inlineImages);
+        if (cancelled) {
+          for (const objectUrl of loadedObjectUrls) {
+            URL.revokeObjectURL(objectUrl);
+          }
+          return;
+        }
+        objectUrls.push(...loadedObjectUrls);
+        startTransition(() =>
+          setRenderHtml(rewriteInlineImageSources(rewrittenHtml, inlineImages)),
+        );
       },
       () => {
         if (cancelled) return;
@@ -55,8 +88,9 @@ export function HtmlEmail({
 
     return () => {
       cancelled = true;
+      for (const objectUrl of objectUrls) URL.revokeObjectURL(objectUrl);
     };
-  }, [messageId, sanitizedHtml]);
+  }, [emailAccountId, inlineAttachments, messageId, sanitizedHtml]);
 
   const { mainContent, hasReplies } = useMemo(
     () => getEmailContent(renderHtml),
@@ -243,12 +277,15 @@ function getIframeHtml(
     imageProxyBaseUrl && imageProxyOrigin && html.includes(imageProxyBaseUrl)
       ? imageProxyOrigin
       : "https:";
+  const localImageSourceDirective = html.includes("blob:")
+    ? "data: blob:"
+    : "data:";
 
   const securityHeaders = `
     <meta http-equiv="Content-Security-Policy" content="
       default-src 'none';
       style-src 'unsafe-inline';
-      img-src data: ${imageSourceDirective};
+      img-src ${localImageSourceDirective} ${imageSourceDirective};
       font-src 'none';
       media-src 'none';
       connect-src 'none';
@@ -288,6 +325,50 @@ function getIframeHtml(
 
   const htmlWithHead = wrapWithProperStructure(html);
   return addDarkModeClass(htmlWithHead, isDarkMode);
+}
+
+async function loadInlineImageSources({
+  emailAccountId,
+  html,
+  inlineAttachments,
+  messageId,
+}: {
+  emailAccountId?: string;
+  html: string;
+  inlineAttachments: ParsedMessage["inline"];
+  messageId: string;
+}) {
+  if (!emailAccountId || !inlineAttachments.length) return {};
+
+  const attachmentByContentId = new Map(
+    inlineAttachments.flatMap((attachment) => {
+      const contentId = normalizeContentId(attachment.headers["content-id"]);
+      return contentId ? [[contentId, attachment] as const] : [];
+    }),
+  );
+  const entries = await Promise.all(
+    getInlineImageContentIds(html).map(async (contentId) => {
+      const attachment = attachmentByContentId.get(contentId);
+      if (!attachment?.attachmentId) return;
+
+      try {
+        const blob = await fetchAttachment({
+          emailAccountId,
+          url: getAttachmentUrl({
+            messageId,
+            attachmentId: attachment.attachmentId,
+            mimeType: attachment.mimeType,
+            filename: attachment.filename,
+          }),
+        });
+        return [contentId, URL.createObjectURL(blob)] as const;
+      } catch {
+        return;
+      }
+    }),
+  );
+
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined));
 }
 
 function addDarkModeClass(html: string, isDarkMode: boolean) {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -57,6 +57,7 @@ export function EmailMessage({
   onSendSuccess: (messageId: string, threadId: string) => void;
   generateNudge?: boolean;
 }) {
+  const { emailAccountId } = useAccount();
   // `null` follows `defaultShowReply`, which the reader's Reply button flips
   // long after this message mounted.
   const [replyOverride, setReplyOverride] = useState<boolean | null>(null);
@@ -97,7 +98,12 @@ export function EmailMessage({
           {showDetails && <EmailDetails message={message} />}
 
           {message.textHtml ? (
-            <HtmlEmail html={message.textHtml} messageId={message.id} />
+            <HtmlEmail
+              emailAccountId={emailAccountId}
+              html={message.textHtml}
+              inlineAttachments={message.inline}
+              messageId={message.id}
+            />
           ) : (
             <PlainEmail text={message.textPlain || ""} />
           )}

--- a/apps/web/utils/attachments/download.ts
+++ b/apps/web/utils/attachments/download.ts
@@ -1,5 +1,26 @@
 import { fetchWithAccount } from "@/utils/fetch";
 
+export function getAttachmentUrl({
+  messageId,
+  attachmentId,
+  mimeType,
+  filename,
+}: {
+  messageId: string;
+  attachmentId: string;
+  mimeType: string;
+  filename: string;
+}) {
+  const searchParams = new URLSearchParams({
+    messageId,
+    attachmentId,
+    mimeType,
+    filename,
+  });
+
+  return `/api/messages/attachment?${searchParams.toString()}`;
+}
+
 export async function fetchAttachment({
   url,
   emailAccountId,

--- a/apps/web/utils/email/inline-images.test.ts
+++ b/apps/web/utils/email/inline-images.test.ts
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import {
+  getInlineImageContentIds,
+  rewriteInlineImageSources,
+} from "./inline-images";
+
+describe("inline email images", () => {
+  it("finds normalized Content-IDs referenced by image elements", () => {
+    expect(
+      getInlineImageContentIds(
+        '<p><img src="cid:%3Cscreenshot%40inboxzero.local%3E"><a href="cid:ignore-me">Link</a></p>',
+      ),
+    ).toEqual(["screenshot@inboxzero.local"]);
+  });
+
+  it("replaces matching cid image sources without changing unknown references", () => {
+    const html =
+      '<p><img alt="Screenshot" src="cid:screenshot@inboxzero.local"><img src="cid:unknown@example.com"></p>';
+
+    const rewritten = rewriteInlineImageSources(html, {
+      "screenshot@inboxzero.local": "blob:https://app.example.com/image-1",
+    });
+
+    expect(rewritten).toContain('src="blob:https://app.example.com/image-1"');
+    expect(rewritten).toContain('src="cid:unknown@example.com"');
+  });
+});

--- a/apps/web/utils/email/inline-images.ts
+++ b/apps/web/utils/email/inline-images.ts
@@ -1,0 +1,71 @@
+const DOCUMENT_PATTERN = /<!doctype|<html[\s>]|<head[\s>]|<body[\s>]/i;
+
+export function getInlineImageContentIds(html: string): string[] {
+  const document = new DOMParser().parseFromString(html, "text/html");
+  const contentIds = new Set<string>();
+
+  for (const image of document.querySelectorAll("img[src]")) {
+    const contentId = getContentIdFromSource(image.getAttribute("src"));
+    if (contentId) contentIds.add(contentId);
+  }
+
+  return [...contentIds];
+}
+
+export function rewriteInlineImageSources(
+  html: string,
+  sourceByContentId: Record<string, string>,
+): string {
+  const normalizedSources = new Map(
+    Object.entries(sourceByContentId).flatMap(([contentId, source]) => {
+      const normalizedContentId = normalizeContentId(contentId);
+      return normalizedContentId
+        ? ([[normalizedContentId, source]] as const)
+        : [];
+    }),
+  );
+  if (!normalizedSources.size) return html;
+
+  const isDocument = DOCUMENT_PATTERN.test(html);
+  const document = new DOMParser().parseFromString(html, "text/html");
+  let changed = false;
+
+  for (const image of document.querySelectorAll("img[src]")) {
+    const contentId = getContentIdFromSource(image.getAttribute("src"));
+    if (!contentId) continue;
+
+    const source = normalizedSources.get(contentId);
+    if (!source) continue;
+
+    image.setAttribute("src", source);
+    changed = true;
+  }
+
+  if (!changed) return html;
+  return isDocument
+    ? document.documentElement.outerHTML
+    : document.body.innerHTML;
+}
+
+export function normalizeContentId(value: string | null | undefined) {
+  if (!value) return;
+
+  let normalized = value.trim();
+  if (normalized.toLowerCase().startsWith("cid:")) {
+    normalized = normalized.slice(4);
+  }
+
+  try {
+    normalized = decodeURIComponent(normalized);
+  } catch {
+    // Keep the original value when a sender used malformed URL encoding.
+  }
+
+  normalized = normalized.trim().replace(/^<|>$/g, "").trim();
+  return normalized ? normalized.toLowerCase() : undefined;
+}
+
+function getContentIdFromSource(source: string | null) {
+  if (!source?.trim().toLowerCase().startsWith("cid:")) return;
+  return normalizeContentId(source);
+}

--- a/apps/web/utils/email/inline-images.ts
+++ b/apps/web/utils/email/inline-images.ts
@@ -16,14 +16,11 @@ export function rewriteInlineImageSources(
   html: string,
   sourceByContentId: Record<string, string>,
 ): string {
-  const normalizedSources = new Map(
-    Object.entries(sourceByContentId).flatMap(([contentId, source]) => {
-      const normalizedContentId = normalizeContentId(contentId);
-      return normalizedContentId
-        ? ([[normalizedContentId, source]] as const)
-        : [];
-    }),
-  );
+  const normalizedSources = new Map<string, string>();
+  for (const [contentId, source] of Object.entries(sourceByContentId)) {
+    const normalizedContentId = normalizeContentId(contentId);
+    if (normalizedContentId) normalizedSources.set(normalizedContentId, source);
+  }
   if (!normalizedSources.size) return html;
 
   const isDocument = DOCUMENT_PATTERN.test(html);

--- a/apps/web/utils/email/inline-images.ts
+++ b/apps/web/utils/email/inline-images.ts
@@ -1,10 +1,10 @@
 const DOCUMENT_PATTERN = /<!doctype|<html[\s>]|<head[\s>]|<body[\s>]/i;
 
 export function getInlineImageContentIds(html: string): string[] {
-  const document = new DOMParser().parseFromString(html, "text/html");
+  const parsedDocument = new DOMParser().parseFromString(html, "text/html");
   const contentIds = new Set<string>();
 
-  for (const image of document.querySelectorAll("img[src]")) {
+  for (const image of parsedDocument.querySelectorAll("img[src]")) {
     const contentId = getContentIdFromSource(image.getAttribute("src"));
     if (contentId) contentIds.add(contentId);
   }
@@ -27,10 +27,10 @@ export function rewriteInlineImageSources(
   if (!normalizedSources.size) return html;
 
   const isDocument = DOCUMENT_PATTERN.test(html);
-  const document = new DOMParser().parseFromString(html, "text/html");
+  const parsedDocument = new DOMParser().parseFromString(html, "text/html");
   let changed = false;
 
-  for (const image of document.querySelectorAll("img[src]")) {
+  for (const image of parsedDocument.querySelectorAll("img[src]")) {
     const contentId = getContentIdFromSource(image.getAttribute("src"));
     if (!contentId) continue;
 
@@ -43,8 +43,8 @@ export function rewriteInlineImageSources(
 
   if (!changed) return html;
   return isDocument
-    ? document.documentElement.outerHTML
-    : document.body.innerHTML;
+    ? parsedDocument.documentElement.outerHTML
+    : parsedDocument.body.innerHTML;
 }
 
 export function normalizeContentId(value: string | null | undefined) {

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getMessagesBatch,
   hasPreviousCommunicationsWithSenderOrDomain,
+  parseMessage,
 } from "./message";
 import { getBatch } from "@/utils/gmail/batch";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -17,6 +18,48 @@ vi.mock("gmail-api-parse-message", () => ({
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("parseMessage", () => {
+  it("keeps large inline images out of the downloadable attachment list", () => {
+    const inlineImage = {
+      attachmentId: "inline-image",
+      filename: "screenshot.png",
+      headers: {
+        "content-description": "",
+        "content-disposition": "inline; filename=screenshot.png",
+        "content-id": "<screenshot@inboxzero.local>",
+        "content-transfer-encoding": "base64",
+        "content-type": "image/png",
+      },
+      mimeType: "image/png",
+      size: 100_000,
+    };
+    const document = {
+      attachmentId: "document",
+      filename: "report.pdf",
+      headers: {
+        "content-description": "",
+        "content-disposition": "attachment; filename=report.pdf",
+        "content-id": "",
+        "content-transfer-encoding": "base64",
+        "content-type": "application/pdf",
+      },
+      mimeType: "application/pdf",
+      size: 200_000,
+    };
+
+    const message = parseMessage({
+      attachments: [inlineImage, document],
+      headers: { date: "", subject: "" },
+      id: "message-1",
+      inline: [],
+      threadId: "thread-1",
+    } as never);
+
+    expect(message.inline).toEqual([inlineImage]);
+    expect(message.attachments).toEqual([document]);
+  });
 });
 
 describe("getMessagesBatch", () => {

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -35,7 +35,7 @@ describe("parseMessage", () => {
       mimeType: "image/png",
       size: 100_000,
     };
-    const document = {
+    const pdfAttachment = {
       attachmentId: "document",
       filename: "report.pdf",
       headers: {
@@ -50,7 +50,7 @@ describe("parseMessage", () => {
     };
 
     const message = parseMessage({
-      attachments: [inlineImage, document],
+      attachments: [inlineImage, pdfAttachment],
       headers: { date: "", subject: "" },
       id: "message-1",
       inline: [],
@@ -58,7 +58,7 @@ describe("parseMessage", () => {
     } as never);
 
     expect(message.inline).toEqual([inlineImage]);
-    expect(message.attachments).toEqual([document]);
+    expect(message.attachments).toEqual([pdfAttachment]);
   });
 });
 

--- a/apps/web/utils/gmail/message.ts
+++ b/apps/web/utils/gmail/message.ts
@@ -18,10 +18,17 @@ export function parseMessage(
   message: MessageWithPayload,
 ): ParsedMessage & { subject: string; date: string } {
   const parsed = parse(message) as ParsedMessage;
+  const inlineAttachments = parsed.attachments?.filter(isInlineAttachment);
+  const attachments = parsed.attachments?.filter(
+    (attachment) => !isInlineAttachment(attachment),
+  );
+
   return {
     ...parsed,
+    attachments: attachments?.length ? attachments : undefined,
     subject: parsed.headers?.subject || "",
     date: parsed.headers?.date || "",
+    inline: [...(parsed.inline ?? []), ...(inlineAttachments ?? [])],
     // gmail-api-parse-message converts internalDate to a number, but our type expects string
     internalDate:
       parsed.internalDate != null ? String(parsed.internalDate) : null,
@@ -213,6 +220,17 @@ function isMessage(
   message: gmail_v1.Schema$Message,
 ): message is { id: string; threadId: string } {
   return !!message.id && !!message.threadId;
+}
+
+function isInlineAttachment(
+  attachment: NonNullable<ParsedMessage["attachments"]>[number],
+) {
+  return (
+    attachment.headers["content-disposition"]
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase() === "inline"
+  );
 }
 
 export async function queryBatchMessages(


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260826-113654_pr-3396_4047d72d390f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix inline images that appeared as broken CID references immediately after sending.

- normalize large Gmail inline MIME parts so they are not shown as regular downloads
- resolve referenced CID images through authenticated attachment fetches in email readers
- restrict blob image access to messages with resolved inline images and cover the behavior with focused tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline images in HTML emails now load securely and display correctly using their embedded attachments.
  * Email content preserves inline image references while separating them from downloadable attachments.
  * Attachment links now use consistent URL generation.

* **Bug Fixes**
  * Improved handling of Content-ID formatting and matching for inline images.
  * Failed inline image lookups no longer prevent the rest of an email from rendering.

* **Tests**
  * Added coverage for inline image rendering, attachment classification, and Content-ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->