### PR TITLE
test(mail): Stabilize cleanup mailbox sync

### DIFF
--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../mail/mail-test-helpers";
 import {
   CLEANUP_ARCHIVE_THREAD_ID,
+  CLEANUP_BLOCK_THREAD_ID,
   CLEANUP_KEEP_THREAD_ID,
   cleanUpFixture,
   type CleanupFixture,
@@ -16,6 +17,14 @@ import {
 const ARCHIVE_SENDER = "cleanup-archive@example.com";
 const ARCHIVE_SUBJECT = "Cleanup Category Archive Candidate";
 const KEEP_SUBJECT = "Cleanup Category Keep Candidate";
+const BULK_ARCHIVE_THREAD_IDS = [
+  CLEANUP_ARCHIVE_THREAD_ID,
+  CLEANUP_KEEP_THREAD_ID,
+];
+const CLEANUP_MAILBOX_THREAD_IDS = [
+  CLEANUP_BLOCK_THREAD_ID,
+  ...BULK_ARCHIVE_THREAD_IDS,
+];
 let fixture: CleanupFixture | undefined;
 
 test.beforeEach(async ({ page }) => {
@@ -270,8 +279,7 @@ function blockServerActions(route: Route) {
 }
 
 async function restoreFixtureThreads(page: Page, emailAccountId: string) {
-  const threadIds = [CLEANUP_ARCHIVE_THREAD_ID, CLEANUP_KEEP_THREAD_ID];
-  for (const threadId of threadIds) {
+  for (const threadId of BULK_ARCHIVE_THREAD_IDS) {
     await expect
       .poll(
         async () => {
@@ -289,22 +297,43 @@ async function restoreFixtureThreads(page: Page, emailAccountId: string) {
       )
       .toBe(true);
   }
-  await restoreCleanupThreads(page, emailAccountId, threadIds);
+  await restoreCleanupThreads(page, emailAccountId, BULK_ARCHIVE_THREAD_IDS);
 }
 
 function stubMailboxSync(page: Page, emailAccountId: string) {
-  return page.route("**/api/mobile/mailbox-sync", (route) =>
-    route.fulfill({
+  return page.route("**/api/mobile/mailbox-sync", async (route) => {
+    const upsertedMessages = await getCleanupMailboxMessages(
+      page,
+      emailAccountId,
+    );
+    return route.fulfill({
       body: JSON.stringify({
         accountId: emailAccountId,
         cursor: "playwright-cleanup-sync",
         deletedMessageIds: [],
         hasMore: false,
         reset: false,
-        upsertedMessages: [],
+        upsertedMessages,
       }),
       contentType: "application/json",
       status: 200,
-    }),
-  );
+    });
+  });
+}
+
+async function getCleanupMailboxMessages(page: Page, emailAccountId: string) {
+  const response = await page.request.get("/api/threads?type=inbox&view=list", {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  if (!response.ok()) {
+    throw new Error(`Inbox request failed with ${response.status()}`);
+  }
+  const result = (await response.json()) as {
+    threads: { id: string; messages: unknown[] }[];
+  };
+  return result.threads
+    .filter((thread) =>
+      CLEANUP_MAILBOX_THREAD_IDS.some((threadId) => threadId === thread.id),
+    )
+    .flatMap((thread) => thread.messages);
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260826-143029_pr-3401_f1b604a4ad01/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix the cleanup Playwright mailbox-sync stub so a completed local snapshot reflects the emulator inbox instead of hiding fixture threads.

- populate each stubbed sync page from the current cleanup inbox threads
- keep local cache state aligned after archive, read, and delete operations
- verify the cleanup spec twice with retries disabled (7 tests passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup for bulk archive and mailbox synchronization scenarios.
  * Ensured affected threads and messages are restored correctly after test execution.
  * Updated mailbox synchronization behavior to return messages for cleanup threads instead of an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->