### PR TITLE
calendars: Ignore disconnected calendars in availability

### DIFF
--- a/apps/web/utils/calendar/providers/google-availability.test.ts
+++ b/apps/web/utils/calendar/providers/google-availability.test.ts
@@ -51,7 +51,7 @@ describe("createGoogleAvailabilityProvider", () => {
   });
 
   it("fails closed on individual calendar errors when requested", async () => {
-    const calendarErrors = [{ reason: "notFound" }];
+    const calendarErrors = [{ reason: "internalError" }];
     query.mockResolvedValue({
       data: {
         calendars: {
@@ -82,5 +82,45 @@ describe("createGoogleAvailabilityProvider", () => {
       provider: "google",
       calendarErrors: [{ calendarId: "cal-1", errors: calendarErrors }],
     } satisfies Partial<CalendarAvailabilityError>);
+  });
+
+  it("ignores a missing calendar when failing closed", async () => {
+    query.mockResolvedValue({
+      data: {
+        calendars: {
+          "disconnected-calendar": {
+            errors: [{ reason: "notFound" }],
+          },
+          "connected-calendar": {
+            busy: [
+              {
+                start: "2026-05-04T10:00:00.000Z",
+                end: "2026-05-04T11:00:00.000Z",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const provider = createGoogleAvailabilityProvider(logger);
+    const result = await provider.fetchBusyPeriods({
+      accessToken: "token",
+      calendarIds: ["disconnected-calendar", "connected-calendar"],
+      connectionId: "connection-id",
+      emailAccountId: "email-account-id",
+      expiresAt: Date.now() + 60_000,
+      failOnCalendarError: true,
+      refreshToken: "refresh-token",
+      timeMax: "2026-05-05T00:00:00.000Z",
+      timeMin: "2026-05-04T00:00:00.000Z",
+    });
+
+    expect(result).toEqual([
+      {
+        start: "2026-05-04T10:00:00.000Z",
+        end: "2026-05-04T11:00:00.000Z",
+      },
+    ]);
   });
 });

--- a/apps/web/utils/calendar/providers/google-availability.ts
+++ b/apps/web/utils/calendar/providers/google-availability.ts
@@ -41,23 +41,26 @@ async function fetchGoogleCalendarBusyPeriods({
         response.data.calendars,
       )) {
         if (calendar.errors?.length) {
-          logger.error("Google Calendar returned availability errors", {
-            ...getCalendarAvailabilityErrorLogContext(
-              new CalendarAvailabilityError({
-                provider: "google",
-                calendarErrors: [
-                  { calendarId: _calendarId, errors: calendar.errors },
-                ],
-              }),
-            ),
+          const availabilityError = new CalendarAvailabilityError({
+            provider: "google",
+            calendarErrors: [
+              { calendarId: _calendarId, errors: calendar.errors },
+            ],
           });
-          if (failOnCalendarError) {
-            throw new CalendarAvailabilityError({
-              provider: "google",
-              calendarErrors: [
-                { calendarId: _calendarId, errors: calendar.errors },
-              ],
+          const logContext =
+            getCalendarAvailabilityErrorLogContext(availabilityError);
+          const calendarIsMissing = isMissingCalendar(calendar.errors);
+
+          if (calendarIsMissing) {
+            logger.warn("Skipping unavailable Google calendar", logContext);
+          } else {
+            logger.error("Google Calendar returned availability errors", {
+              ...logContext,
             });
+          }
+
+          if (failOnCalendarError && !calendarIsMissing) {
+            throw availabilityError;
           }
           continue;
         }
@@ -127,4 +130,8 @@ export function createGoogleAvailabilityProvider(
       });
     },
   };
+}
+
+function isMissingCalendar(errors: calendar_v3.Schema$Error[]) {
+  return errors.every((error) => error.reason === "notFound");
 }

--- a/apps/web/utils/calendar/providers/microsoft-availability.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-availability.test.ts
@@ -294,5 +294,43 @@ describe("createMicrosoftAvailabilityProvider", () => {
         }),
       ).rejects.toThrow("calendar failed");
     });
+
+    it("should ignore a missing calendar when failing closed", async () => {
+      mockApiResponse.get
+        .mockRejectedValueOnce(
+          Object.assign(new Error("Calendar not found"), {
+            code: "ErrorItemNotFound",
+            statusCode: 404,
+          }),
+        )
+        .mockResolvedValueOnce({
+          value: [
+            {
+              showAs: "busy",
+              start: { dateTime: "2025-11-17T14:00:00.0000000" },
+              end: { dateTime: "2025-11-17T15:00:00.0000000" },
+            },
+          ],
+        });
+
+      const provider = createMicrosoftAvailabilityProvider(logger);
+      const result = await provider.fetchBusyPeriods({
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: Date.now() + 3_600_000,
+        emailAccountId: "email-account-id",
+        calendarIds: ["disconnected-calendar", "connected-calendar"],
+        failOnCalendarError: true,
+        timeMin: "2025-11-17T00:00:00Z",
+        timeMax: "2025-11-17T23:59:59Z",
+      });
+
+      expect(result).toEqual([
+        {
+          start: "2025-11-17T14:00:00.0000000Z",
+          end: "2025-11-17T15:00:00.0000000Z",
+        },
+      ]);
+    });
   });
 });

--- a/apps/web/utils/calendar/providers/microsoft-availability.ts
+++ b/apps/web/utils/calendar/providers/microsoft-availability.ts
@@ -74,12 +74,19 @@ async function fetchMicrosoftCalendarBusyPeriods({
           nextLink = response["@odata.nextLink"];
         } while (nextLink);
       } catch (calendarError) {
-        logger.error("Error fetching calendar events", {
-          calendarId,
-          error: calendarError,
-        });
+        const calendarIsMissing = isMissingCalendarError(calendarError);
+        if (calendarIsMissing) {
+          logger.warn("Skipping unavailable Microsoft calendar", {
+            calendarIdIsPrimary: calendarId === "primary",
+          });
+        } else {
+          logger.error("Error fetching calendar events", {
+            calendarId,
+            error: calendarError,
+          });
+        }
 
-        if (failOnCalendarError) throw calendarError;
+        if (failOnCalendarError && !calendarIsMissing) throw calendarError;
       }
     }
 
@@ -124,4 +131,13 @@ export function createMicrosoftAvailabilityProvider(
       });
     },
   };
