### PR TITLE
INB-341: Close compose modal after leaving mail

### DIFF
--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils";
+import { useCloseComposeOnMailExit } from "./useCloseComposeOnMailExit";
 
 type Context = {
   onOpen: () => void;
@@ -30,8 +31,9 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [isExpanded, setIsExpanded] = useState(false);
+  const isMailView = pathname.endsWith("/mail");
   const isAllAccountsMailView =
-    pathname.endsWith("/mail") && searchParams.get("accountScope") === "all";
+    isMailView && searchParams.get("accountScope") === "all";
   const { data: accountsData } = useAccounts(isAllAccountsMailView);
   const openCompose = useCallback(() => {
     setIsExpanded(false);
@@ -41,6 +43,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
     setIsExpanded(false);
     closeModal();
   }, [closeModal]);
+  useCloseComposeOnMailExit({ isMailView, closeCompose });
 
   return (
     <ComposeModalContext.Provider value={{ onOpen: openCompose }}>

--- a/apps/web/providers/useCloseComposeOnMailExit.test.ts
+++ b/apps/web/providers/useCloseComposeOnMailExit.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCloseComposeOnMailExit } from "./useCloseComposeOnMailExit";
+
+describe("useCloseComposeOnMailExit", () => {
+  it("closes compose when navigation leaves the mail view", () => {
+    const closeCompose = vi.fn();
+    const { rerender } = renderHook(
+      ({ isMailView }) =>
+        useCloseComposeOnMailExit({ isMailView, closeCompose }),
+      { initialProps: { isMailView: true } },
+    );
+
+    rerender({ isMailView: false });
+
+    expect(closeCompose).toHaveBeenCalledOnce();
+  });
+
+  it("does not close compose while staying in the mail view", () => {
+    const closeCompose = vi.fn();
+    const { rerender } = renderHook(
+      ({ isMailView }) =>
+        useCloseComposeOnMailExit({ isMailView, closeCompose }),
+      { initialProps: { isMailView: true } },
+    );
+
+    rerender({ isMailView: true });
+
+    expect(closeCompose).not.toHaveBeenCalled();
+  });
+
+  it("does not close compose when entering the mail view", () => {
+    const closeCompose = vi.fn();
+    const { rerender } = renderHook(
+      ({ isMailView }) =>
+        useCloseComposeOnMailExit({ isMailView, closeCompose }),
+      { initialProps: { isMailView: false } },
+    );
+
+    rerender({ isMailView: true });
+
+    expect(closeCompose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/providers/useCloseComposeOnMailExit.ts
+++ b/apps/web/providers/useCloseComposeOnMailExit.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from "react";
+
+export function useCloseComposeOnMailExit({
+  isMailView,
+  closeCompose,
+}: {
+  isMailView: boolean;
+  closeCompose: () => void;
+}) {
+  const wasMailView = useRef(isMailView);
+
+  useEffect(() => {
+    if (wasMailView.current && !isMailView) closeCompose();
+    wasMailView.current = isMailView;
+  }, [isMailView, closeCompose]);
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260827-181019_pr-3416_5e1e7127a666/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Closes the compose modal when navigation leaves the mail view so it does not persist across app sections.

- Track mail-view transitions in a focused client hook
- Reset expanded compose state when closing
- Add unit coverage for leaving, staying in, and entering mail
- Test: `pnpm test providers/useCloseComposeOnMailExit.test.ts`

Linear: https://linear.app/inbox-zero-ai/issue/INB-341/compose-modal-remains-open-after-navigating-away-from-mail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The compose window now closes automatically when navigating away from the mail view.
  * The compose window remains open when staying in the mail view or navigating into it.

* **Tests**
  * Added coverage to verify compose-window behavior during mail-view navigation, including leaving the mail view, remaining in it, and entering it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->