### PR TITLE
INB-336: Expand email body when images finish loading

### DIFF
--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 
 import React from "react";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-themes", () => ({
@@ -20,9 +20,22 @@ import { HtmlEmail, PlainEmail } from "./EmailContents";
 
 (globalThis as { React?: typeof React }).React = React;
 
+let triggerResize: (() => void) | undefined;
+
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    triggerResize = () => callback([], this);
+  }
+
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
 describe("HtmlEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -107,6 +120,40 @@ describe("HtmlEmail", () => {
         "img-src data: https://app.example.com;",
       );
     });
+  });
+
+  it("expands when an image increases the iframe document height after loading", async () => {
+    const { getByTitle } = render(
+      <HtmlEmail
+        html='<img src="https://cdn.example.com/tall-image.png" />'
+        messageId="message-tall-image"
+      />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    let contentHeight = 40;
+
+    Object.defineProperty(
+      iframe.contentDocument!.documentElement,
+      "scrollHeight",
+      {
+        configurable: true,
+        get: () => contentHeight,
+      },
+    );
+
+    iframe.dispatchEvent(new Event("load"));
+    await waitFor(() =>
+      expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(40),
+    );
+
+    contentHeight = 640;
+    act(() => triggerResize?.());
+
+    await waitFor(() =>
+      expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(
+        640,
+      ),
+    );
   });
 
   it("resolves authenticated cid images to temporary local URLs", async () => {

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -414,40 +414,40 @@ function useIframeHeight(iframeRef: React.RefObject<HTMLIFrameElement | null>) {
   const [height, setHeight] = useState(0);
 
   useEffect(() => {
-    let attempts = 0;
-    const maxAttempts = 5;
-    const initialDelay = 100;
+    const iframe = iframeRef.current;
+    if (!iframe) return;
 
     const updateHeight = () => {
-      try {
-        if (iframeRef.current?.contentWindow) {
-          const newHeight =
-            iframeRef.current.contentWindow.document.documentElement
-              ?.scrollHeight;
-          if (newHeight) {
-            setHeight(newHeight);
-            return true;
-          }
-        }
-      } catch (error) {
-        console.error("Failed to get iframe height:", error);
-      }
-      return false;
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeDocument) return;
+
+      const newHeight = Math.max(
+        iframeDocument.documentElement.scrollHeight,
+        iframeDocument.body.scrollHeight,
+      );
+      if (newHeight) setHeight(newHeight);
     };
 
-    const attemptUpdate = () => {
-      if (attempts >= maxAttempts) return;
+    const resizeObserver = new ResizeObserver(updateHeight);
 
-      const success = updateHeight();
-      if (!success) {
-        attempts++;
-        setTimeout(attemptUpdate, initialDelay * 2 ** attempts);
-      }
+    const observeDocument = () => {
+      resizeObserver.disconnect();
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeDocument) return;
+
+      updateHeight();
+      resizeObserver.observe(iframeDocument.documentElement);
+      resizeObserver.observe(iframeDocument.body);
     };
 
-    const initialTimeoutId = setTimeout(attemptUpdate, initialDelay);
-    return () => clearTimeout(initialTimeoutId);
-  }, [iframeRef?.current?.contentWindow]);
+    iframe.addEventListener("load", observeDocument);
+    observeDocument();
+
+    return () => {
+      iframe.removeEventListener("load", observeDocument);
+      resizeObserver.disconnect();
+    };
+  }, [iframeRef]);
 
   return height;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260827-124458_pr-3403_86d4c37db96c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates HTML email iframe sizing whenever embedded content changes so image-only messages expand after late image loads. Replaces bounded retry polling with lifecycle-aware resize observation.

- Observe iframe document and body size changes, including after iframe reloads.
- Add regression coverage for image-driven height changes.
- Tests: `pnpm test components/email-list/EmailContents.test.tsx` (6 passed); focused Ultracite check (2 files clean).
- Performance: one observer per mounted HTML email; no additional database or network calls; callbacks run only on content-size changes, with low hot-path risk.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-336/email-body-area-too-small-to-display-image-only-emails-in-mail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email preview sizing to accurately expand when content, including images, increases in height.
  * Updated resizing behavior to respond immediately to content changes and iframe loading.
  * Improved cleanup of resize monitoring to support more reliable previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->