### PR TITLE
INB-339: Leave calls promptly when only other bots remain

### DIFF
--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -49,6 +49,25 @@ describe("RecallBotProvider", () => {
     });
   });
 
+  it("leaves promptly when only other meeting bots remain", async () => {
+    const { RecallBotProvider } = await import("@/utils/recall/client");
+    const provider = new RecallBotProvider(createTestLogger());
+
+    await provider.scheduleBot({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      joinAt: new Date("2026-05-04T09:00:00.000Z"),
+    });
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    const botDetection = JSON.parse(request?.body as string).automatic_leave
+      ?.bot_detection;
+    expect(botDetection.using_participant_names.matches).toContain("notetaker");
+    expect(botDetection.using_participant_names.activate_after).toBe(0);
+    expect(
+      botDetection.using_participant_events.activate_after,
+    ).toBeGreaterThan(0);
+  });
+
   it("schedules the bot without video when the camera image cannot be loaded", async () => {
     const readError = Object.assign(new Error("Temporary read failure"), {
       code: "EIO",
@@ -69,14 +88,13 @@ describe("RecallBotProvider", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const request = vi.mocked(fetch).mock.calls[0]?.[1];
-    expect(JSON.parse(request?.body as string)).toEqual({
+    const requestBody = JSON.parse(request?.body as string);
+    expect(requestBody).toMatchObject({
       meeting_url: "https://meet.google.com/abc-defg-hij",
       bot_name: "Inbox Zero Notetaker",
       join_at: "2026-05-04T09:00:00.000Z",
-      automatic_leave: {
-        everyone_left_timeout: { timeout: 2 },
-      },
     });
+    expect(requestBody).not.toHaveProperty("automatic_video_output");
   });
 
   it("retries loading the camera image for the next bot", async () => {

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -33,6 +33,18 @@ const DEFAULT_RECALL_REGION = "us-west-2";
 // Use participant presence to end successful recordings; a calendar duration
 // is not the call's actual lifetime.
 const EVERYONE_LEFT_TIMEOUT_SECONDS = 2;
+const MEETING_BOT_NAME_MATCHES = [
+  "notetaker",
+  "recorder",
+  "copilot",
+  "grain",
+  "fellow",
+  "tl;dv",
+  "read.ai",
+  "fathom",
+  "otter.ai",
+  "fireflies.ai",
+];
 
 // Overridden only to point at the local emulator, same as GOOGLE_BASE_URL.
 function getRecallApiBase(): string {
@@ -91,6 +103,20 @@ export class RecallBotProvider implements MeetingBotProvider {
         join_at: joinAt.toISOString(),
         automatic_leave: {
           everyone_left_timeout: { timeout: EVERYONE_LEFT_TIMEOUT_SECONDS },
+          // Timings are in seconds.
+          bot_detection: {
+            using_participant_names: {
+              matches: MEETING_BOT_NAME_MATCHES,
+              activate_after: 0,
+              timeout: 5,
+            },
+            using_participant_events: {
+              // Give real attendees time to speak or share before using
+              // inactivity as a fallback signal for unfamiliar bots.
+              activate_after: 120,
+              timeout: 10,
+            },
+          },
         },
         ...(cameraImage && {
           automatic_video_output: {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260827-221216_pr-3412_f31dc575d93b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Configure Recall meeting bots to leave promptly once only other meeting bots remain, while retaining a delayed participant-event fallback for unfamiliar bots. This reduces idle bot time after human participants depart.

- Add participant-name detection for common meeting bot names with immediate activation.
- Keep participant-event detection delayed to avoid ending active human meetings.
- Update Recall client unit coverage for automatic-leave behavior and camera-image fallback.
- Tests: `pnpm test utils/recall/client.test.ts`; `pnpm exec ultracite check apps/web/utils/recall/client.ts apps/web/utils/recall/client.test.ts`.
- Performance: no extra application runtime work or database/network calls; the added Recall payload configuration is outside local hot paths.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-339/notetaker-bot-takes-too-long-to-leave-the-call-after-all

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->