### PR TITLE
fix: add meeting notes deletion and retention cleanup

### DIFF
--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -136,6 +136,28 @@ describe.skipIf(!RUN_DB_TESTS)(
       );
     });
 
+    test("deletes an account's transcript when the email account is deleted", async () => {
+      await reconcile.reconcileSingleEvent({
+        emailAccount: account(accountAId, ACCOUNT_A),
+        event: calendarEvent(),
+        logger,
+      });
+
+      const recording = await prisma.meetingRecording.findFirstOrThrow({
+        where: { emailAccountId: accountAId },
+      });
+      await prisma.meetingRecording.update({
+        where: { id: recording.id },
+        data: { transcript: [{ speakerName: "Speaker", text: "Private" }] },
+      });
+
+      await prisma.emailAccount.delete({ where: { id: accountAId } });
+
+      await expect(
+        prisma.meetingRecording.findUnique({ where: { id: recording.id } }),
+      ).resolves.toBeNull();
+    });
+
     test("updates the bot name for an existing scheduled recording", async () => {
       const event = calendarEvent();
       const emailAccount = account(accountAId, ACCOUNT_A);
@@ -292,6 +314,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       // its bot is gone, so the reschedule cannot land there yet.
       const cancelling = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           botProvider: original.botProvider,
           externalBotId: "cancelling_bot",
           meetingUrl: original.meetingUrl,
@@ -351,6 +374,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       const movedTo = addMinutes(event.startTime, 45);
       const conflicting = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           botProvider: original.botProvider,
           externalBotId: "conflicting_bot",
           meetingUrl: original.meetingUrl,
@@ -518,6 +542,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       const normalizedMeetingUrl = "meet.google.com/abc-defg-hij";
       const recording = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           botProvider: "recall",
           externalBotId: "cancelling_during_link",
           meetingUrl: event.videoConferenceLink ?? "",
@@ -775,6 +800,7 @@ describe.skipIf(!RUN_DB_TESTS)(
     test("deletes media for terminal recordings and for DONE recordings with transcripts", async () => {
       const withoutTranscript = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/aaa-bbbb-ccc",
           normalizedMeetingUrl: "meet.google.com/aaa-bbbb-ccc",
           meetingStartTime: new Date(),
@@ -784,6 +810,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
       const withTranscript = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/ddd-eeee-fff",
           normalizedMeetingUrl: "meet.google.com/ddd-eeee-fff",
           meetingStartTime: new Date(),
@@ -795,6 +822,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
       const failed = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/ggg-hhhh-iii",
           normalizedMeetingUrl: "meet.google.com/ggg-hhhh-iii",
           meetingStartTime: new Date(),
@@ -804,6 +832,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
       const cancelled = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/jjj-kkkk-lll",
           normalizedMeetingUrl: "meet.google.com/jjj-kkkk-lll",
           meetingStartTime: new Date(),
@@ -927,6 +956,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       const meetingUrl = "https://acme.zoom.us/j/8123456789?pwd=SuPerSecret";
       const recording = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl,
           normalizedMeetingUrl: "zoom.us/j/8123456789",
           activeKey: "zoom.us/j/8123456789",
@@ -1103,6 +1133,7 @@ describe.skipIf(!RUN_DB_TESTS)(
     test("re-requests transcription when the first request never produced one", async () => {
       const recording = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/mmm-nnnn-ooo",
           normalizedMeetingUrl: "meet.google.com/mmm-nnnn-ooo",
           activeKey: "meet.google.com/mmm-nnnn-ooo",
@@ -1130,6 +1161,7 @@ describe.skipIf(!RUN_DB_TESTS)(
     test("leaves a recent transcription request alone", async () => {
       await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/ppp-qqqq-rrr",
           normalizedMeetingUrl: "meet.google.com/ppp-qqqq-rrr",
           activeKey: "meet.google.com/ppp-qqqq-rrr",
@@ -1150,6 +1182,7 @@ describe.skipIf(!RUN_DB_TESTS)(
     test("clears stale claims and closes recordings that never reported back by engagement", async () => {
       const stale = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/ggg-hhhh-iii",
           normalizedMeetingUrl: "meet.google.com/ggg-hhhh-iii",
           activeKey: "meet.google.com/ggg-hhhh-iii",
@@ -1162,6 +1195,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       // closes it as a no-show instead of a failed recording.
       const noShow = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/jjj-kkkk-lll",
           normalizedMeetingUrl: "meet.google.com/jjj-kkkk-lll",
           activeKey: "meet.google.com/jjj-kkkk-lll",
@@ -1174,6 +1208,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       // recording the user should see.
       const engaged = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/mmm-nnnn-ooo",
           normalizedMeetingUrl: "meet.google.com/mmm-nnnn-ooo",
           activeKey: "meet.google.com/mmm-nnnn-ooo",
@@ -1209,6 +1244,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       // lost. Failing it here would be terminal.
       const recoverable = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/rrr-ssss-ttt",
           normalizedMeetingUrl: "meet.google.com/rrr-ssss-ttt",
           activeKey: "meet.google.com/rrr-ssss-ttt",
@@ -1222,6 +1258,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       // transcript, so the sweep must finally fail the row.
       const expired = await prisma.meetingRecording.create({
         data: {
+          emailAccountId: accountAId,
           meetingUrl: "https://meet.google.com/uuu-vvvv-www",
           normalizedMeetingUrl: "meet.google.com/uuu-vvvv-www",
           activeKey: "meet.google.com/uuu-vvvv-www",

--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -158,6 +158,37 @@ describe.skipIf(!RUN_DB_TESTS)(
       ).resolves.toBeNull();
     });
 
+    test("preserves the meeting when its recording is deleted", async () => {
+      await reconcile.reconcileSingleEvent({
+        emailAccount: account(accountAId, ACCOUNT_A),
+        event: calendarEvent(),
+        logger,
+      });
+
+      const meeting = await prisma.meeting.findFirstOrThrow({
+        where: { emailAccountId: accountAId },
+      });
+      const recording = await prisma.meetingRecording.findFirstOrThrow({
+        where: { meetings: { some: { id: meeting.id } } },
+      });
+      await prisma.meeting.update({
+        where: { id: meeting.id },
+        data: { summary: { overview: "Stored notes" } },
+      });
+
+      await prisma.meetingRecording.delete({
+        where: { id: recording.id },
+      });
+
+      await expect(
+        prisma.meeting.findUnique({ where: { id: meeting.id } }),
+      ).resolves.toMatchObject({
+        id: meeting.id,
+        recordingId: null,
+        summary: { overview: "Stored notes" },
+      });
+    });
+
     test("updates the bot name for an existing scheduled recording", async () => {
       const event = calendarEvent();
       const emailAccount = account(accountAId, ACCOUNT_A);

--- a/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/meetings/meeting-bot-test-helpers.ts
@@ -242,16 +242,17 @@ async function seedRecordedMeeting(
   await client.query(
     `INSERT INTO "MeetingRecording" (
        id, "createdAt", "updatedAt", "meetingUrl", "normalizedMeetingUrl",
-       "meetingStartTime", status, transcript, "transcriptFetchedAt"
+       "meetingStartTime", status, transcript, "transcriptFetchedAt",
+       "emailAccountId"
      )
      VALUES (
        $1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
        'https://meet.google.com/recorded-demo',
        'https://meet.google.com/recorded-demo',
        CURRENT_TIMESTAMP - INTERVAL '2 hours', 'DONE', $2::jsonb,
-       CURRENT_TIMESTAMP - INTERVAL '1 hour'
+       CURRENT_TIMESTAMP - INTERVAL '1 hour', $3
      )`,
-    [fixture.recordingId, JSON.stringify(transcript)],
+    [fixture.recordingId, JSON.stringify(transcript), fixture.emailAccountId],
   );
   await client.query(
     `INSERT INTO "Meeting" (

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -67,10 +67,12 @@ export function MeetingDetail({
   const analytics = useProductAnalytics();
   const { mutate } = useSWRConfig();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const { data, isLoading, error } = useMeetingRecorderMeeting(
-    meetingId,
-    emailAccountId,
-  );
+  const {
+    data,
+    isLoading,
+    error,
+    mutate: mutateMeeting,
+  } = useMeetingRecorderMeeting(meetingId, emailAccountId);
 
   const summary = data?.summary;
   const transcript = data?.recording?.transcript;
@@ -85,12 +87,15 @@ export function MeetingDetail({
     deleteMeetingNotesAction.bind(null, emailAccountId),
     {
       onSuccess: async () => {
-        await mutate(
-          getAccountScopedKey(
-            "/api/user/meeting-recorder/meetings",
-            emailAccountId,
+        await Promise.all([
+          mutateMeeting(undefined, { revalidate: false }),
+          mutate(
+            getAccountScopedKey(
+              "/api/user/meeting-recorder/meetings",
+              emailAccountId,
+            ),
           ),
-        );
+        ]);
         toastSuccess({ description: "Meeting notes deleted." });
         setIsDeleteOpen(false);
         onClose();

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -122,6 +122,7 @@ export function MeetingDetail({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
+                    type="button"
                     variant="ghost"
                     size="icon"
                     aria-label="Meeting options"

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -118,7 +118,7 @@ export function MeetingDetail({
                 </DialogDescription>
               )}
             </div>
-            {data && (
+            {data?.recording && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingDetail.tsx
@@ -1,12 +1,31 @@
 "use client";
 
 import { useAccount } from "@/providers/EmailAccountProvider";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { format } from "date-fns";
-import { ChevronDownIcon, MailPlusIcon, TextQuoteIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  MailPlusIcon,
+  MoreHorizontalIcon,
+  TextQuoteIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useSWRConfig } from "swr";
 import { LoadingContent } from "@/components/LoadingContent";
 import { MutedText } from "@/components/Typography";
+import { toastError, toastSuccess } from "@/components/Toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardBlue, CardContent } from "@/components/ui/card";
@@ -22,11 +41,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getMeetingDetailState } from "@/app/(app)/[emailAccountId]/meetings/meeting-detail-state";
 import { useMeetingRecorderMeeting } from "@/hooks/useMeetingRecorder";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { deleteMeetingNotesAction } from "@/utils/actions/meeting-recorder";
+import { getActionErrorMessage } from "@/utils/error";
 import { formatTranscriptTimestamp } from "@/utils/meeting-recorder/transcript-prompt";
+import { getAccountScopedKey } from "@/utils/swr";
 
 export function MeetingDetail({
   meetingId,
@@ -37,6 +65,8 @@ export function MeetingDetail({
 }) {
   const { emailAccountId } = useAccount();
   const analytics = useProductAnalytics();
+  const { mutate } = useSWRConfig();
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const { data, isLoading, error } = useMeetingRecorderMeeting(
     meetingId,
     emailAccountId,
@@ -51,17 +81,66 @@ export function MeetingDetail({
     recordingStatus: data?.recording?.status,
     processingStatus: data?.processingStatus,
   });
+  const { execute: deleteNotes, isExecuting: isDeleting } = useAction(
+    deleteMeetingNotesAction.bind(null, emailAccountId),
+    {
+      onSuccess: async () => {
+        await mutate(
+          getAccountScopedKey(
+            "/api/user/meeting-recorder/meetings",
+            emailAccountId,
+          ),
+        );
+        toastSuccess({ description: "Meeting notes deleted." });
+        setIsDeleteOpen(false);
+        onClose();
+      },
+      onError: ({ error: actionError }) => {
+        toastError({
+          description: getActionErrorMessage(actionError, {
+            prefix: "Failed to delete meeting notes",
+          }),
+        });
+      },
+    },
+  );
 
   return (
     <Dialog open={!!meetingId} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>{data?.eventTitle ?? "Meeting"}</DialogTitle>
-          {data && (
-            <DialogDescription>
-              {formatMeetingTimeRange(data.startTime, data.endTime)}
-            </DialogDescription>
-          )}
+          <div className="flex items-start justify-between gap-3 pr-8">
+            <div className="space-y-1.5">
+              <DialogTitle>{data?.eventTitle ?? "Meeting"}</DialogTitle>
+              {data && (
+                <DialogDescription>
+                  {formatMeetingTimeRange(data.startTime, data.endTime)}
+                </DialogDescription>
+              )}
+            </div>
+            {data && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Meeting options"
+                  >
+                    <MoreHorizontalIcon className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onSelect={() => setIsDeleteOpen(true)}
+                  >
+                    <Trash2Icon className="mr-2 size-4" />
+                    Delete notes
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         </DialogHeader>
 
         <LoadingContent
@@ -225,6 +304,34 @@ export function MeetingDetail({
             </MutedText>
           )}
         </LoadingContent>
+
+        <AlertDialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete meeting notes?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The summary and transcript will be permanently deleted from
+                Inbox Zero. Recap emails already sent and follow-up drafts in
+                your mailbox will remain.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={isDeleting || !meetingId}
+                onClick={(event) => {
+                  event.preventDefault();
+                  if (meetingId) deleteNotes({ meetingId });
+                }}
+              >
+                {isDeleting ? "Deleting..." : "Delete"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
+++ b/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
@@ -1,17 +1,47 @@
+BEGIN;
+
 ALTER TABLE "MeetingRecording" ADD COLUMN "emailAccountId" TEXT;
 
+-- Recording ownership is account-scoped in the application. Refuse to guess
+-- if historical data violates that invariant, because choosing either account
+-- would let one account deletion remove another account's transcript.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "Meeting"
+    WHERE "recordingId" IS NOT NULL
+    GROUP BY "recordingId"
+    HAVING COUNT(DISTINCT "emailAccountId") > 1
+  ) THEN
+    RAISE EXCEPTION 'MeetingRecording ownership is ambiguous across email accounts';
+  END IF;
+END $$;
+
 UPDATE "MeetingRecording" AS recording
-SET "emailAccountId" = owner."emailAccountId"
-FROM (
-  SELECT "recordingId", MIN("emailAccountId") AS "emailAccountId"
-  FROM "Meeting"
-  WHERE "recordingId" IS NOT NULL
-  GROUP BY "recordingId"
-) AS owner
-WHERE recording.id = owner."recordingId";
+SET "emailAccountId" = meeting."emailAccountId"
+FROM "Meeting" AS meeting
+WHERE recording.id = meeting."recordingId";
+
+-- An unowned bot whose provider media has not been deleted still carries the
+-- only cancellation and cleanup handle. Abort without deleting it so provider
+-- reconciliation can finish before this migration is retried.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "MeetingRecording"
+    WHERE "emailAccountId" IS NULL
+      AND "externalBotId" IS NOT NULL
+      AND "mediaDeletedAt" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Unowned MeetingRecording rows require provider reconciliation';
+  END IF;
+END $$;
 
 -- These rows are unreachable by any account. Removing them also clears any
--- transcripts that were orphaned by earlier account deletions.
+-- transcripts orphaned by earlier account deletions; provider media is already
+-- confirmed deleted or no provider bot was ever created.
 DELETE FROM "MeetingRecording" WHERE "emailAccountId" IS NULL;
 
 ALTER TABLE "MeetingRecording" ALTER COLUMN "emailAccountId" SET NOT NULL;
@@ -29,3 +59,5 @@ ALTER TABLE "Meeting"
 ADD CONSTRAINT "Meeting_recordingId_fkey"
 FOREIGN KEY ("recordingId") REFERENCES "MeetingRecording"("id")
 ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT;

--- a/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
+++ b/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
@@ -1,0 +1,31 @@
+ALTER TABLE "MeetingRecording" ADD COLUMN "emailAccountId" TEXT;
+
+UPDATE "MeetingRecording" AS recording
+SET "emailAccountId" = owner."emailAccountId"
+FROM (
+  SELECT "recordingId", MIN("emailAccountId") AS "emailAccountId"
+  FROM "Meeting"
+  WHERE "recordingId" IS NOT NULL
+  GROUP BY "recordingId"
+) AS owner
+WHERE recording.id = owner."recordingId";
+
+-- These rows are unreachable by any account. Removing them also clears any
+-- transcripts that were orphaned by earlier account deletions.
+DELETE FROM "MeetingRecording" WHERE "emailAccountId" IS NULL;
+
+ALTER TABLE "MeetingRecording" ALTER COLUMN "emailAccountId" SET NOT NULL;
+
+CREATE INDEX "MeetingRecording_emailAccountId_idx"
+ON "MeetingRecording"("emailAccountId");
+
+ALTER TABLE "MeetingRecording"
+ADD CONSTRAINT "MeetingRecording_emailAccountId_fkey"
+FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Meeting" DROP CONSTRAINT "Meeting_recordingId_fkey";
+ALTER TABLE "Meeting"
+ADD CONSTRAINT "Meeting_recordingId_fkey"
+FOREIGN KEY ("recordingId") REFERENCES "MeetingRecording"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
+++ b/apps/web/prisma/migrations/20260828013000_meeting_recording_account_ownership/migration.sql
@@ -58,6 +58,6 @@ ALTER TABLE "Meeting" DROP CONSTRAINT "Meeting_recordingId_fkey";
 ALTER TABLE "Meeting"
 ADD CONSTRAINT "Meeting_recordingId_fkey"
 FOREIGN KEY ("recordingId") REFERENCES "MeetingRecording"("id")
-ON DELETE CASCADE ON UPDATE CASCADE;
+ON DELETE SET NULL ON UPDATE CASCADE;
 
 COMMIT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1548,7 +1548,7 @@ model Meeting {
   recapSentAt            DateTime?
 
   recordingId String?
-  recording   MeetingRecording? @relation(fields: [recordingId], references: [id], onDelete: Cascade)
+  recording   MeetingRecording? @relation(fields: [recordingId], references: [id], onDelete: SetNull)
 
   emailAccountId String
   emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -218,6 +218,7 @@ model EmailAccount {
   mcpConnections         McpConnection[]
   meetingBriefings       MeetingBriefing[]
   meetings               Meeting[]
+  meetingRecordings      MeetingRecording[]
   driveConnections       DriveConnection[]
   messagingChannels      MessagingChannel[]
   documentFilings        DocumentFiling[]
@@ -1508,6 +1509,9 @@ model MeetingRecording {
   transcriptFetchedAt DateTime?
   mediaDeletedAt      DateTime?
 
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
   meetings Meeting[]
 
   @@unique([botProvider, externalBotId])
@@ -1515,6 +1519,7 @@ model MeetingRecording {
   @@index([normalizedMeetingUrl, meetingStartTime])
   @@index([status, meetingStartTime])
   @@index([status, mediaDeletedAt])
+  @@index([emailAccountId])
 }
 
 model Meeting {
@@ -1543,7 +1548,7 @@ model Meeting {
   recapSentAt            DateTime?
 
   recordingId String?
-  recording   MeetingRecording? @relation(fields: [recordingId], references: [id], onDelete: SetNull)
+  recording   MeetingRecording? @relation(fields: [recordingId], references: [id], onDelete: Cascade)
 
   emailAccountId String
   emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)

--- a/apps/web/utils/actions/meeting-recorder.test.ts
+++ b/apps/web/utils/actions/meeting-recorder.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
@@ -57,31 +58,55 @@ describe("deleteMeetingNotesAction", () => {
     } as never);
   });
 
-  it("deletes the recording only through a meeting owned by the account", async () => {
-    prisma.meetingRecording.deleteMany.mockResolvedValue({ count: 1 });
+  it("clears the summary and deletes the recording atomically", async () => {
+    const clearMeeting = Promise.resolve({}) as never;
+    const deleteRecording = Promise.resolve({}) as never;
+    prisma.meeting.findFirst.mockResolvedValue({
+      recordingId: "recording-1",
+    } as never);
+    prisma.meeting.update.mockReturnValue(clearMeeting);
+    prisma.meetingRecording.delete.mockReturnValue(deleteRecording);
 
     const result = await deleteMeetingNotesAction(EMAIL_ACCOUNT_ID, {
       meetingId: "meeting-1",
     });
 
-    expect(prisma.meetingRecording.deleteMany).toHaveBeenCalledWith({
+    expect(prisma.meeting.findFirst).toHaveBeenCalledWith({
       where: {
+        id: "meeting-1",
         emailAccountId: EMAIL_ACCOUNT_ID,
-        meetings: {
-          some: { id: "meeting-1", emailAccountId: EMAIL_ACCOUNT_ID },
-        },
+        recording: { emailAccountId: EMAIL_ACCOUNT_ID },
       },
+      select: { recordingId: true },
     });
+    expect(prisma.meeting.update).toHaveBeenCalledWith({
+      where: {
+        id: "meeting-1",
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        recordingId: "recording-1",
+      },
+      data: { recordingId: null, summary: Prisma.DbNull },
+    });
+    expect(prisma.meetingRecording.delete).toHaveBeenCalledWith({
+      where: { id: "recording-1" },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledWith([
+      clearMeeting,
+      deleteRecording,
+    ]);
     expect(result?.serverError).toBeUndefined();
   });
 
   it("does not delete notes that do not belong to the account", async () => {
-    prisma.meetingRecording.deleteMany.mockResolvedValue({ count: 0 });
+    prisma.meeting.findFirst.mockResolvedValue(null);
 
     const result = await deleteMeetingNotesAction(EMAIL_ACCOUNT_ID, {
       meetingId: "another-account-meeting",
     });
 
+    expect(prisma.meeting.update).not.toHaveBeenCalled();
+    expect(prisma.meetingRecording.delete).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
     expect(result?.serverError).toBe("Meeting not found");
   });
 });

--- a/apps/web/utils/actions/meeting-recorder.test.ts
+++ b/apps/web/utils/actions/meeting-recorder.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
+  deleteMeetingNotesAction,
   setMeetingJoinOverrideAction,
   updateMeetingRecorderSettingsAction,
 } from "./meeting-recorder";
@@ -43,6 +44,47 @@ vi.mock("@/utils/meeting-recorder/reconcile", () => ({
 }));
 
 const EMAIL_ACCOUNT_ID = "email-account-1";
+
+describe("deleteMeetingNotesAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com" },
+    });
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: { userId: "user-1", provider: "google" },
+    } as never);
+  });
+
+  it("deletes the recording only through a meeting owned by the account", async () => {
+    prisma.meetingRecording.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await deleteMeetingNotesAction(EMAIL_ACCOUNT_ID, {
+      meetingId: "meeting-1",
+    });
+
+    expect(prisma.meetingRecording.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        meetings: {
+          some: { id: "meeting-1", emailAccountId: EMAIL_ACCOUNT_ID },
+        },
+      },
+    });
+    expect(result?.serverError).toBeUndefined();
+  });
+
+  it("does not delete notes that do not belong to the account", async () => {
+    prisma.meetingRecording.deleteMany.mockResolvedValue({ count: 0 });
+
+    const result = await deleteMeetingNotesAction(EMAIL_ACCOUNT_ID, {
+      meetingId: "another-account-meeting",
+    });
+
+    expect(result?.serverError).toBe("Meeting not found");
+  });
+});
 
 describe("setMeetingJoinOverrideAction", () => {
   beforeEach(() => {

--- a/apps/web/utils/actions/meeting-recorder.ts
+++ b/apps/web/utils/actions/meeting-recorder.ts
@@ -5,6 +5,7 @@ import { differenceInMinutes } from "date-fns/differenceInMinutes";
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 import { actionClient } from "@/utils/actions/safe-action";
 import {
+  deleteMeetingNotesBody,
   setMeetingJoinOverrideBody,
   updateMeetingRecorderSettingsBody,
 } from "@/utils/actions/meeting-recorder.validation";
@@ -24,6 +25,20 @@ import {
   upsertMeeting,
 } from "@/utils/meeting-recorder/reconcile";
 import prisma from "@/utils/prisma";
+
+export const deleteMeetingNotesAction = actionClient
+  .metadata({ name: "deleteMeetingNotes" })
+  .inputSchema(deleteMeetingNotesBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { meetingId } }) => {
+    const deleted = await prisma.meetingRecording.deleteMany({
+      where: {
+        emailAccountId,
+        meetings: { some: { id: meetingId, emailAccountId } },
+      },
+    });
+
+    if (deleted.count === 0) throw new SafeError("Meeting not found");
+  });
 
 export const updateMeetingRecorderSettingsAction = actionClient
   .metadata({ name: "updateMeetingRecorderSettings" })

--- a/apps/web/utils/actions/meeting-recorder.ts
+++ b/apps/web/utils/actions/meeting-recorder.ts
@@ -2,6 +2,7 @@
 
 import { addHours } from "date-fns/addHours";
 import { differenceInMinutes } from "date-fns/differenceInMinutes";
+import { Prisma } from "@/generated/prisma/client";
 import { MeetingJoinRule } from "@/generated/prisma/enums";
 import { actionClient } from "@/utils/actions/safe-action";
 import {
@@ -30,14 +31,29 @@ export const deleteMeetingNotesAction = actionClient
   .metadata({ name: "deleteMeetingNotes" })
   .inputSchema(deleteMeetingNotesBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { meetingId } }) => {
-    const deleted = await prisma.meetingRecording.deleteMany({
+    const meeting = await prisma.meeting.findFirst({
       where: {
+        id: meetingId,
         emailAccountId,
-        meetings: { some: { id: meetingId, emailAccountId } },
+        recording: { emailAccountId },
       },
+      select: { recordingId: true },
     });
+    if (!meeting?.recordingId) throw new SafeError("Meeting not found");
 
-    if (deleted.count === 0) throw new SafeError("Meeting not found");
+    await prisma.$transaction([
+      prisma.meeting.update({
+        where: {
+          id: meetingId,
+          emailAccountId,
+          recordingId: meeting.recordingId,
+        },
+        data: { recordingId: null, summary: Prisma.DbNull },
+      }),
+      prisma.meetingRecording.delete({
+        where: { id: meeting.recordingId },
+      }),
+    ]);
   });
 
 export const updateMeetingRecorderSettingsAction = actionClient

--- a/apps/web/utils/actions/meeting-recorder.validation.ts
+++ b/apps/web/utils/actions/meeting-recorder.validation.ts
@@ -19,3 +19,7 @@ export const setMeetingJoinOverrideBody = z.object({
   calendarEventId: z.string(),
   join: z.boolean(),
 });
+
+export const deleteMeetingNotesBody = z.object({
+  meetingId: z.string(),
+});

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -273,6 +273,7 @@ async function findOrCreateRecording({
   try {
     claimed = await prisma.meetingRecording.create({
       data: {
+        emailAccountId,
         botProvider: DEFAULT_MEETING_BOT_PROVIDER,
         meetingUrl,
         normalizedMeetingUrl,
@@ -362,6 +363,7 @@ async function bookBot({
       // A null activeKey keeps it out of the winner's dedup slot.
       await prisma.meetingRecording.create({
         data: {
+          emailAccountId: recording.emailAccountId,
           botProvider: recording.botProvider,
           externalBotId,
           meetingUrl: recording.meetingUrl,

--- a/docs/essentials/meeting-recorder.mdx
+++ b/docs/essentials/meeting-recorder.mdx
@@ -52,6 +52,8 @@ Completed and processing calls appear under **Recorded** on the Meetings page. O
 
 AI-generated notes can be incomplete or inaccurate. Compare important decisions, commitments, names, and dates with the transcript or the other attendees before relying on them.
 
+To permanently remove a meeting's summary and transcript from Inbox Zero, open the meeting, select the three-dot menu, and choose **Delete notes**. Recap emails already sent and follow-up drafts in your mailbox are separate copies and are not deleted.
+
 ## Troubleshooting
 
 ### A call does not appear under Up next
@@ -69,4 +71,3 @@ Transcription and summarization continue after the call ends and may take time. 
 ### No summary was created
 
 Open the meeting detail to see whether recording or summarization failed. A failed recording cannot be recovered after the call.
-


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260828-010335_pr-3419_e3a2589da067/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensures meeting recordings are owned by email accounts and cascade-delete with account removal.

- Adds an account-scoped delete-notes action and confirmation UI.
- Backfills recording ownership and removes orphaned transcripts.
- Validated with meeting-recorder tests, lint, and Prisma schema validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to permanently delete meeting notes and transcripts from the meeting details dialog, with confirmation and success/error feedback.

* **Bug Fixes**
  * Improved recording ownership and cleanup when an associated email account is deleted.
  * Preserved meetings when their recordings are deleted.
  * Improved recording reconciliation and duplicate recording cleanup.

* **Documentation**
  * Clarified that deleting meeting notes does not remove sent recap emails or mailbox drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->