### PR TITLE
INB-335: Keep recording status active after scheduled end

### DIFF
--- a/apps/web/app/(app)/MailMutationOutboxManager.tsx
+++ b/apps/web/app/(app)/MailMutationOutboxManager.tsx
@@ -31,6 +31,7 @@ import {
   retryMailMutationSyncGroup,
   subscribeToMailMutations,
 } from "@/utils/email-cache/mail-mutations";
+import { randomUuid } from "@/utils/uuid";
 
 const REQUEST_TIMEOUT_MS = 20 * 1000;
 const LEASE_MS = 30 * 1000;
@@ -40,7 +41,7 @@ const MAX_CONCURRENCY = 2;
 export function MailMutationOutboxManager() {
   useEffect(() => {
     removeLegacyMailActionQueue();
-    const ownerId = crypto.randomUUID();
+    const ownerId = randomUuid();
     let active = 0;
     let activeSyncs = 0;
     let stopped = false;

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -74,6 +74,7 @@ import {
   validateSendEmailPayloadSize,
 } from "@/utils/types/mail";
 import { cn } from "@/utils";
+import { randomUuid } from "@/utils/uuid";
 import { resolveComposeRecipients } from "./compose-recipients";
 import { queueReaderEmail } from "./queued-reply";
 
@@ -1029,7 +1030,7 @@ function createComposeAttachmentMetadata(
   file: File,
   disposition: ComposeAttachment["disposition"],
 ): EmailAttachmentMetadata {
-  const id = crypto.randomUUID();
+  const id = randomUuid();
   return {
     id,
     filename: file.name,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -9,6 +9,7 @@ import {
   enqueueMailMutation,
   type MailMutationPayload,
 } from "@/utils/email-cache/mail-mutations";
+import { randomUuid } from "@/utils/uuid";
 import {
   getListThreadEmailAccountId,
   getListThreadKey,
@@ -78,7 +79,7 @@ export function useThreadActions({
       payload: MailMutationPayload,
     ) => {
       if (!targets.length) return [];
-      const batchId = crypto.randomUUID();
+      const batchId = randomUuid();
       const results = await Promise.allSettled(
         targets.map((target) =>
           enqueueMailMutation({
@@ -108,7 +109,7 @@ export function useThreadActions({
 
     const compensationKind =
       batch.action === "archive" ? "unarchive" : "untrash";
-    const batchId = crypto.randomUUID();
+    const batchId = randomUuid();
     const results = await Promise.allSettled(
       batch.snapshots.map(async (snapshot) => {
         const cancelled = await cancelPendingMailMutation(snapshot.mutationId);

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
@@ -39,9 +39,15 @@ describe("getRecordingStatusBadge", () => {
   });
 
   it.each([
-    MeetingRecordingStatus.IN_CALL,
-    MeetingRecordingStatus.RECORDING,
-  ])("shows processing after the scheduled end while the recorder is still in progress (%s)", (status) => {
+    [
+      MeetingRecordingStatus.IN_CALL,
+      { label: "Notetaker joined", variant: "default" },
+    ],
+    [
+      MeetingRecordingStatus.RECORDING,
+      { label: "Recording", variant: "green" },
+    ],
+  ] as const)("uses the bot status after the scheduled end while capture is still in progress (%s)", (status, expectedBadge) => {
     expect(
       getRecordingStatusBadge({
         status,
@@ -49,7 +55,7 @@ describe("getRecordingStatusBadge", () => {
         endTime: new Date("2026-07-30T16:30:00.000Z"),
         now: NOW,
       }),
-    ).toEqual({ label: "Processing", variant: "secondary" });
+    ).toEqual(expectedBadge);
   });
 
   it("keeps actionable recorder progress visible while the meeting is ongoing", () => {

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
@@ -1,8 +1,7 @@
 import { MeetingRecordingStatus } from "@/generated/prisma/enums";
 import {
+  CAPTURED_MEETING_STATUSES,
   NO_RECORDING_STATUSES,
-  RECORDED_SECTION_STATUSES,
-  STILL_CAPTURING_STATUSES,
 } from "@/utils/meeting-recorder/recording-lifecycle";
 
 type StatusBadge = {
@@ -70,16 +69,10 @@ export function getRecordingStatusBadge({
     }
   }
 
-  if (end <= now && status) {
-    if (!RECORDED_SECTION_STATUSES.includes(status)) return null;
-    // A recorder still capturing past the scheduled end means the call ran
-    // long, so show the recording wrapping up rather than the stale live badge.
-    if (STILL_CAPTURING_STATUSES.includes(status)) {
-      return STATUS_BADGES[MeetingRecordingStatus.CALL_ENDED];
-    }
-    if (NO_RECORDING_STATUSES.includes(status)) {
-      return { label: "Not recorded", variant: "red" };
-    }
+  if (end <= now && status && !CAPTURED_MEETING_STATUSES.includes(status)) {
+    return NO_RECORDING_STATUSES.includes(status)
+      ? { label: "Not recorded", variant: "red" }
+      : null;
   }
 
   return status ? STATUS_BADGES[status] : null;

--- a/apps/web/app/book/[slug]/BookingPageClient.tsx
+++ b/apps/web/app/book/[slug]/BookingPageClient.tsx
@@ -12,6 +12,7 @@ import { ArrowLeft, ArrowRight, Check, Info } from "lucide-react";
 import type { GetPublicBookingLinkResponse } from "@/app/api/public/booking-links/[slug]/route";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils";
+import { randomUuid } from "@/utils/uuid";
 import { BookingSidebar } from "./BookingSidebar";
 import { useAvailability } from "./useAvailability";
 import { PickTimeStep, useSlotSelection } from "./PickTimeStep";
@@ -104,7 +105,7 @@ export function BookingPageClient({
           guestName: formValues.name,
           guestEmail: formValues.email,
           guestNote: formValues.note || undefined,
-          idempotencyToken: crypto.randomUUID(),
+          idempotencyToken: randomUuid(),
         }),
       });
       const body = await response.json();

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -40,6 +40,7 @@ import {
   getChatHistoryLabel,
 } from "@/components/assistant-chat/chat-history-types";
 import { RenameChatDialog } from "@/components/assistant-chat/RenameChatDialog";
+import { randomUuid } from "@/utils/uuid";
 import { DeleteChatDialog } from "@/components/assistant-chat/DeleteChatDialog";
 
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB
@@ -114,7 +115,7 @@ export function Chat({
         const reader = new FileReader();
         reader.onload = () => {
           resolve({
-            id: crypto.randomUUID(),
+            id: randomUuid(),
             name: file.name,
             url: reader.result as string,
             contentType: file.type,

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -1,4 +1,5 @@
 import type { SendEmailBody } from "@/utils/types/mail";
+import { randomUuid } from "@/utils/uuid";
 import {
   getEmailCacheDatabase,
   type MailMutationClientSource,
@@ -94,11 +95,11 @@ export async function enqueueMailMutationBatch(
   if (suppliedBatchIds.size > 1) {
     throw new Error("Mail mutation batches must use one batch ID");
   }
-  const batchId = suppliedBatchIds.values().next().value ?? crypto.randomUUID();
+  const batchId = suppliedBatchIds.values().next().value ?? randomUuid();
   const preparedInputs = inputs.map((input) => ({
     ...input,
     batchId,
-    id: input.id ?? crypto.randomUUID(),
+    id: input.id ?? randomUuid(),
   }));
   const database = await getEmailCacheDatabase();
   if (!database) throw new Error("Offline mail storage is unavailable");

--- a/apps/web/utils/email-cache/thread-mail-mutations.ts
+++ b/apps/web/utils/email-cache/thread-mail-mutations.ts
@@ -3,6 +3,7 @@ import {
   type MailMutationPayload,
 } from "./mail-mutations";
 import type { MailMutationClientSource } from "./database";
+import { randomUuid } from "@/utils/uuid";
 
 type ThreadMailMutationTarget = {
   id: string;
@@ -11,7 +12,7 @@ type ThreadMailMutationTarget = {
 
 export async function enqueueThreadMailMutationBatch(
   {
-    batchId = crypto.randomUUID(),
+    batchId = randomUuid(),
     clientSource,
     emailAccountId,
     payload,

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -23,14 +23,6 @@ export const CHANGEABLE_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.SCHEDULED,
 ];
 
-// The bot is in the call with capture still underway. A recording still in one
-// of these states after the meeting's scheduled end means the call ran long and
-// the recording is wrapping up, not missing.
-export const STILL_CAPTURING_STATUSES: MeetingRecordingStatus[] = [
-  MeetingRecordingStatus.IN_CALL,
-  MeetingRecordingStatus.RECORDING,
-];
-
 // The bot engaged with the call (tried to join, or failed trying) but delivered
 // no media. A recording still in one of these states after the meeting ended
 // produced nothing.
@@ -43,7 +35,8 @@ export const NO_RECORDING_STATUSES: MeetingRecordingStatus[] = [
 // The bot made it into the call, so media exists or is still being captured.
 // Meetings in these states must never be presented as "not recorded".
 export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
-  ...STILL_CAPTURING_STATUSES,
+  MeetingRecordingStatus.IN_CALL,
+  MeetingRecordingStatus.RECORDING,
   MeetingRecordingStatus.CALL_ENDED,
   MeetingRecordingStatus.DONE,
 ];

--- a/apps/web/utils/uuid.test.ts
+++ b/apps/web/utils/uuid.test.ts
@@ -1,0 +1,23 @@
+import { webcrypto } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUuid } from "./uuid";
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("randomUuid", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a v4 UUID", () => {
+    expect(randomUuid()).toMatch(UUID_V4_REGEX);
+  });
+
+  it("falls back when crypto.randomUUID is unavailable (insecure context)", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (array: Uint8Array) => webcrypto.getRandomValues(array),
+    });
+    expect(randomUuid()).toMatch(UUID_V4_REGEX);
+  });
+});

--- a/apps/web/utils/uuid.ts
+++ b/apps/web/utils/uuid.ts
@@ -1,0 +1,16 @@
+// crypto.randomUUID is only defined in secure contexts (HTTPS/localhost), so
+// self-hosted deployments served over plain HTTP need the manual v4 fallback.
+export function randomUuid(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260827-124003_pr-3402_81b15c438636/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keep meeting recording badges aligned with the recorder lifecycle after a meeting passes its scheduled end. Active capture now remains visible until the recorder reports that processing has started.

- Reuse the shared captured-status classification when choosing the badge.
- Cover post-schedule IN_CALL and RECORDING behavior with focused regression tests.
- Tests: `pnpm test app/(app)/[emailAccountId]/meetings/recording-status.test.ts` (10 passed).
- Performance: constant-time in-memory status checks only; no new database or network calls, with negligible hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-335/ui-status-shows-processing-while-bot-is-still-recording

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-meeting recording statuses to accurately show when recording is still active.
  * Prevented active recordings from being incorrectly labeled as “Processing” after the scheduled meeting end time.
  * Improved the “Not recorded” badge so it appears only when no recording was captured.
  * Improved reliability when creating bookings, email actions, and attachments in environments with limited browser UUID support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->