### PR TITLE
mail: Support label splits across accounts

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -261,11 +261,8 @@ export function MailShell() {
       ),
     ];
   }, [combinedLabelSplits, isAllAccounts, settings?.splits]);
-  const displayedActiveSplitId = splits.some(
-    (split) => split.id === activeSplitId,
-  )
-    ? activeSplitId
-    : "all";
+  const displayedActiveSplitId =
+    splits.find((split) => split.id === activeSplitId)?.id ?? "all";
   const activeCombinedLabelName = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
   )?.labelName;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -96,6 +96,7 @@ import {
   updateMailboxItemAction,
 } from "@/utils/actions/mail";
 import {
+  getPortableLabelSplits,
   mailSplitToThreadsQuery,
   mailTypeToThreadsQuery,
 } from "@/utils/mail/split-query";
@@ -238,23 +239,36 @@ export function MailShell() {
   }, [scopeFolderId, scopeLabelId, scopeType]);
   const isScoped = !isAllAccounts && scopeQuery !== null;
 
+  const combinedLabelSplits = useMemo(
+    () => getPortableLabelSplits(settings?.splits ?? [], userLabels),
+    [settings?.splits, userLabels],
+  );
+
   const splits: MailSplitTab[] = useMemo(() => {
     const builtInSplits = BUILT_IN_SPLITS.map((split) => ({
       id: split.id,
       name: split.name,
       deletable: false,
     }));
-    if (isAllAccounts) return builtInSplits;
-
     return [
       ...builtInSplits,
-      ...(settings?.splits ?? []).map((split) => ({
-        id: split.id,
-        name: split.name,
-        deletable: true,
-      })),
+      ...(isAllAccounts ? combinedLabelSplits : (settings?.splits ?? [])).map(
+        (split) => ({
+          id: split.id,
+          name: split.name,
+          deletable: true,
+        }),
+      ),
     ];
-  }, [isAllAccounts, settings?.splits]);
+  }, [combinedLabelSplits, isAllAccounts, settings?.splits]);
+  const displayedActiveSplitId = splits.some(
+    (split) => split.id === activeSplitId,
+  )
+    ? activeSplitId
+    : "all";
+  const activeCombinedLabelName = combinedLabelSplits.find(
+    (split) => split.id === displayedActiveSplitId,
+  )?.labelName;
 
   const query: ThreadsQuery = useMemo(() => {
     if (scopeQuery) return scopeQuery;
@@ -276,7 +290,8 @@ export function MailShell() {
     accounts: combinedAccounts,
     emailAccountId,
     enabled: isAllAccounts,
-    isUnread: activeSplitId === "unread",
+    isUnread: displayedActiveSplitId === "unread",
+    labelName: activeCombinedLabelName,
   });
   const { labelsByAccount } = combinedThreadState;
   const { threads, isLoading, error, hasMore, isLoadingMore, loadMore } =
@@ -620,7 +635,9 @@ export function MailShell() {
             else if (layout === "list") setOpenThread(null);
           },
       nextSplit: () => {
-        const index = splits.findIndex((s) => s.id === activeSplitId);
+        const index = splits.findIndex(
+          (split) => split.id === displayedActiveSplitId,
+        );
         const next = splits[(index + 1) % splits.length];
         if (next) setActiveSplitId(next.id);
       },
@@ -881,12 +898,16 @@ export function MailShell() {
     setScopeType(null);
     setScopeLabelId(null);
     setScopeFolderId(null);
-    if (!BUILT_IN_SPLITS.some((split) => split.id === activeSplitId)) {
+    if (
+      !BUILT_IN_SPLITS.some((split) => split.id === activeSplitId) &&
+      !combinedLabelSplits.some((split) => split.id === activeSplitId)
+    ) {
       setActiveSplitId("all");
     }
     setAccountScope("all");
   }, [
     activeSplitId,
+    combinedLabelSplits,
     selection.clear,
     setAccountScope,
     setActiveSplitId,
@@ -960,7 +981,7 @@ export function MailShell() {
             {!isScoped && (
               <SplitTabs
                 splits={splits}
-                activeSplitId={activeSplitId}
+                activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}
                 newSplitOptions={newSplitOptions}
@@ -999,7 +1020,7 @@ export function MailShell() {
                 onLoadMore={loadMore}
                 listKey={
                   isAllAccounts
-                    ? `all-accounts:${activeSplitId}`
+                    ? `all-accounts:${displayedActiveSplitId}`
                     : JSON.stringify(query)
                 }
               />

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -25,7 +25,7 @@ export type SplitTabsProps = {
   newSplitOptions: NewSplitOption[];
   onCreateSplit: (draft: NewSplitDraft) => void;
   onCreateSplitFromPrompt: (prompt: string) => Promise<boolean>;
-  /** The All accounts view only shows built-in tabs, so creation is hidden there. */
+  /** Split creation stays account-scoped, so it is hidden in All accounts. */
   canCreateSplits: boolean;
   className?: string;
 };

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -227,6 +227,39 @@ describe("useCombinedMailThreads", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("loads a named-label view without mixing in the generic inbox snapshot", async () => {
+    const fetcher = vi.fn(() =>
+      Promise.resolve({
+        failedAccountIds: [],
+        labelsByAccount: {},
+        nextPageToken: null,
+        threads: [createThread("account-1", "matching-label")],
+      }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+          labelName: "Receipts & orders",
+        }),
+      { wrapper: createWrapper(fetcher) },
+    );
+
+    await waitFor(() =>
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "matching-label",
+      ]),
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      expect.stringContaining("labelName=Receipts+%26+orders"),
+    );
+    expect(mailbox.read).not.toHaveBeenCalled();
+  });
+
   it("uses a newer server page when the persisted mailbox predates the request", async () => {
     mailbox.read.mockResolvedValue({
       accountStates: ACCOUNT_STATES,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -80,11 +80,13 @@ export function useCombinedMailThreads({
   emailAccountId,
   enabled,
   isUnread,
+  labelName,
 }: {
   accounts: CombinedThread["account"][];
   emailAccountId: string;
   enabled: boolean;
   isUnread: boolean;
+  labelName?: string;
 }) {
   const accountIdentity = useMemo(
     () =>
@@ -108,8 +110,9 @@ export function useCombinedMailThreads({
       createThreadListCacheKey({
         scope: "combined",
         isUnread: isUnread || undefined,
+        labelName,
       }),
-    [isUnread],
+    [isUnread, labelName],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
   const { fetcher } = useSWRConfig();
@@ -125,11 +128,12 @@ export function useCombinedMailThreads({
       const params = createSearchParams({
         limit: COMBINED_PAGE_SIZE,
         isUnread: isUnread || undefined,
+        labelName,
         cursor: pageIndex > 0 ? previousPageData?.nextPageToken : undefined,
       });
       return `/api/threads/all?${params.toString()}`;
     },
-    [enabled, isUnread],
+    [enabled, isUnread, labelName],
   );
   const fetchCombinedPage = useCallback(
     async (key: string) => {
@@ -221,7 +225,7 @@ export function useCombinedMailThreads({
   }, [emailAccountId, enabled, viewIdentity, viewKey]);
 
   useEffect(() => {
-    if (!enabled || !accountIdentity) return;
+    if (!enabled || !accountIdentity || labelName) return;
     let cancelled = false;
     const accountIds = new Set(
       accountsRef.current.map((account) => account.id),
@@ -278,7 +282,14 @@ export function useCombinedMailThreads({
       cancelled = true;
       unsubscribe();
     };
-  }, [accountIdentity, enabled, isUnread, localSnapshotLimit, viewIdentity]);
+  }, [
+    accountIdentity,
+    enabled,
+    isUnread,
+    labelName,
+    localSnapshotLimit,
+    viewIdentity,
+  ]);
 
   const remoteThreads = useMemo(
     () => data?.flatMap((page) => page.threads),

--- a/apps/web/app/api/threads/all/route.test.ts
+++ b/apps/web/app/api/threads/all/route.test.ts
@@ -155,4 +155,72 @@ describe("GET /api/threads/all", () => {
       failedAccountIds: [],
     });
   });
+
+  it("resolves label filters to each account's matching label id", async () => {
+    getConnectedEmailAccountsMock.mockResolvedValue([
+      {
+        id: "account-1",
+        email: "first@example.com",
+        name: "First",
+        image: null,
+        provider: "google",
+      },
+      {
+        id: "account-2",
+        email: "second@example.com",
+        name: "Second",
+        image: null,
+        provider: "microsoft",
+      },
+      {
+        id: "account-3",
+        email: "third@example.com",
+        name: "Third",
+        image: null,
+        provider: "google",
+      },
+    ]);
+    createEmailProviderMock.mockImplementation(
+      async ({ emailAccountId }: { emailAccountId: string }) => ({
+        name: emailAccountId === "account-2" ? "microsoft" : "google",
+        getLabels: vi
+          .fn()
+          .mockResolvedValue(
+            emailAccountId === "account-1"
+              ? [{ id: "google-label", name: "Receipts", type: "user" }]
+              : emailAccountId === "account-2"
+                ? [{ id: "outlook-category", name: "receipts", type: "user" }]
+                : [{ id: "other-label", name: "Marketing", type: "user" }],
+          ),
+      }),
+    );
+
+    await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads/all?labelName=Receipts",
+      ),
+      {} as never,
+    );
+
+    expect(loadThreadsMock).toHaveBeenCalledTimes(2);
+    expect(loadThreadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        query: expect.objectContaining({
+          labelIds: ["google-label", "INBOX"],
+        }),
+      }),
+    );
+    expect(loadThreadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-2",
+        query: expect.objectContaining({
+          labelIds: ["outlook-category", "INBOX"],
+        }),
+      }),
+    );
+    expect(loadThreadsMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ emailAccountId: "account-3" }),
+    );
+  });
 });

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -12,6 +12,7 @@ export const maxDuration = 30;
 const querySchema = z.object({
   cursor: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
+  labelName: z.string().trim().min(1).max(255).optional(),
   isUnread: z
     .enum(["true", "false"])
     .transform((value) => value === "true")
@@ -23,7 +24,7 @@ export type GetAllThreadsResponse = Awaited<
 >;
 
 export const GET = withAuth("threads/all", async (request) => {
-  const { cursor, limit, isUnread } = querySchema.parse(
+  const { cursor, limit, isUnread, labelName } = querySchema.parse(
     Object.fromEntries(new URL(request.url).searchParams),
   );
   const accounts = await getConnectedEmailAccounts({
@@ -41,6 +42,29 @@ export const GET = withAuth("threads/all", async (request) => {
         provider: account.provider,
         logger,
       });
+      if (labelName) {
+        const labels = await emailProvider.getLabels();
+        const normalizedLabelName = labelName.toLowerCase();
+        const matchingLabel = labels.find(
+          (label) => label.name.trim().toLowerCase() === normalizedLabelName,
+        );
+        if (!matchingLabel) {
+          return { threads: [], nextPageToken: null, labels };
+        }
+
+        const loaded = await loadThreads({
+          query: threadsQuery.parse({
+            labelIds: [matchingLabel.id, "INBOX"],
+            limit,
+            nextPageToken: pageToken,
+          }),
+          emailAccountId: account.id,
+          emailProvider,
+          messageFormat: "metadata",
+        });
+        return { ...toListThreads(loaded), labels };
+      }
+
       const [loaded, labels] = await Promise.all([
         loadThreads({
           query: threadsQuery.parse({

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { MailSplitKind } from "@/generated/prisma/enums";
-import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+import {
+  getPortableLabelSplits,
+  mailSplitToThreadsQuery,
+} from "@/utils/mail/split-query";
 
 function split(
   kind: MailSplitKind,
@@ -53,5 +56,27 @@ describe("mailSplitToThreadsQuery", () => {
     expect(() => mailSplitToThreadsQuery(split(kind))).toThrow(
       /has no (label|category)/,
     );
+  });
+});
+
+describe("getPortableLabelSplits", () => {
+  it("uses the source label name as the cross-account identity", () => {
+    const labelSplit = {
+      ...split(MailSplitKind.LABEL, "source-label-id"),
+      name: "Custom tab title",
+    };
+
+    expect(
+      getPortableLabelSplits(
+        [labelSplit, split(MailSplitKind.CATEGORY, "CATEGORY_UPDATES")],
+        { "source-label-id": { name: "Receipts" } },
+      ),
+    ).toEqual([{ ...labelSplit, labelName: "Receipts" }]);
+  });
+
+  it("omits label splits whose source label no longer exists", () => {
+    expect(
+      getPortableLabelSplits([split(MailSplitKind.LABEL, "missing-label")], {}),
+    ).toEqual([]);
   });
 });

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -9,6 +9,8 @@ export type MailSplit = {
   value: string | null;
 };
 
+export type PortableLabelSplit = MailSplit & { labelName: string };
+
 /**
  * Every split is its own server query. Filtering a paginated list client-side would
  * only ever search the pages already loaded, which silently under-reports.
@@ -37,4 +39,15 @@ export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
     return { type: "inbox", inboxSection: type };
   }
   return { type };
+}
+
+export function getPortableLabelSplits(
+  splits: MailSplit[],
+  labelsById: Record<string, { name: string }>,
+): PortableLabelSplit[] {
+  return splits.flatMap((split) => {
+    if (split.kind !== MailSplitKind.LABEL || !split.value) return [];
+    const labelName = labelsById[split.value]?.name.trim();
+    return labelName ? [{ ...split, labelName }] : [];
+  });
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260828-111255_pr-3424_02a7ccf16564/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Enable saved label splits in the combined mailbox by matching label names to each account's provider-specific identifier.

- Preserve compatible split tabs and selection in the combined view.
- Isolate filtered caches and skip accounts without a matching label.
- Add focused coverage for cross-provider resolution and cache behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All Accounts mail views now include saved label-based splits.
  * Selecting a label split displays matching messages across connected accounts.
  * Invalid or unavailable split selections now safely fall back to the All view.

* **Bug Fixes**
  * Prevented labeled views from mixing in unrelated inbox messages.
  * Label matching now works across providers and ignores accounts without the requested label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->