### PR TITLE
fix: Refresh email watches after account linking

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -168,17 +168,18 @@ test("renders a cached thread body when the reader request is offline", async ({
   page,
 }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const threadId = await openFirstThread(page, conversations);
+  const { readerUrl, threadId } = await openFirstThread(page, conversations);
+  await leaveThreadReader(page, emailAccountId);
+  await page.route(threadDetailRoute(threadId), (route) =>
+    route.abort("connectionfailed"),
+  );
   await seedThreadDetail(page, {
     emailAccountId,
     textPlain: WARM_READER_BODY,
     threadId,
   });
 
-  await page.route(threadDetailRoute(threadId), (route) =>
-    route.abort("connectionfailed"),
-  );
-  await page.reload();
+  await page.goto(readerUrl);
 
   await expect(readerBody(page, WARM_READER_BODY)).toBeVisible();
   await testInfo.attach("cached-thread-reader", {
@@ -191,7 +192,7 @@ test("falls back to the network for an uncached thread body and persists it", as
   page,
 }) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const threadId = await openFirstThread(page, conversations);
+  const { threadId } = await openFirstThread(page, conversations);
   await clearThreadDetail(page, { emailAccountId, threadId });
 
   await page.route(threadDetailRoute(threadId), async (route) => {
@@ -218,14 +219,10 @@ test("shows cached reader content immediately and refreshes it from the network"
   page,
 }) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const threadId = await openFirstThread(page, conversations);
+  const { readerUrl, threadId } = await openFirstThread(page, conversations);
   const network = Promise.withResolvers<void>();
 
-  await seedThreadDetail(page, {
-    emailAccountId,
-    textPlain: WARM_READER_BODY,
-    threadId,
-  });
+  await leaveThreadReader(page, emailAccountId);
   await page.route(threadDetailRoute(threadId), async (route) => {
     await network.promise;
     await route.fulfill({
@@ -239,7 +236,13 @@ test("shows cached reader content immediately and refreshes it from the network"
       status: 200,
     });
   });
-  await page.reload();
+  await seedThreadDetail(page, {
+    emailAccountId,
+    textPlain: WARM_READER_BODY,
+    threadId,
+  });
+
+  await page.goto(readerUrl);
 
   await expect(readerBody(page, WARM_READER_BODY)).toBeVisible();
   network.resolve();
@@ -406,7 +409,11 @@ async function openFirstThread(
   await conversations.getByRole("option").first().click();
   const threadId = new URL(page.url()).searchParams.get("thread-id");
   if (!threadId) throw new Error("Expected an open thread id");
-  return threadId;
+  return { readerUrl: page.url(), threadId };
+}
+
+async function leaveThreadReader(page: Page, emailAccountId: string) {
+  await page.goto(`/${emailAccountId}/settings`);
 }
 
 async function seedThreadDetail(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.undo.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.undo.test.ts
@@ -25,6 +25,28 @@ vi.mock("swr/infinite", () => ({
     },
   }),
 }));
+vi.mock("@/hooks/useMailMutationOverlay", () => ({
+  applyMailMutationOverlayToThreads: ({ threads }: { threads: unknown[] }) =>
+    threads,
+  useRetainedMailMutationOverlay: () => ({
+    isReady: true,
+    mutations: [],
+  }),
+}));
+vi.mock("@/utils/email-cache/thread-lists", () => ({
+  readCachedThreadList: vi.fn().mockResolvedValue(undefined),
+  removeCachedThreadsFromView: vi.fn().mockResolvedValue(undefined),
+  restoreCachedThreadsToView: vi.fn().mockResolvedValue(undefined),
+  writeCachedThreadList: vi.fn().mockResolvedValue(undefined),
+  writeCachedThreadRows: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/utils/email-cache/mailbox", () => ({
+  readSyncedMailboxThreads: vi.fn().mockResolvedValue(undefined),
+  subscribeToMailboxStore: vi.fn(() => () => {}),
+}));
+vi.mock("@/utils/email-cache/analytics", () => ({
+  trackMailboxListReady: vi.fn(),
+}));
 
 const ids = () => pages.current[0].threads.map((thread) => thread.id);
 

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -12,6 +12,7 @@ const {
   mockGetToken,
   mockFetchGoogleOpenIdProfile,
   mockIsGoogleOauthEmulationEnabled,
+  mockEnsureEmailAccountsWatched,
   mockAuth,
 } = vi.hoisted(() => ({
   mockValidateOAuthCallback: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockGetToken: vi.fn(),
   mockFetchGoogleOpenIdProfile: vi.fn(),
   mockIsGoogleOauthEmulationEnabled: vi.fn(() => true),
+  mockEnsureEmailAccountsWatched: vi.fn(),
   mockAuth: vi.fn(),
 }));
 
@@ -83,6 +85,10 @@ vi.mock("@/utils/auth", () => ({
   auth: mockAuth,
 }));
 
+vi.mock("@/utils/email/watch-manager", () => ({
+  ensureEmailAccountsWatched: mockEnsureEmailAccountsWatched,
+}));
+
 vi.mock("@/utils/error", async (importActual) => {
   const actual = await importActual<typeof import("@/utils/error")>();
   return actual;
@@ -108,6 +114,7 @@ describe("google linking callback route", () => {
     });
     mockGetOAuthCodeResult.mockResolvedValue(null);
     mockAcquireOAuthCodeLock.mockResolvedValue(true);
+    mockEnsureEmailAccountsWatched.mockResolvedValue([]);
     mockAuth.mockResolvedValue({
       user: {
         id: "user-123",
@@ -166,6 +173,10 @@ describe("google linking callback route", () => {
     expect(prisma.account.create).not.toHaveBeenCalled();
     expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("valid-auth-code", {
       success: "tokens_updated",
+    });
+    expect(mockEnsureEmailAccountsWatched).toHaveBeenCalledWith({
+      userIds: ["user-123"],
+      logger: expect.anything(),
     });
   });
 

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -14,6 +14,7 @@ const {
   mockIsGoogleOauthEmulationEnabled,
   mockEnsureEmailAccountsWatched,
   mockAuth,
+  mockAfter,
 } = vi.hoisted(() => ({
   mockValidateOAuthCallback: vi.fn(),
   mockHandleAccountLinking: vi.fn(),
@@ -26,6 +27,12 @@ const {
   mockIsGoogleOauthEmulationEnabled: vi.fn(() => true),
   mockEnsureEmailAccountsWatched: vi.fn(),
   mockAuth: vi.fn(),
+  mockAfter: vi.fn(),
+}));
+
+vi.mock("next/server", async (importActual) => ({
+  ...(await importActual<typeof import("next/server")>()),
+  after: mockAfter,
 }));
 
 vi.mock("@/env", () => ({
@@ -174,6 +181,13 @@ describe("google linking callback route", () => {
     expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("valid-auth-code", {
       success: "tokens_updated",
     });
+    expect(mockSetOAuthCodeResult.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAfter.mock.invocationCallOrder[0],
+    );
+    expect(mockEnsureEmailAccountsWatched).not.toHaveBeenCalled();
+
+    await runScheduledAfterCallback();
+
     expect(mockEnsureEmailAccountsWatched).toHaveBeenCalledWith({
       userIds: ["user-123"],
       logger: expect.anything(),
@@ -265,3 +279,9 @@ describe("google linking callback route", () => {
     consoleWarn.mockRestore();
   });
 });
+
+async function runScheduledAfterCallback() {
+  const callback = mockAfter.mock.calls.at(-1)?.[0];
+  expect(callback).toBeTypeOf("function");
+  await callback();
+}

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { env } from "@/env";
 import { auth } from "@/utils/auth";
 import { hash } from "@/utils/hash";
@@ -409,16 +410,22 @@ async function completeGoogleAccountLinking({
   success: "account_created_and_linked" | "account_merged" | "tokens_updated";
   targetUserId: string;
 }) {
-  await ensureEmailAccountsWatched({
-    userIds: [targetUserId],
-    logger,
-  }).catch((error) => {
-    logger.error("Failed to re-register email watches after account linking", {
-      error,
-    });
-  });
-
   await setOAuthCodeResult(code, { success });
+
+  after(() =>
+    ensureEmailAccountsWatched({
+      userIds: [targetUserId],
+      logger,
+    }).catch((error) => {
+      logger.error(
+        "Failed to re-register email watches after account linking",
+        {
+          error,
+        },
+      );
+    }),
+  );
+
   return createAccountLinkingRedirect({
     query: { success },
     stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -26,6 +26,7 @@ import {
 } from "@/utils/redis/oauth-code";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { SafeError } from "@/utils/error";
+import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 
 export const GET = withError("google/linking/callback", async (request) => {
   const actorUserId = (await auth(request.headers))?.user.id ?? null;
@@ -161,10 +162,11 @@ export const GET = withError("google/linking/callback", async (request) => {
         providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
       });
 
-      await setOAuthCodeResult(code, { success: "tokens_updated" });
-      return createAccountLinkingRedirect({
-        query: { success: "tokens_updated" },
-        stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+      return completeGoogleAccountLinking({
+        code,
+        logger,
+        success: "tokens_updated",
+        targetUserId,
       });
     }
 
@@ -197,10 +199,11 @@ export const GET = withError("google/linking/callback", async (request) => {
             tokens,
           });
 
-          await setOAuthCodeResult(code, { success: "tokens_updated" });
-          return createAccountLinkingRedirect({
-            query: { success: "tokens_updated" },
-            stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+          return completeGoogleAccountLinking({
+            code,
+            logger,
+            success: "tokens_updated",
+            targetUserId,
           });
         }
       }
@@ -288,10 +291,11 @@ export const GET = withError("google/linking/callback", async (request) => {
         }
       }
 
-      await setOAuthCodeResult(code, { success: "account_created_and_linked" });
-      return createAccountLinkingRedirect({
-        query: { success: "account_created_and_linked" },
-        stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+      return completeGoogleAccountLinking({
+        code,
+        logger,
+        success: "account_created_and_linked",
+        targetUserId,
       });
     }
 
@@ -319,10 +323,11 @@ export const GET = withError("google/linking/callback", async (request) => {
         providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
       });
 
-      await setOAuthCodeResult(code, { success: "tokens_updated" });
-      return createAccountLinkingRedirect({
-        query: { success: "tokens_updated" },
-        stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+      return completeGoogleAccountLinking({
+        code,
+        logger,
+        success: "tokens_updated",
+        targetUserId,
       });
     }
 
@@ -368,10 +373,11 @@ export const GET = withError("google/linking/callback", async (request) => {
       sourceUserId: linkingResult.sourceUserId,
     });
 
-    await setOAuthCodeResult(code, { success: successMessage });
-    return createAccountLinkingRedirect({
-      query: { success: successMessage },
-      stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+    return completeGoogleAccountLinking({
+      code,
+      logger,
+      success: successMessage,
+      targetUserId,
     });
   } catch (error) {
     await clearOAuthCode(code);
@@ -390,6 +396,33 @@ interface GoogleTokens {
   refresh_token?: string | null;
   scope?: string | null;
   token_type?: string | null;
+}
+
+async function completeGoogleAccountLinking({
+  code,
+  logger,
+  success,
+  targetUserId,
+}: {
+  code: string;
+  logger: Parameters<typeof handleOAuthCallbackError>[0]["logger"];
+  success: "account_created_and_linked" | "account_merged" | "tokens_updated";
+  targetUserId: string;
+}) {
+  await ensureEmailAccountsWatched({
+    userIds: [targetUserId],
+    logger,
+  }).catch((error) => {
+    logger.error("Failed to re-register email watches after account linking", {
+      error,
+    });
+  });
+
+  await setOAuthCodeResult(code, { success });
+  return createAccountLinkingRedirect({
+    query: { success },
+    stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+  });
 }
 
 async function updateGoogleAccount({

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Account } from "better-auth";
 import { cookies } from "next/headers";
 import { createReferral } from "@/utils/referral/referral-code";
 import { captureException } from "@/utils/error";
@@ -369,40 +370,45 @@ describe("handleLinkAccount", () => {
   });
 
   it("re-registers email watches after a Google account is linked", async () => {
-    vi.mocked(getContactsClient).mockReturnValue({
-      people: {
-        get: vi.fn().mockResolvedValue({
-          data: {
-            emailAddresses: [
-              {
-                value: "user@example.com",
-                metadata: { primary: true },
-              },
-            ],
-            names: [{ displayName: "Test User", metadata: { primary: true } }],
-            photos: [],
-          },
-        }),
-      },
-    } as any);
+    mockGoogleProfile();
     prisma.emailAccount.findUnique.mockResolvedValue(null);
-    prisma.user.findUnique.mockResolvedValue({
+    const user = {
       email: "user@example.com",
       name: "Test User",
       image: null,
-    } as any);
-    prisma.$transaction.mockResolvedValue([
-      { id: "email_account_1" },
-      { id: "account_1" },
-    ] as any);
+    };
+    prisma.user.findUnique.mockResolvedValue(
+      user as Awaited<ReturnType<typeof prisma.user.findUnique>>,
+    );
+    const transactionResult = [{ id: "email_account_1" }, { id: "account_1" }];
+    prisma.$transaction.mockResolvedValue(transactionResult as never);
     vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
 
-    await handleLinkAccount({
-      id: "account_1",
+    await handleLinkAccount(getGoogleAccount());
+
+    expect(ensureEmailAccountsWatched).toHaveBeenCalledWith({
+      userIds: ["user_1"],
+      logger: expect.anything(),
+    });
+  });
+
+  it("re-registers email watches after a cross-provider account link", async () => {
+    mockGoogleProfile();
+    const existingEmailAccount = {
+      id: "email_account_1",
       userId: "user_1",
-      providerId: "google",
-      accessToken: "access_token",
-    } as any);
+      accountId: "microsoft_account_1",
+      account: { provider: "microsoft" },
+    };
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      existingEmailAccount as Awaited<
+        ReturnType<typeof prisma.emailAccount.findUnique>
+      >,
+    );
+    prisma.$transaction.mockResolvedValue([] as never);
+    vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
+
+    await handleLinkAccount(getGoogleAccount());
 
     expect(ensureEmailAccountsWatched).toHaveBeenCalledWith({
       userIds: ["user_1"],
@@ -410,3 +416,36 @@ describe("handleLinkAccount", () => {
     });
   });
 });
+
+function mockGoogleProfile() {
+  const people = {
+    get: vi.fn().mockResolvedValue({
+      data: {
+        emailAddresses: [
+          {
+            value: "user@example.com",
+            metadata: { primary: true },
+          },
+        ],
+        names: [{ displayName: "Test User", metadata: { primary: true } }],
+        photos: [],
+      },
+    }),
+  } as ReturnType<typeof getContactsClient>["people"];
+
+  vi.mocked(getContactsClient).mockReturnValue({
+    people,
+  } as ReturnType<typeof getContactsClient>);
+}
+
+function getGoogleAccount(): Account {
+  return {
+    id: "account_1",
+    accountId: "provider_account_1",
+    userId: "user_1",
+    providerId: "google",
+    accessToken: "access_token",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  };
+}

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -15,6 +15,10 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 
+const { mockAfter } = vi.hoisted(() => ({
+  mockAfter: vi.fn(),
+}));
+
 vi.mock("better-auth", () => {
   class APIError extends Error {
     body?: { code?: string; message?: string };
@@ -74,6 +78,11 @@ vi.mock("@/utils/encryption", () => ({
 
 vi.mock("next/headers", () => ({
   cookies: vi.fn(),
+}));
+
+vi.mock("next/server", async (importActual) => ({
+  ...(await importActual<typeof import("next/server")>()),
+  after: mockAfter,
 }));
 
 vi.mock("@/utils/referral/referral-code", () => ({
@@ -369,7 +378,7 @@ describe("handleLinkAccount", () => {
     });
   });
 
-  it("re-registers email watches after a Google account is linked", async () => {
+  it("schedules email watch registration after a Google account is linked", async () => {
     mockGoogleProfile();
     prisma.emailAccount.findUnique.mockResolvedValue(null);
     const user = {
@@ -385,6 +394,11 @@ describe("handleLinkAccount", () => {
     vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
 
     await handleLinkAccount(getGoogleAccount());
+
+    expect(mockAfter).toHaveBeenCalledOnce();
+    expect(ensureEmailAccountsWatched).not.toHaveBeenCalled();
+
+    await runScheduledAfterCallback();
 
     expect(ensureEmailAccountsWatched).toHaveBeenCalledWith({
       userIds: ["user_1"],
@@ -409,6 +423,10 @@ describe("handleLinkAccount", () => {
     vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
 
     await handleLinkAccount(getGoogleAccount());
+
+    expect(mockAfter).toHaveBeenCalledOnce();
+
+    await runScheduledAfterCallback();
 
     expect(ensureEmailAccountsWatched).toHaveBeenCalledWith({
       userIds: ["user_1"],
@@ -448,4 +466,10 @@ function getGoogleAccount(): Account {
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
   };
+}
+
+async function runScheduledAfterCallback() {
+  const callback = mockAfter.mock.calls.at(-1)?.[0];
+  expect(callback).toBeTypeOf("function");
+  await callback();
 }

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -4,6 +4,8 @@ import { createReferral } from "@/utils/referral/referral-code";
 import { captureException } from "@/utils/error";
 import { saveTokens } from "@/utils/auth/save-tokens";
 import { createOutlookClient } from "@/utils/outlook/client";
+import { getContactsClient } from "@/utils/gmail/client";
+import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import {
   betterAuthConfig,
   handleLinkAccount,
@@ -54,6 +56,16 @@ vi.mock("@googleapis/gmail", () => ({
 }));
 vi.mock("@/utils/outlook/client", () => ({
   createOutlookClient: vi.fn(),
+}));
+vi.mock("@/utils/gmail/client", () => ({
+  getContactsClient: vi.fn(),
+}));
+vi.mock("@/utils/email/watch-manager", () => ({
+  ensureEmailAccountsWatched: vi.fn(),
+}));
+vi.mock("@/utils/premium/seats", () => ({
+  claimPendingPremiumInvite: vi.fn(),
+  updateAccountSeats: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/utils/encryption", () => ({
   encryptToken: vi.fn((t) => t),
@@ -353,6 +365,48 @@ describe("handleLinkAccount", () => {
         code: "email_already_linked",
         message: "email_already_linked",
       },
+    });
+  });
+
+  it("re-registers email watches after a Google account is linked", async () => {
+    vi.mocked(getContactsClient).mockReturnValue({
+      people: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            emailAddresses: [
+              {
+                value: "user@example.com",
+                metadata: { primary: true },
+              },
+            ],
+            names: [{ displayName: "Test User", metadata: { primary: true } }],
+            photos: [],
+          },
+        }),
+      },
+    } as any);
+    prisma.emailAccount.findUnique.mockResolvedValue(null);
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      name: "Test User",
+      image: null,
+    } as any);
+    prisma.$transaction.mockResolvedValue([
+      { id: "email_account_1" },
+      { id: "account_1" },
+    ] as any);
+    vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
+
+    await handleLinkAccount({
+      id: "account_1",
+      userId: "user_1",
+      providerId: "google",
+      accessToken: "access_token",
+    } as any);
+
+    expect(ensureEmailAccountsWatched).toHaveBeenCalledWith({
+      userIds: ["user_1"],
+      logger: expect.anything(),
     });
   });
 });

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -22,6 +22,7 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
+import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import { captureException } from "@/utils/error";
 import { getContactsClient as getGoogleContactsClient } from "@/utils/gmail/client";
 import { SCOPES as GMAIL_SCOPES } from "@/utils/gmail/scopes";
@@ -745,6 +746,19 @@ export async function handleLinkAccount(account: Account) {
         error,
       });
       captureException(error, { extra: { userId: account.userId } });
+    });
+
+    await ensureEmailAccountsWatched({
+      userIds: [account.userId],
+      logger,
+    }).catch((error) => {
+      logger.error("[linkAccount] Error re-registering email watches", {
+        userId: account.userId,
+        error,
+      });
+      captureException(error, {
+        extra: { userId: account.userId, location: "linkAccountWatch" },
+      });
     });
 
     logger.info("[linkAccount] Successfully linked account", {

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -688,7 +688,7 @@ export async function handleLinkAccount(account: Account) {
         logger,
       });
 
-      await ensureEmailWatchesAfterLink(account.userId);
+      scheduleEmailWatchesAfterLink(account.userId);
       return;
     }
     const user = await prisma.user.findUnique({
@@ -749,7 +749,7 @@ export async function handleLinkAccount(account: Account) {
       captureException(error, { extra: { userId: account.userId } });
     });
 
-    await ensureEmailWatchesAfterLink(account.userId);
+    scheduleEmailWatchesAfterLink(account.userId);
 
     logger.info("[linkAccount] Successfully linked account", {
       email: user.email,
@@ -813,17 +813,19 @@ async function autoJoinOrganization(emailAccountId: string) {
   });
 }
 
-async function ensureEmailWatchesAfterLink(userId: string) {
-  await ensureEmailAccountsWatched({
-    userIds: [userId],
-    logger,
-  }).catch((error) => {
-    logger.error("[linkAccount] Error re-registering email watches", {
-      userId,
-      error,
-    });
-    captureException(error, {
-      extra: { userId, location: "linkAccountWatch" },
-    });
-  });
+function scheduleEmailWatchesAfterLink(userId: string) {
+  after(() =>
+    ensureEmailAccountsWatched({
+      userIds: [userId],
+      logger,
+    }).catch((error) => {
+      logger.error("[linkAccount] Error re-registering email watches", {
+        userId,
+        error,
+      });
+      captureException(error, {
+        extra: { userId, location: "linkAccountWatch" },
+      });
+    }),
+  );
 }

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -688,6 +688,7 @@ export async function handleLinkAccount(account: Account) {
         logger,
       });
 
+      await ensureEmailWatchesAfterLink(account.userId);
       return;
     }
     const user = await prisma.user.findUnique({
@@ -748,18 +749,7 @@ export async function handleLinkAccount(account: Account) {
       captureException(error, { extra: { userId: account.userId } });
     });
 
-    await ensureEmailAccountsWatched({
-      userIds: [account.userId],
-      logger,
-    }).catch((error) => {
-      logger.error("[linkAccount] Error re-registering email watches", {
-        userId: account.userId,
-        error,
-      });
-      captureException(error, {
-        extra: { userId: account.userId, location: "linkAccountWatch" },
-      });
-    });
+    await ensureEmailWatchesAfterLink(account.userId);
 
     logger.info("[linkAccount] Successfully linked account", {
       email: user.email,
@@ -820,5 +810,20 @@ async function autoJoinOrganization(emailAccountId: string) {
     emailAccountId,
     organizationId,
     memberId: member.id,
+  });
+}
+
+async function ensureEmailWatchesAfterLink(userId: string) {
+  await ensureEmailAccountsWatched({
+    userIds: [userId],
+    logger,
+  }).catch((error) => {
+    logger.error("[linkAccount] Error re-registering email watches", {
+      userId,
+      error,
+    });
+    captureException(error, {
+      extra: { userId, location: "linkAccountWatch" },
+    });
   });
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260828-010145_pr-3421_f317daa6187d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensures email watches are refreshed whenever an account is linked or reauthenticated.

- refresh watches through authentication and provider-linking callback paths
- keep watch setup failures from invalidating successful account linking
- add focused regression coverage for both flows

Validation:
- `pnpm test app/api/google/linking/callback/route.test.ts utils/auth.test.ts`
- `pnpm check` (existing warnings only)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Google account linking now automatically restores email monitoring after a successful connection.
  - Linking and callback completion continue successfully even when email-monitoring setup encounters an error.
  - Improved reliability when connecting Google accounts across different linking flows, including alternate providers.
  - Email monitoring remains available after accounts are merged or linked, reducing manual recovery.
  - Improved consistency when returning to cached email threads after navigating away from the reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->