### PR TITLE
outlook: Stop requesting unsupported online meetings (INB-333)

### DIFF
--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -308,9 +308,6 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
   });
 
-  // Graph ignores isOnlineMeeting on consumer calendars and never returns a
-  // join URL, so requesting one only delays the booking behind refetches and a
-  // patch that cannot succeed.
   it("does not request an online meeting on a personal Outlook calendar", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",

--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -308,7 +308,10 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
   });
 
-  it("falls back to a personal Outlook calendar's default meeting provider", async () => {
+  // Graph ignores isOnlineMeeting on consumer calendars and never returns a
+  // join URL, so requesting one only delays the booking behind refetches and a
+  // patch that cannot succeed.
+  it("does not request an online meeting on a personal Outlook calendar", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
       allowedOnlineMeetingProviders: ["skypeForConsumer"],
@@ -316,7 +319,9 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
-      onlineMeeting: { joinUrl: "https://join.skype.com/example" },
+      isOnlineMeeting: false,
+      onlineMeetingProvider: "unknown",
+      onlineMeeting: null,
       webLink: "https://outlook.example.com/event",
     });
 
@@ -335,18 +340,48 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
 
     const createPayload = graphMocks.post.mock.calls[0]?.[0];
-    expect(createPayload).toEqual(
-      expect.objectContaining({
-        isOnlineMeeting: true,
-        onlineMeetingProvider: "skypeForConsumer",
-      }),
-    );
+    expect(createPayload).not.toHaveProperty("isOnlineMeeting");
+    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
+    expect(graphMocks.api).not.toHaveBeenCalledWith("/me/events/event-id");
+    expect(graphMocks.patch).not.toHaveBeenCalled();
     expect(result).toEqual({
       id: "event-id",
       providerCalendarId: "calendar-id",
       eventUrl: "https://outlook.example.com/event",
-      videoConferenceLink: "https://join.skype.com/example",
+      videoConferenceLink: undefined,
     });
+  });
+
+  it("still requests Skype for Business, which work calendars can generate", async () => {
+    graphMocks.get.mockResolvedValue({
+      id: "calendar-id",
+      allowedOnlineMeetingProviders: ["skypeForBusiness"],
+      defaultOnlineMeetingProvider: "skypeForBusiness",
+    });
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      onlineMeeting: { joinUrl: "https://meet.example.com/join" },
+      webLink: "https://outlook.example.com/event",
+    });
+
+    await createProvider().createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    expect(graphMocks.post.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        isOnlineMeeting: true,
+        onlineMeetingProvider: "skypeForBusiness",
+      }),
+    );
   });
 
   it("prefers Teams when it is allowed but is not the calendar default", async () => {

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -15,6 +15,12 @@ import { sleep } from "@/utils/sleep";
 
 const ONLINE_MEETING_JOIN_URL_POLL_DELAYS_MS = [500, 1000, 2000] as const;
 const MICROSOFT_TEAMS_PROVIDER = "teamsForBusiness";
+// Graph ignores isOnlineMeeting and onlineMeetingProvider on consumer
+// calendars: the event comes back with isOnlineMeeting false and onlineMeeting
+// null, and no join URL is ever produced. Personal Outlook.com accounts offer
+// only skypeForConsumer, so requesting a meeting there costs several round
+// trips and delays every booking without ever returning a link.
+const UNSUPPORTED_ONLINE_MEETING_PROVIDERS = ["skypeForConsumer", "unknown"];
 
 export interface MicrosoftCalendarConnectionParams {
   accessToken: string | null;
@@ -156,6 +162,8 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           logger: this.logger,
         })
       : null;
+    // Null fields mean the calendar cannot host an online meeting at all, so
+    // the follow-up refetch and patch below would never find a join URL.
     const requestedOnlineMeeting = Boolean(onlineMeetingFields);
     const response: MicrosoftEvent = await client
       .api(`/me/calendars/${input.calendarId}/events`)
@@ -182,7 +190,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
         })),
         ...(onlineMeetingFields ?? {}),
         location:
-          !requestedOnlineMeeting && input.locationValue
+          !useMicrosoftTeams && input.locationValue
             ? { displayName: input.locationValue }
             : undefined,
       });
@@ -222,11 +230,12 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       });
     }
 
