### PR TITLE
INB-342: Focus recipient field in new messages

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -12,6 +12,9 @@ test("keeps keyboard focus in the composer and follows the message field order",
   await page.getByRole("button", { name: /^Compose/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
+  const toField = dialog.getByRole("textbox", { name: "To" });
+  await expect(toField).toBeFocused();
+
   const showCcBccButton = dialog.getByRole("button", { name: "Cc/Bcc" });
   await showCcBccButton.focus();
   await showCcBccButton.press("Enter");
@@ -19,7 +22,6 @@ test("keeps keyboard focus in the composer and follows the message field order",
     dialog.getByRole("button", { name: "Hide Cc/Bcc" }),
   ).toBeFocused();
 
-  const toField = dialog.getByRole("textbox", { name: "To" });
   await toField.focus();
 
   await page.keyboard.press("Shift+Tab");

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -214,6 +214,7 @@ function ComposeEmailFormContent({
   const [showCcBcc, setShowCcBcc] = useState(
     Boolean(replyingToEmail?.cc || replyingToEmail?.bcc),
   );
+  const focusRecipientField = !replyingToEmail;
   const [attachments, setAttachments] = useState<ComposeAttachment[]>([]);
   const attachmentsRef = useRef<ComposeAttachment[]>([]);
   const isMountedRef = useRef(true);
@@ -685,6 +686,7 @@ function ComposeEmailFormContent({
                     <ComposeContactRecipientField
                       {...recipientFieldProps}
                       active={activeRecipientField === "to"}
+                      autoFocus={focusRecipientField}
                       name="to"
                       selectedRecipients={watch("to") ?? ""}
                     />
@@ -694,7 +696,10 @@ function ComposeEmailFormContent({
                     type="text"
                     name="to"
                     label={isComposeWindow ? undefined : "To"}
-                    registerProps={register("to", { required: true })}
+                    registerProps={{
+                      ...register("to", { required: true }),
+                      autoFocus: focusRecipientField,
+                    }}
                     error={errors.to}
                     className={cn(
                       isComposeWindow &&
@@ -773,6 +778,7 @@ function ComposeEmailFormContent({
 
       <EmailEditor
         appearance={isComposeWindow ? "seamless" : "contained"}
+        autofocus={!focusRecipientField}
         ref={editorRef}
         initialHtml={initialDraft.editableHtml}
         mode={initialDraft.mode}
@@ -918,6 +924,7 @@ const RECIPIENT_LABELS: Record<ComposeRecipientField, string> = {
 
 function ComposeContactRecipientField({
   active,
+  autoFocus,
   className,
   emailAccountId,
   isReconnectingContacts,
@@ -931,6 +938,7 @@ function ComposeContactRecipientField({
   selectedRecipients,
 }: {
   active: boolean;
+  autoFocus?: boolean;
   className?: string;
   emailAccountId: string;
   isReconnectingContacts: boolean;
@@ -1029,6 +1037,7 @@ function ComposeContactRecipientField({
         <div className="relative min-w-32 flex-1">
           <ComboboxInput
             aria-label={label}
+            autoFocus={autoFocus}
             className="w-full border-none bg-background p-0 text-sm focus:border-none focus:ring-0"
             id={name}
             onChange={(event) => updateSearchQuery(event.target.value)}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260828-190009_pr-3435_aabd4dc3c375/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Focus the recipient field when opening a new composer while preserving editor focus for replies. This aligns initial keyboard focus with the expected message-entry order.

- Apply recipient autofocus to both contacts-enabled and plain-input composers.
- Keep reply editor autofocus behavior unchanged.
- Tests: changed Playwright focus case passed; Ultracite check passed.
- Test note: the full compose-and-reply spec passed 7/8 locally; the reply-send case timed out while optional local Redis/emulator services were unavailable.
- Performance: negligible render-time boolean/DOM prop work, no new database or network calls, and no meaningful hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-342/incorrect-initial-focus-in-message-composer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New email composition now automatically focuses the recipient field.
  * Replying to an email now automatically focuses the message editor.
  * Improved test coverage verifies the expected focus behavior and recipient-field interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->