### PR TITLE
mail: Preserve unread styling across threads

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/read-state.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/read-state.test.ts
@@ -3,6 +3,12 @@ import type { ListThread } from "./types";
 import { isThreadUnread, withThreadReadState } from "./read-state";
 
 describe("thread read state", () => {
+  it("is unread when any message in the thread is unread", () => {
+    const thread = createThread([["INBOX", "UNREAD"], ["DRAFT"]]);
+
+    expect(isThreadUnread(thread.messages)).toBe(true);
+  });
+
   it("removes the unread label from every message", () => {
     const thread = createThread([
       ["INBOX", "UNREAD"],

--- a/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/read-state.ts
@@ -2,14 +2,16 @@ import type { ListThread } from "@/app/(app)/[emailAccountId]/mail/types";
 import { GmailLabel } from "@/utils/gmail/label";
 
 /**
- * A thread is unread when its latest message is. The row's styling, the reader's
- * ⋯ menu and the update below all have to agree on that, so they read it here.
+ * A thread is unread when any of its messages is unread. The row's styling, the
+ * reader's ⋯ menu and the update below all have to agree on that, so they read it here.
  * Both providers normalise to these ids, so this is not a provider branch.
  */
 export function isThreadUnread(
   messages: readonly { labelIds?: string[] | null }[],
 ) {
-  return messages.at(-1)?.labelIds?.includes(GmailLabel.UNREAD) ?? false;
+  return messages.some((message) =>
+    message.labelIds?.includes(GmailLabel.UNREAD),
+  );
 }
 
 /** Read state lives on every message, so marking a thread rewrites all of them. */


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260827-230544_pr-3418_fb7037bd3466/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Updates thread-level read-state detection so a conversation remains unread when any message is unread.

- Keeps split inbox styling and unread filtering consistent for threads with later drafts
- Adds focused regression coverage; 49 related tests pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread unread status detection so a thread is marked unread when any message contains the unread label, including threads with drafts or other message types.
- **Tests**
  - Added coverage to verify unread status is correctly detected across all messages in a thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->