### PR TITLE
fix: exclude application notifications from cold email detection

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/TestRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/TestRules.tsx
@@ -205,14 +205,18 @@ function Result(props: { coldEmailResponse: ColdEmailBlockerResponse | null }) {
       />
     );
   }
+
+  let title = "Our AI determined this is not a cold email!";
+  if (coldEmailResponse.reason === "hasPreviousEmail") {
+    title = "This person has previously emailed you. This is not a cold email!";
+  } else if (coldEmailResponse.reason === "applicationSender") {
+    title = "This is an application notification, not a cold email!";
+  }
+
   return (
     <AlertBasic
       variant="success"
-      title={
-        coldEmailResponse.reason === "hasPreviousEmail"
-          ? "This person has previously emailed you. This is not a cold email!"
-          : "Our AI determined this is not a cold email!"
-      }
+      title={title}
       description={coldEmailResponse.aiReason}
     />
   );

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -6,6 +6,7 @@ import { GroupItemType } from "@/generated/prisma/enums";
 import { env } from "@/env";
 import prisma from "@/utils/__mocks__/prisma";
 import { extractEmailAddress } from "@/utils/email";
+import { createGenerateObject } from "@/utils/llms";
 
 vi.mock("@/utils/prisma");
 
@@ -218,10 +219,12 @@ describe("isColdEmail", () => {
     });
 
     expect(result.isColdEmail).toBe(false);
+    expect(result.reason).toBe("applicationSender");
     expect(prisma.groupItem.findFirst).not.toHaveBeenCalled();
     expect(
       mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
     ).not.toHaveBeenCalled();
+    expect(createGenerateObject).not.toHaveBeenCalled();
   });
 
   // Blocking a sender we could not verify is worse than missing a cold email.

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -3,6 +3,7 @@ import { isColdEmail } from "./is-cold-email";
 import { getEmailAccount } from "@/__tests__/helpers";
 import type { EmailForLLM } from "@/utils/types";
 import { GroupItemType } from "@/generated/prisma/enums";
+import { env } from "@/env";
 import prisma from "@/utils/__mocks__/prisma";
 import { extractEmailAddress } from "@/utils/email";
 
@@ -196,6 +197,31 @@ describe("isColdEmail", () => {
     });
 
     expect(result.isColdEmail).toBe(false);
+  });
+
+  it("should not classify the application notification sender as cold", async () => {
+    const result = await isColdEmail({
+      email: {
+        id: "msg-application-notification",
+        from: env.RESEND_FROM_EMAIL,
+        to: "user@customer.test",
+        subject: "Product update",
+        content: "Here is the latest product update.",
+        date: new Date(),
+      },
+      emailAccount: getEmailAccount({
+        id: "test-account-id",
+        email: "user@customer.test",
+      }),
+      provider: mockProvider as never,
+      coldEmailRule: { instructions: "test instructions", groupId: "group-id" },
+    });
+
+    expect(result.isColdEmail).toBe(false);
+    expect(prisma.groupItem.findFirst).not.toHaveBeenCalled();
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).not.toHaveBeenCalled();
   });
 
   // Blocking a sender we could not verify is worse than missing a cold email.

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { env } from "@/env";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { Group, GroupItem, Rule } from "@/generated/prisma/client";
 import { GroupItemType } from "@/generated/prisma/enums";
@@ -10,7 +11,11 @@ import type { EmailForLLM } from "@/utils/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { getModel, type ModelType } from "@/utils/llms/model";
 import { createGenerateObject } from "@/utils/llms";
-import { extractEmailAddress, isSameOrganization } from "@/utils/email";
+import {
+  extractEmailAddress,
+  isSameEmailAddress,
+  isSameOrganization,
+} from "@/utils/email";
 import { hasPriorContactOrAssumeYes } from "@/utils/cold-email/has-prior-contact";
 
 export const COLD_EMAIL_FOLDER_NAME = "Cold Emails";
@@ -52,6 +57,11 @@ export async function isColdEmail({
   });
 
   logger.info("Checking is cold email");
+
+  if (isSameEmailAddress(email.from, env.RESEND_FROM_EMAIL)) {
+    logger.info("Sender is the application notification sender");
+    return { isColdEmail: false, reason: "hasPreviousEmail" };
+  }
 
   // Nobody at your own company is a cold emailer. Checked here rather than only at the
   // actions, so a colleague is never labelled or archived either.

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -22,6 +22,7 @@ export const COLD_EMAIL_FOLDER_NAME = "Cold Emails";
 
 type ColdEmailBlockerReason =
   | "hasPreviousEmail"
+  | "applicationSender"
   | "ai"
   | "ai-already-labeled"
   | "excluded";
@@ -60,7 +61,7 @@ export async function isColdEmail({
 
   if (isSameEmailAddress(email.from, env.RESEND_FROM_EMAIL)) {
     logger.info("Sender is the application notification sender");
-    return { isColdEmail: false, reason: "hasPreviousEmail" };
+    return { isColdEmail: false, reason: "applicationSender" };
   }
 
   // Nobody at your own company is a cold emailer. Checked here rather than only at the


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260827-232515_pr-3420_03af7057585c/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents application notifications from entering cold-email classification by checking the configured sender before learned patterns, contact lookup, or AI.

Adds regression coverage proving these messages are left untouched without downstream checks. Focused unit tests and formatting checks pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emails sent from the application’s notification address are no longer incorrectly classified as cold emails.
  * These messages now bypass unnecessary contact and pattern checks, improving classification reliability.
  * Cold-email test results now clearly identify messages recognized as application notifications, while retaining distinct messaging for previously contacted senders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->