### PR TITLE
mail: Keep email content visible during sizing

### DIFF
--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -156,6 +156,16 @@ describe("HtmlEmail", () => {
     );
   });
 
+  it("does not collapse cached html while measuring the iframe", () => {
+    const { getByTitle } = render(
+      <HtmlEmail html="<p>Cached email body</p>" messageId="message-cached" />,
+    );
+
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+
+    expect(iframe.style.height).toBe("");
+  });
+
   it("resolves authenticated cid images to temporary local URLs", async () => {
     const html = '<img src="cid:screenshot@inboxzero.local" />';
     const objectUrl = "blob:https://app.example.com/inline-image";

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -51,7 +51,7 @@ describe("HtmlEmail", () => {
     vi.unstubAllGlobals();
   });
 
-  it("reuses recently prepared html after remounting the same email", async () => {
+  it("reuses prepared html without collapsing while measuring the iframe", async () => {
     const html = "<p>Hello</p>";
 
     const firstRender = render(<HtmlEmail html={html} messageId="message-1" />);
@@ -60,10 +60,16 @@ describe("HtmlEmail", () => {
     });
     firstRender.unmount();
 
-    render(<HtmlEmail html={html} messageId="message-1" />);
+    const { getByTitle } = render(
+      <HtmlEmail html={html} messageId="message-1" />,
+    );
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
+
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    expect(iframe.getAttribute("srcdoc")).toContain("<p>proxied</p>");
+    expect(iframe.style.height).toBe("");
   });
 
   it("keeps https images allowed when proxy rewriting leaves the html unchanged", async () => {
@@ -154,16 +160,6 @@ describe("HtmlEmail", () => {
         640,
       ),
     );
-  });
-
-  it("does not collapse cached html while measuring the iframe", () => {
-    const { getByTitle } = render(
-      <HtmlEmail html="<p>Cached email body</p>" messageId="message-cached" />,
-    );
-
-    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
-
-    expect(iframe.style.height).toBe("");
   });
 
   it("resolves authenticated cid images to temporary local URLs", async () => {

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -118,7 +118,7 @@ export function HtmlEmail({
         ref={iframeRef}
         srcDoc={srcDoc}
         className="min-h-0 w-full"
-        style={{ height: `${iframeHeight + 3}px` }}
+        style={iframeHeight ? { height: `${iframeHeight + 3}px` } : undefined}
         title="Email content preview"
         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         referrerPolicy="no-referrer"


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260828-140951_pr-3431_a90a011ec352/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents rendered email content from collapsing while its iframe height is being measured.

- Preserve the iframe’s native height until a measured value is available.
- Add regression coverage for cached content during initial sizing.
- Validated with focused tests and repository lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email display behavior when loading cached HTML content.
  * Prevented the email preview from collapsing while its height is being measured.
  * Ensured the preview retains its rendered content when reopening the same email.

* **Tests**
  * Added coverage verifying cached email content and iframe sizing after remounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->