### PR TITLE
test: mirror Recall past join-time rejection

### DIFF
--- a/apps/web/__tests__/emulators/recall.ts
+++ b/apps/web/__tests__/emulators/recall.ts
@@ -260,11 +260,14 @@ export async function createRecallEmulator({
         body: { meeting_url: ["Not a valid meeting URL."] },
       };
     }
-    if (payload.join_at && new Date(payload.join_at).getTime() <= Date.now()) {
-      return {
-        status: 400,
-        body: { join_at: ["The datetime must be in the future."] },
-      };
+    if (payload.join_at !== undefined) {
+      const joinAt = new Date(payload.join_at).getTime();
+      if (Number.isNaN(joinAt) || joinAt <= Date.now()) {
+        return {
+          status: 400,
+          body: { join_at: ["The datetime must be in the future."] },
+        };
+      }
     }
 
     const bot: RecallEmulatorBot = {

--- a/apps/web/__tests__/emulators/recall.ts
+++ b/apps/web/__tests__/emulators/recall.ts
@@ -260,6 +260,12 @@ export async function createRecallEmulator({
         body: { meeting_url: ["Not a valid meeting URL."] },
       };
     }
+    if (payload.join_at && new Date(payload.join_at).getTime() <= Date.now()) {
+      return {
+        status: 400,
+        body: { join_at: ["The datetime must be in the future."] },
+      };
+    }
 
     const bot: RecallEmulatorBot = {
       id: `bot_${nextId++}`,

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -97,6 +97,39 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(create?.body).not.toHaveProperty("recording_config");
     });
 
+    test("rejects a past join time like Recall", async () => {
+      const response = await fetch(`${emulator.apiBase}/bot/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${emulator.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          meeting_url: "https://meet.google.com/abc-defg-hij",
+          join_at: "2026-05-04T07:55:00.000Z",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        join_at: expect.any(Array),
+      });
+    });
+
+    test("joins an ongoing meeting without scheduling it in the past", async () => {
+      const { externalBotId } = await provider.scheduleBot({
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        joinAt: new Date("2026-05-04T07:55:00.000Z"),
+      });
+
+      expect(emulator.getBot(externalBotId)?.join_at).toBeNull();
+      const create = emulator.requests.find(
+        (request) =>
+          request.method === "POST" && request.path === "/api/v1/bot/",
+      );
+      expect(create?.body).not.toHaveProperty("join_at");
+    });
+
     test("requests async transcription for a finished recording", async () => {
       const { externalBotId } = await provider.scheduleBot({
         meetingUrl: "https://meet.google.com/abc-defg-hij",

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -97,7 +97,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(create?.body).not.toHaveProperty("recording_config");
     });
 
-    test("rejects a past join time like Recall", async () => {
+    test.each([
+      { joinAt: "2026-05-04T07:55:00.000Z", state: "past" },
+      { joinAt: "", state: "empty" },
+      { joinAt: "not-a-date", state: "malformed" },
+    ])("rejects a $state join time like Recall", async ({ joinAt }) => {
       const response = await fetch(`${emulator.apiBase}/bot/`, {
         method: "POST",
         headers: {
@@ -106,7 +110,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         },
         body: JSON.stringify({
           meeting_url: "https://meet.google.com/abc-defg-hij",
-          join_at: "2026-05-04T07:55:00.000Z",
+          join_at: joinAt,
         }),
       });
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260831-195105_pr-3445_3cd5be0483f3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Make the local Recall emulator reject past scheduled join times so it matches the production API behavior learned from the bot-join incident.

- return a 400 response when bot creation includes a past join_at
- cover the emulator contract directly
- verify ongoing meetings are created without join_at through the real provider and emulator

Validation:
- Recall provider integration: 15 passed
- Recall lifecycle integration: 6 passed
- Recall unit suite: 31 passed
- ultracite check on both changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid, empty, malformed, or past join times are now rejected with a clear validation error.
  * Scheduling a bot for a meeting already in progress now starts it immediately instead of sending an invalid join time.

* **Tests**
  * Added coverage for invalid join-time validation and immediate joining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->