### PR TITLE
test: Stabilize cleanup mailbox reconciliation

### DIFF
--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -150,11 +150,12 @@ test("deletes a selected sender through the durable sender queue", async ({
 }) => {
   test.setTimeout(360_000);
   if (!fixture) throw new Error("Cleanup fixture was not initialized");
-  await stubMailboxSync(page, fixture.emailAccountId);
+  const mailboxSync = await stubMailboxSync(page, fixture.emailAccountId);
   await openCleanupFeature(page, fixture, "bulk-archive");
   await chooseBulkAction(page, "Delete");
   await selectOnlyArchiveSender(page);
 
+  mailboxSync.expectDeleted(CLEANUP_ARCHIVE_THREAD_ID);
   page.once("dialog", (dialog) => dialog.accept());
   await newsletterCard(page)
     .getByRole("button", { name: "Delete 1 of 2" })
@@ -300,29 +301,58 @@ async function restoreFixtureThreads(page: Page, emailAccountId: string) {
   await restoreCleanupThreads(page, emailAccountId, BULK_ARCHIVE_THREAD_IDS);
 }
 
-function stubMailboxSync(page: Page, emailAccountId: string) {
-  return page.route("**/api/mobile/mailbox-sync", async (route) => {
-    const upsertedMessages = await getCleanupMailboxMessages(
+async function stubMailboxSync(page: Page, emailAccountId: string) {
+  const initialThreads = await getCleanupMailboxThreads(
+    page,
+    emailAccountId,
+    CLEANUP_MAILBOX_THREAD_IDS,
+  );
+  const deletedThreadIds = new Set<string>();
+
+  await page.route("**/api/mobile/mailbox-sync", async (route) => {
+    const expectedThreadIds = CLEANUP_MAILBOX_THREAD_IDS.filter(
+      (threadId) => !deletedThreadIds.has(threadId),
+    );
+    const threads = await getCleanupMailboxThreads(
       page,
       emailAccountId,
+      expectedThreadIds,
     );
-    return route.fulfill({
+    const returnedThreadIds = new Set(threads.map((thread) => thread.id));
+    const deletedMessageIds = initialThreads
+      .filter(
+        (thread) =>
+          deletedThreadIds.has(thread.id) && !returnedThreadIds.has(thread.id),
+      )
+      .flatMap((thread) => thread.messages.map((message) => message.id));
+
+    await route.fulfill({
       body: JSON.stringify({
         accountId: emailAccountId,
         cursor: "playwright-cleanup-sync",
-        deletedMessageIds: [],
+        deletedMessageIds,
         hasMore: false,
         reset: false,
-        upsertedMessages,
+        upsertedMessages: threads.flatMap((thread) => thread.messages),
       }),
       contentType: "application/json",
       status: 200,
     });
   });
+
+  return {
+    expectDeleted(threadId: string) {
+      deletedThreadIds.add(threadId);
+    },
+  };
 }
 
-async function getCleanupMailboxMessages(page: Page, emailAccountId: string) {
-  let messages: unknown[] | undefined;
+async function getCleanupMailboxThreads(
+  page: Page,
+  emailAccountId: string,
+  expectedThreadIds: string[],
+) {
+  let threads: { id: string; messages: { id: string }[] }[] | undefined;
   await expect
     .poll(
       async () => {
@@ -334,9 +364,20 @@ async function getCleanupMailboxMessages(page: Page, emailAccountId: string) {
           if (!response.ok()) return false;
 
           const result = (await response.json()) as {
-            threads: { messages: unknown[] }[];
+            threads: { id: string; messages: { id: string }[] }[];
           };
-          messages = result.threads.flatMap((thread) => thread.messages);
+          const returnedThreadIds = new Set(
+            result.threads.map((thread) => thread.id),
+          );
+          if (
+            !expectedThreadIds.every((threadId) =>
+              returnedThreadIds.has(threadId),
+            )
+          ) {
+            return false;
+          }
+
+          threads = result.threads;
           return true;
         } catch {
           return false;
@@ -346,6 +387,8 @@ async function getCleanupMailboxMessages(page: Page, emailAccountId: string) {
     )
     .toBe(true);
 
-  if (!messages) throw new Error("Mailbox thread request returned no messages");
-  return messages;
+  if (!threads?.length) {
+    throw new Error("Mailbox thread request returned no threads");
+  }
+  return threads;
 }

--- a/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/cleanup/bulk-archive.spec.ts
@@ -322,18 +322,30 @@ function stubMailboxSync(page: Page, emailAccountId: string) {
 }
 
 async function getCleanupMailboxMessages(page: Page, emailAccountId: string) {
-  const response = await page.request.get("/api/threads?type=inbox&view=list", {
-    headers: { "X-Email-Account-ID": emailAccountId },
-  });
-  if (!response.ok()) {
-    throw new Error(`Inbox request failed with ${response.status()}`);
-  }
-  const result = (await response.json()) as {
-    threads: { id: string; messages: unknown[] }[];
-  };
-  return result.threads
-    .filter((thread) =>
-      CLEANUP_MAILBOX_THREAD_IDS.some((threadId) => threadId === thread.id),
+  let messages: unknown[] | undefined;
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get(
+            `/api/threads/batch?threadIds=${CLEANUP_MAILBOX_THREAD_IDS.join(",")}`,
+            { headers: { "X-Email-Account-ID": emailAccountId } },
+          );
+          if (!response.ok()) return false;
+
+          const result = (await response.json()) as {
+            threads: { messages: unknown[] }[];
+          };
+          messages = result.threads.flatMap((thread) => thread.messages);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 120_000 },
     )
-    .flatMap((thread) => thread.messages);
+    .toBe(true);
+
+  if (!messages) throw new Error("Mailbox thread request returned no messages");
+  return messages;
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260826-212908_pr-3405_b3e44ecbdeb1/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes the cleanup Web E2E race by reconciling the exact seeded threads instead of filtering an inbox-only snapshot. This preserves the archived thread with its current labels so stale sync responses cannot restore it to the inbox.

- fetch the cleanup fixture through the exact thread batch endpoint
- retry transient fixture request failures with a bounded poll
- validated the failed reconnect scenario and the full four-test cleanup spec

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved coverage for bulk archive cleanup workflows, including selected sender deletion.
  - Added validation that deleted threads are correctly reflected in mailbox synchronization responses.
  - Enhanced polling and retry behavior for asynchronous mailbox updates.
  - Strengthened checks for expected thread availability and non-empty responses, reducing failures caused by delayed processing or incomplete API results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->