### PR TITLE
mail: Add provider link to thread actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentProps } from "react";
 import {
+  ExternalLinkIcon,
   MailXIcon,
   MailIcon,
   MailOpenIcon,
@@ -12,6 +13,7 @@ import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assista
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
 import { useUnsubscribeSender } from "@/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender";
+import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,7 +24,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { useAccount } from "@/providers/EmailAccountProvider";
 import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
+import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import type { ParsedMessage } from "@/utils/types";
 
 type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
@@ -64,9 +68,19 @@ export function ThreadActionsMenu({
   onOpenChange,
 }: ThreadActionsMenuProps) {
   const hint = getShortcutHint("moreActions");
+  const { provider, userEmail } = useAccount();
   const { canUnsubscribe, onUnsubscribe, PremiumModal } =
     useUnsubscribeSender(message);
   const ReadIcon = isUnread ? MailOpenIcon : MailIcon;
+  const openUrl = message
+    ? getEmailMessageCellActions({
+        externalUrl: message.externalUrl,
+        messageId: message.id,
+        provider,
+        threadId: message.threadId,
+        userEmail,
+      })?.openUrl
+    : undefined;
 
   return (
     <>
@@ -99,6 +113,15 @@ export function ThreadActionsMenu({
           ))}
 
           {plans.length > 0 ? <DropdownMenuSeparator /> : null}
+
+          {openUrl ? (
+            <DropdownMenuItem asChild>
+              <a href={openUrl} rel="noopener noreferrer" target="_blank">
+                <ExternalLinkIcon className="mr-2 size-4" />
+                Open in {isMicrosoftProvider(provider) ? "Outlook" : "Gmail"}
+              </a>
+            </DropdownMenuItem>
+          ) : null}
 
           <DropdownMenuItem onSelect={onToggleRead}>
             <ReadIcon className="mr-2 size-4" />


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260828-000338_pr-3423_176e02cd2a12/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a provider-specific external link to the mail thread actions menu.

- Labels the action for Gmail or Outlook and opens it in a new tab.
- Reuses the existing safe URL selection behavior.
- Validated with focused URL tests and the repository code-style check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open in Outlook” or “Open in Gmail” option to the thread actions menu.
  * Messages can now be opened directly in the provider’s web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->