### PR TITLE
desktop: Make mail the primary mode

### DIFF
--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -3,6 +3,7 @@ import {
   findDesktopProtocolUrl,
   getDesktopAppOrigin,
   getDesktopBrowserStartUrl,
+  getDesktopHomeUrl,
   getDesktopLoginUrl,
   DESKTOP_WINDOW_DRAG_CSS,
   getDesktopPostAuthUrl,
@@ -24,6 +25,9 @@ describe("desktop shell helpers", () => {
     );
     expect(getDesktopLoginUrl("https://www.getinboxzero.com")).toBe(
       "https://www.getinboxzero.com/login",
+    );
+    expect(getDesktopHomeUrl("https://www.getinboxzero.com")).toBe(
+      "https://www.getinboxzero.com/welcome-redirect?mode=mail",
     );
   });
 
@@ -120,7 +124,7 @@ describe("desktop shell helpers", () => {
     expect(isAllowedExternalUrl("inboxzero://auth-callback")).toBe(false);
   });
 
-  it("loads a validated post-auth path and falls back to login", () => {
+  it("loads a validated post-auth path and falls back to mail", () => {
     expect(
       getDesktopPostAuthUrl(
         "https://www.getinboxzero.com",
@@ -134,7 +138,7 @@ describe("desktop shell helpers", () => {
         "https://www.getinboxzero.com",
         "https://evil.test",
       ),
-    ).toBe("https://www.getinboxzero.com/login");
+    ).toBe("https://www.getinboxzero.com/welcome-redirect?mode=mail");
     expect(normalizeDesktopCallbackPath("//evil.test")).toBeNull();
     expect(normalizeDesktopCallbackPath("/.//evil.test")).toBe("/evil.test");
     expect(
@@ -186,11 +190,17 @@ describe("desktop shell helpers", () => {
     expect(shouldPersistDesktopUrl(`${origin}/loginish`, origin)).toBe(true);
   });
 
-  it("restores only validated same-origin URLs on launch", () => {
+  it("restores only validated mail URLs on launch", () => {
     const origin = "https://www.getinboxzero.com";
     expect(
+      getDesktopSessionRestoreUrl(
+        origin,
+        `${origin}/account-1/mail?type=archive`,
+      ),
+    ).toBe(`${origin}/account-1/mail?type=archive`);
+    expect(
       getDesktopSessionRestoreUrl(origin, `${origin}/account-1/automation`),
-    ).toBe(`${origin}/account-1/automation`);
+    ).toBeNull();
     expect(getDesktopSessionRestoreUrl(origin, `${origin}/login`)).toBeNull();
     expect(
       getDesktopSessionRestoreUrl(origin, "https://evil.test/automation"),

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -23,6 +23,10 @@ export function getDesktopLoginUrl(appOrigin: string): string {
   return new URL("/login", appOrigin).toString();
 }
 
+export function getDesktopHomeUrl(appOrigin: string): string {
+  return new URL("/welcome-redirect?mode=mail", appOrigin).toString();
+}
+
 export function getDesktopBrowserStartUrl(
   appOrigin: string,
   provider: DesktopAuthProvider,
@@ -141,10 +145,10 @@ export function getDesktopPostAuthUrl(
   appOrigin: string,
   callbackPath?: string | null,
 ): string {
-  return new URL(
-    normalizeDesktopCallbackPath(callbackPath) ?? "/login",
-    appOrigin,
-  ).toString();
+  const normalizedCallbackPath = normalizeDesktopCallbackPath(callbackPath);
+  return normalizedCallbackPath
+    ? new URL(normalizedCallbackPath, appOrigin).toString()
+    : getDesktopHomeUrl(appOrigin);
 }
 
 export function findDesktopProtocolUrl(argv: readonly string[]): string | null {
@@ -180,7 +184,15 @@ export function getDesktopSessionRestoreUrl(
 ): string | null {
   if (typeof persistedUrl !== "string") return null;
   if (!shouldPersistDesktopUrl(persistedUrl, appOrigin)) return null;
-  return new URL(persistedUrl).toString();
+  const parsed = new URL(persistedUrl);
+  // Mail is the desktop's primary mode. Preserve its selected view across a
+  // full restart, but send utility pages back through the desktop home gate.
+  if (!isDesktopMailPath(parsed.pathname)) return null;
+  return parsed.toString();
+}
+
+function isDesktopMailPath(pathname: string): boolean {
+  return pathname === "/mail" || /^\/[^/]+\/mail\/?$/u.test(pathname);
 }
 
 const DESKTOP_WINDOW_BACKGROUND = "#ffffff";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -22,7 +22,7 @@ import {
   findDesktopProtocolUrl,
   getDesktopAppOrigin,
   getDesktopBrowserStartUrl,
-  getDesktopLoginUrl,
+  getDesktopHomeUrl,
   getDesktopPostAuthUrl,
   getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
@@ -44,7 +44,7 @@ let pendingAuthUrl: string | null = null;
 let pendingCallbackPath: string | null = null;
 let isQuitting = false;
 const appOrigin = getDesktopAppOrigin();
-const loginUrl = getDesktopLoginUrl(appOrigin);
+const homeUrl = getDesktopHomeUrl(appOrigin);
 
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -174,7 +174,7 @@ function createMainWindow() {
 }
 
 function getStartUrl(): string {
-  return getDesktopSessionRestoreUrl(appOrigin, readLastAppUrl()) ?? loginUrl;
+  return getDesktopSessionRestoreUrl(appOrigin, readLastAppUrl()) ?? homeUrl;
 }
 
 function trackLastAppUrl(contents: WebContents) {

--- a/apps/web/app/(landing)/welcome-redirect/page.test.ts
+++ b/apps/web/app/(landing)/welcome-redirect/page.test.ts
@@ -67,6 +67,21 @@ describe("WelcomeRedirectPage", () => {
     expect(mocks.findPremium).not.toHaveBeenCalled();
   });
 
+  it("sends completed mail-mode users to mail without loading premium", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: new Date("2026-01-01T00:00:00.000Z"),
+      premiumId: "premium-1",
+    });
+
+    await expect(
+      WelcomeRedirectPage({
+        searchParams: Promise.resolve({ mode: "mail" }),
+      }),
+    ).rejects.toThrow("account-redirect:/mail");
+
+    expect(mocks.findPremium).not.toHaveBeenCalled();
+  });
+
   it("sends mobile-paid users with active Apple premium to setup", async () => {
     mocks.findUser.mockResolvedValue({
       completedOnboardingAt: null,
@@ -99,14 +114,16 @@ describe("WelcomeRedirectPage", () => {
     expect(mocks.redirectToEmailAccountPath).toHaveBeenCalledWith("/setup");
   });
 
-  it("keeps incomplete users without premium in onboarding", async () => {
+  it("keeps incomplete mail-mode users without premium in onboarding", async () => {
     mocks.findUser.mockResolvedValue({
       completedOnboardingAt: null,
       premiumId: null,
     });
 
     await expect(
-      WelcomeRedirectPage({ searchParams: Promise.resolve({}) }),
+      WelcomeRedirectPage({
+        searchParams: Promise.resolve({ mode: "mail" }),
+      }),
     ).rejects.toThrow("redirect:/onboarding");
 
     expect(mocks.findPremium).not.toHaveBeenCalled();

--- a/apps/web/app/(landing)/welcome-redirect/page.tsx
+++ b/apps/web/app/(landing)/welcome-redirect/page.tsx
@@ -5,7 +5,7 @@ import { redirectToEmailAccountPath } from "@/utils/account";
 import { isPremiumRecord, premiumEntitlementSelect } from "@/utils/premium";
 
 export default async function WelcomeRedirectPage(props: {
-  searchParams: Promise<{ force?: boolean }>;
+  searchParams: Promise<{ force?: boolean; mode?: string }>;
 }) {
   const searchParams = await props.searchParams;
   const session = await auth();
@@ -24,7 +24,9 @@ export default async function WelcomeRedirectPage(props: {
   if (!user) redirect("/logout");
   if (searchParams.force) redirect("/onboarding");
   if (user.completedOnboardingAt) {
-    await redirectToEmailAccountPath("/automation");
+    await redirectToEmailAccountPath(
+      searchParams.mode === "mail" ? "/mail" : "/automation",
+    );
   }
 
   if (user.premiumId) {

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -66,6 +66,7 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { NavUser } from "@/components/NavUser";
 import { PremiumCard } from "@/components/PremiumCard";
 import { FeedbackDialog } from "@/components/FeedbackDialog";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
 
 type NavItem = {
   name: string;
@@ -84,12 +85,26 @@ export const useNavigation = () => {
   const showMeetingBriefs = useMeetingBriefsEnabled();
   const showMeetingRecorder = useMeetingRecorderEnabled();
   const showIntegrations = useIntegrationsEnabled();
+  const [isDesktopApp, setIsDesktopApp] = useState(false);
+
+  useEffect(() => {
+    setIsDesktopApp(Boolean(getInboxZeroDesktopApp()));
+  }, []);
 
   const { emailAccount, emailAccountId, provider } = useAccount();
   const currentEmailAccountId = emailAccount?.id || emailAccountId;
 
   const manageItems: NavItem[] = useMemo(
     () => [
+      ...(isDesktopApp
+        ? [
+            {
+              name: "Inbox",
+              href: prefixPath(currentEmailAccountId, "/mail"),
+              icon: InboxIcon,
+            },
+          ]
+        : []),
       {
         name: "Chat",
         href: prefixPath(currentEmailAccountId, "/assistant"),
@@ -115,7 +130,7 @@ export const useNavigation = () => {
           ]
         : []),
     ],
-    [currentEmailAccountId, showMeetingRecorder],
+    [currentEmailAccountId, isDesktopApp, showMeetingRecorder],
   );
 
   const cleanupItems: NavItem[] = useMemo(

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -89,6 +89,7 @@ describe("mailbox sync coordinator", () => {
         emailAccountId: "account-1",
         fetchPage: resumedFetch,
         maxPages: 1,
+        now: new Date("2026-08-23T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ hasMore: false, pagesSynced: 1 });
     expect(resumedFetch).toHaveBeenCalledWith({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260831-162549_pr-3443_51c39b4a6784/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Makes Mail the default desktop destination while preserving required onboarding flows.

- Restores mail views across full restarts and routes other desktop launches through the mail-aware welcome gate.
- Adds a desktop-only Inbox entry to the main navigation.
- Validated with desktop tests, welcome-routing tests, lint, and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mail-mode routing from the welcome flow, sending completed onboarding users directly to Mail.
  * Desktop app now opens the Mail home page by default.
  * Added an Inbox link to navigation when using the desktop app.

* **Bug Fixes**
  * Improved desktop session restoration to reject unsupported pages and restore only valid Mail views.
  * Updated post-authentication fallback routing to use the Mail home page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->