### PR TITLE
fix: recover Recall bot scheduling and cancellation

### DIFF
--- a/apps/web/__tests__/emulators/recall.ts
+++ b/apps/web/__tests__/emulators/recall.ts
@@ -345,10 +345,10 @@ export async function createRecallEmulator({
     }
 
     if (method === "DELETE") {
-      // Recall answers 400 once the bot is in the call: too late to cancel.
+      // Recall answers 405 once the bot is dispatched: too late to delete.
       if (!isScheduled(bot)) {
         return {
-          status: 400,
+          status: 405,
           body: {
             code: "cannot_delete_bot",
             detail:

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -1,5 +1,6 @@
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -42,7 +43,14 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       provider = new RecallBotProvider(createTestLogger());
     });
 
-    beforeEach(() => emulator.reset());
+    beforeEach(() => {
+      emulator.reset();
+      vi.spyOn(Date, "now").mockReturnValue(
+        new Date("2026-05-04T08:00:00.000Z").getTime(),
+      );
+    });
+
+    afterEach(() => vi.restoreAllMocks());
 
     afterAll(() => emulator?.close());
 

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -89,6 +89,7 @@ describe("mailbox sync coordinator", () => {
         emailAccountId: "account-1",
         fetchPage: resumedFetch,
         maxPages: 1,
+        now: new Date("2026-08-23T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ hasMore: false, pagesSynced: 1 });
     expect(resumedFetch).toHaveBeenCalledWith({

--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -13,6 +13,8 @@ vi.mock("node:fs/promises", () => ({ readFile: readFileMock }));
 
 describe("RecallBotProvider", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T08:00:00.000Z"));
     vi.resetModules();
     readFileMock.mockReset();
     readFileMock.mockResolvedValue("camera-image");
@@ -27,6 +29,7 @@ describe("RecallBotProvider", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("uses the configured Recall workspace region", async () => {
@@ -66,6 +69,57 @@ describe("RecallBotProvider", () => {
     expect(
       botDetection.using_participant_events.activate_after,
     ).toBeGreaterThan(0);
+  });
+
+  it("joins an ongoing meeting immediately instead of sending a past join time", async () => {
+    const { RecallBotProvider } = await import("@/utils/recall/client");
+    const provider = new RecallBotProvider(createTestLogger());
+
+    await provider.scheduleBot({
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      joinAt: new Date("2026-05-04T07:55:00.000Z"),
+    });
+
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(JSON.parse(request?.body as string)).not.toHaveProperty("join_at");
+  });
+
+  it("removes a dispatched bot from the call after Recall rejects deletion", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: "cannot_delete_bot",
+            detail:
+              "Only scheduled bots which have not joined a call can be deleted.",
+          }),
+          {
+            status: 405,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const { RecallBotProvider } = await import("@/utils/recall/client");
+    const provider = new RecallBotProvider(createTestLogger());
+
+    await expect(provider.cancelBot("bot-1")).resolves.toBeUndefined();
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://eu-central-1.recall.ai/api/v1/bot/bot-1/",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://eu-central-1.recall.ai/api/v1/bot/bot-1/leave_call/",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("schedules the bot without video when the camera image cannot be loaded", async () => {

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -100,7 +100,9 @@ export class RecallBotProvider implements MeetingBotProvider {
       body: {
         meeting_url: meetingUrl,
         bot_name: botName,
-        join_at: joinAt.toISOString(),
+        // Recall rejects a past `join_at`. Omitting it creates an ad-hoc bot
+        // that joins an ongoing meeting immediately.
+        ...(joinAt.getTime() > Date.now() && { join_at: joinAt.toISOString() }),
         automatic_leave: {
           everyone_left_timeout: { timeout: EVERYONE_LEFT_TIMEOUT_SECONDS },
           // Timings are in seconds.
@@ -178,7 +180,7 @@ export class RecallBotProvider implements MeetingBotProvider {
         return;
       }
 
-      if (!isAlreadyJoining(error)) throw error;
+      if (!isDispatched(error)) throw error;
 
       try {
         await this.request(`/bot/${externalBotId}/leave_call/`, {
@@ -291,10 +293,10 @@ function isMissing(error: unknown): boolean {
   return error instanceof RecallApiError && error.status === 404;
 }
 
-function isAlreadyJoining(error: unknown): boolean {
+function isDispatched(error: unknown): boolean {
   return (
     error instanceof RecallApiError &&
-    error.status === 400 &&
+    (error.status === 400 || error.status === 405) &&
     getRecallErrorCode(error) === "cannot_delete_bot"
   );
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260831-153858_pr-3444_9d0aa4fbc556/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fix Recall meeting bots that were failing to join ongoing calls and repeatedly retrying completed cancellations.

- omit stale join times so Recall creates an ad-hoc bot for an ongoing meeting
- treat dispatched-bot 405 responses as a signal to remove the bot from the call
- update the Recall emulator and add unit and integration regression coverage

Validation:
- pnpm test utils/recall
- RUN_INTEGRATION_TESTS=true pnpm exec vitest --run __tests__/integration/recall-bot-provider.test.ts
- RUN_INTEGRATION_TESTS=true pnpm exec vitest --run __tests__/integration/recall-meeting-lifecycle.test.ts
- pnpm exec ultracite check on the four changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bots scheduled for meetings that have already started now join immediately.
  * Bot cancellation now handles dispatched bots more reliably, including cases where deletion is rejected.
  * Updated error handling provides the appropriate response for bots that cannot be deleted.

* **Tests**
  * Added coverage for immediate joins and cancellation fallback behavior.
  * Improved test reliability by using consistent timestamps and restoring mocked timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->