+}
+
+function isMissingCalendarError(error: unknown) {
+  if (typeof error !== "object" || error === null) return false;
+
+  const graphError = error as { code?: unknown; statusCode?: unknown };
+  return (
+    graphError.statusCode === 404 || graphError.code === "ErrorItemNotFound"
+  );
 }

--- a/apps/web/utils/calendar/providers/microsoft-availability.ts
+++ b/apps/web/utils/calendar/providers/microsoft-availability.ts
@@ -136,8 +136,8 @@ export function createMicrosoftAvailabilityProvider(
 function isMissingCalendarError(error: unknown) {
   if (typeof error !== "object" || error === null) return false;
 
-  const graphError = error as { code?: unknown; statusCode?: unknown };
   return (
-    graphError.statusCode === 404 || graphError.code === "ErrorItemNotFound"
+    ("statusCode" in error && error.statusCode === 404) ||
+    ("code" in error && error.code === "ErrorItemNotFound")
   );
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260826-145818_pr-3399_d179da560bc0/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- ignore individual Google and Microsoft calendars that providers report as missing
- preserve busy periods from healthy calendars instead of making the booking page appear fully booked
- continue failing closed for connection-wide outages and other provider errors

## Tests

- `pnpm test utils/calendar/providers/google-availability.test.ts utils/calendar/providers/microsoft-availability.test.ts utils/calendar/unified-availability.test.ts utils/booking/public.test.ts`
- `pnpm check` (passes with existing repository warnings)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing Google and Microsoft calendars are now skipped gracefully instead of causing availability checks to fail.
  * Availability from other connected calendars continues to be returned when one calendar is unavailable.
  * Genuine calendar service errors still trigger failures when strict error handling is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->