### PR TITLE
mail: Show selection shortcuts on hover

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { Button } from "@/components/ui/button";
-import { Kbd } from "@/components/Kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 export type SelectionBarProps = {
   selectedCount: number;
@@ -29,19 +33,27 @@ export function SelectionBar({
 
       <div className="flex-1" />
 
-      <Button onClick={onArchive} size="xs-2" variant="outline">
-        Archive
-        <Kbd className="ml-1.5">{getShortcutHint("archive")}</Kbd>
-      </Button>
-      <Button
-        className="hover:border-destructive/30 hover:bg-destructive/5 hover:text-destructive"
-        onClick={onDelete}
-        size="xs-2"
-        variant="outline"
-      >
-        Delete
-        <Kbd className="ml-1.5">{getShortcutHint("delete")}</Kbd>
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={onArchive} size="xs-2" variant="outline">
+            Archive
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Archive ({getShortcutHint("archive")})</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            className="hover:border-destructive/30 hover:bg-destructive/5 hover:text-destructive"
+            onClick={onDelete}
+            size="xs-2"
+            variant="outline"
+          >
+            Delete
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Delete ({getShortcutHint("delete")})</TooltipContent>
+      </Tooltip>
       <Button onClick={onClear} size="xs-2" variant="ghost">
         Clear
       </Button>


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260831-224854_pr-3446_9136c3481e88/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Removes always-visible keyboard shortcut badges from selection actions while preserving shortcut discoverability on hover and focus.

- Adds accessible tooltips for archive and delete actions
- Keeps button labels compact and unchanged in meaning
- Validated with a focused Ultracite check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Archive and Delete action controls to show keyboard shortcut hints in tooltips.
  * Removed inline shortcut labels for a cleaner selection toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->