### PR TITLE
mail: Reduce sidebar visual noise

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -142,6 +142,7 @@ test("filters the mail list by state, category, and label", async ({
     conversationWithSubject(page, conversations, "Read Command Message"),
   ).toHaveCount(0);
 
+  await page.getByRole("button", { name: "Categories" }).click();
   await page.getByRole("link", { name: /^Promotions/ }).click();
   await expect(
     conversationWithSubject(page, conversations, "Promotion Category Message"),

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -932,6 +932,7 @@ export function MailShell() {
               countsById={isAllAccounts ? NO_COUNTS : countsById}
               categories={isAllAccounts ? [] : categories}
               categoryHeading={isOutlook ? "Inbox" : "Categories"}
+              collapsibleCategories={!isOutlook}
               labelsHeading={terminology.label.pluralCapitalized}
               labelSingular={terminology.label.singular}
               backToAppHref={prefixPath(emailAccountId, "/automation")}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { type FormEvent, type ReactNode, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ArchiveIcon,
   ArrowLeftIcon,
   BellIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   FileIcon,
   FolderIcon,
   InboxIcon,
@@ -70,23 +72,39 @@ export type MailSidebarProps = {
   onOpenShortcuts: () => void;
   labelEditMode: "color" | "name-and-color";
   labelColorOptions: readonly MailboxItemColorOption[];
+  /** Hide the categories group behind a toggle, collapsed by default. */
+  collapsibleCategories?: boolean;
   footer?: ReactNode;
   unified?: boolean;
   className?: string;
 };
 
-const SYSTEM_ITEMS = [
-  { name: "Inbox", type: "inbox", countId: "INBOX", Icon: InboxIcon },
+type SystemItem = {
+  name: string;
+  type: string;
+  /** null means the row never shows a count (a "sent unread" number is noise). */
+  countId: string | null;
+  Icon: LucideIcon;
+  emphasizeCount?: boolean;
+};
+
+const SYSTEM_ITEMS: SystemItem[] = [
+  {
+    name: "Inbox",
+    type: "inbox",
+    countId: "INBOX",
+    Icon: InboxIcon,
+    emphasizeCount: true,
+  },
   { name: "Drafts", type: "draft", countId: "DRAFT", Icon: FileIcon },
-  { name: "Sent", type: "sent", countId: "SENT", Icon: SendIcon },
+  { name: "Sent", type: "sent", countId: null, Icon: SendIcon },
   { name: "Archived", type: "archive", countId: "ARCHIVE", Icon: ArchiveIcon },
-] as const;
+];
 
 export type MailCategory = {
   name: string;
   type: string;
   Icon: LucideIcon;
-  showCount: boolean;
 };
 
 export const MAIL_CATEGORIES: MailCategory[] = [
@@ -94,31 +112,26 @@ export const MAIL_CATEGORIES: MailCategory[] = [
     name: "Personal",
     type: GmailLabel.PERSONAL,
     Icon: UserIcon,
-    showCount: true,
   },
   {
     name: "Social",
     type: GmailLabel.SOCIAL,
     Icon: Users2Icon,
-    showCount: true,
   },
   {
     name: "Updates",
     type: GmailLabel.UPDATES,
     Icon: BellIcon,
-    showCount: true,
   },
   {
     name: "Forums",
     type: GmailLabel.FORUMS,
     Icon: MessagesSquareIcon,
-    showCount: true,
   },
   {
     name: "Promotions",
     type: GmailLabel.PROMOTIONS,
     Icon: MegaphoneIcon,
-    showCount: true,
   },
 ];
 
@@ -126,7 +139,6 @@ export const OUTLOOK_INBOX_CATEGORIES: MailCategory[] =
   OUTLOOK_INBOX_SECTIONS.map((section) => ({
     ...section,
     Icon: section.type === "focused" ? SparklesIcon : InboxIcon,
-    showCount: false,
   }));
 
 export function MailSidebar({
@@ -149,6 +161,7 @@ export function MailSidebar({
   onOpenShortcuts,
   labelEditMode,
   labelColorOptions,
+  collapsibleCategories = false,
   footer,
   unified = false,
   className,
@@ -156,6 +169,16 @@ export function MailSidebar({
   const [isAddingLabel, setIsAddingLabel] = useState(false);
   const [newLabelName, setNewLabelName] = useState("");
   const sidebarFolders = getMailSidebarFolders(folders);
+
+  const isCategoryActive =
+    !activeLabelId &&
+    !activeFolderId &&
+    categories.some((category) => category.type === activeType);
+  const [showCategories, setShowCategories] = useState(isCategoryActive);
+
+  useEffect(() => {
+    if (isCategoryActive) setShowCategories(true);
+  }, [isCategoryActive]);
 
   const submitNewLabel = (event: FormEvent) => {
     event.preventDefault();
@@ -205,7 +228,7 @@ export function MailSidebar({
       <div className="-mr-1.5 flex min-h-0 flex-1 flex-col overflow-y-auto pr-1.5 scrollbar-thin">
         <nav className="flex flex-col gap-px">
           {(unified ? SYSTEM_ITEMS.slice(0, 1) : SYSTEM_ITEMS).map(
-            ({ name, type, countId, Icon }) => (
+            ({ name, type, countId, Icon, emphasizeCount }) => (
               <NavRow
                 key={type}
                 href={unified ? undefined : hrefFor({ kind: "type", type })}
@@ -220,7 +243,7 @@ export function MailSidebar({
                     ? null
                     : displayCount(countsById.get(countId))
                 }
-                emphasizeCount
+                emphasizeCount={emphasizeCount}
               />
             ),
           )}
@@ -228,21 +251,32 @@ export function MailSidebar({
 
         {!unified && categories.length > 0 && (
           <>
-            <GroupHeading>{categoryHeading}</GroupHeading>
-            <nav className="flex flex-col gap-px">
-              {categories.map(({ name, type, Icon, showCount }) => (
-                <NavRow
-                  key={type}
-                  href={hrefFor({ kind: "type", type })}
-                  active={
-                    !activeLabelId && !activeFolderId && activeType === type
-                  }
-                  icon={<Icon className="size-3.5 shrink-0" />}
-                  name={name}
-                  count={showCount ? displayCount(countsById.get(type)) : null}
-                />
-              ))}
-            </nav>
+            <GroupHeading
+              expanded={collapsibleCategories ? showCategories : undefined}
+              onToggle={
+                collapsibleCategories
+                  ? () => setShowCategories((open) => !open)
+                  : undefined
+              }
+            >
+              {categoryHeading}
+            </GroupHeading>
+            {(!collapsibleCategories || showCategories) && (
+              <nav className="flex flex-col gap-px">
+                {categories.map(({ name, type, Icon }) => (
+                  <NavRow
+                    key={type}
+                    href={hrefFor({ kind: "type", type })}
+                    active={
+                      !activeLabelId && !activeFolderId && activeType === type
+                    }
+                    icon={<Icon className="size-3.5 shrink-0" />}
+                    name={name}
+                    count={null}
+                  />
+                ))}
+              </nav>
+            )}
           </>
         )}
 
@@ -377,10 +411,35 @@ export function MailSidebar({
 function GroupHeading({
   children,
   action,
+  expanded,
+  onToggle,
 }: {
   children: ReactNode;
   action?: ReactNode;
+  expanded?: boolean;
+  onToggle?: () => void;
 }) {
+  if (onToggle) {
+    return (
+      <div className="flex items-center gap-1.5 px-2.5 pt-4 pb-1.5">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          className="flex flex-1 cursor-pointer items-center gap-1 font-medium text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span>{children}</span>
+          {expanded ? (
+            <ChevronDownIcon className="size-3 shrink-0" />
+          ) : (
+            <ChevronRightIcon className="size-3 shrink-0" />
+          )}
+        </button>
+        {action}
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-1.5 px-2.5 pt-4 pb-1.5">
       <span className="flex-1 font-medium text-muted-foreground text-xs">
@@ -409,7 +468,7 @@ function NavRow({
   const className = cn(
     "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
     active
-      ? "bg-background font-medium text-foreground shadow-sm ring-1 ring-border"
+      ? "bg-primary/10 font-medium text-foreground"
       : "text-muted-foreground hover:bg-accent hover:text-foreground",
   );
   const content = (

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -98,7 +98,7 @@ const SYSTEM_ITEMS: SystemItem[] = [
   },
   { name: "Drafts", type: "draft", countId: "DRAFT", Icon: FileIcon },
   { name: "Sent", type: "sent", countId: null, Icon: SendIcon },
-  { name: "Archived", type: "archive", countId: "ARCHIVE", Icon: ArchiveIcon },
+  { name: "Archived", type: "archive", countId: null, Icon: ArchiveIcon },
 ];
 
 export type MailCategory = {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260828-151224_pr-3433_54b8353a4f61/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Calms the mail sidebar so unread state has a single signal channel instead of competing pills and totals.

- Show the accent count pill only on the inbox row; drafts render as a muted plain count and sent/archived no longer show counts
- Remove unread totals from Gmail category rows
- Collapse the Categories group behind a heading toggle, hidden by default and auto-expanded when a category view is active
- Flatten the active row style from an elevated card (shadow + ring) to a flat tinted row

Verified in the emulated Gmail environment: collapsed/expanded category states, active-row styling, and count rendering across system rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collapsible category sections to the mail sidebar for Google accounts.
  * Categories automatically expand when an active category is selected.
  * Added visual expand/collapse indicators.

* **UI Improvements**
  * Refined active navigation highlighting.
  * Removed unread counts from category, Sent, and Archived rows.
  * Improved emphasis for the Inbox count.
  * Preserved the existing non-collapsible category layout for Outlook accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->