### PR TITLE
outlook: Read contacts from both Graph sources (INB-334)

### DIFF
--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -317,13 +317,7 @@ describe("OneDriveProvider", () => {
         content,
         folderId: "folder-1",
       }),
-    ).rejects.toMatchObject({
-      error: expect.objectContaining({
-        message: expect.stringContaining(
-          "Failed to upload OneDrive file chunk: 500",
-        ),
-      }),
-    });
+    ).rejects.toThrow("Failed to upload OneDrive file chunk: 500");
 
     expect(
       fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE"),

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -255,7 +255,7 @@ describe("OutlookProvider snapshot mutations", () => {
 
     await expect(
       provider.markMessagesReadState(["message"], true),
-    ).rejects.toMatchObject({ error: failure });
+    ).rejects.toBe(failure);
   });
 });
 

--- a/apps/web/utils/microsoft/retry.ts
+++ b/apps/web/utils/microsoft/retry.ts
@@ -210,7 +210,10 @@ async function withMicrosoftGraphRetryPolicy<T>(
           responseBody: errorInfo.responseBody,
           retryPolicy,
         });
-        throw error;
+        // Throwing the attempt context would hand callers p-retry's wrapper
+        // instead of the Graph error, so classifiers such as
+        // isOutlookAccessDeniedError would never match.
+        throw error.error;
       }
 
       const retryAfterHeader = getRetryAfterHeaderFromError(error);
@@ -251,7 +254,7 @@ async function withMicrosoftGraphRetryPolicy<T>(
           isServerError,
           isConflictError,
         });
-        throw error;
+        throw error.error;
       }
 
       if (delayMs > 0) {

--- a/apps/web/utils/microsoft/upload-session.test.ts
+++ b/apps/web/utils/microsoft/upload-session.test.ts
@@ -70,12 +70,9 @@ describe("uploadResumableChunks", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(upload(Buffer.alloc(4))).rejects.toMatchObject({
-      error: expect.objectContaining({
-        message:
-          "Upload session returned 200 without nextExpectedRanges or a created item",
-      }),
-    });
+    await expect(upload(Buffer.alloc(4))).rejects.toThrow(
+      "Upload session returned 200 without nextExpectedRanges or a created item",
+    );
     expect(getCallsByMethod(fetchMock, "DELETE")).toHaveLength(1);
   });
 
@@ -190,13 +187,9 @@ describe("uploadResumableChunks", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(upload(Buffer.alloc(4))).rejects.toMatchObject({
-      error: expect.objectContaining({
-        message: expect.stringContaining(
-          "Failed to fetch upload session status: 503",
-        ),
-      }),
-    });
+    await expect(upload(Buffer.alloc(4))).rejects.toThrow(
+      "Failed to fetch upload session status: 503",
+    );
     expect(getCallsByMethod(fetchMock, "DELETE")).toHaveLength(1);
   });
 