-    if (requestedOnlineMeeting && !videoConferenceLink) {
+    if (useMicrosoftTeams && !videoConferenceLink) {
       this.logger.warn(
         "Microsoft online meeting link missing after event creation",
         {
           eventId: response.id,
+          requestedOnlineMeeting,
           isOnlineMeeting: response.isOnlineMeeting,
           onlineMeetingProvider: response.onlineMeetingProvider,
         },
@@ -315,18 +324,15 @@ async function getOnlineMeetingFields({
     logger,
   });
 
-  // Prefer Teams when the calendar allows it; otherwise fall back to the
-  // calendar's default provider (personal Outlook calendars don't allow
-  // teamsForBusiness). When the settings fetch fails, still request Teams.
-  const onlineMeetingProvider =
-    !settings ||
-    settings.allowedOnlineMeetingProviders?.includes(MICROSOFT_TEAMS_PROVIDER)
-      ? MICROSOFT_TEAMS_PROVIDER
-      : settings.defaultOnlineMeetingProvider;
+  const onlineMeetingProvider = selectOnlineMeetingProvider(settings);
 
-  if (!onlineMeetingProvider || onlineMeetingProvider === "unknown") {
-    logger.warn("No online meeting provider is available for calendar", {
+  if (
+    !onlineMeetingProvider ||
+    UNSUPPORTED_ONLINE_MEETING_PROVIDERS.includes(onlineMeetingProvider)
+  ) {
+    logger.warn("Calendar cannot generate an online meeting link", {
       calendarId,
+      onlineMeetingProvider,
       allowedOnlineMeetingProviders: settings?.allowedOnlineMeetingProviders,
       defaultOnlineMeetingProvider: settings?.defaultOnlineMeetingProvider,
     });
@@ -337,6 +343,21 @@ async function getOnlineMeetingFields({
     isOnlineMeeting: true,
     onlineMeetingProvider,
   } satisfies MicrosoftOnlineMeetingFields;
+}
+
+function selectOnlineMeetingProvider(
+  settings: MicrosoftCalendarOnlineMeetingSettings | null,
+) {
+  // Teams is the right assumption when the lookup fails: only work and school
+  // calendars can generate a link, and those allow Teams.
+  if (!settings) return MICROSOFT_TEAMS_PROVIDER;
+  if (
+    settings.allowedOnlineMeetingProviders?.includes(MICROSOFT_TEAMS_PROVIDER)
+  ) {
+    return MICROSOFT_TEAMS_PROVIDER;
+  }
+
+  return settings.defaultOnlineMeetingProvider;
 }
 
 async function getCalendarOnlineMeetingSettings({

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -15,12 +15,6 @@ import { sleep } from "@/utils/sleep";
 
 const ONLINE_MEETING_JOIN_URL_POLL_DELAYS_MS = [500, 1000, 2000] as const;
 const MICROSOFT_TEAMS_PROVIDER = "teamsForBusiness";
-// Graph ignores isOnlineMeeting and onlineMeetingProvider on consumer
-// calendars: the event comes back with isOnlineMeeting false and onlineMeeting
-// null, and no join URL is ever produced. Personal Outlook.com accounts offer
-// only skypeForConsumer, so requesting a meeting there costs several round
-// trips and delays every booking without ever returning a link.
-const UNSUPPORTED_ONLINE_MEETING_PROVIDERS = ["skypeForConsumer", "unknown"];
 
 export interface MicrosoftCalendarConnectionParams {
   accessToken: string | null;
@@ -162,8 +156,6 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           logger: this.logger,
         })
       : null;
-    // Null fields mean the calendar cannot host an online meeting at all, so
-    // the follow-up refetch and patch below would never find a join URL.
     const requestedOnlineMeeting = Boolean(onlineMeetingFields);
     const response: MicrosoftEvent = await client
       .api(`/me/calendars/${input.calendarId}/events`)
@@ -230,12 +222,11 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       });
     }
 
-    if (useMicrosoftTeams && !videoConferenceLink) {
+    if (requestedOnlineMeeting && !videoConferenceLink) {
       this.logger.warn(
         "Microsoft online meeting link missing after event creation",
         {
           eventId: response.id,
-          requestedOnlineMeeting,
           isOnlineMeeting: response.isOnlineMeeting,
           onlineMeetingProvider: response.onlineMeetingProvider,
         },
@@ -324,11 +315,19 @@ async function getOnlineMeetingFields({
     logger,
   });
 
-  const onlineMeetingProvider = selectOnlineMeetingProvider(settings);
+  let onlineMeetingProvider = settings?.defaultOnlineMeetingProvider;
+  if (
+    !settings ||
+    settings.allowedOnlineMeetingProviders?.includes(MICROSOFT_TEAMS_PROVIDER)
+  ) {
+    onlineMeetingProvider = MICROSOFT_TEAMS_PROVIDER;
+  }
 
+  // Personal Outlook calendars advertise Skype but ignore meeting fields.
   if (
     !onlineMeetingProvider ||
-    UNSUPPORTED_ONLINE_MEETING_PROVIDERS.includes(onlineMeetingProvider)
+    onlineMeetingProvider === "skypeForConsumer" ||
+    onlineMeetingProvider === "unknown"
   ) {
     logger.warn("Calendar cannot generate an online meeting link", {
       calendarId,
@@ -343,21 +342,6 @@ async function getOnlineMeetingFields({
     isOnlineMeeting: true,
     onlineMeetingProvider,
   } satisfies MicrosoftOnlineMeetingFields;
-}
-
-function selectOnlineMeetingProvider(
-  settings: MicrosoftCalendarOnlineMeetingSettings | null,
-) {
-  // Teams is the right assumption when the lookup fails: only work and school
-  // calendars can generate a link, and those allow Teams.
-  if (!settings) return MICROSOFT_TEAMS_PROVIDER;
-  if (
-    settings.allowedOnlineMeetingProviders?.includes(MICROSOFT_TEAMS_PROVIDER)
-  ) {
-    return MICROSOFT_TEAMS_PROVIDER;
-  }
-
-  return settings.defaultOnlineMeetingProvider;
 }
 
 async function getCalendarOnlineMeetingSettings({


### PR DESCRIPTION
## The link cannot be generated, and that is the finding

Microsoft Graph **does not support creating online meetings on personal Outlook.com accounts** through the events API. Setting `isOnlineMeeting: true` with an `onlineMeetingProvider` is silently ignored on consumer calendars: the event is created with `isOnlineMeeting: false` and `onlineMeeting: null`, and no join URL is ever produced. Personal accounts expose `skypeForConsumer` at most, and [per Microsoft](https://learn.microsoft.com/en-us/answers/questions/5729598/inconsistent-joinurl-when-creating-microsoft-teams) "even that doesn't work for event creation."

The `/me/onlineMeetings` alternative suggested in the ticket does not help either — it is a Teams API and requires a work or school account.

This is why #3339 did not fix the issue. That PR correctly read `allowedOnlineMeetingProviders`, selected a provider, and passed it through, but the provider it lands on for a personal account (`skypeForConsumer`) is one Graph will not act on. **No code change in this repository can make a Teams link appear for a personal Outlook account.**

## What this PR does

It stops the product from doing pointless, slow work and makes the reason visible:

- Treat `skypeForConsumer` and `unknown` as providers that cannot generate a link. When one is selected, skip the online-meeting request entirely, along with the refetch → patch → second poll chain that followed it. That chain sleeps up to 3.5s per booking and could never succeed.
- Keep requesting `skypeForBusiness`, which work and school calendars can honour, so business accounts are unaffected.
- Log the selected provider so the cause is visible in a warning rather than inferred.

The host already receives a "Microsoft Teams link was not generated" notice from `sendBookingConfirmationEmails`, so the booking still completes and the host is told.

## Validation

- Replaced the test that asserted `skypeForConsumer` is requested and returns a Skype join URL — it encoded behaviour the real API does not have.
- Added coverage that a personal calendar gets no online-meeting request and no retry chain, and that `skypeForBusiness` is still requested.
- `utils/calendar` and `utils/booking` suites pass: 18 files, 134 tests.

## What still needs a product decision

This PR makes the failure fast and legible, but the underlying problem is that a host on a personal Outlook account can still choose "Microsoft Teams" as a booking-link location, and we cannot deliver it. Two follow-ups worth considering:

1. **Do not offer Microsoft Teams as a location type for personal Outlook accounts.** `getProviderVideoLocationType` derives the type from google/microsoft alone, with no personal-vs-work distinction, so this needs account-type detection at booking-link configuration time. That is the real fix for the reported experience.
2. **The guest is not told.** The host sees "link was not generated", but the guest's confirmation still shows the location as "Microsoft Teams" with no link and no explanation, so the guest has no way to join. Changing that copy is a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Microsoft consumer calendars no longer attempt to create unsupported online meetings or attach invalid meeting details.
  - Microsoft Teams requests now correctly handle calendars that cannot provide a join link.
  - Calendar locations now accurately reflect when Microsoft Teams was requested.
  - Skype for Business work calendars continue to support online meeting creation with the appropriate provider.
  - Event details no longer trigger unnecessary follow-up updates when consumer calendars cannot host online meetings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->