### PR TITLE
Meeting notetaker launch: drafting context, pricing, analytics

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -308,7 +308,6 @@ LOOPS_API_SECRET=
 #      below. Staging and production need separate Recall workspaces because
 #      the webhook is configured per workspace.
 #   3. Set RECALL_REGION to your workspace region. It defaults to us-west-2.
-#   4. Set NEXT_PUBLIC_MEETING_RECORDER_ENABLED=true (Feature flags below).
 # The docker-compose cron service already calls /api/meeting-recorder/schedule;
 # without both credentials set, that route is a no-op.
 # RECALL_API_KEY=
@@ -318,7 +317,7 @@ LOOPS_API_SECRET=
 # Feature flags
 # NEXT_PUBLIC_DIGEST_ENABLED=true
 # NEXT_PUBLIC_MEETING_BRIEFS_ENABLED=true
-# NEXT_PUBLIC_MEETING_RECORDER_ENABLED=false # beta
+# NEXT_PUBLIC_MEETING_RECORDER_ENABLED=false # set true to show the meeting notetaker (requires Recall.ai)
 # NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED=true
 # NEXT_PUBLIC_INTEGRATIONS_ENABLED=false # beta
 # NEXT_PUBLIC_SMART_FILING_ENABLED=false # beta

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -308,6 +308,8 @@ LOOPS_API_SECRET=
 #      below. Staging and production need separate Recall workspaces because
 #      the webhook is configured per workspace.
 #   3. Set RECALL_REGION to your workspace region. It defaults to us-west-2.
+#   4. Set NEXT_PUBLIC_MEETING_RECORDER_ENABLED=true (Feature flags below) to
+#      show the feature in the app.
 # The docker-compose cron service already calls /api/meeting-recorder/schedule;
 # without both credentials set, that route is a no-op.
 # RECALL_API_KEY=

