### PR TITLE
eval: default the model matrix to GPT-5.6 Luna

### DIFF
--- a/apps/web/__tests__/eval/models.ts
+++ b/apps/web/__tests__/eval/models.ts
@@ -26,7 +26,7 @@ export function shouldRunEvalTests(): boolean {
  * Runs a describe block for each model in the eval matrix.
  *
  * When EVAL_MODELS is not set, runs a single block using the catalog's
- * default model (deepseek-v4-flash), so results are comparable across
+ * default model (gpt-5.6-luna), so results are comparable across
  * machines regardless of local env model configuration.
  *
  * When EVAL_MODELS=all or a JSON array, runs one block per model
@@ -48,7 +48,7 @@ export function describeEvalMatrix(
   const models = getEvalModels();
 
   if (models.length === 0) {
-    const fallback = EVAL_MODEL_CATALOG["deepseek-v4-flash"];
+    const fallback = EVAL_MODEL_CATALOG["gpt-5.6-luna"];
     describe(name, () => {
       fn(fallback, getEmailAccountForModel(fallback, overrides));
     });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260827-161858_pr-3411_88e000eafb15/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Changes the eval harness's default model (used when EVAL_MODELS is unset) from DeepSeek V4 Flash to GPT-5.6 Luna. The DeepSeek entry stays available in the catalog as an explicit opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default model used for evaluation runs when no model selection is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->