### PR TITLE
test(mail): harden durable outbox browser coverage

### DIFF
--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -1,4 +1,8 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
+import {
+  conversationWithSubject,
+  readLatestMailMutation,
+} from "../mail/mail-test-helpers";
 import {
   CLEANUP_ARCHIVE_THREAD_ID,
   CLEANUP_KEEP_THREAD_ID,
@@ -9,35 +13,163 @@ import {
   restoreCleanupThreads,
 } from "./cleanup-test-helpers";
 
+const ARCHIVE_SENDER = "cleanup-archive@example.com";
+const ARCHIVE_SUBJECT = "Cleanup Category Archive Candidate";
+const KEEP_SUBJECT = "Cleanup Category Keep Candidate";
 let fixture: CleanupFixture | undefined;
 
 test.beforeEach(async ({ page }) => {
   fixture = undefined;
   fixture = await prepareCleanupFixture(page);
-  await restoreCleanupThreads(page, fixture.emailAccountId, [
-    CLEANUP_ARCHIVE_THREAD_ID,
-    CLEANUP_KEEP_THREAD_ID,
-  ]);
+  await restoreFixtureThreads(page, fixture.emailAccountId);
 });
 
-test.afterEach(async () => {
-  if (fixture) await cleanUpFixture(fixture);
+test.afterEach(async ({ page }) => {
+  if (!fixture) return;
+  try {
+    await restoreFixtureThreads(page, fixture.emailAccountId);
+  } finally {
+    await cleanUpFixture(fixture);
+  }
 });
 
-test("archives only selected senders from a category", async ({ page }) => {
+test("rehydrates an interrupted sender archive and completes after reconnect", async ({
+  page,
+}) => {
   test.setTimeout(360_000);
   if (!fixture) throw new Error("Cleanup fixture was not initialized");
   await stubMailboxSync(page, fixture.emailAccountId);
   await openCleanupFeature(page, fixture, "bulk-archive");
-  await expect(page.getByRole("heading", { name: "Bulk Archive" })).toBeVisible(
-    { timeout: 60_000 },
-  );
+  await selectOnlyArchiveSender(page);
 
-  const newsletterCard = page
-    .locator('[role="button"]')
-    .filter({ has: page.getByRole("heading", { name: "Newsletter" }) });
-  await newsletterCard.click();
+  try {
+    await page.route("**/*", blockServerActions);
+    await newsletterCard(page)
+      .getByRole("button", { name: "Archive 1 of 2" })
+      .click();
 
+    await expect
+      .poll(() =>
+        readLatestMailMutation(page, {
+          emailAccountId: fixture?.emailAccountId ?? "",
+          kind: "archive",
+          sender: ARCHIVE_SENDER,
+          threadId: CLEANUP_ARCHIVE_THREAD_ID,
+        }),
+      )
+      .toMatchObject({
+        clientSource: { kind: "sender", sender: ARCHIVE_SENDER },
+        status: "retry_wait",
+      });
+
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Bulk Archive" }),
+    ).toBeVisible({ timeout: 60_000 });
+    await expect(
+      page.getByText("Archiving 1 of 1 senders...", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("0 / 1", { exact: true })).toBeVisible();
+
+    await page.unroute("**/*", blockServerActions);
+    await page.evaluate(() => window.dispatchEvent(new Event("online")));
+    await expect
+      .poll(
+        () =>
+          readLatestMailMutation(page, {
+            emailAccountId: fixture?.emailAccountId ?? "",
+            kind: "archive",
+            sender: ARCHIVE_SENDER,
+            threadId: CLEANUP_ARCHIVE_THREAD_ID,
+          }),
+        { timeout: 60_000 },
+      )
+      .toMatchObject({ status: "succeeded" });
+
+    await assertOnlySelectedSenderWasRemovedFromInbox(page, fixture);
+  } finally {
+    await page.unroute("**/*", blockServerActions);
+  }
+});
+
+test("marks a selected sender read through the durable sender queue", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+  if (!fixture) throw new Error("Cleanup fixture was not initialized");
+  await stubMailboxSync(page, fixture.emailAccountId);
+
+  try {
+    await openCleanupFeature(page, fixture, "bulk-archive");
+    await chooseBulkAction(page, "Mark as read");
+    await selectOnlyArchiveSender(page);
+    await newsletterCard(page)
+      .getByRole("button", { name: "Mark 1 of 2 as read" })
+      .click();
+
+    await expect
+      .poll(
+        () =>
+          readLatestMailMutation(page, {
+            emailAccountId: fixture?.emailAccountId ?? "",
+            kind: "set_read_state",
+            sender: ARCHIVE_SENDER,
+            threadId: CLEANUP_ARCHIVE_THREAD_ID,
+          }),
+        { timeout: 60_000 },
+      )
+      .toMatchObject({ payload: { read: true }, status: "succeeded" });
+    await expect(
+      page.getByText("Marked 1 read!", { exact: true }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        getThreadLabelIds(
+          page,
+          fixture?.emailAccountId ?? "",
+          CLEANUP_ARCHIVE_THREAD_ID,
+        ),
+      )
+      .not.toContain("UNREAD");
+  } finally {
+    await restoreUnreadState(page, fixture);
+  }
+});
+
+test("deletes a selected sender through the durable sender queue", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+  if (!fixture) throw new Error("Cleanup fixture was not initialized");
+  await stubMailboxSync(page, fixture.emailAccountId);
+  await openCleanupFeature(page, fixture, "bulk-archive");
+  await chooseBulkAction(page, "Delete");
+  await selectOnlyArchiveSender(page);
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await newsletterCard(page)
+    .getByRole("button", { name: "Delete 1 of 2" })
+    .click();
+
+  await expect
+    .poll(
+      () =>
+        readLatestMailMutation(page, {
+          emailAccountId: fixture?.emailAccountId ?? "",
+          kind: "trash",
+          sender: ARCHIVE_SENDER,
+          threadId: CLEANUP_ARCHIVE_THREAD_ID,
+        }),
+      { timeout: 60_000 },
+    )
+    .toMatchObject({ status: "succeeded" });
+  await expect(page.getByText("Deleted 1!", { exact: true })).toBeVisible();
+  await assertOnlySelectedSenderWasRemovedFromInbox(page, fixture);
+});
+
+async function selectOnlyArchiveSender(page: Page) {
+  const card = newsletterCard(page);
+  await card.click();
   await expect(
     page.getByText("2 of 2 selected", { exact: true }),
   ).toBeVisible();
@@ -45,24 +177,120 @@ test("archives only selected senders from a category", async ({ page }) => {
   await expect(
     page.getByText("1 of 2 selected", { exact: true }),
   ).toBeVisible();
+}
 
-  await newsletterCard.getByRole("button", { name: "Archive 1 of 2" }).click();
-  await expect(page.getByText("Archived 1!", { exact: true })).toBeVisible({
-    timeout: 120_000,
+async function chooseBulkAction(page: Page, action: "Delete" | "Mark as read") {
+  await page.getByRole("button", { name: "Settings" }).click();
+  const settings = page.getByRole("dialog", {
+    name: "Bulk Archive Settings",
   });
+  await settings.getByRole("combobox").click();
+  await page.getByRole("option", { name: action }).click();
+  await settings.getByRole("button", { name: "Close" }).click();
+}
 
-  await openCleanupFeature(page, fixture, "mail");
+async function assertOnlySelectedSenderWasRemovedFromInbox(
+  page: Page,
+  cleanupFixture: CleanupFixture,
+) {
+  await openCleanupFeature(page, cleanupFixture, "mail");
   const conversations = page.getByRole("listbox", { name: "Conversations" });
   await expect(conversations).toBeVisible({ timeout: 120_000 });
   await expect(
-    conversations.getByText("Cleanup Category Archive Candidate", {
-      exact: true,
-    }),
+    conversationWithSubject(page, conversations, ARCHIVE_SUBJECT),
   ).toHaveCount(0);
   await expect(
-    conversations.getByText("Cleanup Category Keep Candidate", { exact: true }),
+    conversationWithSubject(page, conversations, KEEP_SUBJECT),
   ).toBeVisible();
-});
+}
+
+async function restoreUnreadState(page: Page, cleanupFixture: CleanupFixture) {
+  await openCleanupFeature(page, cleanupFixture, "mail");
+  const conversations = page.getByRole("listbox", { name: "Conversations" });
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    ARCHIVE_SUBJECT,
+  );
+  await expect(conversation).toBeVisible();
+  await conversation.click();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  const markUnread = page.getByRole("menuitem", { name: "Mark as unread" });
+  const markRead = page.getByRole("menuitem", { name: "Mark as read" });
+  await expect(markUnread.or(markRead)).toBeVisible();
+  if (await markUnread.isVisible()) {
+    await markUnread.click();
+    await expect
+      .poll(() =>
+        getThreadLabelIds(
+          page,
+          cleanupFixture.emailAccountId,
+          CLEANUP_ARCHIVE_THREAD_ID,
+        ),
+      )
+      .toContain("UNREAD");
+  } else {
+    await page.keyboard.press("Escape");
+  }
+}
+
+async function getThreadLabelIds(
+  page: Page,
+  emailAccountId: string,
+  threadId: string,
+) {
+  const response = await page.request.get(`/api/threads/${threadId}`, {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  if (!response.ok()) {
+    throw new Error(`Thread request failed with ${response.status()}`);
+  }
+  const result = (await response.json()) as {
+    thread: { messages: { labelIds?: string[] }[] };
+  };
+  return Array.from(
+    new Set(
+      result.thread.messages.flatMap((message) => message.labelIds ?? []),
+    ),
+  );
+}
+
+function newsletterCard(page: Page) {
+  return page
+    .locator('[role="button"]')
+    .filter({ has: page.getByRole("heading", { name: "Newsletter" }) });
+}
+
+function blockServerActions(route: Route) {
+  const request = route.request();
+  if (request.method() === "POST" && request.headers()["next-action"]) {
+    return route.abort("connectionfailed");
+  }
+  return route.fallback();
+}
+
+async function restoreFixtureThreads(page: Page, emailAccountId: string) {
+  const threadIds = [CLEANUP_ARCHIVE_THREAD_ID, CLEANUP_KEEP_THREAD_ID];
+  for (const threadId of threadIds) {
+    await expect
+      .poll(
+        async () => {
+          try {
+            const response = await page.request.post(
+              `/api/threads/${threadId}/untrash`,
+              { headers: { "X-Email-Account-ID": emailAccountId } },
+            );
+            return response.ok();
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 120_000 },
+      )
+      .toBe(true);
+  }
+  await restoreCleanupThreads(page, emailAccountId, threadIds);
+}
 
 function stubMailboxSync(page: Page, emailAccountId: string) {
   return page.route("**/api/mobile/mailbox-sync", (route) =>

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -9,8 +9,12 @@ import {
 } from "@playwright/test";
 import { Client } from "pg";
 import { getEmailAccountId } from "../account-test-helpers";
+import { readLatestMailMutation } from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
+const SIDE_PANEL_ARCHIVE_MESSAGE_ID = "msg_playwright_archive";
+const SIDE_PANEL_ARCHIVE_SUBJECT = "Archive Action Message";
+const SIDE_PANEL_ARCHIVE_THREAD_ID = "thr_playwright_archive";
 const SEEDED_THREAD_IDS = [
   "thr_playwright_1",
   "thr_playwright_2",
@@ -20,9 +24,62 @@ let emailAccountIdForCleanup: string | undefined;
 
 test.afterEach(async ({ request }) => {
   if (emailAccountIdForCleanup) {
-    await restoreActiveSnoozes(request, emailAccountIdForCleanup);
+    const emailAccountId = emailAccountIdForCleanup;
     emailAccountIdForCleanup = undefined;
+    try {
+      await restoreActiveSnoozes(request, emailAccountId);
+    } finally {
+      await request.post(
+        `/api/threads/${SIDE_PANEL_ARCHIVE_THREAD_ID}/unarchive`,
+        { headers: { "X-Email-Account-ID": emailAccountId } },
+      );
+    }
   }
+});
+
+test("Command K archives the open side-panel conversation through the durable outbox", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  emailAccountIdForCleanup = emailAccountId;
+  await stubMailboxSync(page, emailAccountId);
+  await page.request.post(
+    `/api/threads/${SIDE_PANEL_ARCHIVE_THREAD_ID}/unarchive`,
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+
+  await page.goto(
+    `/${emailAccountId}/mail?side-panel-thread-id=${SIDE_PANEL_ARCHIVE_THREAD_ID}`,
+  );
+  const sidePanel = page
+    .getByRole("dialog")
+    .filter({ hasText: SIDE_PANEL_ARCHIVE_SUBJECT });
+  await expect(sidePanel).toBeVisible({ timeout: 60_000 });
+  const archivedConversation = page
+    .locator('[role="listbox"][aria-label="Conversations"] [role="option"]')
+    .filter({ hasText: SIDE_PANEL_ARCHIVE_SUBJECT });
+  await expect(archivedConversation).toHaveCount(1, { timeout: 60_000 });
+  await page.keyboard.press(`${commandModifier}+KeyK`);
+  const archiveCommand = page.getByRole("option", {
+    exact: true,
+    name: "Archive E",
+  });
+  await expect(archiveCommand).toBeVisible();
+  await archiveCommand.click();
+
+  await expect(sidePanel).toBeHidden();
+  await expect
+    .poll(
+      () =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "archive",
+          threadId: SIDE_PANEL_ARCHIVE_THREAD_ID,
+        }),
+      { timeout: 60_000 },
+    )
+    .toMatchObject({ status: "succeeded" });
+  await expect(archivedConversation).toHaveCount(0);
 });
 
 test("Command K acts on highlighted and selected conversations", async ({
@@ -232,6 +289,48 @@ async function attachScreenshotForChangedTest(
   await testInfo.attach(name, {
     contentType: "image/png",
     path: screenshotPath,
+  });
+}
+
+function stubMailboxSync(page: Page, emailAccountId: string) {
+  let seededArchiveMessage = false;
+  return page.route("**/api/mobile/mailbox-sync", (route) => {
+    const internalDate = new Date().toISOString();
+    const upsertedMessages = seededArchiveMessage
+      ? []
+      : [
+          {
+            date: internalDate,
+            headers: {
+              date: internalDate,
+              from: "Erin Example <erin@example.com>",
+              subject: SIDE_PANEL_ARCHIVE_SUBJECT,
+              to: "playwright-test@gmail.com",
+            },
+            historyId: "playwright-command-palette-history",
+            id: SIDE_PANEL_ARCHIVE_MESSAGE_ID,
+            inline: [],
+            internalDate,
+            labelIds: ["INBOX"],
+            snippet:
+              "This conversation is reserved for archive and undo coverage.",
+            subject: SIDE_PANEL_ARCHIVE_SUBJECT,
+            threadId: SIDE_PANEL_ARCHIVE_THREAD_ID,
+          },
+        ];
+    seededArchiveMessage = true;
+    return route.fulfill({
+      body: JSON.stringify({
+        accountId: emailAccountId,
+        cursor: "playwright-command-palette-sync",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: false,
+        upsertedMessages,
+      }),
+      contentType: "application/json",
+      status: 200,
+    });
   });
 }
 

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -20,3 +20,105 @@ export function conversationWithSubject(
     .getByRole("option")
     .filter({ has: page.getByText(subject, { exact: true }) });
 }
+
+export async function readLatestMailMutation(
+  page: Page,
+  expected: {
+    emailAccountId: string;
+    kind: string;
+    sender?: string;
+    threadId?: string;
+  },
+) {
+  try {
+    return await page.evaluate(
+      async (match) =>
+        await new Promise<Record<string, unknown> | undefined>(
+          (resolve, reject) => {
+            const openRequest = indexedDB.open("inbox-zero-email-cache");
+            openRequest.onerror = () => reject(openRequest.error);
+            openRequest.onsuccess = () => {
+              const database = openRequest.result;
+              if (!database.objectStoreNames.contains("mailMutations")) {
+                database.close();
+                resolve(undefined);
+                return;
+              }
+              const transaction = database.transaction(
+                "mailMutations",
+                "readonly",
+              );
+              transaction.onerror = () => reject(transaction.error);
+              const request = transaction.objectStore("mailMutations").getAll();
+              request.onerror = () => reject(request.error);
+              request.onsuccess = () => {
+                database.close();
+                resolve(
+                  request.result
+                    .filter(
+                      (mutation) =>
+                        mutation.emailAccountId === match.emailAccountId &&
+                        mutation.kind === match.kind &&
+                        (!match.threadId ||
+                          mutation.threadId === match.threadId) &&
+                        (!match.sender ||
+                          mutation.clientSource?.sender === match.sender),
+                    )
+                    .sort((left, right) => right.createdAt - left.createdAt)[0],
+                );
+              };
+            };
+          },
+        ),
+      expected,
+    );
+  } catch (error) {
+    if (String(error).includes("Execution context was destroyed")) return;
+    throw error;
+  }
+}
+
+export function clearMailMutations(
+  page: Page,
+  expected: { emailAccountId: string; threadId?: string },
+) {
+  return page.evaluate(
+    async (match) =>
+      await new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          if (!database.objectStoreNames.contains("mailMutations")) {
+            database.close();
+            resolve();
+            return;
+          }
+          const transaction = database.transaction(
+            "mailMutations",
+            "readwrite",
+          );
+          transaction.onerror = () => reject(transaction.error);
+          transaction.oncomplete = () => {
+            database.close();
+            resolve();
+          };
+          const request = transaction.objectStore("mailMutations").openCursor();
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) return;
+            const mutation = cursor.value;
+            if (
+              mutation.emailAccountId === match.emailAccountId &&
+              (!match.threadId || mutation.threadId === match.threadId)
+            ) {
+              cursor.delete();
+            }
+            cursor.continue();
+          };
+        };
+      }),
+    expected,
+  );
+}

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -295,6 +295,17 @@ function seedAccountIsolationMailbox(
         openRequest.onerror = () => reject(openRequest.error);
         openRequest.onsuccess = () => {
           const database = openRequest.result;
+          const requiredStores = ["mailboxMessages", "mailboxSyncStates"];
+          const missingStores = requiredStores.filter(
+            (store) => !database.objectStoreNames.contains(store),
+          );
+          if (missingStores.length) {
+            database.close();
+            reject(
+              new Error(`Missing object stores: ${missingStores.join(", ")}`),
+            );
+            return;
+          }
           const transaction = database.transaction(
             ["mailboxMessages", "mailboxSyncStates"],
             "readwrite",

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -1,10 +1,22 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import {
+  createSecondEmailAccount,
+  deleteSecondEmailAccount,
+} from "./account-test-helpers";
+import {
+  clearMailMutations,
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 const ARCHIVE_SUBJECT = "Archive Action Message";
 const ARCHIVE_THREAD_ID = "thr_playwright_archive";
 const REPLY_SUBJECT = "Reply Workflow Message";
 const REPLY_THREAD_ID = "thr_playwright_reply";
+const ISOLATED_THREAD_ID = "playwright-account-isolation-thread";
+const PRIMARY_ISOLATION_SUBJECT = "Primary durable mutation control";
+const SECONDARY_ISOLATION_SUBJECT = "Secondary durable mutation target";
 
 test("keeps a queued archive hidden across reload and replays it after reconnect", async ({
   page,
@@ -34,7 +46,7 @@ test("keeps a queued archive hidden across reload and replays it after reconnect
     await expect(conversation).toHaveCount(0);
     await expect
       .poll(() =>
-        readMailMutation(page, {
+        readLatestMailMutation(page, {
           emailAccountId,
           kind: "archive",
           threadId: ARCHIVE_THREAD_ID,
@@ -60,7 +72,7 @@ test("keeps a queued archive hidden across reload and replays it after reconnect
     await expect
       .poll(
         () =>
-          readMailMutation(page, {
+          readLatestMailMutation(page, {
             emailAccountId,
             kind: "archive",
             threadId: ARCHIVE_THREAD_ID,
@@ -109,7 +121,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     ).toBeVisible();
     await expect
       .poll(() =>
-        readMailMutation(page, {
+        readLatestMailMutation(page, {
           emailAccountId,
           kind: "reply",
           threadId: REPLY_THREAD_ID,
@@ -124,7 +136,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     await page.waitForLoadState("networkidle");
     await expect
       .poll(() =>
-        readMailMutation(page, {
+        readLatestMailMutation(page, {
           emailAccountId,
           kind: "reply",
           threadId: REPLY_THREAD_ID,
@@ -136,7 +148,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
       contentType: "image/png",
     });
 
-    const queuedReply = await readMailMutation(page, {
+    const queuedReply = await readLatestMailMutation(page, {
       emailAccountId,
       kind: "reply",
       threadId: REPLY_THREAD_ID,
@@ -160,7 +172,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     ).toBeVisible();
     await expect
       .poll(() =>
-        readMailMutation(page, {
+        readLatestMailMutation(page, {
           emailAccountId,
           kind: "reply",
           threadId: REPLY_THREAD_ID,
@@ -173,7 +185,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     await expect
       .poll(
         () =>
-          readMailMutation(page, {
+          readLatestMailMutation(page, {
             emailAccountId,
             kind: "reply",
             threadId: REPLY_THREAD_ID,
@@ -192,55 +204,166 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
   }
 });
 
-async function readMailMutation(
-  page: Page,
-  expected: { emailAccountId: string; kind: string; threadId: string },
-) {
+test("keeps a unified-mailbox mutation isolated to its owning account", async ({
+  page,
+}) => {
+  const { emailAccountId } = await openMail(page);
+  const secondAccount = await createSecondEmailAccount(emailAccountId);
+
   try {
-    return await page.evaluate(
-      async (match) =>
-        await new Promise<Record<string, unknown> | undefined>(
-          (resolve, reject) => {
-            const openRequest = indexedDB.open("inbox-zero-email-cache");
-            openRequest.onerror = () => reject(openRequest.error);
-            openRequest.onsuccess = () => {
-              const database = openRequest.result;
-              if (!database.objectStoreNames.contains("mailMutations")) {
-                database.close();
-                resolve(undefined);
-                return;
-              }
-              const transaction = database.transaction(
-                "mailMutations",
-                "readonly",
-              );
-              transaction.onerror = () => reject(transaction.error);
-              const request = transaction.objectStore("mailMutations").getAll();
-              request.onerror = () => reject(request.error);
-              request.onsuccess = () => {
-                database.close();
-                resolve(
-                  request.result
-                    .filter(
-                      (mutation) =>
-                        mutation.emailAccountId === match.emailAccountId &&
-                        mutation.kind === match.kind &&
-                        mutation.threadId === match.threadId,
-                    )
-                    .sort((left, right) => right.createdAt - left.createdAt)[0],
-                );
-              };
-            };
-          },
-        ),
-      expected,
+    await page.route("**/api/threads/all?**", (route) =>
+      route.abort("connectionfailed"),
     );
-  } catch (error) {
-    if (String(error).includes("Execution context was destroyed")) {
-      return;
+    await page.route("**/api/mobile/mailbox-sync", (route) =>
+      route.abort("connectionfailed"),
+    );
+    await page.route("**/*", blockServerActions);
+    await seedAccountIsolationMailbox(page, emailAccountId, secondAccount.id);
+
+    await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    const conversations = page.getByRole("listbox", {
+      name: "Conversations",
+    });
+    const primaryConversation = conversationWithSubject(
+      page,
+      conversations,
+      PRIMARY_ISOLATION_SUBJECT,
+    );
+    const secondaryConversation = conversationWithSubject(
+      page,
+      conversations,
+      SECONDARY_ISOLATION_SUBJECT,
+    );
+    await expect(primaryConversation).toBeVisible();
+    await expect(secondaryConversation).toBeVisible();
+
+    await secondaryConversation.getByRole("checkbox").click();
+    await page.getByRole("button", { name: /^Archive E$/ }).click();
+    await expect(secondaryConversation).toHaveCount(0);
+    await expect(primaryConversation).toBeVisible();
+    await expect
+      .poll(() =>
+        readLatestMailMutation(page, {
+          emailAccountId: secondAccount.id,
+          kind: "archive",
+          threadId: ISOLATED_THREAD_ID,
+        }),
+      )
+      .toMatchObject({ status: "retry_wait" });
+    await expect
+      .poll(() =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "archive",
+          threadId: ISOLATED_THREAD_ID,
+        }),
+      )
+      .toBeUndefined();
+
+    await page.reload();
+    await expect(primaryConversation).toBeVisible();
+    await expect(secondaryConversation).toHaveCount(0);
+  } finally {
+    try {
+      await clearMailMutations(page, {
+        emailAccountId: secondAccount.id,
+        threadId: ISOLATED_THREAD_ID,
+      });
+    } finally {
+      await deleteSecondEmailAccount(secondAccount.accountId);
     }
-    throw error;
   }
+});
+
+function blockServerActions(route: Route) {
+  const request = route.request();
+  if (request.method() === "POST" && request.headers()["next-action"]) {
+    return route.abort("connectionfailed");
+  }
+  return route.fallback();
+}
+
+function seedAccountIsolationMailbox(
+  page: Page,
+  primaryAccountId: string,
+  secondaryAccountId: string,
+) {
+  return page.evaluate(
+    async ({ primaryAccountId, secondaryAccountId, threadId, subjects }) =>
+      await new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open("inbox-zero-email-cache");
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction(
+            ["mailboxMessages", "mailboxSyncStates"],
+            "readwrite",
+          );
+          transaction.onerror = () => reject(transaction.error);
+          transaction.oncomplete = () => {
+            database.close();
+            resolve();
+          };
+
+          const now = Date.now();
+          const messages = transaction.objectStore("mailboxMessages");
+          const states = transaction.objectStore("mailboxSyncStates");
+          for (const [index, account] of [
+            {
+              emailAccountId: primaryAccountId,
+              subject: subjects.primary,
+            },
+            {
+              emailAccountId: secondaryAccountId,
+              subject: subjects.secondary,
+            },
+          ].entries()) {
+            const receivedAt = now - index * 1000;
+            const internalDate = new Date(receivedAt).toISOString();
+            const messageId = `${account.emailAccountId}-isolation-message`;
+            messages.put({
+              data: {
+                date: internalDate,
+                headers: {
+                  date: internalDate,
+                  from: "Unified Sender <unified@example.com>",
+                  subject: account.subject,
+                  to: "playwright-test@gmail.com",
+                },
+                id: messageId,
+                internalDate,
+                labelIds: ["INBOX"],
+                snippet: `${account.subject} snippet`,
+                subject: account.subject,
+                threadId,
+              },
+              emailAccountId: account.emailAccountId,
+              lastAccessedAt: now,
+              messageId,
+              receivedAt,
+              threadId,
+            });
+            states.put({
+              after: new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString(),
+              completedAt: now,
+              cursor: `${account.emailAccountId}-isolation-cursor`,
+              emailAccountId: account.emailAccountId,
+              hasMore: false,
+              lastSyncedAt: now,
+            });
+          }
+        };
+      }),
+    {
+      primaryAccountId,
+      secondaryAccountId,
+      subjects: {
+        primary: PRIMARY_ISOLATION_SUBJECT,
+        secondary: SECONDARY_ISOLATION_SUBJECT,
+      },
+      threadId: ISOLATED_THREAD_ID,
+    },
+  );
 }
 
 function setNavigatorOnline(page: Page, online: boolean) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -36,7 +36,7 @@ import { createSearchParams } from "@/utils/url";
 import { isThreadUnread } from "./read-state";
 import {
   applyMailMutationOverlayToThreads,
-  useMailMutationOverlay,
+  useRetainedMailMutationOverlay,
 } from "@/hooks/useMailMutationOverlay";
 
 type RemovedThread = {
@@ -84,11 +84,6 @@ export function useMailThreads({
 }) {
   const viewKey = useMemo(() => createThreadListCacheKey(query), [query]);
   const viewIdentity = `${emailAccountId}:${viewKey}`;
-  const { isReady: mutationOverlayReady, mutations: mailMutations } =
-    useMailMutationOverlay({
-      emailAccountIds: [emailAccountId],
-      enabled,
-    });
   const getKey = useCallback(
     (pageIndex: number, previousPageData: ThreadsListResponse | null) => {
       if (!enabled) return null;
@@ -115,6 +110,13 @@ export function useMailThreads({
       keepPreviousData: false,
       revalidateOnFocus: false,
       revalidateFirstPage: false,
+    });
+  const reconcileMailMutations = useCallback(() => mutate(), [mutate]);
+  const { isReady: mutationOverlayReady, mutations: mailMutations } =
+    useRetainedMailMutationOverlay({
+      emailAccountId,
+      enabled,
+      onReconcile: reconcileMailMutations,
     });
   const [persistent, setPersistent] = useState<PersistentView>();
   const [synced, setSynced] = useState<SyncedView>();

--- a/apps/web/hooks/useMailMutationOverlay.hook.test.tsx
+++ b/apps/web/hooks/useMailMutationOverlay.hook.test.tsx
@@ -8,7 +8,7 @@ import { useRetainedMailMutationOverlay } from "./useMailMutationOverlay";
 const outbox = vi.hoisted(() => ({
   active: [] as MailMutation[],
   activeError: false,
-  listener: undefined as (() => void) | undefined,
+  listener: undefined as ((mutations?: MailMutation[]) => void) | undefined,
   stored: new Map<string, MailMutation>(),
 }));
 
@@ -30,10 +30,12 @@ vi.mock("@/utils/email-cache/mail-mutations", async (importOriginal) => {
         return mutation ? [mutation] : [];
       }),
     ),
-    subscribeToMailMutations: vi.fn((listener: () => void) => {
-      outbox.listener = listener;
-      return vi.fn();
-    }),
+    subscribeToMailMutations: vi.fn(
+      (listener: (mutations?: MailMutation[]) => void) => {
+        outbox.listener = listener;
+        return vi.fn();
+      },
+    ),
   };
 });
 
@@ -154,6 +156,28 @@ describe("useRetainedMailMutationOverlay", () => {
     act(() => result.current.retainMutations([succeeded]));
 
     await waitFor(() => expect(onReconcile).toHaveBeenCalledOnce());
+    await waitFor(() => expect(result.current.mutations).toEqual([]));
+  });
+
+  it("retains an enqueued mutation announced before active loading", async () => {
+    const mutation = archiveMutation("account-1");
+    outbox.stored.set(mutation.id, { ...mutation, status: "succeeded" });
+    const reconciliation = Promise.withResolvers<void>();
+    const onReconcile = vi.fn(() => reconciliation.promise);
+    const { result } = renderHook(() =>
+      useRetainedMailMutationOverlay({
+        emailAccountId: "account-1",
+        onReconcile,
+      }),
+    );
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    act(() => outbox.listener?.([mutation]));
+
+    await waitFor(() => expect(onReconcile).toHaveBeenCalledOnce());
+    expect(result.current.mutations).toEqual([mutation]);
+
+    reconciliation.resolve();
     await waitFor(() => expect(result.current.mutations).toEqual([]));
   });
 

--- a/apps/web/hooks/useMailMutationOverlay.hook.test.tsx
+++ b/apps/web/hooks/useMailMutationOverlay.hook.test.tsx
@@ -138,6 +138,26 @@ describe("useRetainedMailMutationOverlay", () => {
     expect(result.current.mutations).toEqual([]);
   });
 
+  it("clears retained mutations while the overlay is disabled", async () => {
+    const mutation = archiveMutation("account-1");
+    outbox.active = [mutation];
+    const reconciliation = Promise.withResolvers<void>();
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useRetainedMailMutationOverlay({
+          emailAccountId: "account-1",
+          enabled,
+          onReconcile: () => reconciliation.promise,
+        }),
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.mutations).toEqual([mutation]));
+
+    rerender({ enabled: false });
+
+    expect(result.current.mutations).toEqual([]);
+  });
+
   it("revalidates an injected mutation that completed before active loading", async () => {
     const succeeded = {
       ...archiveMutation("account-1"),

--- a/apps/web/hooks/useMailMutationOverlay.ts
+++ b/apps/web/hooks/useMailMutationOverlay.ts
@@ -145,12 +145,23 @@ export function useRetainedMailMutationOverlay({
       reconciliationState.current = createReconciliationState(emailAccountId);
     }
     const state = reconciliationState.current;
-    state.stopped = false;
+    state.stopped = !enabled;
     return () => {
       state.stopped = true;
       if (state.retryTimer) clearTimeout(state.retryTimer);
     };
-  }, [emailAccountId]);
+  }, [emailAccountId, enabled]);
+
+  useEffect(() => {
+    if (enabled) return;
+    previous.current = undefined;
+    const state = reconciliationState.current;
+    state.pendingIds.clear();
+    state.retryAttempts = 0;
+    if (state.retryTimer) clearTimeout(state.retryTimer);
+    state.retryTimer = undefined;
+    setRetained(undefined);
+  }, [enabled]);
 
   const runReconciliation = useCallback(() => {
     const state = reconciliationState.current;
@@ -294,10 +305,13 @@ export function useRetainedMailMutationOverlay({
     reconcileCompleted,
   ]);
 
-  const mutations =
-    retained?.identity === emailAccountId
-      ? mergeMutations(retained.mutations, active.mutations)
-      : active.mutations;
+  let mutations: MailMutation[] = [];
+  if (enabled) {
+    mutations =
+      retained?.identity === emailAccountId
+        ? mergeMutations(retained.mutations, active.mutations)
+        : active.mutations;
+  }
 
   return {
     isReady: active.isReady,

--- a/apps/web/hooks/useMailMutationOverlay.ts
+++ b/apps/web/hooks/useMailMutationOverlay.ts
@@ -34,9 +34,11 @@ const MAX_RECONCILIATION_RETRY_MS = 30_000;
 export function useMailMutationOverlay({
   emailAccountIds,
   enabled,
+  onMutationsEnqueued,
 }: {
   emailAccountIds: string[];
   enabled: boolean;
+  onMutationsEnqueued?: (mutations: MailMutation[]) => void;
 }) {
   const accountIdentity = useMemo(
     () => [...new Set(emailAccountIds)].sort().join("\u0000"),
@@ -44,6 +46,11 @@ export function useMailMutationOverlay({
   );
   const identity = enabled ? accountIdentity || "*" : "disabled";
   const [snapshot, setSnapshot] = useState<MutationSnapshot>();
+  const onMutationsEnqueuedRef = useRef(onMutationsEnqueued);
+
+  useEffect(() => {
+    onMutationsEnqueuedRef.current = onMutationsEnqueued;
+  }, [onMutationsEnqueued]);
 
   useEffect(() => {
     if (!enabled) {
@@ -76,7 +83,16 @@ export function useMailMutationOverlay({
           setSnapshot({ identity, mutations: [], readable: false });
         });
     };
-    const unsubscribe = subscribeToMailMutations(load);
+    const unsubscribe = subscribeToMailMutations((mutations) => {
+      const matchingMutations = mutations?.filter(
+        (mutation) =>
+          !accountIds.size || accountIds.has(mutation.emailAccountId),
+      );
+      if (matchingMutations?.length) {
+        onMutationsEnqueuedRef.current?.(matchingMutations);
+      }
+      load();
+    });
     load();
 
     return () => {
@@ -94,14 +110,20 @@ export function useMailMutationOverlay({
 
 export function useRetainedMailMutationOverlay({
   emailAccountId,
+  enabled = Boolean(emailAccountId),
   onReconcile,
 }: {
   emailAccountId: string;
+  enabled?: boolean;
   onReconcile: () => unknown;
 }) {
+  const retainMutationsRef = useRef<(mutations: MailMutation[]) => void>(
+    () => {},
+  );
   const active = useMailMutationOverlay({
     emailAccountIds: [emailAccountId],
-    enabled: Boolean(emailAccountId),
+    enabled,
+    onMutationsEnqueued: (mutations) => retainMutationsRef.current(mutations),
   });
   const onReconcileRef = useRef(onReconcile);
   const previous = useRef<MutationSnapshot | undefined>(undefined);
@@ -233,6 +255,9 @@ export function useRetainedMailMutationOverlay({
     },
     [emailAccountId, reconcileCompleted],
   );
+  useEffect(() => {
+    retainMutationsRef.current = retainMutations;
+  }, [retainMutations]);
 
   useEffect(() => {
     if (!active.isReady || !active.isReadable) return;

--- a/apps/web/utils/email-cache/mail-mutation-settlement.test.ts
+++ b/apps/web/utils/email-cache/mail-mutation-settlement.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
 import "fake-indexeddb/auto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
+import { subscribeToMailboxStore } from "./mailbox";
 import { settleMailMutationInCache } from "./mail-mutation-settlement";
 import type { MailMutation } from "./mail-mutations";
 
@@ -104,6 +105,18 @@ describe("mail mutation cache settlement", () => {
     ).resolves.toMatchObject({
       data: { messages: [{ id: "old", labelIds: ["INBOX"] }] },
     });
+  });
+
+  it("notifies the live mailbox after settling cached state", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToMailboxStore(listener);
+
+    try {
+      await settleMailMutationInCache(mutation("old"));
+      expect(listener).toHaveBeenCalledExactlyOnceWith("account-1");
+    } finally {
+      unsubscribe();
+    }
   });
 });
 

--- a/apps/web/utils/email-cache/mail-mutation-settlement.ts
+++ b/apps/web/utils/email-cache/mail-mutation-settlement.ts
@@ -1,5 +1,6 @@
 import type { ParsedMessage } from "@/utils/types";
 import { getEmailCacheDatabase } from "./database";
+import { notifyMailboxStoreChange } from "./mailbox";
 import { updateMessageReadState } from "./mail-mutation-overlay";
 import type { MailMutation } from "./mail-mutations";
 
@@ -83,6 +84,7 @@ export async function settleMailMutationInCache(mutation: MailMutation) {
     viewCursor = await viewCursor.continue();
   }
   await transaction.done;
+  notifyMailboxStoreChange(mutation.emailAccountId);
 }
 
 function updateRowData(data: unknown, mutation: MailMutation): unknown {

--- a/apps/web/utils/email-cache/mail-mutations.test.ts
+++ b/apps/web/utils/email-cache/mail-mutations.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import "fake-indexeddb/auto";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
 import {
   cancelPendingMailMutation,
@@ -27,6 +27,7 @@ import {
   renewMailMutationLease,
   renewMailMutationSyncGroupLease,
   resumeBlockedMailMutations,
+  subscribeToMailMutations,
 } from "./mail-mutations";
 
 describe("mail mutation outbox", () => {
@@ -85,6 +86,25 @@ describe("mail mutation outbox", () => {
     ]);
     expect(mutations[0]?.batchId).toBe(mutations[1]?.batchId);
     await expect(getActiveMailMutations()).resolves.toHaveLength(2);
+  });
+
+  it("announces newly persisted mutations to live overlays", async () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToMailMutations(listener);
+
+    try {
+      const mutation = await enqueueMailMutation({
+        id: "announced",
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        messageIds: ["message-1"],
+        kind: "archive",
+      });
+
+      expect(listener).toHaveBeenCalledWith([mutation]);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("persists client sender metadata on every mutation in a batch", async () => {

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -51,13 +51,22 @@ const PROVIDER_ACTIVE_STATUSES = new Set<StoredMailMutation["status"]>(
   PROVIDER_ACTIVE_STATUS_VALUES,
 );
 
-const listeners = new Set<() => void>();
+const listeners = new Set<(mutations?: MailMutation[]) => void>();
 const channel =
   typeof window === "undefined" || typeof BroadcastChannel === "undefined"
     ? null
     : new BroadcastChannel("inbox-zero-mail-mutations");
 
-channel?.addEventListener("message", () => notifyListeners());
+channel?.addEventListener("message", (event: MessageEvent<unknown>) => {
+  const mutationIds = getMutationChangeIds(event.data);
+  if (!mutationIds?.length) {
+    notifyListeners();
+    return;
+  }
+  getMailMutations(mutationIds)
+    .then((mutations) => notifyListeners(mutations))
+    .catch(() => notifyListeners());
+});
 
 export function isActiveMailMutationStatus(
   status: StoredMailMutation["status"],
@@ -109,8 +118,9 @@ export async function enqueueMailMutationBatch(
     await transaction.done.catch(() => {});
     throw error;
   }
-  notifyMailMutationChange();
-  return storedMutations.map(toMailMutation);
+  const mutations = storedMutations.map(toMailMutation);
+  notifyMailMutationChange(mutations);
+  return mutations;
 }
 
 export async function getActiveMailMutations(
@@ -583,7 +593,9 @@ export async function cancelPendingMailMutation(id: string) {
   return cancelled;
 }
 
-export function subscribeToMailMutations(listener: () => void) {
+export function subscribeToMailMutations(
+  listener: (mutations?: MailMutation[]) => void,
+) {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }
@@ -783,13 +795,27 @@ function readActiveStoredMutations(index: {
   ).then((mutations) => mutations.flat());
 }
 
-function notifyMailMutationChange() {
-  notifyListeners();
-  channel?.postMessage(null);
+function notifyMailMutationChange(mutations?: MailMutation[]) {
+  notifyListeners(mutations);
+  channel?.postMessage(
+    mutations?.length
+      ? { mutationIds: mutations.map((mutation) => mutation.id) }
+      : null,
+  );
 }
 
-function notifyListeners() {
-  for (const listener of listeners) listener();
+function notifyListeners(mutations?: MailMutation[]) {
+  for (const listener of listeners) listener(mutations);
+}
+
+function getMutationChangeIds(value: unknown) {
+  if (!value || typeof value !== "object" || !("mutationIds" in value)) {
+    return;
+  }
+  const { mutationIds } = value;
+  return Array.isArray(mutationIds)
+    ? mutationIds.filter((id): id is string => typeof id === "string")
+    : undefined;
 }
 
 type MailMutationWriteStore = {

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -94,7 +94,7 @@ export async function applyMailboxSyncPage({
 
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
   scheduleEmailCacheCleanup();
-  notifyMailboxListeners(emailAccountId);
+  notifyMailboxStoreChange(emailAccountId);
 }
 
 export async function readMailboxSyncState(emailAccountId: string) {
@@ -390,7 +390,7 @@ export async function markSyncedMailboxThreadsRead({
 
   await transaction.done;
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
-  notifyMailboxListeners(emailAccountId);
+  notifyMailboxStoreChange(emailAccountId);
 }
 
 export async function removeSyncedMailboxThreads({
@@ -426,7 +426,7 @@ export async function removeSyncedMailboxThreads({
 
   await transaction.done;
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
-  notifyMailboxListeners(emailAccountId);
+  notifyMailboxStoreChange(emailAccountId);
 }
 
 export function subscribeToMailboxStore(
@@ -436,7 +436,7 @@ export function subscribeToMailboxStore(
   return () => mailboxListeners.delete(listener);
 }
 
-function notifyMailboxListeners(emailAccountId: string) {
+export function notifyMailboxStoreChange(emailAccountId: string) {
   for (const listener of mailboxListeners) listener(emailAccountId);
 }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260826-114719_pr-3397_0d7bd2a4b534/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- cover interrupted sender archive rehydration and reconnect replay in the provider emulator
- cover durable sender mark-read/delete, Command-K archive, and All Accounts ownership isolation
- retain newly enqueued single-account overlays until fresh list revalidation, fixing the fast-settlement row resurrection exposed by the Command-K test

## Testing

- `pnpm test utils/email-cache/mail-mutations.test.ts utils/email-cache/mailbox.test.ts utils/email-cache/mail-mutation-settlement.test.ts hooks/useMailMutationOverlay.hook.test.tsx hooks/useMailMutationOverlay.test.ts app/(app)/[emailAccountId]/mail/use-mail-threads.test.tsx app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx app/(app)/MailMutationOutboxManager.test.tsx` (113 passed)
- provider-emulator Playwright: interrupted archive, mark-read, delete, Command-K archive, and All Accounts isolation all passed in targeted local runs
- `pnpm check` (passes with existing schema/desktop/dev-setup warnings)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of offline mailbox actions, including archiving, marking messages as read, and deleting senders.
  * Ensured queued actions remain isolated to the correct email account across reloads.
  * Improved recovery when actions are interrupted or completed in another browser tab.
  * Fixed archive behavior from the command palette so the side panel closes and the conversation is removed correctly.
  * Improved mailbox refresh and synchronization after queued actions are completed.

* **Tests**
  * Added coverage for durable queued actions, offline recovery, cross-tab updates, and mailbox synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->