### PR TITLE
Add durable email sending for mobile clients

### DIFF
--- a/apps/web/app/api/messages/send/route.test.ts
+++ b/apps/web/app/api/messages/send/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
 
 const executeDurableEmailSend = vi.hoisted(() => vi.fn());
 const emailProvider = vi.hoisted(() => ({
@@ -7,24 +8,28 @@ const emailProvider = vi.hoisted(() => ({
   sendEmailWithHtml: vi.fn(),
 }));
 
+type MockedRequest = NextRequest & {
+  auth: { emailAccountId: string };
+  emailProvider: typeof emailProvider;
+  logger: { error: () => void };
+};
+
 vi.mock("@/utils/email/durable-email-send", () => ({
   executeDurableEmailSend,
 }));
 
 vi.mock("@/utils/middleware", () => ({
   withEmailProvider:
-    (_name: string, handler: (request: any) => Promise<Response>) =>
+    (_name: string, handler: (request: MockedRequest) => Promise<Response>) =>
     (request: NextRequest) =>
       handler(
         Object.assign(request, {
           auth: { emailAccountId: "account-1" },
           emailProvider,
           logger: { error: vi.fn() },
-        }),
+        }) as MockedRequest,
       ),
 }));
-
-import { POST } from "./route";
 
 describe("POST /api/messages/send", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -95,6 +100,23 @@ describe("POST /api/messages/send", () => {
       }),
     ).rejects.toThrow();
     expect(emailProvider.sendEmailWithHtml).not.toHaveBeenCalled();
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects durable sends without a message to reconcile", async () => {
+    await expect(
+      post({
+        mutationId: "41ec6d2b-d0e8-4f75-924a-f6f4e5bab4cf",
+        queuedAt: 1_788_000_000_000,
+        threadId: "thread-1",
+        messageIds: [],
+        email: {
+          to: "recipient@example.com",
+          subject: "Re: Hello",
+          messageHtml: "<p>Reply</p>",
+        },
+      }),
+    ).rejects.toThrow();
     expect(executeDurableEmailSend).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/messages/send/route.test.ts
+++ b/apps/web/app/api/messages/send/route.test.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeDurableEmailSend = vi.hoisted(() => vi.fn());
+const emailProvider = vi.hoisted(() => ({
+  name: "google" as const,
+  sendEmailWithHtml: vi.fn(),
+}));
+
+vi.mock("@/utils/email/durable-email-send", () => ({
+  executeDurableEmailSend,
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailProvider:
+    (_name: string, handler: (request: any) => Promise<Response>) =>
+    (request: NextRequest) =>
+      handler(
+        Object.assign(request, {
+          auth: { emailAccountId: "account-1" },
+          emailProvider,
+          logger: { error: vi.fn() },
+        }),
+      ),
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/messages/send", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps accepting the legacy direct-send payload", async () => {
+    emailProvider.sendEmailWithHtml.mockResolvedValue({
+      messageId: "message-1",
+      threadId: "thread-1",
+    });
+
+    const response = await post({
+      to: "recipient@example.com",
+      subject: "Hello",
+      messageHtml: "<p>Hello</p>",
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      messageId: "message-1",
+      threadId: "thread-1",
+    });
+    expect(emailProvider.sendEmailWithHtml).toHaveBeenCalledOnce();
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+  });
+
+  it("routes mutation-wrapped sends through the durable operation", async () => {
+    executeDurableEmailSend.mockResolvedValue({
+      status: "applied",
+      result: { messageId: "message-1", threadId: "thread-1" },
+    });
+    const input = {
+      mutationId: "41ec6d2b-d0e8-4f75-924a-f6f4e5bab4cf",
+      queuedAt: 1_788_000_000_000,
+      threadId: "thread-1",
+      messageIds: ["message-1"],
+      email: {
+        to: "recipient@example.com",
+        subject: "Re: Hello",
+        messageHtml: "<p>Reply</p>",
+      },
+    };
+
+    const response = await post(input);
+
+    await expect(response.json()).resolves.toEqual({
+      status: "applied",
+      result: { messageId: "message-1", threadId: "thread-1" },
+    });
+    expect(executeDurableEmailSend).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      getEmailProvider: expect.any(Function),
+      input,
+      provider: "google",
+    });
+    await expect(
+      executeDurableEmailSend.mock.calls[0][0].getEmailProvider(),
+    ).resolves.toBe(emailProvider);
+    expect(emailProvider.sendEmailWithHtml).not.toHaveBeenCalled();
+  });
+
+  it("does not treat an invalid mutation wrapper as a legacy payload", async () => {
+    await expect(
+      post({
+        mutationId: "not-a-uuid",
+        to: "recipient@example.com",
+        subject: "Hello",
+        messageHtml: "<p>Hello</p>",
+      }),
+    ).rejects.toThrow();
+    expect(emailProvider.sendEmailWithHtml).not.toHaveBeenCalled();
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+  });
+});
+
+function post(body: unknown) {
+  return POST(
+    new NextRequest("http://localhost/api/messages/send", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}

--- a/apps/web/app/api/messages/send/route.ts
+++ b/apps/web/app/api/messages/send/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
 import { sendEmailBody } from "@/utils/types/mail";
+import { executeDurableEmailSend } from "@/utils/email/durable-email-send";
+import { durableEmailSendBody } from "@/utils/email/durable-email-send.validation";
 
 export type SendMessageResponse = {
   success: true;
@@ -15,7 +17,18 @@ export type SendMessageResponse = {
  * an existing thread, or omit it to send a new email.
  */
 export const POST = withEmailProvider("messages/send", async (request) => {
-  const body = sendEmailBody.parse(await request.json());
+  const json: unknown = await request.json();
+  if (isDurableSend(json)) {
+    const input = durableEmailSendBody.parse(json);
+    const result = await executeDurableEmailSend({
+      emailAccountId: request.auth.emailAccountId,
+      getEmailProvider: async () => request.emailProvider,
+      input,
+      provider: request.emailProvider.name,
+    });
+    return NextResponse.json(result);
+  }
+  const body = sendEmailBody.parse(json);
 
   try {
     const result = await request.emailProvider.sendEmailWithHtml(body);
@@ -37,3 +50,7 @@ export const POST = withEmailProvider("messages/send", async (request) => {
     );
   }
 });
+
+function isDurableSend(value: unknown): value is { mutationId: unknown } {
+  return typeof value === "object" && value !== null && "mutationId" in value;
+}

--- a/apps/web/app/api/messages/send/route.ts
+++ b/apps/web/app/api/messages/send/route.ts
@@ -10,6 +10,10 @@ export type SendMessageResponse = {
   threadId: string;
 };
 
+export type DurableSendMessageResponse = Awaited<
+  ReturnType<typeof executeDurableEmailSend>
+>;
+
 /**
  * REST equivalent of `sendEmailAction` for clients that cannot call server
  * actions (e.g. the mobile app). Accepts the same `sendEmailBody` payload:

--- a/apps/web/utils/actions/mail-mutation.ts
+++ b/apps/web/utils/actions/mail-mutation.ts
@@ -1,17 +1,12 @@
 "use server";
 
-import { createHash } from "node:crypto";
-import { EmailSendOperationStatus } from "@/generated/prisma/enums";
 import { actionClient } from "@/utils/actions/safe-action";
-import {
-  executeMailMutationBody,
-  type ExecuteMailMutationBody,
-} from "./mail-mutation.validation";
+import { executeMailMutationBody } from "./mail-mutation.validation";
+import { executeDurableEmailSend } from "@/utils/email/durable-email-send";
 import { createEmailProvider } from "@/utils/email/provider";
 import { classifyEmailAccountProviderIssue } from "@/utils/email/provider-health";
 import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
 import { isGoogleProvider } from "@/utils/email/provider-types";
-import { MAIL_MUTATION_RETRY_WINDOW_MS } from "@/utils/email-cache/policy";
 import {
   extractErrorInfo as extractGmailErrorInfo,
   isRetryableError as isGmailRetryableError,
@@ -20,15 +15,11 @@ import {
   extractErrorInfo as extractMicrosoftErrorInfo,
   isRetryableError as isMicrosoftRetryableError,
 } from "@/utils/microsoft/retry";
-import prisma from "@/utils/prisma";
-import { isDuplicateError } from "@/utils/prisma-helpers";
 import {
   activatePreparedSnoozedThread,
   cancelSnoozedThreadByClientMutationId,
   prepareSnoozedThread,
 } from "@/utils/snooze/scheduler";
-
-const REPLY_PROCESSING_LEASE_MS = 2 * 60 * 1000;
 
 export const executeMailMutationAction = actionClient
   .metadata({ name: "executeMailMutation" })
@@ -37,7 +28,7 @@ export const executeMailMutationAction = actionClient
     const { emailAccountId, logger, provider } = ctx;
 
     if (parsedInput.kind === "reply") {
-      return executeReplyMutation({
+      return executeDurableEmailSend({
         emailAccountId,
         getEmailProvider: () =>
           createEmailProvider({ emailAccountId, provider, logger }),
@@ -158,140 +149,6 @@ export const executeMailMutationAction = actionClient
       return classifyFailure({ error, provider });
     }
   });
-
-async function executeReplyMutation({
-  emailAccountId,
-  getEmailProvider,
-  input,
-  provider,
-}: {
-  emailAccountId: string;
-  getEmailProvider: () => ReturnType<typeof createEmailProvider>;
-  input: Extract<ExecuteMailMutationBody, { kind: "reply" }>;
-  provider: string;
-}) {
-  const payloadHash = createHash("sha256")
-    .update(
-      JSON.stringify({
-        threadId: input.threadId,
-        messageIds: input.messageIds,
-        email: input.email,
-        queuedAt: input.queuedAt,
-      }),
-    )
-    .digest("hex");
-  const found = await findEmailSendOperation(emailAccountId, input.mutationId);
-  if (!found && input.queuedAt < Date.now() - MAIL_MUTATION_RETRY_WINDOW_MS) {
-    return {
-      status: "rejected" as const,
-      error: "Queued email is too old to send safely",
-    };
-  }
-  const existing = found
-    ? { ...found, created: false }
-    : await createEmailSendOperation({
-        emailAccountId,
-        mutationId: input.mutationId,
-        payloadHash,
-      });
-  if (existing.payloadHash !== payloadHash) {
-    return { status: "rejected" as const, error: "Mutation ID was reused" };
-  }
-  if (existing.status === EmailSendOperationStatus.SENT) {
-    return { status: "already_applied" as const, result: existing.result };
-  }
-  if (existing.status === EmailSendOperationStatus.UNCERTAIN) {
-    return { status: "uncertain" as const };
-  }
-  if (!existing.created) {
-    const staleBefore = new Date(Date.now() - REPLY_PROCESSING_LEASE_MS);
-    const stale = await prisma.emailSendOperation.updateMany({
-      where: {
-        id: existing.id,
-        status: EmailSendOperationStatus.PROCESSING,
-        processingStartedAt: { lte: staleBefore },
-      },
-      data: { status: EmailSendOperationStatus.UNCERTAIN },
-    });
-    return stale.count
-      ? { status: "uncertain" as const }
-      : { status: "retry" as const };
-  }
-
-  try {
-    const emailProvider = await getEmailProvider();
-    const result = await emailProvider.sendEmailWithHtml(input.email);
-    await prisma.emailSendOperation.update({
-      where: { id: existing.id },
-      data: { result, status: EmailSendOperationStatus.SENT },
-    });
-    return { status: "applied" as const, result };
-  } catch (error) {
-    if (isEmailProviderRateLimitError({ error, provider })) {
-      await prisma.emailSendOperation.deleteMany({
-        where: { id: existing.id },
-      });
-      return { status: "retry" as const };
-    }
-    if (
-      classifyEmailAccountProviderIssue({
-        error,
-        provider: provider as "google" | "microsoft",
-      })
-    ) {
-      await prisma.emailSendOperation.deleteMany({
-        where: { id: existing.id },
-      });
-      return { status: "blocked_auth" as const };
-    }
-    await prisma.emailSendOperation.updateMany({
-      where: { id: existing.id, status: EmailSendOperationStatus.PROCESSING },
-      data: { status: EmailSendOperationStatus.UNCERTAIN },
-    });
-    return { status: "uncertain" as const };
-  }
-}
-
-async function findEmailSendOperation(
-  emailAccountId: string,
-  mutationId: string,
-) {
-  return prisma.emailSendOperation.findUnique({
-    where: {
-      emailAccountId_clientMutationId: {
-        emailAccountId,
-        clientMutationId: mutationId,
-      },
-    },
-  });
-}
-
-async function createEmailSendOperation({
-  emailAccountId,
-  mutationId,
-  payloadHash,
-}: {
-  emailAccountId: string;
-  mutationId: string;
-  payloadHash: string;
-}) {
-  try {
-    const operation = await prisma.emailSendOperation.create({
-      data: {
-        clientMutationId: mutationId,
-        emailAccountId,
-        payloadHash,
-      },
-    });
-    return { ...operation, created: true };
-  } catch (error) {
-    if (!isDuplicateError(error, ["emailAccountId", "clientMutationId"]))
-      throw error;
-    const operation = await findEmailSendOperation(emailAccountId, mutationId);
-    if (!operation) throw error;
-    return { ...operation, created: false };
-  }
-}
 
 function classifyFailure({
   error,

--- a/apps/web/utils/actions/mail-mutation.validation.ts
+++ b/apps/web/utils/actions/mail-mutation.validation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { sendEmailBody } from "@/utils/types/mail";
+import { durableEmailSendBody } from "@/utils/email/durable-email-send.validation";
 
 const snapshot = z.object({
   mutationId: z.string().uuid(),
@@ -24,13 +24,8 @@ export const executeMailMutationBody = z.discriminatedUnion("kind", [
     kind: z.literal("cancel_snooze"),
     snoozeMutationId: z.string().uuid(),
   }),
-  z.object({
+  durableEmailSendBody.extend({
     kind: z.literal("reply"),
-    mutationId: z.string().uuid(),
-    queuedAt: z.number().int().nonnegative(),
-    threadId: z.string().min(1).max(512),
-    messageIds: z.array(z.string().min(1).max(512)).max(1000),
-    email: sendEmailBody,
   }),
 ]);
 

--- a/apps/web/utils/email/durable-email-send.ts
+++ b/apps/web/utils/email/durable-email-send.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { EmailSendOperationStatus } from "@/generated/prisma/enums";
+import { classifyEmailAccountProviderIssue } from "@/utils/email/provider-health";
+import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
+import type { EmailProvider } from "@/utils/email/types";
+import { MAIL_MUTATION_RETRY_WINDOW_MS } from "@/utils/email-cache/policy";
+import prisma from "@/utils/prisma";
+import { isDuplicateError } from "@/utils/prisma-helpers";
+import type { DurableEmailSendBody } from "./durable-email-send.validation";
+
+const PROCESSING_LEASE_MS = 2 * 60 * 1000;
+
+export async function executeDurableEmailSend({
+  emailAccountId,
+  getEmailProvider,
+  input,
+  provider,
+}: {
+  emailAccountId: string;
+  getEmailProvider: () => Promise<EmailProvider>;
+  input: DurableEmailSendBody;
+  provider: string;
+}) {
+  const payloadHash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        threadId: input.threadId,
+        messageIds: input.messageIds,
+        email: input.email,
+        queuedAt: input.queuedAt,
+      }),
+    )
+    .digest("hex");
+  const found = await findEmailSendOperation(emailAccountId, input.mutationId);
+  if (!found && input.queuedAt < Date.now() - MAIL_MUTATION_RETRY_WINDOW_MS) {
+    return {
+      status: "rejected" as const,
+      error: "Queued email is too old to send safely",
+    };
+  }
+  const existing = found
+    ? { ...found, created: false }
+    : await createEmailSendOperation({
+        emailAccountId,
+        mutationId: input.mutationId,
+        payloadHash,
+      });
+  if (existing.payloadHash !== payloadHash) {
+    return { status: "rejected" as const, error: "Mutation ID was reused" };
+  }
+  if (existing.status === EmailSendOperationStatus.SENT) {
+    return { status: "already_applied" as const, result: existing.result };
+  }
+  if (existing.status === EmailSendOperationStatus.UNCERTAIN) {
+    return { status: "uncertain" as const };
+  }
+  if (!existing.created) {
+    const staleBefore = new Date(Date.now() - PROCESSING_LEASE_MS);
+    const stale = await prisma.emailSendOperation.updateMany({
+      where: {
+        id: existing.id,
+        status: EmailSendOperationStatus.PROCESSING,
+        processingStartedAt: { lte: staleBefore },
+      },
+      data: { status: EmailSendOperationStatus.UNCERTAIN },
+    });
+    return stale.count
+      ? { status: "uncertain" as const }
+      : { status: "retry" as const };
+  }
+
+  try {
+    const emailProvider = await getEmailProvider();
+    const result = await emailProvider.sendEmailWithHtml(input.email);
+    await prisma.emailSendOperation.update({
+      where: { id: existing.id },
+      data: { result, status: EmailSendOperationStatus.SENT },
+    });
+    return { status: "applied" as const, result };
+  } catch (error) {
+    if (isEmailProviderRateLimitError({ error, provider })) {
+      await prisma.emailSendOperation.deleteMany({
+        where: { id: existing.id },
+      });
+      return { status: "retry" as const };
+    }
+    if (
+      classifyEmailAccountProviderIssue({
+        error,
+        provider: provider as "google" | "microsoft",
+      })
+    ) {
+      await prisma.emailSendOperation.deleteMany({
+        where: { id: existing.id },
+      });
+      return { status: "blocked_auth" as const };
+    }
+    await prisma.emailSendOperation.updateMany({
+      where: { id: existing.id, status: EmailSendOperationStatus.PROCESSING },
+      data: { status: EmailSendOperationStatus.UNCERTAIN },
+    });
+    return { status: "uncertain" as const };
+  }
+}
+
+async function findEmailSendOperation(
+  emailAccountId: string,
+  mutationId: string,
+) {
+  return prisma.emailSendOperation.findUnique({
+    where: {
+      emailAccountId_clientMutationId: {
+        emailAccountId,
+        clientMutationId: mutationId,
+      },
+    },
+  });
+}
+
+async function createEmailSendOperation({
+  emailAccountId,
+  mutationId,
+  payloadHash,
+}: {
+  emailAccountId: string;
+  mutationId: string;
+  payloadHash: string;
+}) {
+  try {
+    const operation = await prisma.emailSendOperation.create({
+      data: {
+        clientMutationId: mutationId,
+        emailAccountId,
+        payloadHash,
+      },
+    });
+    return { ...operation, created: true };
+  } catch (error) {
+    if (!isDuplicateError(error, ["emailAccountId", "clientMutationId"])) {
+      throw error;
+    }
+    const operation = await findEmailSendOperation(emailAccountId, mutationId);
+    if (!operation) throw error;
+    return { ...operation, created: false };
+  }
+}

--- a/apps/web/utils/email/durable-email-send.validation.ts
+++ b/apps/web/utils/email/durable-email-send.validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { sendEmailBody } from "@/utils/types/mail";
+
+export const durableEmailSendBody = z.object({
+  mutationId: z.string().uuid(),
+  queuedAt: z.number().int().nonnegative(),
+  threadId: z.string().min(1).max(512),
+  messageIds: z.array(z.string().min(1).max(512)).max(1000),
+  email: sendEmailBody,
+});
+
+export type DurableEmailSendBody = z.infer<typeof durableEmailSendBody>;

--- a/apps/web/utils/email/durable-email-send.validation.ts
+++ b/apps/web/utils/email/durable-email-send.validation.ts
@@ -5,7 +5,7 @@ export const durableEmailSendBody = z.object({
   mutationId: z.string().uuid(),
   queuedAt: z.number().int().nonnegative(),
   threadId: z.string().min(1).max(512),
-  messageIds: z.array(z.string().min(1).max(512)).max(1000),
+  messageIds: z.array(z.string().min(1).max(512)).min(1).max(1000),
   email: sendEmailBody,
 });
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260826-162300_pr-3398_b72e32cfc067/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- extract the existing idempotent reply-send operation into a shared server helper
- allow `POST /api/messages/send` to accept durable mutation envelopes while preserving legacy clients
- reconcile duplicate, retryable, auth-blocked, rejected, and uncertain sends without duplicate delivery
- add endpoint coverage for legacy and durable request shapes

This is the backend dependency for the Inbox Zero mobile durable draft/outbox work.

## Validation

- `pnpm vitest run app/api/messages/send/route.test.ts utils/actions/mail-mutation.test.ts` (18 tests)
- `pnpm exec ultracite check app/api/messages/send/route.ts app/api/messages/send/route.test.ts utils/actions/mail-mutation.ts utils/actions/mail-mutation.validation.ts utils/email/durable-email-send.ts utils/email/durable-email-send.validation.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable, duplicate-safe email sending for queued and reply messages.
  * Email operations now track completion and support retries, uncertain outcomes, rate limits, and provider authentication failures.

* **Bug Fixes**
  * Prevented invalid or malformed durable email requests from being processed.
  * Improved handling of repeated send attempts to help avoid duplicate deliveries.

* **Tests**
  * Added coverage for legacy and durable sends, provider selection, invalid requests, and incomplete message details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->