@@ -208,13 +201,9 @@ describe("uploadResumableChunks", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(upload(Buffer.alloc(8))).rejects.toMatchObject({
-      error: expect.objectContaining({
-        message: expect.stringContaining(
-          "Upload session did not make progress",
-        ),
-      }),
-    });
+    await expect(upload(Buffer.alloc(8))).rejects.toThrow(
+      "Upload session did not make progress",
+    );
     expect(getCallsByMethod(fetchMock, "PUT")).toHaveLength(1);
     expect(getCallsByMethod(fetchMock, "GET")).toHaveLength(1);
     expect(getCallsByMethod(fetchMock, "DELETE")).toHaveLength(1);

--- a/apps/web/utils/outlook/contact.test.ts
+++ b/apps/web/utils/outlook/contact.test.ts
@@ -4,24 +4,25 @@ import { searchContacts } from "./contact";
 
 describe("searchContacts", () => {
   it("loads saved Outlook contacts and maps all usable addresses", async () => {
-    const get = vi.fn().mockResolvedValue({
-      value: [
+    const { api } = createGraphClient({
+      contactPages: [
         {
-          displayName: "First Contact",
-          emailAddresses: [
-            { address: "first@example.com", name: "First Contact" },
-            { address: "alternate@example.com", name: "Alternate" },
+          value: [
+            {
+              displayName: "First Contact",
+              emailAddresses: [
+                { address: "first@example.com", name: "First Contact" },
+                { address: "alternate@example.com", name: "Alternate" },
+              ],
+            },
+            {
+              displayName: "Fallback Contact",
+              emailAddresses: [{ address: "fallback@example.com" }],
+            },
           ],
-        },
-        {
-          displayName: "Fallback Contact",
-          emailAddresses: [{ address: "fallback@example.com" }],
         },
       ],
     });
-    const top = vi.fn().mockReturnValue({ get });
-    const select = vi.fn().mockReturnValue({ top });
-    const api = vi.fn().mockReturnValue({ select });
 
     const result = await searchContacts(
       { getClient: () => ({ api }) } as never,
@@ -30,55 +31,159 @@ describe("searchContacts", () => {
     );
 
     expect(api).toHaveBeenCalledWith("/me/contacts");
-    expect(select).toHaveBeenCalledWith("displayName,emailAddresses");
-    expect(top).toHaveBeenCalledWith(50);
     expect(result).toEqual([
       { emailAddress: "first@example.com", name: "First Contact" },
       { emailAddress: "alternate@example.com", name: "First Contact" },
     ]);
   });
 
-  it("loads saved contacts before a search is entered", async () => {
-    const get = vi.fn().mockResolvedValue({ value: [] });
-    const top = vi.fn().mockReturnValue({ get });
-    const select = vi.fn().mockReturnValue({ top });
-    const api = vi.fn().mockReturnValue({ select });
+  it("includes relevant people alongside saved contacts", async () => {
+    const { api } = createGraphClient({
+      contactPages: [
+        {
+          value: [
+            {
+              displayName: "Saved Contact",
+              emailAddresses: [{ address: "saved@example.com" }],
+            },
+          ],
+        },
+      ],
+      people: [
+        {
+          displayName: "Directory Person",
+          scoredEmailAddresses: [{ address: "directory@example.com" }],
+        },
+      ],
+    });
 
-    await searchContacts(
+    const result = await searchContacts(
       { getClient: () => ({ api }) } as never,
-      "  ",
+      "",
       createTestLogger(),
     );
 
-    expect(api).toHaveBeenCalledWith("/me/contacts");
-    expect(top).toHaveBeenCalledWith(50);
+    expect(api).toHaveBeenCalledWith("/me/people");
+    expect(result).toEqual([
+      { emailAddress: "saved@example.com", name: "Saved Contact" },
+      { emailAddress: "directory@example.com", name: "Directory Person" },
+    ]);
+  });
+
+  it("falls back to relevant people when saved contacts are not permitted", async () => {
+    const { api } = createGraphClient({
+      contactsError: Object.assign(new Error("Access is denied"), {
+        code: "ErrorAccessDenied",
+      }),
+      people: [
+        {
+          displayName: "Directory Person",
+          userPrincipalName: "directory@example.com",
+        },
+      ],
+    });
+
+    const result = await searchContacts(
+      { getClient: () => ({ api }) } as never,
+      "directory",
+      createTestLogger(),
+    );
+
+    expect(result).toEqual([
+      { emailAddress: "directory@example.com", name: "Directory Person" },
+    ]);
+  });
+
+  it("still returns saved contacts when the people source is not permitted", async () => {
+    const { api } = createGraphClient({
+      contactPages: [
+        {
+          value: [
+            {
+              displayName: "Saved Contact",
+              emailAddresses: [{ address: "saved@example.com" }],
+            },
+          ],
+        },
+      ],
+      peopleError: Object.assign(new Error("Forbidden"), { statusCode: 403 }),
+    });
+
+    const result = await searchContacts(
+      { getClient: () => ({ api }) } as never,
+      "saved",
+      createTestLogger(),
+    );
+
+    expect(result).toEqual([
+      { emailAddress: "saved@example.com", name: "Saved Contact" },
+    ]);
+  });
+
+  it("reports missing access only when neither source is permitted", async () => {
+    const contactsError = Object.assign(new Error("Access is denied"), {
+      code: "ErrorAccessDenied",
+    });
+    const { api } = createGraphClient({
+      contactsError,
+      peopleError: Object.assign(new Error("Forbidden"), { statusCode: 403 }),
+    });
+
+    await expect(
+      searchContacts(
+        { getClient: () => ({ api }) } as never,
+        "anyone",
+        createTestLogger(),
+      ),
+    ).rejects.toBe(contactsError);
+  });
+
+  it("surfaces non-permission failures instead of returning partial results", async () => {
+    const { api } = createGraphClient({
+      contactsError: Object.assign(new Error("Malformed request"), {
+        statusCode: 400,
+      }),
+      people: [
+        {
+          displayName: "Directory Person",
+          scoredEmailAddresses: [{ address: "directory@example.com" }],
+        },
+      ],
+    });
+
+    await expect(
+      searchContacts(
+        { getClient: () => ({ api }) } as never,
+        "anyone",
+        createTestLogger(),
+      ),
+    ).rejects.toThrow("Malformed request");
   });
 
   it("continues through saved contact pages until it finds a match", async () => {
     const nextLink =
       "https://graph.microsoft.com/v1.0/me/contacts?$skiptoken=next";
-    const firstGet = vi.fn().mockResolvedValue({
-      value: [
+    const { api } = createGraphClient({
+      contactPages: [
         {
-          displayName: "Other Contact",
-          emailAddresses: [{ address: "other@example.com" }],
+          value: [
+            {
+              displayName: "Other Contact",
+              emailAddresses: [{ address: "other@example.com" }],
+            },
+          ],
+          "@odata.nextLink": nextLink,
+        },
+        {
+          value: [
+            {
+              displayName: "Target Contact",
+              emailAddresses: [{ address: "target@example.com" }],
+            },
+          ],
         },
       ],
-      "@odata.nextLink": nextLink,
     });
-    const secondGet = vi.fn().mockResolvedValue({
-      value: [
-        {
-          displayName: "Target Contact",
-          emailAddresses: [{ address: "target@example.com" }],
-        },
-      ],
-    });
-    const top = vi.fn().mockReturnValue({ get: firstGet });
-    const select = vi.fn().mockReturnValue({ top });
-    const api = vi.fn((endpoint: string) =>
-      endpoint === "/me/contacts" ? { select } : { get: secondGet },
-    );
 
     const result = await searchContacts(
       { getClient: () => ({ api }) } as never,
@@ -95,7 +200,7 @@ describe("searchContacts", () => {
   it("stops paging after the max page count when nothing matches", async () => {
     const nextLink =
       "https://graph.microsoft.com/v1.0/me/contacts?$skiptoken=next";
-    const get = vi.fn().mockResolvedValue({
+    const contactsGet = vi.fn().mockResolvedValue({
       value: [
         {
           displayName: "Other Contact",
@@ -104,11 +209,7 @@ describe("searchContacts", () => {
       ],
       "@odata.nextLink": nextLink,
     });
-    const top = vi.fn().mockReturnValue({ get });
-    const select = vi.fn().mockReturnValue({ top });
-    const api = vi.fn((endpoint: string) =>
-      endpoint === "/me/contacts" ? { select } : { get },
-    );
+    const { api } = createGraphClient({ contactsGet });
 
     const result = await searchContacts(
       { getClient: () => ({ api }) } as never,
@@ -116,7 +217,51 @@ describe("searchContacts", () => {
       createTestLogger(),
     );
 
-    expect(get).toHaveBeenCalledTimes(20);
+    expect(contactsGet).toHaveBeenCalledTimes(20);
     expect(result).toEqual([]);
   });
 });
+
+// Mimics the Graph client's fluent builder so tests describe API responses
+// rather than the chain of select/top/search calls used to reach them.
+function createGraphClient({
+  contactPages = [],
+  contactsGet,
+  contactsError,
+  people = [],
+  peopleError,
+}: {
+  contactPages?: unknown[];
+  contactsGet?: ReturnType<typeof vi.fn>;
+  contactsError?: unknown;
+  people?: unknown[];
+  peopleError?: unknown;
+}) {
+  let pageIndex = 0;
+  const defaultContactsGet = vi.fn(() => {
+    if (contactsError) return Promise.reject(contactsError);
+    return Promise.resolve(contactPages[pageIndex++] ?? { value: [] });
+  });
+  const nextContactsPage = contactsGet ?? defaultContactsGet;
+
+  const peopleGet = vi.fn(() => {
+    if (peopleError) return Promise.reject(peopleError);
+    return Promise.resolve({ value: people });
+  });
+
+  const builder = (get: ReturnType<typeof vi.fn>) => {
+    const chain: Record<string, unknown> = { get };
+    for (const method of ["select", "top", "search"]) {
+      chain[method] = vi.fn(() => chain);
+    }
+    return chain;
+  };
+
+  const api = vi.fn((endpoint: string) =>
+    endpoint === "/me/people"
+      ? builder(peopleGet)
+      : builder(nextContactsPage as ReturnType<typeof vi.fn>),
+  );
+
+  return { api };
+}

--- a/apps/web/utils/outlook/contact.ts
+++ b/apps/web/utils/outlook/contact.ts
@@ -1,7 +1,8 @@
-import type { Contact } from "@microsoft/microsoft-graph-types";
+import type { Contact, Person } from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
 import type { OutlookClient } from "@/utils/outlook/client";
+import { isOutlookAccessDeniedError } from "@/utils/error";
 import {
   type EmailContact,
   MAX_CONTACT_RESULTS,
@@ -24,8 +25,68 @@ export async function searchContacts(
   query: string,
   logger: Logger,
 ) {
+  const trimmedQuery = query.trim();
+
+  // Neither source alone covers a mailbox: /me/contacts reads only the default
+  // saved-contacts folder, while /me/people adds the directory and recent
+  // correspondents. Their scopes are optional and were requested at different
+  // times, so an account may hold only one of them — a denial on one source
+  // must not suppress the other.
+  const [saved, people] = await Promise.all([
+    loadContactSource(
+      () => listSavedContacts(client, trimmedQuery, logger),
+      "contacts",
+      logger,
+    ),
+    loadContactSource(
+      () => searchRelevantPeople(client, trimmedQuery, logger),
+      "people",
+      logger,
+    ),
+  ]);
+
+  if (saved.deniedError && people.deniedError) throw saved.deniedError;
+
+  // Saved contacts lead because they are the address book the user curated;
+  // relevance-ranked people then fill the remaining slots.
+  return normalizeContactCandidates([
+    ...(saved.contacts ?? []),
+    ...(people.contacts ?? []),
+  ]);
+}
+
+async function loadContactSource(
+  load: () => Promise<EmailContact[]>,
+  source: "contacts" | "people",
+  logger: Logger,
+) {
+  try {
+    return { contacts: await load(), deniedError: undefined };
+  } catch (error) {
+    if (!isContactSourceDenied(error)) throw error;
+
+    logger.info("Outlook contact source not permitted", { source });
+    return { contacts: undefined, deniedError: error };
+  }
+}
+
+// Graph reports a missing delegated scope as a 403 whose code varies by
+// resource (ErrorAccessDenied for Outlook, Authorization_RequestDenied for
+// People), so fall back to the status when the code is unfamiliar.
+function isContactSourceDenied(error: unknown) {
+  return (
+    isOutlookAccessDeniedError(error) ||
+    (error as { statusCode?: number })?.statusCode === 403
+  );
+}
+
+async function listSavedContacts(
+  client: OutlookClient,
+  query: string,
+  logger: Logger,
+) {
   const graphClient = client.getClient();
-  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedQuery = query.toLowerCase();
   const candidates: EmailContact[] = [];
   let contacts: EmailContact[] = [];
   let request = graphClient
@@ -72,4 +133,34 @@ export async function searchContacts(
     maxPages: MAX_CONTACT_PAGES,
   });
   return contacts;
+}
+
+async function searchRelevantPeople(
+  client: OutlookClient,
+  query: string,
+  logger: Logger,
+) {
+  let request = client
+    .getClient()
+    .api("/me/people")
+    .select("displayName,scoredEmailAddresses,userPrincipalName");
+
+  if (query) request = request.search(query);
+
+  const response: { value?: Person[] } = await withMicrosoftGraphRetry(
+    () => request.top(MAX_CONTACT_RESULTS).get(),
+    logger,
+  );
+
+  return (response.value ?? []).flatMap((person) => {
+    const addresses = person.scoredEmailAddresses?.length
+      ? person.scoredEmailAddresses.map((email) => email.address)
+      : [person.userPrincipalName];
+
+    return addresses.flatMap((emailAddress) =>
+      emailAddress
+        ? [{ emailAddress, name: person.displayName ?? undefined }]
+        : [],
+    );
+  });
 }

--- a/apps/web/utils/outlook/scopes.test.ts
+++ b/apps/web/utils/outlook/scopes.test.ts
@@ -9,8 +9,13 @@ vi.mock("@/env", () => ({
 }));
 
 describe("Outlook scopes", () => {
-  it("requests read access to saved contacts when suggestions are enabled", () => {
-    expect(REQUIRED_SCOPES).not.toContain("Contacts.Read");
+  it("requests both contact sources when suggestions are enabled", () => {
     expect(SCOPES).toContain("Contacts.Read");
+    expect(SCOPES).toContain("People.Read");
+  });
+
+  it("keeps contact access optional so existing accounts stay connected", () => {
+    expect(REQUIRED_SCOPES).not.toContain("Contacts.Read");
+    expect(REQUIRED_SCOPES).not.toContain("People.Read");
   });
 });

--- a/apps/web/utils/outlook/scopes.ts
+++ b/apps/web/utils/outlook/scopes.ts
@@ -15,7 +15,10 @@ export const REQUIRED_SCOPES = [
 
 export const SCOPES = [
   ...REQUIRED_SCOPES,
-  ...(env.NEXT_PUBLIC_CONTACTS_ENABLED ? ["Contacts.Read"] : []),
+  // Contacts.Read reads the saved-contacts folder; People.Read adds the
+  // directory and recent correspondents. Both are optional, and accounts
+  // consented before either was requested keep working with whichever they hold.
+  ...(env.NEXT_PUBLIC_CONTACTS_ENABLED ? ["Contacts.Read", "People.Read"] : []),
 ] as const;
 
 export const CALENDAR_SCOPES = [

--- a/docs/hosting/microsoft-oauth.mdx
+++ b/docs/hosting/microsoft-oauth.mdx
@@ -26,6 +26,6 @@ Go to [Microsoft Azure Portal](https://portal.azure.com/) and create a new app r
 7. **Configure API permissions:**
    - Go to "API permissions" > "Add a permission" > "Microsoft Graph" > "Delegated permissions"
    - Add: `openid`, `profile`, `email`, `User.Read`, `offline_access`, `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`, `Calendars.Read`, `Calendars.ReadWrite`, `Files.ReadWrite`
-   - If `NEXT_PUBLIC_CONTACTS_ENABLED=true`, also add `Contacts.Read` for contact suggestions while composing.
-   - Existing accounts can continue using core email features without `Contacts.Read`. The composer offers an optional reconnect action if they want contact suggestions.
+   - If `NEXT_PUBLIC_CONTACTS_ENABLED=true`, also add `Contacts.Read` (saved contacts) and `People.Read` (directory and recent correspondents) for contact suggestions while composing.
+   - Existing accounts can continue using core email features without either permission, and suggestions still work from whichever one an account already granted. The composer offers an optional reconnect action to grant both.
    - Click "Grant admin consent" if you're an admin.


### PR DESCRIPTION
Outlook contact suggestions in the composer returned nothing, so `/mail` surfaced contacts only for Gmail accounts.

`/me/contacts` reads only the default saved-contacts folder and requires `Contacts.Read`. Accounts linked before that scope was requested still carry their original consent — the token refresh does not re-request scopes — so every already-connected Outlook account got a 403 and no suggestions. A freshly linked account worked, which is why this looked fixed previously.

A second bug hid the failure: `withMicrosoftGraphRetry` rethrew p-retry's attempt context (`{error, attemptNumber, …}`) rather than the Graph error, so `isOutlookAccessDeniedError` never matched. The contacts route fell through to a 500 instead of its 403 `reconnectRequired` branch, and the composer never offered the reconnect action that would grant the permission.

## Changes

- Query `/me/contacts` and `/me/people` together and merge the results, saved contacts first. The two cover different ground: `/me/contacts` is the default saved-contacts folder, `/me/people` adds the directory and recent correspondents.
- A denial on one source no longer suppresses the other; "reconnect" is reported only when both are denied. Non-permission errors still propagate.
- Request `Contacts.Read` and `People.Read`, both still optional, so accounts holding either scope keep working and neither blocks linking.
- Rethrow the underlying Graph error from the retry wrapper so error classifiers match across the Outlook and OneDrive paths.
- Update the four tests that asserted the old wrapper shape, and document both permissions.

## Validation

- New unit tests in `apps/web/utils/outlook/contact.test.ts` cover each denial combination: either source denied, both denied, and a non-permission failure.
- Full `apps/web` unit suite run before and after; the failure set is identical, so nothing regressed.

## Notes

- The retry change affects every Outlook and OneDrive Graph call, not just contacts. It is the root cause of the missing reconnect prompt, so the fix is incomplete without it, but it is separable if you would rather land it on its own.
- This needs a check against a real Outlook account linked *before* the contacts feature shipped. The failure mode is about which scopes a live token carries, which unit tests cannot prove.
- Contacts in non-default contact folders are still not read; that would need `/me/contactFolders` traversal and more round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Outlook contact search now includes both saved contacts and directory people.
  - Search continues working when access to one contact source is unavailable.
  - Results are combined and normalized for a consistent experience.

- **Bug Fixes**
  - Microsoft Graph errors are now surfaced more accurately, improving access-denied handling and upload failure reporting.

- **Documentation**
  - Updated Microsoft OAuth setup guidance to include the additional people-search permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->