### PR TITLE
INB-338: Focus composer from empty body area

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -5,6 +5,26 @@ import {
 } from "./account-test-helpers";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
+test("focuses the message field from the empty composer body", async ({
+  page,
+}) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const editorRoot = dialog.locator("[data-email-editor-root]");
+  const editor = editorRoot.locator("[contenteditable='true']");
+  await expect(editor).toBeVisible();
+  await dialog.getByPlaceholder("Subject").focus();
+  await expect(editor).not.toBeFocused();
+
+  // The empty composer's content is a single paragraph at the top, so the
+  // root's center point lands in the empty body area below it.
+  await editorRoot.click();
+
+  await expect(editor).toBeFocused();
+});
+
 test("keeps editing state stable across formatting, links, paste, and files", async ({
   page,
 }, testInfo) => {

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -39,10 +39,15 @@
   outline: none;
 }
 
+.surface[data-email-editor-appearance="seamless"] .editor > div {
+  display: flex;
+  flex-direction: column;
+}
+
 .surface[data-email-editor-appearance="seamless"]
   .editor
   [data-email-editor-content] {
-  min-height: 100%;
+  flex: 1;
   padding: 1rem;
   font-size: 0.9375rem;
   line-height: 1.6;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260827-150001_pr-3410_d15d2b122268/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes composer focus behavior by making seamless editor content fill the available body height, so clicks anywhere in the empty area reach the editable field. Adds a Playwright regression test for the focus behavior.

- Make the seamless editor wrapper a flex column and expand its editable content
- Add emulated Playwright coverage for clicking the empty composer body
- Validate with Biome and the Playwright changed-test dry run; CI runs the browser test

Performance impact:
- Runtime: one scoped CSS flex layout for seamless email editors
- Database/network calls: none
- Hot-path risk: low; the change only affects composer layout and focus hit area

Linear: https://linear.app/inbox-zero-ai/issue/INB-338/clicking-in-the-empty-body-area-of-the-composer-does-not-focus-the

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the seamless email editor layout so the content area expands to fill available space.
  * Ensured clicking the empty message body correctly focuses the editor after moving focus to the subject field.

* **Tests**
  * Added coverage for composer focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->