### PR TITLE
Mail: remove reader navigation controls

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -49,6 +49,6 @@ test("switches between list, split, and focused reading layouts", async ({
   await page.getByRole("button", { name: /^Exit focus mode/ }).click();
   await expect(conversations).toBeVisible();
   await page.getByRole("button", { name: "Switch list or split view" }).click();
-  await page.getByRole("button", { name: /^Back/ }).click();
+  await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();
 });

--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -154,7 +154,7 @@ test("opens the owning account's cached reader in place from All Accounts", asyn
       contentType: "image/png",
     });
 
-    await page.getByRole("button", { name: /^Back/ }).click();
+    await page.keyboard.press("Escape");
     await expect(conversations).toBeVisible();
     await expect(page).not.toHaveURL(/thread-id=/);
     await expect(page).not.toHaveURL(/thread-account-id=/);

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -77,8 +77,10 @@ test("opens a complete conversation and updates its read state", async ({
     page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
   ).toBeVisible();
   await expect(page).toHaveURL(/thread-id=thr_playwright_reader/);
+  await expect(page.getByRole("button", { name: /^Back/ })).toHaveCount(0);
+  await expect(page.getByText(/^\d+ of \d+$/)).toHaveCount(0);
 
-  await page.getByRole("button", { name: /^Back/ }).click();
+  await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();
   await expect(readerConversation).toBeVisible();
   await expect(page).not.toHaveURL(/thread-id=/);

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -73,7 +73,6 @@ test("selects ranges and opens conversations with the keyboard", async ({
 
   await page.keyboard.press("j");
   await page.keyboard.press("Enter");
-  await expect(page.getByRole("button", { name: /^Back/ })).toBeVisible();
   await expect(page).toHaveURL(/thread-id=/);
   await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1042,17 +1042,8 @@ export function MailShell() {
               userLabels={readerUserLabels}
               layout={layout}
               isFocusMode={isFocusMode}
-              position={
-                openThread
-                  ? { index: clampedIndex + 1, total: threads.length }
-                  : undefined
-              }
               labelHref={labelHref}
               onRemoveLabel={onRemoveLabel}
-              onBack={() => {
-                setIsFocusMode(false);
-                setOpenThread(null);
-              }}
               onArchive={archiveTargets}
               onDelete={trashTargets}
               onReply={requestReaderReply}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -3,7 +3,6 @@
 import type { ReactNode } from "react";
 import {
   ArchiveIcon,
-  ArrowLeftIcon,
   MaximizeIcon,
   MinimizeIcon,
   ReplyIcon,
@@ -14,7 +13,6 @@ import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import { Kbd } from "@/components/Kbd";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 type ReaderToolbarProps = {
@@ -39,59 +37,6 @@ type ReaderToolbarProps = {
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
-
-type ReaderNavigationProps = {
-  /** 1-based position of the open thread in the list, for the "N of M" readout. */
-  position?: { index: number; total: number };
-  onBack: () => void;
-  showSidebarToggle?: boolean;
-};
-
-export function ReaderNavigation({
-  position,
-  onBack,
-  showSidebarToggle = false,
-}: ReaderNavigationProps) {
-  return (
-    <>
-      <div className="h-5" />
-      <div className="sticky top-0 z-10 mb-4 flex items-center bg-card">
-        {showSidebarToggle ? (
-          <div className="flex w-10 shrink-0 justify-end">
-            <SidebarTrigger
-              name="left-sidebar"
-              className="hidden lg:inline-flex"
-            />
-          </div>
-        ) : null}
-
-        <div className="min-w-0 flex-1">
-          <div className="mx-auto w-full max-w-[54rem] px-6">
-            <div className="-mx-1 flex items-center gap-3 px-1 py-2">
-              <Button
-                onClick={onBack}
-                size="xs-2"
-                type="button"
-                variant="outline"
-              >
-                <ArrowLeftIcon className="mr-1.5 size-3.5" />
-                Back
-                <Kbd className="ml-1.5">{getShortcutHint("backToList")}</Kbd>
-              </Button>
-              {position ? (
-                <span className="font-mono text-muted-foreground text-xs">
-                  {`${position.index} of ${position.total}`}
-                </span>
-              ) : null}
-            </div>
-          </div>
-        </div>
-
-        {showSidebarToggle ? <div className="w-10 shrink-0" /> : null}
-      </div>
-    </>
-  );
-}
 
 /**
  * The reader's header: what the thread is, and what you can do to it.

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -3,10 +3,7 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { Loader2Icon, MailIcon } from "lucide-react";
-import {
-  ReaderNavigation,
-  ReaderToolbar,
-} from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
+import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
 import type {
   ListThread,
   MailLayoutMode,
@@ -15,6 +12,7 @@ import { EmailThread } from "@/components/email-list/EmailThread";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
 import { LoadingContent } from "@/components/LoadingContent";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { EmailLabels } from "@/providers/email-label-types";
 import {
   extractEmailAddress,
@@ -49,11 +47,8 @@ export type ThreadReaderProps = {
   userLabels: EmailLabels;
   layout: MailLayoutMode;
   isFocusMode: boolean;
-  /** 1-based position of the open thread in the list. */
-  position?: { index: number; total: number };
   labelHref: (labelId: string) => string;
   onRemoveLabel?: (labelId: string) => void;
-  onBack: () => void;
   onArchive: () => void;
   onReply: () => void;
   onDelete: () => void;
@@ -81,10 +76,8 @@ export function ThreadReader({
   userLabels,
   layout,
   isFocusMode,
-  position,
   labelHref,
   onRemoveLabel,
-  onBack,
   onArchive,
   onReply,
   onDelete,
@@ -147,12 +140,13 @@ export function ThreadReader({
         data-detail-selection-settled={detailSelectionSettled}
         data-testid="thread-reader"
       >
-        {layout === "list" && !isFocusMode ? (
-          <ReaderNavigation
-            onBack={onBack}
-            position={position}
-            showSidebarToggle={showSidebarToggle}
-          />
+        {layout === "list" && !isFocusMode && showSidebarToggle ? (
+          <div
+            className="hidden px-3 py-3 lg:flex"
+            data-desktop-mac-titlebar-spacer
+          >
+            <SidebarTrigger name="left-sidebar" />
+          </div>
         ) : null}
 
         <div className={readerMeasure({ layout, isFocusMode })}>
@@ -214,5 +208,5 @@ function readerMeasure({
   // ~860px: the mock's measure, and about as wide as an email body stays legible.
   if (isFocusMode) return "mx-auto w-full max-w-[54rem] px-10 py-10";
   if (layout === "split") return "px-6 py-5";
-  return "mx-auto w-full max-w-[54rem] px-6 pb-5";
+  return "mx-auto w-full max-w-[54rem] px-6 py-5";
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260828-140457_pr-3432_1aff850c3309/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Removes the redundant reader navigation strip from the mail thread view while keeping Escape navigation and the collapsed-sidebar control.

- Updates mail browser scenarios to use Escape and cover the removed controls.
- Validation: app lint and focused shortcut tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard-based conversation dismissal with the Escape key.
  * Improved desktop mail reading layout with a sidebar toggle.

* **Bug Fixes**
  * Fixed conversation navigation behavior when returning to the message list.
  * Removed outdated reader navigation controls and pagination indicators.

* **Tests**
  * Updated mail navigation and cached-reader coverage to verify the streamlined keyboard workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->