### PR TITLE
INB-340: Preserve keyboard focus in message composer

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -13,7 +13,15 @@ test("keeps keyboard focus in the composer and follows the message field order",
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
   await dialog.getByRole("button", { name: "Cc/Bcc" }).click();
-  await dialog.getByRole("textbox", { name: "To" }).focus();
+  const toField = dialog.getByRole("textbox", { name: "To" });
+  await toField.focus();
+
+  await page.keyboard.press("Shift+Tab");
+  await expect(
+    dialog.getByRole("button", { name: "Hide Cc/Bcc" }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(toField).toBeFocused();
 
   for (const field of [
     dialog.getByRole("textbox", { exact: true, name: "Cc" }),

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -5,6 +5,38 @@ import {
 } from "./account-test-helpers";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
+test("keeps keyboard focus in the composer and follows the message field order", async ({
+  page,
+}) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  await dialog.getByRole("button", { name: "Cc/Bcc" }).click();
+  await dialog.getByRole("textbox", { name: "To" }).focus();
+
+  for (const field of [
+    dialog.getByRole("textbox", { exact: true, name: "Cc" }),
+    dialog.getByRole("textbox", { exact: true, name: "Bcc" }),
+    dialog.getByPlaceholder("Subject"),
+    dialog.getByRole("textbox", { name: "Email message" }),
+    dialog.getByRole("button", { name: /^Send/ }),
+    dialog.getByRole("button", { name: "Attach files" }),
+    dialog.getByRole("button", { name: "Insert inline images" }),
+    dialog.getByRole("button", { name: "Discard draft" }),
+  ]) {
+    await page.keyboard.press("Tab");
+    await expect(field).toBeFocused();
+  }
+
+  // Focus wraps from the dialog's last control back to its first instead of
+  // escaping the non-modal composer.
+  await page.keyboard.press("Tab");
+  await expect(
+    dialog.getByRole("button", { name: "Expand compose" }),
+  ).toBeFocused();
+});
+
 test("focuses the message field from the empty composer body", async ({
   page,
 }) => {

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -12,7 +12,13 @@ test("keeps keyboard focus in the composer and follows the message field order",
   await page.getByRole("button", { name: /^Compose/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
-  await dialog.getByRole("button", { name: "Cc/Bcc" }).click();
+  const showCcBccButton = dialog.getByRole("button", { name: "Cc/Bcc" });
+  await showCcBccButton.focus();
+  await showCcBccButton.press("Enter");
+  await expect(
+    dialog.getByRole("button", { name: "Hide Cc/Bcc" }),
+  ).toBeFocused();
+
   const toField = dialog.getByRole("textbox", { name: "To" });
   await toField.focus();
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -655,6 +655,19 @@ function ComposeEmailFormContent({
                 isComposeWindow && "min-h-11 items-center border-b",
               )}
             >
+              {showCcBcc && (
+                <button
+                  aria-label="Hide Cc/Bcc"
+                  className={cn(
+                    "order-last mt-2 text-xs text-muted-foreground hover:text-foreground",
+                    isComposeWindow && "mt-0",
+                  )}
+                  onClick={() => setShowCcBcc(false)}
+                  type="button"
+                >
+                  Cc/Bcc
+                </button>
+              )}
               {isComposeWindow && <ComposeFieldLabel htmlFor="to" label="To" />}
               <div className="min-w-0 flex-1">
                 {env.NEXT_PUBLIC_CONTACTS_ENABLED ? (
@@ -808,17 +821,18 @@ function ComposeEmailFormContent({
                   />
                 )}
               </div>
-              <button
-                className={cn(
-                  "mt-2 text-xs text-muted-foreground hover:text-foreground",
-                  isComposeWindow && "mt-0",
-                )}
-                onClick={() => setShowCcBcc((visible) => !visible)}
-                tabIndex={showCcBcc ? -1 : undefined}
-                type="button"
-              >
-                Cc/Bcc
-              </button>
+              {!showCcBcc && (
+                <button
+                  className={cn(
+                    "mt-2 text-xs text-muted-foreground hover:text-foreground",
+                    isComposeWindow && "mt-0",
+                  )}
+                  onClick={() => setShowCcBcc(true)}
+                  type="button"
+                >
+                  Cc/Bcc
+                </button>
+              )}
             </div>
 
             {showCcBcc && (

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -814,6 +814,7 @@ function ComposeEmailFormContent({
                   isComposeWindow && "mt-0",
                 )}
                 onClick={() => setShowCcBcc((visible) => !visible)}
+                tabIndex={showCcBcc ? -1 : undefined}
                 type="button"
               >
                 Cc/Bcc

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -204,6 +204,7 @@ function ComposeEmailFormContent({
   const isMountedRef = useRef(true);
   const editorRef = useRef<EmailEditorHandle>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const hideCcBccButtonRef = useRef<HTMLButtonElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const inlineImageInputRef = useRef<HTMLInputElement>(null);
   const { symbol } = useModifierKey();
@@ -663,6 +664,7 @@ function ComposeEmailFormContent({
                     isComposeWindow && "mt-0",
                   )}
                   onClick={() => setShowCcBcc(false)}
+                  ref={hideCcBccButtonRef}
                   type="button"
                 >
                   Cc/Bcc
@@ -827,7 +829,12 @@ function ComposeEmailFormContent({
                     "mt-2 text-xs text-muted-foreground hover:text-foreground",
                     isComposeWindow && "mt-0",
                   )}
-                  onClick={() => setShowCcBcc(true)}
+                  onClick={() => {
+                    setShowCcBcc(true);
+                    requestAnimationFrame(() =>
+                      hideCcBccButtonRef.current?.focus(),
+                    );
+                  }}
                   type="button"
                 >
                   Cc/Bcc

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -159,7 +159,7 @@ function renderShortcuts(
     <ShortcutsProvider scopes={scopes}>
       <Bindings handlers={handlers} />
       <textarea />
-      <div role="dialog">
+      <div aria-label="Test dialog" role="dialog">
         <button type="button">Dialog action</button>
       </div>
       {withEmailEditor && (

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -66,19 +66,28 @@ describe("useShortcuts", () => {
     expect(commandPalette).not.toHaveBeenCalled();
   });
 
-  it("leaves Tab navigation inside dialogs to the browser", () => {
+  it("leaves Tab and Enter navigation inside dialogs to the browser", () => {
+    const open = vi.fn();
     const nextSplit = vi.fn();
-    renderShortcuts({ nextSplit });
+    renderShortcuts({ nextSplit, open });
 
     const mailEvent = press({ key: "Tab", code: "Tab" });
-    const dialogEvent = press(
+    const mailOpenEvent = press({ key: "Enter", code: "Enter" });
+    const dialogTabEvent = press(
       { key: "Tab", code: "Tab" },
+      screen.getByRole("button", { name: "Dialog action" }),
+    );
+    const dialogOpenEvent = press(
+      { key: "Enter", code: "Enter" },
       screen.getByRole("button", { name: "Dialog action" }),
     );
 
     expect(nextSplit).toHaveBeenCalledOnce();
+    expect(open).toHaveBeenCalledOnce();
     expect(mailEvent.defaultPrevented).toBe(true);
-    expect(dialogEvent.defaultPrevented).toBe(false);
+    expect(mailOpenEvent.defaultPrevented).toBe(true);
+    expect(dialogTabEvent.defaultPrevented).toBe(false);
+    expect(dialogOpenEvent.defaultPrevented).toBe(false);
   });
 
   it("ignores modified presses of a plain shortcut", () => {

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -66,6 +66,21 @@ describe("useShortcuts", () => {
     expect(commandPalette).not.toHaveBeenCalled();
   });
 
+  it("leaves Tab navigation inside dialogs to the browser", () => {
+    const nextSplit = vi.fn();
+    renderShortcuts({ nextSplit });
+
+    const mailEvent = press({ key: "Tab", code: "Tab" });
+    const dialogEvent = press(
+      { key: "Tab", code: "Tab" },
+      screen.getByRole("button", { name: "Dialog action" }),
+    );
+
+    expect(nextSplit).toHaveBeenCalledOnce();
+    expect(mailEvent.defaultPrevented).toBe(true);
+    expect(dialogEvent.defaultPrevented).toBe(false);
+  });
+
   it("ignores modified presses of a plain shortcut", () => {
     const archive = vi.fn();
     renderShortcuts({ archive });
@@ -144,6 +159,9 @@ function renderShortcuts(
     <ShortcutsProvider scopes={scopes}>
       <Bindings handlers={handlers} />
       <textarea />
+      <div role="dialog">
+        <button type="button">Dialog action</button>
+      </div>
       {withEmailEditor && (
         <div
           aria-label="Email message"
@@ -164,7 +182,11 @@ function Bindings({ handlers }: { handlers: ShortcutHandlers }) {
 }
 
 function press(init: KeyboardEventInit, target: Element = document.body) {
-  const event = new KeyboardEvent("keydown", { bubbles: true, ...init });
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
   fireEvent(target, event);
   return event;
 }

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -173,6 +173,14 @@ function resolveTarget(
   ) {
     return;
   }
+  if (
+    target?.type === "entry" &&
+    target.entry.id === "nextSplit" &&
+    event.target instanceof Element &&
+    event.target.closest('[role="dialog"]')
+  ) {
+    return;
+  }
   return target;
 }
 

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -175,7 +175,7 @@ function resolveTarget(
   }
   if (
     target?.type === "entry" &&
-    target.entry.id === "nextSplit" &&
+    (target.entry.id === "open" || target.entry.id === "nextSplit") &&
     event.target instanceof Element &&
     event.target.closest('[role="dialog"]')
   ) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260827-220548_pr-3415_7810ca49890f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes tab navigation in the new-message composer so recipient fields follow the intended order and keyboard focus remains inside the dialog. Mail navigation shortcuts now yield to native Tab and Enter behavior within dialogs.

- Keep the expanded Cc/Bcc control keyboard-accessible and preserve focus when it mounts.
- Preserve native dialog Tab/Enter behavior and focus wrapping.
- Add focused shortcut unit and emulated Playwright regression coverage.
- Tests: pnpm test lib/shortcuts/useShortcuts.test.tsx; focused composer Playwright test; Ultracite check on all changed files.
- Performance: adds a DOM ancestor check for resolved Tab/Enter shortcuts plus one scheduled focus only when Cc/Bcc expands; no additional database or network calls, with negligible hot-path risk.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-340/tab-navigation-order-incorrect-and-focus-lost-in-new-message-composer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the email composer, including focus wrapping within the compose window.
  * Moving focus to the Cc/Bcc fields now provides a clear path back to the To field through the hide controls.
  * Prevented mail navigation shortcuts from triggering while interacting with dialogs.

* **Tests**
  * Added coverage for composer focus order, focus wrapping, Cc/Bcc navigation, and dialog shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->