### PR TITLE
fix: prevent hydration mismatch from conditional contactPoint in home…

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -82,11 +82,15 @@ const jsonLd: WithContext<WebApplication> = {
       "https://x.com/inboxzero_ai",
       "https://github.com/elie222/inbox-zero",
     ],
-    contactPoint: {
-      "@type": "ContactPoint",
-      email: SUPPORT_EMAIL,
-      contactType: "customer support",
-    },
+    ...(SUPPORT_EMAIL
+      ? {
+          contactPoint: {
+            "@type": "ContactPoint" as const,
+            email: SUPPORT_EMAIL,
+            contactType: "customer support",
+          },
+        }
+      : {}),
     address: {
       "@type": "PostalAddress",
       streetAddress: "131 Continental Dr, Suite 305",


### PR DESCRIPTION
…page schema

Fixes #3400. The Organization schema's contactPoint field could be included with an undefined email value inconsistently between server and client render in self-hosted deployments missing NEXT_PUBLIC_SUPPORT_EMAIL at build time, causing React hydration error #412 and breaking the login link on the homepage.

Now contactPoint is only included when SUPPORT_EMAIL is set, ensuring deterministic output on both server and client.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Structured metadata now includes publisher contact information only when a support email is configured, preventing incomplete or invalid contact details from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->