### PR TITLE
fix: hide the upgrade prompt when premium checks are bypassed

### DIFF
--- a/apps/web/components/PremiumCard.tsx
+++ b/apps/web/components/PremiumCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { XIcon, CreditCardIcon, AlertTriangleIcon } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
+import { env } from "@/env";
 import { isPremiumRecord } from "@/utils/premium";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -41,7 +42,11 @@ export function PremiumExpiredCardContent({
 
   const isUserPremium = isPremiumRecord(premium);
 
-  if (isUserPremium) return null;
+  // Self-hosters running with NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS already have
+  // every premium feature enabled — hasAiAccess and friends short-circuit to
+  // true — so prompting them to upgrade is misleading. They have no premium
+  // record, so the isPremiumRecord check alone never hides this.
+  if (isUserPremium || env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return null;
 
   const getSubscriptionMessage = () => {
     const UPGRADE_MESSAGE = {


### PR DESCRIPTION
## Problem

On a self-hosted instance running with `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true`, the sidebar permanently shows:

> **Upgrade to Premium** — Upgrade to Premium to enable your AI email assistant.

The AI email assistant is already enabled. `hasAiAccess` and the other gates in `utils/premium/index.ts` short-circuit to `true` on that flag, so the prompt is advertising something the user already has.

## Cause

`PremiumExpiredCardContent` decides what to show from `isPremiumRecord(premium)` alone:

```ts
const isUserPremium = isPremiumRecord(premium);

if (isUserPremium) return null;
```

A self-hoster has no premium record, so this never returns null and the card is shown forever, regardless of the bypass flag.

## Fix

Check the same flag the feature gates check, so the card agrees with the actual behaviour. This matches how other client components read public config — for example `ConversionAnalytics` returns `null` when its `NEXT_PUBLIC_` var is unset.

Paid users are unaffected: `isPremiumRecord` still hides the card for them, and the flag is off by default.

## Testing

Self-hosted via `ghcr.io/elie222/inbox-zero:latest` with `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true`. Confirmed the placeholder substitution at startup applies the value (`Replacing all statically built instances of NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS_PLACEHOLDER with true`) and that AI features work, while the upgrade card still renders.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Premium expiration notices are now hidden when premium checks are bypassed, including for self-hosted installations without premium records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->