### PR TITLE
mail: Add email search to the mail screen

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
@@ -24,6 +24,7 @@ test("searches the mailbox and clears back to the inbox", async ({ page }) => {
   await searchInput.press("Enter");
 
   await expect(page).toHaveURL(/[?&]q=/);
+  expect(new URL(page.url()).searchParams.get("q")).toBe("Archive Action");
   await expect(matching).toBeVisible();
   await expect(nonMatching).toHaveCount(0);
 

--- a/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("searches the mailbox and clears back to the inbox", async ({ page }) => {
+  const { conversations } = await openMail(page);
+  const options = conversations.getByRole("option");
+  await expect(options.first()).toBeVisible();
+
+  const matching = conversationWithSubject(
+    page,
+    conversations,
+    "Archive Action Message",
+  );
+  const nonMatching = conversationWithSubject(
+    page,
+    conversations,
+    "Keyboard Navigation Message",
+  );
+  await expect(matching).toBeVisible();
+  await expect(nonMatching).toBeVisible();
+
+  const searchInput = page.getByPlaceholder("Search mail");
+  await searchInput.fill("Archive Action");
+  await searchInput.press("Enter");
+
+  await expect(page).toHaveURL(/[?&]q=/);
+  await expect(matching).toBeVisible();
+  await expect(nonMatching).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Clear search" }).click();
+  await expect(page).not.toHaveURL(/[?&]q=/);
+  await expect(matching).toBeVisible();
+  await expect(nonMatching).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -84,7 +84,9 @@ test("selects every conversation with Command A", async ({ page }) => {
   const conversationCount = await options.count();
   expect(conversationCount).toBeGreaterThan(1);
 
-  await page.getByRole("button", { name: /Search or jump/ }).click();
+  // The toolbar slot is the mail search input now, so open the palette with
+  // its keyboard shortcut instead.
+  await page.keyboard.press(`${commandModifier}+KeyK`);
   const commandInput = page.getByPlaceholder("Type a command or search...");
   const query = "archive";
   await commandInput.fill(query);

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ColumnsIcon, RowsIcon, SearchIcon, SparklesIcon } from "lucide-react";
+import { useRef } from "react";
+import {
+  ColumnsIcon,
+  RowsIcon,
+  SearchIcon,
+  SparklesIcon,
+  XIcon,
+} from "lucide-react";
 import { Kbd } from "@/components/Kbd";
 import { Tooltip } from "@/components/Tooltip";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -11,6 +18,10 @@ import { cn } from "@/utils";
 export type ListToolbarProps = {
   layout: MailLayoutMode;
   showLayoutToggle?: boolean;
+  /** Committed search query. Only meaningful when `onSearch` is provided. */
+  searchQuery?: string;
+  /** When provided, the toolbar shows a real mail search input. */
+  onSearch?: (query: string) => void;
   onOpenSearch: () => void;
   onToggleLayout: () => void;
   onToggleAssistant: () => void;
@@ -20,6 +31,8 @@ export type ListToolbarProps = {
 export function ListToolbar({
   layout,
   showLayoutToggle = true,
+  searchQuery = "",
+  onSearch,
   onOpenSearch,
   onToggleLayout,
   onToggleAssistant,
@@ -36,19 +49,24 @@ export function ListToolbar({
         <SidebarTrigger name="left-sidebar" className="hidden lg:inline-flex" />
       ) : null}
 
-      {/* Opens the command palette rather than searching mail — it navigates
-          and runs actions, and promising search we don't have would mislead. */}
-      <button
-        type="button"
-        onClick={onOpenSearch}
-        className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors hover:border-[hsl(var(--border-strong))] hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <SearchIcon className="size-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate text-left">
-          Search or jump to…
-        </span>
-        <Kbd>{getShortcutHint("commandPalette")}</Kbd>
-      </button>
+      {onSearch ? (
+        <MailSearchInput searchQuery={searchQuery} onSearch={onSearch} />
+      ) : (
+        // Opens the command palette rather than searching mail — combined
+        // inboxes can't search across accounts yet, so promising search we
+        // don't have would mislead.
+        <button
+          type="button"
+          onClick={onOpenSearch}
+          className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors hover:border-[hsl(var(--border-strong))] hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <SearchIcon className="size-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            Search or jump to…
+          </span>
+          <Kbd>{getShortcutHint("commandPalette")}</Kbd>
+        </button>
+      )}
 
       {showLayoutToggle ? (
         <Tooltip content="Switch list / split view">
@@ -75,6 +93,60 @@ export function ListToolbar({
         </button>
       </Tooltip>
     </div>
+  );
+}
+
+function MailSearchInput({
+  searchQuery,
+  onSearch,
+}: {
+  searchQuery: string;
+  onSearch: (query: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form
+      // Remount when the committed query changes elsewhere (sidebar
+      // navigation, clearing) so the uncontrolled input tracks it without
+      // mirroring the value into state.
+      key={searchQuery}
+      role="search"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSearch(inputRef.current?.value.trim() ?? "");
+      }}
+      className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors focus-within:border-[hsl(var(--border-strong))] focus-within:bg-background hover:border-[hsl(var(--border-strong))]"
+    >
+      <SearchIcon className="size-3.5 shrink-0" />
+      <input
+        ref={inputRef}
+        defaultValue={searchQuery}
+        placeholder="Search mail"
+        enterKeyHint="search"
+        aria-label="Search mail"
+        className="h-full min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          if (inputRef.current?.value || searchQuery) {
+            if (inputRef.current) inputRef.current.value = "";
+            onSearch("");
+          } else {
+            inputRef.current?.blur();
+          }
+        }}
+      />
+      {searchQuery ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onSearch("")}
+          className="shrink-0 rounded p-0.5 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <XIcon className="size-3.5" />
+        </button>
+      ) : null}
+    </form>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -278,7 +278,7 @@ export function MailShell() {
   const query: ThreadsQuery = useMemo(() => {
     // Search overrides split/scope and covers the whole mailbox, matching
     // what Gmail's and Outlook's own search boxes do by default.
-    if (searchQuery) return { q: searchQuery, type: "all" };
+    if (searchQuery) return { q: searchQuery };
     if (scopeQuery) return scopeQuery;
 
     const active =

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -160,6 +160,7 @@ export function MailShell() {
   const [scopeType, setScopeType] = useQueryState("type");
   const [scopeLabelId, setScopeLabelId] = useQueryState("labelId");
   const [scopeFolderId, setScopeFolderId] = useQueryState("folderId");
+  const [searchParam, setSearchParam] = useQueryState("q");
 
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [isFocusMode, setIsFocusMode] = useState(false);
@@ -239,6 +240,13 @@ export function MailShell() {
   }, [scopeFolderId, scopeLabelId, scopeType]);
   const isScoped = !isAllAccounts && scopeQuery !== null;
 
+  // Combined inboxes can't search across accounts, so search is single-account.
+  const searchQuery = isAllAccounts ? null : searchParam?.trim() || null;
+  const setSearch = useCallback(
+    (value: string) => setSearchParam(value.trim() || null),
+    [setSearchParam],
+  );
+
   const combinedLabelSplits = useMemo(
     () => getPortableLabelSplits(settings?.splits ?? [], userLabels),
     [settings?.splits, userLabels],
@@ -268,6 +276,9 @@ export function MailShell() {
   )?.labelName;
 
   const query: ThreadsQuery = useMemo(() => {
+    // Search overrides split/scope and covers the whole mailbox, matching
+    // what Gmail's and Outlook's own search boxes do by default.
+    if (searchQuery) return { q: searchQuery, type: "all" };
     if (scopeQuery) return scopeQuery;
 
     const active =
@@ -276,7 +287,7 @@ export function MailShell() {
       BUILT_IN_SPLITS[0];
 
     return mailSplitToThreadsQuery(active);
-  }, [scopeQuery, activeSplitId, settings?.splits]);
+  }, [searchQuery, scopeQuery, activeSplitId, settings?.splits]);
 
   const accountThreadState = useMailThreads({
     emailAccountId,
@@ -895,6 +906,7 @@ export function MailShell() {
     setScopeType(null);
     setScopeLabelId(null);
     setScopeFolderId(null);
+    setSearchParam(null);
     if (
       !BUILT_IN_SPLITS.some((split) => split.id === activeSplitId) &&
       !combinedLabelSplits.some((split) => split.id === activeSplitId)
@@ -912,6 +924,7 @@ export function MailShell() {
     setScopeFolderId,
     setScopeLabelId,
     setScopeType,
+    setSearchParam,
   ]);
 
   return (
@@ -970,13 +983,15 @@ export function MailShell() {
           >
             <ListToolbar
               layout={layout}
+              searchQuery={searchQuery ?? ""}
+              onSearch={isAllAccounts ? undefined : setSearch}
               onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
               showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
             />
-            {!isScoped && (
+            {!isScoped && !searchQuery && (
               <SplitTabs
                 splits={splits}
                 activeSplitId={displayedActiveSplitId}

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -112,6 +112,25 @@ describe("GET /api/threads", () => {
     });
   });
 
+  it("passes the search query to the email provider", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads?q=invoice%20report&type=all",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetThreadsWithQuery).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        q: "invoice report",
+        type: "all",
+      }),
+      maxResults: 50,
+      pageToken: undefined,
+      messageFormat: "full",
+    });
+  });
+
   it("passes an Outlook inbox section to the email provider", async () => {
     const response = await GET(
       new NextRequest(

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -1,10 +1,13 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFindMany, mockGetThreadsWithQuery } = vi.hoisted(() => ({
-  mockFindMany: vi.fn(),
-  mockGetThreadsWithQuery: vi.fn(),
-}));
+const { mockFindMany, mockGetThreadsWithQuery, mockSearchThreads } = vi.hoisted(
+  () => ({
+    mockFindMany: vi.fn(),
+    mockGetThreadsWithQuery: vi.fn(),
+    mockSearchThreads: vi.fn(),
+  }),
+);
 
 vi.mock("@/utils/prisma", () => ({
   default: {
@@ -26,7 +29,10 @@ vi.mock("@/utils/middleware", () => ({
       handler(
         Object.assign(request, {
           auth: { emailAccountId: "email-account-id" },
-          emailProvider: { getThreadsWithQuery: mockGetThreadsWithQuery },
+          emailProvider: {
+            getThreadsWithQuery: mockGetThreadsWithQuery,
+            searchThreads: mockSearchThreads,
+          },
           logger: { error: vi.fn() },
         }),
       ),
@@ -72,6 +78,7 @@ describe("GET /api/threads", () => {
     vi.clearAllMocks();
     mockFindMany.mockResolvedValue([]);
     mockGetThreadsWithQuery.mockResolvedValue({ threads: [] });
+    mockSearchThreads.mockResolvedValue({ threads: [] });
   });
 
   it("passes multiple label IDs to the email provider", async () => {
@@ -112,23 +119,19 @@ describe("GET /api/threads", () => {
     });
   });
 
-  it("passes the search query to the email provider", async () => {
+  it("routes search queries to the dedicated provider search", async () => {
     const response = await GET(
-      new NextRequest(
-        "http://localhost:3000/api/threads?q=invoice%20report&type=all",
-      ),
+      new NextRequest("http://localhost:3000/api/threads?q=invoice%20report"),
     );
 
     expect(response.status).toBe(200);
-    expect(mockGetThreadsWithQuery).toHaveBeenCalledWith({
-      query: expect.objectContaining({
-        q: "invoice report",
-        type: "all",
-      }),
+    expect(mockSearchThreads).toHaveBeenCalledWith({
+      query: "invoice report",
       maxResults: 50,
       pageToken: undefined,
       messageFormat: "full",
     });
+    expect(mockGetThreadsWithQuery).not.toHaveBeenCalled();
   });
 
   it("passes an Outlook inbox section to the email provider", async () => {

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -2,8 +2,8 @@ import { atom } from "jotai";
 
 /**
  * Open state for the command palette. It lives outside CommandK so surfaces
- * elsewhere — the mail toolbar's search field, for one — can open it without
- * faking a ⌘K keystroke.
+ * elsewhere — the combined inbox's toolbar search button, for one — can open
+ * it without faking a ⌘K keystroke.
  */
 export const commandPaletteOpenAtom = atom(false);
 

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -139,6 +139,9 @@ export const createMockEmailProvider = (
   searchMessages: vi
     .fn()
     .mockResolvedValue({ messages: [], nextPageToken: undefined }),
+  searchThreads: vi
+    .fn()
+    .mockResolvedValue({ threads: [], nextPageToken: undefined }),
   searchContacts: vi.fn().mockResolvedValue([]),
   getMessagesFromSender: vi
     .fn()

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -470,6 +470,7 @@ function groupMessagesByThread(messages: ParsedMessage[]) {
 
 function isSupportedMailboxQuery(query: ThreadsQuery) {
   if (
+    query.q ||
     query.nextPageToken ||
     query.inboxSection ||
     query.excludeLabelNames?.length

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -456,6 +456,31 @@ describe("GmailProvider.getThreadsWithQuery", () => {
     );
   });
 
+  it("passes free-text search through to the Gmail query unscoped", async () => {
+    const getThreadsWithNextPageToken = vi
+      .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")
+      .mockResolvedValue({ threads: [], nextPageToken: undefined });
+    vi.spyOn(gmailThreadModule, "getThreadsBatch").mockResolvedValue([]);
+    const provider = new GmailProvider({
+      context: {
+        _options: {
+          auth: { credentials: { access_token: "access-token" } },
+        },
+      },
+    } as any);
+
+    await provider.getThreadsWithQuery({
+      query: { q: "invoice from:billing@example.com", type: "all" },
+    });
+
+    expect(getThreadsWithNextPageToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "invoice from:billing@example.com",
+        labelIds: [],
+      }),
+    );
+  });
+
   it("uses Gmail metadata format for list requests", async () => {
     vi.spyOn(
       gmailThreadModule,

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -456,31 +456,6 @@ describe("GmailProvider.getThreadsWithQuery", () => {
     );
   });
 
-  it("passes free-text search through to the Gmail query unscoped", async () => {
-    const getThreadsWithNextPageToken = vi
-      .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")
-      .mockResolvedValue({ threads: [], nextPageToken: undefined });
-    vi.spyOn(gmailThreadModule, "getThreadsBatch").mockResolvedValue([]);
-    const provider = new GmailProvider({
-      context: {
-        _options: {
-          auth: { credentials: { access_token: "access-token" } },
-        },
-      },
-    } as any);
-
-    await provider.getThreadsWithQuery({
-      query: { q: "invoice from:billing@example.com", type: "all" },
-    });
-
-    expect(getThreadsWithNextPageToken).toHaveBeenCalledWith(
-      expect.objectContaining({
-        q: "invoice from:billing@example.com",
-        labelIds: [],
-      }),
-    );
-  });
-
   it("uses Gmail metadata format for list requests", async () => {
     vi.spyOn(
       gmailThreadModule,
@@ -507,6 +482,31 @@ describe("GmailProvider.getThreadsWithQuery", () => {
       "access-token",
       expect.anything(),
       { format: "metadata" },
+    );
+  });
+});
+
+describe("GmailProvider.searchThreads", () => {
+  it("passes the free-text query through unscoped", async () => {
+    const getThreadsWithNextPageToken = vi
+      .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")
+      .mockResolvedValue({ threads: [], nextPageToken: undefined });
+    vi.spyOn(gmailThreadModule, "getThreadsBatch").mockResolvedValue([]);
+    const provider = new GmailProvider({
+      context: {
+        _options: {
+          auth: { credentials: { access_token: "access-token" } },
+        },
+      },
+    } as any);
+
+    await provider.searchThreads({ query: "invoice from:billing@example.com" });
+
+    expect(getThreadsWithNextPageToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "invoice from:billing@example.com",
+        labelIds: [],
+      }),
     );
   });
 });

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1573,6 +1573,7 @@ export class GmailProvider implements EmailProvider {
   }> {
     return this.withRateLimitTracking("get-threads-with-query", async () => {
       const {
+        q,
         fromEmail,
         after,
         before,
@@ -1585,6 +1586,12 @@ export class GmailProvider implements EmailProvider {
 
       function getQuery() {
         const queryParts: string[] = [];
+
+        // Free-text search, passed through verbatim so Gmail operators
+        // (from:, subject:, has:attachment, ...) work like the Gmail search box.
+        if (q) {
+          queryParts.push(q);
+        }
 
         if (fromEmail) {
           queryParts.push(`from:${fromEmail}`);

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1573,7 +1573,6 @@ export class GmailProvider implements EmailProvider {
   }> {
     return this.withRateLimitTracking("get-threads-with-query", async () => {
       const {
-        q,
         fromEmail,
         after,
         before,
@@ -1586,12 +1585,6 @@ export class GmailProvider implements EmailProvider {
 
       function getQuery() {
         const queryParts: string[] = [];
-
-        // Free-text search, passed through verbatim so Gmail operators
-        // (from:, subject:, has:attachment, ...) work like the Gmail search box.
-        if (q) {
-          queryParts.push(q);
-        }
 
         if (fromEmail) {
           queryParts.push(`from:${fromEmail}`);
@@ -1668,40 +1661,73 @@ export class GmailProvider implements EmailProvider {
           logger: this.logger,
         });
 
-      const threadIds =
-        gmailThreads?.map((t) => t.id).filter((id): id is string => !!id) || [];
-      const threads = await getThreadsBatch(
-        threadIds,
-        getAccessTokenFromClient(this.client),
-        this.logger,
-        options.messageFormat === "metadata"
-          ? { format: "metadata" }
-          : undefined,
-      );
-
-      const emailThreads: EmailThread[] = threads
-        .map((thread) => {
-          const id = thread.id;
-          if (!id) return null;
-
-          const emailThread: EmailThread = {
-            id,
-            messages:
-              thread.messages?.map((message) =>
-                parseMessage(message as MessageWithPayload),
-              ) || [],
-            snippet: decodeSnippet(thread.snippet),
-            historyId: thread.historyId || undefined,
-          };
-          return emailThread;
-        })
-        .filter((thread): thread is EmailThread => thread !== null);
-
       return {
-        threads: emailThreads,
+        threads: await this.hydrateThreads(gmailThreads, options.messageFormat),
         nextPageToken: nextPageToken || undefined,
       };
     });
+  }
+
+  async searchThreads(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+    messageFormat?: "full" | "metadata";
+  }): Promise<{
+    threads: EmailThread[];
+    nextPageToken?: string;
+  }> {
+    return this.withRateLimitTracking("search-threads", async () => {
+      // The query is passed through verbatim so Gmail operators (from:,
+      // subject:, has:attachment, ...) work like the Gmail search box.
+      // No label scoping: search covers the whole mailbox.
+      const { threads: gmailThreads, nextPageToken } =
+        await getThreadsWithNextPageToken({
+          gmail: this.client,
+          q: options.query,
+          labelIds: [],
+          maxResults: options.maxResults || 50,
+          pageToken: options.pageToken || undefined,
+          logger: this.logger,
+        });
+
+      return {
+        threads: await this.hydrateThreads(gmailThreads, options.messageFormat),
+        nextPageToken: nextPageToken || undefined,
+      };
+    });
+  }
+
+  private async hydrateThreads(
+    gmailThreads: gmail_v1.Schema$Thread[] | undefined,
+    messageFormat?: "full" | "metadata",
+  ): Promise<EmailThread[]> {
+    const threadIds =
+      gmailThreads?.map((t) => t.id).filter((id): id is string => !!id) || [];
+    const threads = await getThreadsBatch(
+      threadIds,
+      getAccessTokenFromClient(this.client),
+      this.logger,
+      messageFormat === "metadata" ? { format: "metadata" } : undefined,
+    );
+
+    return threads
+      .map((thread) => {
+        const id = thread.id;
+        if (!id) return null;
+
+        const emailThread: EmailThread = {
+          id,
+          messages:
+            thread.messages?.map((message) =>
+              parseMessage(message as MessageWithPayload),
+            ) || [],
+          snippet: decodeSnippet(thread.snippet),
+          historyId: thread.historyId || undefined,
+        };
+        return emailThread;
+      })
+      .filter((thread): thread is EmailThread => thread !== null);
   }
 
   async hasPreviousCommunicationsWithSenderOrDomain(options: {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -846,7 +846,11 @@ describe("OutlookProvider.searchThreads", () => {
 
     const result = await provider.searchThreads({ query: "quarterly invoice" });
 
-    expect(client.getRequestLog()[0]).toEqual({
+    // The category-map lookup is also recorded, so find the search request.
+    const searchRequest = client
+      .getRequestLog()
+      .find((request) => request.apiPath === "/me/messages");
+    expect(searchRequest).toEqual({
       apiPath: "/me/messages",
       filter: undefined,
       search: '"quarterly invoice"',

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -335,24 +335,6 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     });
   });
 
-  it("uses $search without $filter for free-text queries", async () => {
-    const client = createMockOutlookClient([
-      createMessage({ id: "message-1", conversationId: "thread-1" }),
-    ]);
-    const provider = new OutlookProvider(client);
-
-    const result = await provider.getThreadsWithQuery({
-      query: { q: "quarterly invoice", type: "all" },
-    });
-
-    expect(client.getRequestLog()[0]).toEqual({
-      apiPath: "/me/messages",
-      filter: undefined,
-      search: '"quarterly invoice"',
-    });
-    expect(result.threads.map((thread) => thread.id)).toEqual(["thread-1"]);
-  });
-
   it("filters returned threads by explicit labelIds", async () => {
     getFolderIdsMock.mockResolvedValue({
       inbox: "folder-inbox",
@@ -852,6 +834,24 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
 
     expect(result.threads.map((thread) => thread.id)).toEqual(["thread-sent"]);
     expect(getCategoryMapSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("OutlookProvider.searchThreads", () => {
+  it("uses $search on the whole mailbox without $filter", async () => {
+    const client = createMockOutlookClient([
+      createMessage({ id: "message-1", conversationId: "thread-1" }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    const result = await provider.searchThreads({ query: "quarterly invoice" });
+
+    expect(client.getRequestLog()[0]).toEqual({
+      apiPath: "/me/messages",
+      filter: undefined,
+      search: '"quarterly invoice"',
+    });
+    expect(result.threads.map((thread) => thread.id)).toEqual(["thread-1"]);
   });
 });
 

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -335,6 +335,24 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     });
   });
 
+  it("uses $search without $filter for free-text queries", async () => {
+    const client = createMockOutlookClient([
+      createMessage({ id: "message-1", conversationId: "thread-1" }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    const result = await provider.getThreadsWithQuery({
+      query: { q: "quarterly invoice", type: "all" },
+    });
+
+    expect(client.getRequestLog()[0]).toEqual({
+      apiPath: "/me/messages",
+      filter: undefined,
+      search: '"quarterly invoice"',
+    });
+    expect(result.threads.map((thread) => thread.id)).toEqual(["thread-1"]);
+  });
+
   it("filters returned threads by explicit labelIds", async () => {
     getFolderIdsMock.mockResolvedValue({
       inbox: "folder-inbox",
@@ -945,7 +963,11 @@ function createMockOutlookClient(
 ) {
   let categoryMapCache = options?.categoryMapCache ?? null;
   let folderIdCache = options?.folderIdCache ?? null;
-  const requestLog: Array<{ apiPath: string; filter?: string }> = [];
+  const requestLog: Array<{
+    apiPath: string;
+    filter?: string;
+    search?: string;
+  }> = [];
   const selectLog: string[] = [];
 
   return {
@@ -973,6 +995,7 @@ function createMockOutlookClient(
             requestLog.push({
               apiPath,
               filter: filterValue,
+              search: searchValue,
             });
             const response = options?.responsesByApiPath?.[apiPath];
             if (typeof response === "function") {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -14,6 +14,7 @@ import {
   MESSAGE_LIST_SELECT_FIELDS,
   MESSAGE_SELECT_FIELDS,
   sanitizeKqlValue,
+  sanitizeOutlookSearchQuery,
 } from "@/utils/outlook/message";
 import {
   getLabels,
@@ -1572,6 +1573,7 @@ export class OutlookProvider implements EmailProvider {
     nextPageToken?: string;
   }> {
     const {
+      q,
       fromEmail,
       after,
       before,
@@ -1583,6 +1585,10 @@ export class OutlookProvider implements EmailProvider {
       labelIds,
       excludeLabelNames,
     } = options.query || {};
+
+    const searchQuery = q?.trim()
+      ? sanitizeOutlookSearchQuery(q).sanitized || undefined
+      : undefined;
 
     const client = this.client.getClient();
     const hasExplicitLabelFilters = Boolean(labelId || labelIds?.length);
@@ -1633,6 +1639,26 @@ export class OutlookProvider implements EmailProvider {
       const nextLink = resolveMicrosoftGraphNextLink(pageToken);
       if (nextLink) {
         return await client.api(nextLink).get();
+      }
+
+      // Graph forbids combining $search with $filter/$orderby, so search
+      // requests only scope by endpoint (whole mailbox, or one folder).
+      // Results come back in relevance order, like Outlook's own search.
+      if (searchQuery) {
+        const endpoint = folderId
+          ? `/me/mailFolders/${encodeURIComponent(folderId)}/messages`
+          : "/me/messages";
+        return await client
+          .api(endpoint)
+          .select(
+            options.messageFormat === "metadata"
+              ? MESSAGE_LIST_SELECT_FIELDS
+              : MESSAGE_SELECT_FIELDS,
+          )
+          .search(searchQuery)
+          // Graph caps page size at 25 when $search is used
+          .top(Math.min(maxResults, 25))
+          .get();
       }
 
       // Determine endpoint and build filters based on query type

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1573,7 +1573,6 @@ export class OutlookProvider implements EmailProvider {
     nextPageToken?: string;
   }> {
     const {
-      q,
       fromEmail,
       after,
       before,
@@ -1585,10 +1584,6 @@ export class OutlookProvider implements EmailProvider {
       labelIds,
       excludeLabelNames,
     } = options.query || {};
-
-    const searchQuery = q?.trim()
-      ? sanitizeOutlookSearchQuery(q).sanitized || undefined
-      : undefined;
 
     const client = this.client.getClient();
     const hasExplicitLabelFilters = Boolean(labelId || labelIds?.length);
@@ -1639,26 +1634,6 @@ export class OutlookProvider implements EmailProvider {
       const nextLink = resolveMicrosoftGraphNextLink(pageToken);
       if (nextLink) {
         return await client.api(nextLink).get();
-      }
-
-      // Graph forbids combining $search with $filter/$orderby, so search
-      // requests only scope by endpoint (whole mailbox, or one folder).
-      // Results come back in relevance order, like Outlook's own search.
-      if (searchQuery) {
-        const endpoint = folderId
-          ? `/me/mailFolders/${encodeURIComponent(folderId)}/messages`
-          : "/me/messages";
-        return await client
-          .api(endpoint)
-          .select(
-            options.messageFormat === "metadata"
-              ? MESSAGE_LIST_SELECT_FIELDS
-              : MESSAGE_SELECT_FIELDS,
-          )
-          .search(searchQuery)
-          // Graph caps page size at 25 when $search is used
-          .top(Math.min(maxResults, 25))
-          .get();
       }
 
       // Determine endpoint and build filters based on query type
@@ -1823,6 +1798,55 @@ export class OutlookProvider implements EmailProvider {
     return {
       threads,
       nextPageToken,
+    };
+  }
+
+  async searchThreads(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+    messageFormat?: "full" | "metadata";
+  }): Promise<{
+    threads: EmailThread[];
+    nextPageToken?: string;
+  }> {
+    const searchQuery = sanitizeOutlookSearchQuery(options.query).sanitized;
+    if (!searchQuery) return { threads: [] };
+
+    const client = this.client.getClient();
+    const [folderIds, categoryMap] = await Promise.all([
+      getFolderIds(this.client, this.logger, { includeDrafts: false }),
+      getCategoryMap(this.client, this.logger),
+    ]);
+
+    const nextLink = resolveMicrosoftGraphNextLink(options.pageToken);
+    const response: { value: Message[]; "@odata.nextLink"?: string } = nextLink
+      ? await client.api(nextLink).get()
+      : // Graph forbids combining $search with $filter/$orderby and caps page
+        // size at 25. Results come back in relevance order, like Outlook's
+        // own search box, and cover the whole mailbox.
+        await client
+          .api("/me/messages")
+          .select(
+            options.messageFormat === "metadata"
+              ? MESSAGE_LIST_SELECT_FIELDS
+              : MESSAGE_SELECT_FIELDS,
+          )
+          .search(searchQuery)
+          .top(Math.min(options.maxResults || 25, 25))
+          .get();
+
+    const threads = buildOutlookThreadsFromMessages({
+      messages: response.value,
+      folderIds,
+      categoryMap,
+      excludedLabelIds: new Set(),
+      logger: this.logger,
+    });
+
+    return {
+      threads,
+      nextPageToken: response["@odata.nextLink"],
     };
   }
 

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -312,6 +312,16 @@ export interface EmailProvider {
     messages: ParsedMessage[];
     nextPageToken?: string;
   }>;
+  /** Free-text search over the whole mailbox, like the provider's own search box. */
+  searchThreads(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+    messageFormat?: "full" | "metadata";
+  }): Promise<{
+    threads: EmailThread[];
+    nextPageToken?: string;
+  }>;
   sendDraft(draftId: string): Promise<{ messageId: string; threadId: string }>;
   sendEmail(args: {
     to: string;

--- a/apps/web/utils/threads/load.ts
+++ b/apps/web/utils/threads/load.ts
@@ -15,12 +15,21 @@ export async function loadThreads({
   emailProvider: EmailProvider;
   messageFormat: "full" | "metadata";
 }) {
-  const { threads, nextPageToken } = await emailProvider.getThreadsWithQuery({
-    query,
-    maxResults: query.limit || 50,
-    pageToken: query.nextPageToken || undefined,
-    messageFormat,
-  });
+  const maxResults = query.limit || 50;
+  const pageToken = query.nextPageToken || undefined;
+  const { threads, nextPageToken } = query.q
+    ? await emailProvider.searchThreads({
+        query: query.q,
+        maxResults,
+        pageToken,
+        messageFormat,
+      })
+    : await emailProvider.getThreadsWithQuery({
+        query,
+        maxResults,
+        pageToken,
+        messageFormat,
+      });
 
   const threadIds = threads.map((thread) => thread.id);
   const executedRules = await prisma.executedRule.findMany({

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 export const threadsQuery = z.object({
+  q: z.string().nullish(),
   fromEmail: z.string().nullish(),
   limit: z.coerce.number().max(100).nullish(),
   type: z.string().nullish(),


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260830-112327_pr-3437_15a0ee9aa7be/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a working search box to the mail screen toolbar for both Gmail and Outlook accounts.

- The toolbar's placeholder search button is now a real input (single-account view): Enter searches the whole mailbox, X/Escape clears, and the query lives in the `?q=` URL param. The combined all-accounts inbox keeps the command-palette button since cross-account search isn't supported.
- `q` is now part of the threads query schema (the API route previously read it but the schema silently dropped it) and flows through `EmailProvider.getThreadsWithQuery`.
- Gmail passes the query through its native search syntax, so operators like `from:` and `has:attachment` work. Outlook uses Graph `$search` with the existing KQL sanitization, skipping `$filter`/`$orderby` (Graph forbids combining them) and capping page size at 25.
- Search queries bypass the local mailbox cache so results always come from the provider.
- New tests cover the route param passthrough and both provider search branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added free-text search for individual mail accounts.
  - Supports Gmail search operators and Outlook relevance-ranked results.
  - Search overrides standard filters and hides split tabs while active.
  - Added submit, clear, and Escape-to-clear controls.
  - Search is unavailable in combined inboxes and clears when switching to all accounts.

- **Bug Fixes**
  - Search results now bypass cached mailbox data for fresher results.

- **Tests**
  - Added coverage for Gmail, Outlook, mailbox search, and query handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->