--- a/apps/web/__tests__/eval/harness/draft-reply-adapter.ts
+++ b/apps/web/__tests__/eval/harness/draft-reply-adapter.ts
@@ -49,6 +49,7 @@ export async function invokeDraftReply({
     learnedWritingStyle: context.learnedWritingStyle,
     mcpContext: context.mcpContext,
     meetingContext: context.meetingContext,
+    recordedMeetingContext: context.recordedMeetingContext,
     attachmentContext: context.attachmentContext,
     hasConfiguredSignature: input.hasConfiguredSignature,
     currentDate: input.currentDate ? new Date(input.currentDate) : undefined,

--- a/apps/web/__tests__/eval/harness/draft-reply-schema.ts
+++ b/apps/web/__tests__/eval/harness/draft-reply-schema.ts
@@ -69,6 +69,7 @@ export const draftReplyContextSchema = z.object({
   learnedWritingStyle: z.string().nullable().default(null),
   mcpContext: z.string().nullable().default(null),
   meetingContext: z.string().nullable().default(null),
+  recordedMeetingContext: z.string().nullable().default(null),
   attachmentContext: z.string().nullable().default(null),
 });
 

--- a/apps/web/__tests__/eval/model-catalog.ts
+++ b/apps/web/__tests__/eval/model-catalog.ts
@@ -15,6 +15,11 @@ export interface EvalModel {
 }
 
 export const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
+  "deepseek-v4-flash": {
+    provider: "openrouter",
+    model: "deepseek/deepseek-v4-flash",
+    label: "DeepSeek V4 Flash",
+  },
   "gemini-3-flash": {
     provider: "openrouter",
     model: "google/gemini-3-flash-preview",

--- a/apps/web/__tests__/eval/models.ts
+++ b/apps/web/__tests__/eval/models.ts
@@ -25,8 +25,9 @@ export function shouldRunEvalTests(): boolean {
 /**
  * Runs a describe block for each model in the eval matrix.
  *
- * When EVAL_MODELS is not set, runs a single block using the default
- * env-configured model (identical to normal test behavior).
+ * When EVAL_MODELS is not set, runs a single block using the catalog's
+ * default model (deepseek-v4-flash), so results are comparable across
+ * machines regardless of local env model configuration.
  *
  * When EVAL_MODELS=all or a JSON array, runs one block per model
  * with the emailAccount configured to route through that model.
@@ -47,7 +48,7 @@ export function describeEvalMatrix(
   const models = getEvalModels();
 
   if (models.length === 0) {
-    const fallback = EVAL_MODEL_CATALOG["gemini-3-flash"];
+    const fallback = EVAL_MODEL_CATALOG["deepseek-v4-flash"];
     describe(name, () => {
       fn(fallback, getEmailAccountForModel(fallback, overrides));
     });

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -25,6 +25,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/meeting-detail-state";
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
 
 export function MeetingDetail({
@@ -35,6 +36,7 @@ export function MeetingDetail({
   onClose: () => void;
 }) {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics();
   const { data, isLoading, error } = useMeetingRecorderMeeting(
     meetingId,
     emailAccountId,
@@ -174,6 +176,11 @@ export function MeetingDetail({
                     href={getFollowUpDraftUrl(data.id, emailAccountId)}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      analytics.captureAction(
+                        "meeting_recorder_follow_up_draft_opened",
+                      )
+                    }
                   >
                     Go to drafts
                   </a>

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderSettingsDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingRecorderSettingsDialog.tsx
@@ -18,6 +18,7 @@ import {
   useMeetingRecorderSettings,
   useMeetingRecorderUpcoming,
 } from "@/hooks/useMeetingRecorder";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { getActionErrorMessage } from "@/utils/error";
 import { updateMeetingRecorderSettingsAction } from "@/utils/actions/meeting-recorder";
 import type { UpdateMeetingRecorderSettingsBody } from "@/utils/actions/meeting-recorder.validation";
@@ -32,6 +33,7 @@ export function MeetingRecorderSettingsDialog({
   open: boolean;
   onClose: () => void;
 }) {
+  const analytics = useProductAnalytics();
   // Only mounted inside the page's `settings.enabled` branch, so the settings
   // are already loaded and SWR serves them from cache.
   const { data, mutate } = useMeetingRecorderSettings(emailAccountId);
@@ -78,7 +80,13 @@ export function MeetingRecorderSettingsDialog({
                 name="joinRule"
                 ariaLabel="Which meetings to join"
                 value={data.joinRule}
-                onChange={(joinRule) => save({ joinRule })}
+                onChange={(joinRule) => {
+                  analytics.captureAction("meeting_recorder_setting_changed", {
+                    setting: "join_rule",
+                    value: joinRule,
+                  });
+                  save({ joinRule });
+                }}
                 options={JOIN_RULE_OPTIONS}
               />
             </div>
@@ -92,7 +100,13 @@ export function MeetingRecorderSettingsDialog({
                   name="recapEmailEnabled"
                   ariaLabel="Email me the notes"
                   enabled={data.recapEmailEnabled}
-                  onChange={(recapEmailEnabled) => save({ recapEmailEnabled })}
+                  onChange={(recapEmailEnabled) => {
+                    analytics.captureAction(
+                      "meeting_recorder_setting_changed",
+                      { setting: "recap_email", value: recapEmailEnabled },
+                    );
+                    save({ recapEmailEnabled });
+                  }}
                 />
               </Item>
 
@@ -104,9 +118,16 @@ export function MeetingRecorderSettingsDialog({
                   name="followUpDraftEnabled"
                   ariaLabel="Draft a follow-up email"
                   enabled={data.followUpDraftEnabled}
-                  onChange={(followUpDraftEnabled) =>
-                    save({ followUpDraftEnabled })
-                  }
+                  onChange={(followUpDraftEnabled) => {
+                    analytics.captureAction(
+                      "meeting_recorder_setting_changed",
+                      {
+                        setting: "follow_up_draft",
+                        value: followUpDraftEnabled,
+                      },
+                    );
+                    save({ followUpDraftEnabled });
+                  }}
                 />
               </Item>
             </ListCard>
@@ -116,6 +137,7 @@ export function MeetingRecorderSettingsDialog({
               <Button
                 variant="outline"
                 onClick={() => {
+                  analytics.captureAction("meeting_recorder_disabled");
                   save({ enabled: false });
                   onClose();
                 }}

--- a/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
@@ -21,6 +21,7 @@ import type { GetMeetingRecorderUpcomingResponse } from "@/app/api/user/meeting-
 import { MeetingListItem } from "@/app/(app)/[emailAccountId]/meetings/MeetingListItem";
 import { MEETING_DETAIL_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { useMeetingRecorderUpcoming } from "@/hooks/useMeetingRecorder";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { setMeetingJoinOverrideAction } from "@/utils/actions/meeting-recorder";
 import { getActionErrorMessage } from "@/utils/error";
 
@@ -33,6 +34,7 @@ export function UpcomingMeetingsToggleList({
   emailAccountId: string;
   onOpenMeeting: (meetingId: string) => void;
 }) {
+  const analytics = useProductAnalytics();
   const { data, isLoading, error, mutate } =
     useMeetingRecorderUpcoming(emailAccountId);
   const [pendingEventId, setPendingEventId] = useState<string | null>(null);
@@ -55,6 +57,9 @@ export function UpcomingMeetingsToggleList({
   );
 
   const toggleEvent = (event: UpcomingEvent, join: boolean) => {
+    analytics.captureAction("meeting_recorder_join_override_toggled", {
+      join,
+    });
     setPendingEventId(event.id);
     execute({ join, calendarEventId: event.id });
   };

--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { CalendarIcon, MicIcon, SettingsIcon } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -15,6 +14,7 @@ import type { MeetingJoinRule } from "@/generated/prisma/enums";
 import { useCalendars } from "@/hooks/useCalendars";
 import { useMeetingRecorderEnabled } from "@/hooks/useFeatureFlags";
 import { useMeetingRecorderSettings } from "@/hooks/useMeetingRecorder";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { updateMeetingRecorderSettingsAction } from "@/utils/actions/meeting-recorder";
 import { getActionErrorMessage } from "@/utils/error";
@@ -38,13 +38,8 @@ export default function MeetingsPage() {
           <ActionCard
             variant="blue"
             icon={<MicIcon className="h-5 w-5" />}
-            title="Meeting notetaker is not enabled"
-            description="This feature is in limited rollout. Join early access to enable it for your account."
-            action={
-              <Button asChild variant="outline">
-                <Link href="/early-access">Join Early Access</Link>
-              </Button>
-            }
+            title="Meeting notetaker is disabled"
+            description="The meeting notetaker is turned off on this server. Set NEXT_PUBLIC_MEETING_RECORDER_ENABLED=true and see the self-hosting docs to configure it."
           />
         </div>
       </PageWrapper>
@@ -56,6 +51,7 @@ export default function MeetingsPage() {
 
 function MeetingRecorderPageContent() {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [openMeetingId, setOpenMeetingId] = useState<string | null>(null);
 
@@ -74,7 +70,10 @@ function MeetingRecorderPageContent() {
   const { execute, status } = useAction(
     updateMeetingRecorderSettingsAction.bind(null, emailAccountId),
     {
-      onSuccess: () => mutate(),
+      onSuccess: () => {
+        analytics.captureAction("meeting_recorder_enabled");
+        mutate();
+      },
       onError: ({ error }) => {
         toastError({
           description: getActionErrorMessage(error, {
@@ -100,6 +99,11 @@ function MeetingRecorderPageContent() {
 
   const hasCalendarConnected = hasConnectedCalendar(calendarsData?.connections);
 
+  const openMeeting = (meetingId: string) => {
+    analytics.captureAction("meeting_recorder_meeting_opened");
+    setOpenMeetingId(meetingId);
+  };
+
   // Enabling is entitlement-gated server-side, so a non-premium user needs the
   // upgrade path on the onboarding screen too, not just once they are set up.
   if (!settings?.enabled) {
@@ -112,9 +116,13 @@ function MeetingRecorderPageContent() {
         <MeetingRecorderOnboarding
           emailAccountId={emailAccountId}
           hasCalendarConnected={hasCalendarConnected}
-          onEnable={(joinRule: MeetingJoinRule) =>
-            execute({ enabled: true, joinRule })
-          }
+          onEnable={(joinRule: MeetingJoinRule) => {
+            analytics.captureAction("meeting_recorder_enable_started", {
+              join_rule: joinRule,
+              has_calendar_connected: hasCalendarConnected,
+            });
+            execute({ enabled: true, joinRule });
+          }}
           isEnabling={status === "executing"}
         />
       </PageWrapper>
@@ -160,10 +168,10 @@ function MeetingRecorderPageContent() {
 
         <UpcomingMeetingsToggleList
           emailAccountId={emailAccountId}
-          onOpenMeeting={setOpenMeetingId}
+          onOpenMeeting={openMeeting}
         />
 
-        <MeetingsList onOpenMeeting={setOpenMeetingId} />
+        <MeetingsList onOpenMeeting={openMeeting} />
       </div>
 
       <MeetingDetail

--- a/apps/web/app/(app)/premium/config.ts
+++ b/apps/web/app/(app)/premium/config.ts
@@ -304,6 +304,11 @@ const plusTier: Tier = {
         "Each user gets 2 email accounts included. Additional email accounts are billed at the standard per-seat rate.",
     },
     {
+      text: "AI meeting notetaker",
+      tooltip:
+        "A notetaker joins your video calls and turns them into transcripts, summaries, recap emails, and follow-up drafts.",
+    },
+    {
       text: "Slack integration",
       tooltip:
         "Forward important emails and notifications to your Slack channels automatically.",

--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -19,6 +19,7 @@ export const footerNavigation = {
     { name: "Telegram AI Assistant", href: "/telegram-integration" },
     { name: "Teams AI Assistant", href: "/teams-integration" },
     { name: "Brief My Meeting", href: "/brief-my-meeting" },
+    { name: "AI Meeting Notetaker", href: "/ai-meeting-notetaker" },
     { name: "Reply Zero", href: "/reply-zero-ai" },
     { name: "Bulk Email Unsubscriber", href: "/bulk-email-unsubscriber" },
     { name: "Clean your inbox", href: "/clean-inbox" },

--- a/apps/web/app/(landing)/pricing/PricingComparisonTable.tsx
+++ b/apps/web/app/(landing)/pricing/PricingComparisonTable.tsx
@@ -58,6 +58,12 @@ const features: {
     professional: true,
   },
   {
+    name: "AI meeting notetaker",
+    starter: false,
+    plus: true,
+    professional: true,
+  },
+  {
     name: "Email digests",
     starter: false,
     plus: true,

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -111,7 +111,6 @@ export const useNavigation = () => {
               name: "Meetings",
               href: prefixPath(currentEmailAccountId, "/meetings"),
               icon: MicIcon,
-              beta: true,
             },
           ]
         : []),

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -23,8 +23,7 @@ export function useMeetingBriefsEnabled() {
 }
 
 export function useMeetingRecorderEnabled() {
-  const posthogEnabled = useFeatureFlagEnabled("meeting-recorder");
-  return env.NEXT_PUBLIC_MEETING_RECORDER_ENABLED || posthogEnabled;
+  return env.NEXT_PUBLIC_MEETING_RECORDER_ENABLED;
 }
 
 // Returns undefined while the PostHog flag is still loading

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -143,8 +143,7 @@ export default defineConfig({
         NEXT_PUBLIC_DUB_REFER_DOMAIN: "",
         NEXT_PUBLIC_IS_RESEND_CONFIGURED: "",
         NEXT_PUBLIC_CONTACTS_ENABLED: "false",
-        NEXT_PUBLIC_MEETING_RECORDER_ENABLED:
-          process.env.NEXT_PUBLIC_MEETING_RECORDER_ENABLED ?? "true",
+        NEXT_PUBLIC_MEETING_RECORDER_ENABLED: "true",
         PLAYWRIGHT_TEST_EMAIL: playwrightTestEmail,
       },
     },

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 25;
+export const DRAFT_PIPELINE_VERSION = 26;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-context-metadata.ts
+++ b/apps/web/utils/ai/reply/draft-context-metadata.ts
@@ -39,6 +39,13 @@ export const draftContextMetadataSchema = z.object({
     injected: z.boolean(),
     count: z.number(),
   }),
+  // Optional: rows written before this field existed are still parsed.
+  recordedMeetings: z
+    .object({
+      injected: z.boolean(),
+      count: z.number(),
+    })
+    .optional(),
   attachments: z.object({
     injected: z.boolean(),
     selectedCount: z.number(),

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -86,6 +86,7 @@ const getUserPrompt = ({
   learnedWritingStyle,
   mcpContext,
   meetingContext,
+  recordedMeetingContext,
   attachmentContext,
   hasConfiguredSignature,
   currentDate,
@@ -102,6 +103,7 @@ const getUserPrompt = ({
   learnedWritingStyle: string | null;
   mcpContext: string | null;
   meetingContext: string | null;
+  recordedMeetingContext: string | null;
   attachmentContext: string | null;
   hasConfiguredSignature: boolean;
   currentDate?: Date;
@@ -209,12 +211,14 @@ ${mcpContext}
     !emailHistoryContext?.relevantEmails.length &&
     !mcpContext &&
     !meetingContext &&
+    !recordedMeetingContext &&
     !attachmentContext
       ? `No additional factual context was provided beyond the email thread.
 `
       : "";
 
   const upcomingMeetingsContext = meetingContext || "";
+  const recordedMeetingsContext = recordedMeetingContext || "";
   const selectedAttachments = attachmentContext
     ? `Selected PDF attachments that will be included with this draft:
 
@@ -243,6 +247,7 @@ ${schedulingContext}
 ${mcpToolsContext}
 ${missingExternalContext}
 ${upcomingMeetingsContext}
+${recordedMeetingsContext}
 ${selectedAttachments}
 
 Here is the context of the email thread (from oldest to newest):
@@ -285,6 +290,7 @@ export async function aiDraftReplyWithConfidence({
   learnedWritingStyle = null,
   mcpContext,
   meetingContext,
+  recordedMeetingContext = null,
   attachmentContext = null,
   hasConfiguredSignature = false,
   currentDate,
@@ -301,6 +307,7 @@ export async function aiDraftReplyWithConfidence({
   learnedWritingStyle?: string | null;
   mcpContext: string | null;
   meetingContext: string | null;
+  recordedMeetingContext?: string | null;
   attachmentContext?: string | null;
   hasConfiguredSignature?: boolean;
   currentDate?: Date;
@@ -341,6 +348,7 @@ export async function aiDraftReplyWithConfidence({
     learnedWritingStyle: advisoryLearnedWritingStyle,
     mcpContext,
     meetingContext,
+    recordedMeetingContext,
     attachmentContext,
     hasConfiguredSignature,
     currentDate,
@@ -404,6 +412,7 @@ export async function aiDraftReply({
   learnedWritingStyle = null,
   mcpContext,
   meetingContext,
+  recordedMeetingContext = null,
   attachmentContext = null,
   hasConfiguredSignature = false,
   currentDate,
@@ -420,6 +429,7 @@ export async function aiDraftReply({
   learnedWritingStyle?: string | null;
   mcpContext: string | null;
   meetingContext: string | null;
+  recordedMeetingContext?: string | null;
   attachmentContext?: string | null;
   hasConfiguredSignature?: boolean;
   currentDate?: Date;
@@ -437,6 +447,7 @@ export async function aiDraftReply({
     learnedWritingStyle,
     mcpContext,
     meetingContext,
+    recordedMeetingContext,
     attachmentContext,
     hasConfiguredSignature,
     currentDate,

--- a/apps/web/utils/analytics/product.ts
+++ b/apps/web/utils/analytics/product.ts
@@ -39,6 +39,15 @@ export const PRODUCT_ANALYTICS_ACTIONS = {
     enableStarted: "meeting_briefs_enable_started",
     toggled: "meeting_briefs_toggled",
   },
+  meetingRecorder: {
+    disabled: "meeting_recorder_disabled",
+    enabled: "meeting_recorder_enabled",
+    enableStarted: "meeting_recorder_enable_started",
+    followUpDraftOpened: "meeting_recorder_follow_up_draft_opened",
+    joinOverrideToggled: "meeting_recorder_join_override_toggled",
+    meetingOpened: "meeting_recorder_meeting_opened",
+    settingChanged: "meeting_recorder_setting_changed",
+  },
   bulkUnsubscribe: {
     bulkCompleted: "bulk_unsubscribe_completed",
     bulkStarted: "bulk_unsubscribe_started",

--- a/apps/web/utils/meeting-recorder/process-meeting.test.ts
+++ b/apps/web/utils/meeting-recorder/process-meeting.test.ts
@@ -15,6 +15,9 @@ const {
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/error", () => ({ captureException: vi.fn() }));
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: vi.fn().mockResolvedValue(true),
+}));
 vi.mock("@/utils/ai/meeting-recorder/summarize-meeting", () => ({
   aiSummarizeMeeting: (...args: unknown[]) => aiSummarizeMeetingMock(...args),
   parseMeetingSummary: () => null,

--- a/apps/web/utils/meeting-recorder/process-meeting.ts
+++ b/apps/web/utils/meeting-recorder/process-meeting.ts
@@ -22,6 +22,7 @@ import {
   STUCK_PROCESSING_MINUTES,
 } from "@/utils/meeting-recorder/config";
 import { sendMeetingRecapEmail } from "@/utils/meeting-recorder/send-recap";
+import { posthogCaptureEvent } from "@/utils/posthog";
 import { checkHasAccess } from "@/utils/premium/server";
 import prisma from "@/utils/prisma";
 import { textToHtmlParagraphs } from "@/utils/string";
@@ -207,6 +208,8 @@ async function runProcessingSteps({
         followUpDraftCreated: !!refreshedMeeting?.followUpDraftId,
         logger,
       });
+
+      await posthogCaptureEvent(emailAccount.email, "Meeting recap email sent");
     }
   }
 }
@@ -234,6 +237,10 @@ async function summarizeAndSave({
   await prisma.meeting.update({
     where: { id: meetingId },
     data: { summary },
+  });
+
+  await posthogCaptureEvent(emailAccount.email, "Meeting summary created", {
+    attendeeCount: attendees.length,
   });
 
   return summary;
@@ -299,4 +306,10 @@ async function createFollowUpDraft({
   });
 
   logger.info("Created meeting follow-up draft", { draftId: id });
+
+  await posthogCaptureEvent(
+    emailAccount.email,
+    "Meeting follow-up draft created",
+    { recipientCount: recipients.length },
+  );
 }

--- a/apps/web/utils/meeting-recorder/reply-context.test.ts
+++ b/apps/web/utils/meeting-recorder/reply-context.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  getRecordedMeetingContext,
+  formatRecordedMeetingContextForPrompt,
+  type RecordedMeetingContext,
+} from "./reply-context";
+import prisma from "@/utils/prisma";
+import { createTestLogger } from "@/__tests__/helpers";
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    meeting: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const logger = createTestLogger();
+
+const summary = {
+  overview: "Discussed the Q3 rollout plan.",
+  keyDecisions: ["Ship the beta next week"],
+  actionItems: [{ description: "Send pricing doc", owner: "Alex" }],
+  openQuestions: ["Which regions launch first?"],
+  nextSteps: ["Reconvene on Friday"],
+};
+
+function createMeetingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    eventTitle: "Project kickoff",
+    startTime: new Date("2026-08-20T10:00:00Z"),
+    attendees: [
+      { email: "user@example.com" },
+      { email: "sender@example.com", name: "Sender" },
+    ],
+    summary,
+    ...overrides,
+  };
+}
+
+describe("getRecordedMeetingContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns summaries of meetings the recipient attended", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow(),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toEqual([
+      {
+        eventTitle: "Project kickoff",
+        startTime: new Date("2026-08-20T10:00:00Z"),
+        summary,
+      },
+    ]);
+  });
+
+  it("excludes meetings the recipient was not part of", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow({
+        attendees: [
+          { email: "user@example.com" },
+          { email: "someone-else@example.com" },
+        ],
+      }),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes meetings the recipient declined", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow({
+        attendees: [
+          { email: "user@example.com" },
+          { email: "sender@example.com", declined: true },
+        ],
+      }),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("requires every additional recipient to have attended", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow(),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      additionalRecipients: ["cc-recipient@example.com"],
+      logger,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("matches attendee emails case-insensitively", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow({
+        attendees: [{ email: "Sender@Example.com " }],
+      }),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("skips meetings whose stored summary no longer parses", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue([
+      createMeetingRow({ summary: { unrelated: true } }),
+      createMeetingRow({ eventTitle: "Valid meeting" }),
+    ] as any);
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].eventTitle).toBe("Valid meeting");
+  });
+
+  it("caps the number of returned meetings", async () => {
+    vi.mocked(prisma.meeting.findMany).mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) =>
+        createMeetingRow({ eventTitle: `Meeting ${i}` }),
+      ) as any,
+    );
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns an empty list when the query fails", async () => {
+    vi.mocked(prisma.meeting.findMany).mockRejectedValue(new Error("db down"));
+
+    const result = await getRecordedMeetingContext({
+      emailAccountId: "account-1",
+      recipientEmail: "sender@example.com",
+      logger,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("formatRecordedMeetingContextForPrompt", () => {
+  it("returns null when there are no meetings", () => {
+    expect(formatRecordedMeetingContextForPrompt([])).toBeNull();
+  });
+
+  it("formats the summary sections for the prompt", () => {
+    const meetings: RecordedMeetingContext[] = [
+      {
+        eventTitle: "Project kickoff",
+        startTime: new Date("2026-08-20T10:00:00Z"),
+        summary,
+      },
+    ];
+
+    const result = formatRecordedMeetingContextForPrompt(meetings, "UTC");
+
+    expect(result).toContain('"Project kickoff"');
+    expect(result).toContain("Overview: Discussed the Q3 rollout plan.");
+    expect(result).toContain("Decisions: Ship the beta next week");
+    expect(result).toContain("Action items: Send pricing doc (owner: Alex)");
+    expect(result).toContain("Open questions: Which regions launch first?");
+    expect(result).toContain("Next steps: Reconvene on Friday");
+  });
+
+  it("omits empty summary sections", () => {
+    const meetings: RecordedMeetingContext[] = [
+      {
+        eventTitle: "Quick sync",
+        startTime: new Date("2026-08-20T10:00:00Z"),
+        summary: {
+          overview: "Short status check.",
+          keyDecisions: [],
+          actionItems: [],
+          openQuestions: null,
+          nextSteps: null,
+        },
+      },
+    ];
+
+    const result = formatRecordedMeetingContextForPrompt(meetings, "UTC");
+
+    expect(result).toContain("Overview: Short status check.");
+    expect(result).not.toContain("Decisions:");
+    expect(result).not.toContain("Action items:");
+    expect(result).not.toContain("Open questions:");
+    expect(result).not.toContain("Next steps:");
+  });
+});

--- a/apps/web/utils/meeting-recorder/reply-context.ts
+++ b/apps/web/utils/meeting-recorder/reply-context.ts
@@ -1,0 +1,155 @@
+import { subDays } from "date-fns/subDays";
+import { Prisma } from "@/generated/prisma/client";
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+import { formatInUserTimezone } from "@/utils/date";
+import { parseAttendeeSnapshot } from "@/utils/meeting-recorder/attendees";
+import {
+  parseMeetingSummary,
+  type MeetingSummary,
+} from "@/utils/ai/meeting-recorder/summarize-meeting";
+
+const RECORDED_MEETING_LOOKBACK_DAYS = 30;
+const MAX_RECORDED_MEETINGS = 3;
+// Fetched before the attendee filter runs in JS, so this bounds the scan, not
+// the result size.
+const FETCH_LIMIT = 25;
+
+export interface RecordedMeetingContext {
+  eventTitle: string;
+  startTime: Date;
+  summary: MeetingSummary;
+}
+
+/**
+ * Fetches AI summaries of recorded meetings (from the meeting notetaker) that
+ * the email's recipients attended, for use as drafting context.
+ *
+ * Privacy: recorded content is stricter than calendar metadata. A meeting is
+ * only included when every recipient of the email was a non-declined attendee,
+ * so what was said in a call is never surfaced to someone who wasn't on it.
+ */
+export async function getRecordedMeetingContext({
+  emailAccountId,
+  recipientEmail,
+  additionalRecipients = [],
+  logger,
+}: {
+  emailAccountId: string;
+  recipientEmail: string;
+  additionalRecipients?: string[];
+  logger: Logger;
+}): Promise<RecordedMeetingContext[]> {
+  try {
+    const meetings = await prisma.meeting.findMany({
+      where: {
+        emailAccountId,
+        summary: { not: Prisma.DbNull },
+        startTime: { gte: subDays(new Date(), RECORDED_MEETING_LOOKBACK_DAYS) },
+      },
+      orderBy: { startTime: "desc" },
+      take: FETCH_LIMIT,
+      select: {
+        eventTitle: true,
+        startTime: true,
+        attendees: true,
+        summary: true,
+      },
+    });
+
+    const requiredAttendees = [recipientEmail, ...additionalRecipients].map(
+      (email) => email.trim().toLowerCase(),
+    );
+
+    const results: RecordedMeetingContext[] = [];
+
+    for (const meeting of meetings) {
+      if (results.length >= MAX_RECORDED_MEETINGS) break;
+
+      const attendedEmails = new Set(
+        parseAttendeeSnapshot(meeting.attendees)
+          .filter((attendee) => !attendee.declined)
+          .map((attendee) => attendee.email.trim().toLowerCase()),
+      );
+      if (!requiredAttendees.every((email) => attendedEmails.has(email))) {
+        continue;
+      }
+
+      const summary = parseMeetingSummary(meeting.summary);
+      if (!summary) continue;
+
+      results.push({
+        eventTitle: meeting.eventTitle,
+        startTime: meeting.startTime,
+        summary,
+      });
+    }
+
+    return results;
+  } catch (error) {
+    logger.error("Failed to get recorded meeting context", { error });
+    return [];
+  }
+}
+
+/**
+ * Formats recorded meeting summaries for inclusion in the reply-drafting
+ * prompt.
+ */
+export function formatRecordedMeetingContextForPrompt(
+  meetings: RecordedMeetingContext[],
+  timezone?: string | null,
+): string | null {
+  if (meetings.length === 0) return null;
+
+  const notes = meetings
+    .map((meeting) => formatRecordedMeeting(meeting, timezone))
+    .join("\n\n");
+
+  return `You have notes from recorded meetings that the recipients of this email attended:
+
+<recorded_meeting_notes>
+${notes}
+</recorded_meeting_notes>
+
+Treat these notes as factual context about what was discussed and agreed. Reference the conversation naturally when relevant (e.g. "as discussed on our call"). Do not mention recordings, transcripts, or notes, and do not recap the meeting unprompted.`;
+}
+
+function formatRecordedMeeting(
+  meeting: RecordedMeetingContext,
+  timezone?: string | null,
+): string {
+  const dateTime = formatInUserTimezone(
+    meeting.startTime,
+    timezone,
+    "EEEE, MMMM d 'at' h:mm a",
+  );
+  const { summary } = meeting;
+
+  const lines = [
+    `- "${meeting.eventTitle}" on ${dateTime}`,
+    `  Overview: ${summary.overview}`,
+  ];
+
+  if (summary.keyDecisions.length > 0) {
+    lines.push(`  Decisions: ${summary.keyDecisions.join("; ")}`);
+  }
+  if (summary.actionItems.length > 0) {
+    const items = summary.actionItems
+      .map((item) =>
+        item.owner
+          ? `${item.description} (owner: ${item.owner})`
+          : item.description,
+      )
+      .join("; ");
+    lines.push(`  Action items: ${items}`);
+  }
+  if (summary.openQuestions?.length) {
+    lines.push(`  Open questions: ${summary.openQuestions.join("; ")}`);
+  }
+  if (summary.nextSteps?.length) {
+    lines.push(`  Next steps: ${summary.nextSteps.join("; ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -77,6 +77,11 @@ vi.mock("@/utils/meeting-briefs/recipient-context", () => ({
   formatMeetingContextForPrompt: vi.fn().mockReturnValue(null),
 }));
 
+vi.mock("@/utils/meeting-recorder/reply-context", () => ({
+  getRecordedMeetingContext: vi.fn().mockResolvedValue([]),
+  formatRecordedMeetingContextForPrompt: vi.fn().mockReturnValue(null),
+}));
+
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   selectDraftAttachmentsForRule: vi.fn().mockResolvedValue({
     selectedAttachments: [],
@@ -99,6 +104,10 @@ import { aiGetCalendarAvailability } from "@/utils/ai/calendar/availability";
 import { getReplyMemoriesForPrompt } from "@/utils/ai/reply/reply-memory";
 import { selectDraftAttachmentsForRule } from "@/utils/attachments/draft-attachments";
 import { aiExtractFromEmailHistory } from "@/utils/ai/knowledge/extract-from-email-history";
+import {
+  getRecordedMeetingContext,
+  formatRecordedMeetingContextForPrompt,
+} from "@/utils/meeting-recorder/reply-context";
 import prisma from "@/utils/prisma";
 import { getReplyWithConfidence, saveReply } from "@/utils/redis/reply";
 
@@ -712,6 +721,53 @@ describe("fetchMessagesAndGenerateDraft - thread ordering", () => {
       }),
     );
   });
+
+  it("passes recorded meeting notes into the draft prompt", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Draft reply",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+      attribution: null,
+    });
+    vi.mocked(getRecordedMeetingContext).mockResolvedValueOnce([
+      {
+        eventTitle: "Project kickoff",
+        startTime: new Date("2024-01-01T10:00:00Z"),
+        summary: {
+          overview: "Discussed the rollout plan.",
+          keyDecisions: [],
+          actionItems: [],
+          openQuestions: null,
+          nextSteps: null,
+        },
+      },
+    ]);
+    vi.mocked(formatRecordedMeetingContextForPrompt).mockReturnValueOnce(
+      "Recorded meeting notes",
+    );
+
+    const result = await fetchMessagesAndGenerateDraftWithConfidenceThreshold(
+      createMockEmailAccount(),
+      "thread-1",
+      createMockClient(),
+      createMockMessage(),
+      logger,
+      DraftReplyConfidence.ALL_EMAILS,
+    );
+
+    expect(getRecordedMeetingContext).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientEmail: "sender@example.com" }),
+    );
+    expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordedMeetingContext: "Recorded meeting notes",
+      }),
+    );
+    expect(result.draftContextMetadata).toEqual(
+      expect.objectContaining({
+        recordedMeetings: { injected: true, count: 1 },
+      }),
+    );
+  });
 });
 
 describe("fetchMessagesAndGenerateDraftWithConfidenceThreshold", () => {
@@ -1043,6 +1099,7 @@ function createDraftContextMetadata(): DraftContextMetadata {
     writingStyle: { custom: false },
     externalTools: { injected: false },
     meetings: { injected: false, count: 0 },
+    recordedMeetings: { injected: false, count: 0 },
     attachments: { injected: false, selectedCount: 0 },
   };
 }

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -24,6 +24,10 @@ import {
   getMeetingContext,
   formatMeetingContextForPrompt,
 } from "@/utils/meeting-briefs/recipient-context";
+import {
+  getRecordedMeetingContext,
+  formatRecordedMeetingContextForPrompt,
+} from "@/utils/meeting-recorder/reply-context";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import { meetsDraftReplyConfidenceRequirement } from "@/utils/ai/reply/draft-confidence";
 import type { DraftAttribution } from "@/utils/ai/reply/draft-attribution";
@@ -302,6 +306,12 @@ async function generateDraftContent(
           activeBookingLinks[0]?.minimumNoticeMinutes ?? undefined,
       }),
   );
+  // Other To/CC recipients, used for privacy filtering of meeting context:
+  // only meetings where ALL recipients were attendees are included.
+  const additionalRecipients = [
+    ...extractEmailAddresses(lastMessage.headers.to),
+    ...extractEmailAddresses(lastMessage.headers.cc ?? ""),
+  ].filter((email) => email.toLowerCase() !== emailAccount.email.toLowerCase());
   const [
     knowledgeResult,
     replyMemorySelection,
@@ -311,6 +321,7 @@ async function generateDraftContent(
     emailAccountSettings,
     mcpResult,
     upcomingMeetings,
+    recordedMeetings,
     emailHistorySummary,
     attachmentSelection,
     activeBookingLinks,
@@ -343,14 +354,13 @@ async function generateDraftContent(
     getMeetingContext({
       emailAccountId: emailAccount.id,
       recipientEmail: senderEmail,
-      // extract all other recipients (To, CC) for privacy filtering
-      // only meetings where ALL recipients were attendees will be included
-      additionalRecipients: [
-        ...extractEmailAddresses(lastMessage.headers.to),
-        ...extractEmailAddresses(lastMessage.headers.cc ?? ""),
-      ].filter(
-        (email) => email.toLowerCase() !== emailAccount.email.toLowerCase(),
-      ),
+      additionalRecipients,
+      logger,
+    }),
+    getRecordedMeetingContext({
+      emailAccountId: emailAccount.id,
+      recipientEmail: senderEmail,
+      additionalRecipients,
       logger,
     }),
     historicalMessagesForLLM?.length
@@ -377,6 +387,10 @@ async function generateDraftContent(
   } = replyMemorySelection;
   const meetingContext = formatMeetingContextForPrompt(
     upcomingMeetings,
+    emailAccount.timezone,
+  );
+  const recordedMeetingContext = formatRecordedMeetingContextForPrompt(
+    recordedMeetings,
     emailAccount.timezone,
   );
   const precedentThreadCount = emailHistoryContext?.relevantEmails.length ?? 0;
@@ -407,6 +421,10 @@ async function generateDraftContent(
     writingStyle: { custom: !!writingStyle },
     externalTools: { injected: !!mcpResult?.response },
     meetings: { injected: !!meetingContext, count: upcomingMeetings.length },
+    recordedMeetings: {
+      injected: !!recordedMeetingContext,
+      count: recordedMeetings.length,
+    },
     attachments: {
       injected: !!attachmentSelection.attachmentContext,
       selectedCount: attachmentSelection.selectedAttachments.length,
@@ -441,6 +459,7 @@ async function generateDraftContent(
     hasConfiguredSignature: !!emailAccountSettings?.signature?.trim(),
     mcpContext: mcpResult?.response || null,
     meetingContext,
+    recordedMeetingContext,
     attachmentContext: attachmentSelection.attachmentContext,
   });
 

--- a/docs/essentials/meeting-recorder.mdx
+++ b/docs/essentials/meeting-recorder.mdx
@@ -4,10 +4,6 @@ description: 'Record calls with a visible notetaker and receive transcripts, not
 icon: 'microphone'
 ---
 
-<Note>
-Meeting Recorder is in Early Access.
-</Note>
-
 Meeting Recorder adds **Inbox Zero Notetaker** to your video calls as a visible participant. After the call, Inbox Zero produces a transcript and summary with decisions, action items, and next steps. It can also email the notes to you and prepare a follow-up in your Drafts folder.
 
 <Warning>
@@ -16,7 +12,6 @@ The notetaker records and transcribes a meeting. Make sure participants know it 
 
 ## Requirements
 
-- Early Access must be enabled for your account.
 - Meeting recording requires the **Plus plan or higher**.
 - Connect a Google or Microsoft calendar to Inbox Zero.
 - The calendar event must contain a Google Meet, Zoom, or Microsoft Teams meeting link.
@@ -24,14 +19,13 @@ The notetaker records and transcribes a meeting. Make sure participants know it 
 ## Set up Meeting Recorder
 
 1. Open **Meetings** in the left sidebar.
-2. If the feature is not enabled for your account, select **Join Early Access**.
-3. Connect a calendar if prompted.
-4. Select which meetings the notetaker should join:
+2. Connect a calendar if prompted.
+3. Select which meetings the notetaker should join:
    - **Only calls with people outside my company**: the recommended default.
    - **Every call with a video link**.
    - **Only calls I organize**.
    - **Only the ones I turn on myself**: nothing is scheduled automatically.
-5. Select **Start recording my meetings**.
+4. Select **Start recording my meetings**.
 
 The **Up next** list shows your upcoming calls in the next 48 hours. Use the toggle beside a meeting to override the default for that individual call.
 

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -166,7 +166,7 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS` | No | Bypass premium checks (recommended for self-hosting) | `true` |
 | `NEXT_PUBLIC_DIGEST_ENABLED` | No | Enable email digest feature, which sends periodic summaries of emails. Works without QStash (no retries). | `false` |
 | `NEXT_PUBLIC_MEETING_BRIEFS_ENABLED` | No | Enable meeting briefs, which automatically sends pre-meeting briefings to users. Requires the meeting briefs cron job to be running. | `false` |
-| `NEXT_PUBLIC_MEETING_RECORDER_ENABLED` | No | Enable the Early Access Meeting Recorder. Requires Recall.ai credentials, its signed webhook, and the meeting-recorder scheduling job. | `false` |
+| `NEXT_PUBLIC_MEETING_RECORDER_ENABLED` | No | Show the Meeting Recorder in the app. Recording also requires Recall.ai credentials, its signed webhook, and the meeting-recorder scheduling job; without them nothing records. | `false` |
 | `NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED` | No | Enable follow-up reminders, which allows users to add labels to emails for automatic follow-up tracking. Requires the follow-up reminders cron job to be running. | `false` |
 | `NEXT_PUBLIC_INTEGRATIONS_ENABLED` | No | Enable the integrations feature, allowing users to connect external services. | `false` |
 | `NEXT_PUBLIC_SMART_FILING_ENABLED` | No | Enable the Smart Filing feature for automatic document organization from email attachments. | `false` |


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260827-144016_pr-3408_34683312ae86/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prepares the meeting notetaker for launch and connects it to the AI reply drafter.

- Recorded meeting summaries are now injected into the reply-drafting context (privacy-filtered so content only surfaces when every recipient attended), with a new context module, unit tests, metadata key, and eval-harness ablation key; the draft pipeline version is bumped.
- The notetaker is added to the Plus tier feature list and the pricing comparison table, and linked from the footer.
- Early-access/beta gating (PostHog flag, beta badge, enrollment CTA) is replaced by a plain `NEXT_PUBLIC_MEETING_RECORDER_ENABLED` visibility flag (default off; production must set it to launch).
- Adds PostHog product analytics for the notetaker funnel (enable, settings, join overrides, meeting/draft opens, plus server-side summary/draft/recap events) and updates user and hosting docs.
- Bumps the private marketing submodule pointer to its latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI meeting notetaker availability to Plus and Professional plans.
  * Follow-up email drafts can now use relevant recorded meeting summaries.
  * Added an AI Meeting Notetaker link to the website footer.

* **Improvements**
  * Updated meeting recorder settings and status messaging.
  * Removed the “Beta” label from Meetings navigation.
  * Clarified that server-side configuration is also required to enable recording.

* **Documentation**
  * Simplified setup instructions and clarified required meeting recorder configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->