### PR TITLE
mail: Refine toolbar action emphasis

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -69,15 +69,16 @@ export function ListToolbar({
       )}
 
       {showLayoutToggle ? (
-        <Tooltip content="Switch list / split view">
+        <Tooltip
+          content={`Switch list / split view (${getShortcutHint("toggleLayout")})`}
+        >
           <button
             type="button"
             onClick={onToggleLayout}
             aria-label="Switch list or split view"
-            className={toolbarButton}
+            className={cn(toolbarButton, "w-8 justify-center px-0")}
           >
             <LayoutIcon className="size-3.5" />
-            <Kbd>{getShortcutHint("toggleLayout")}</Kbd>
           </button>
         </Tooltip>
       ) : null}
@@ -87,7 +88,10 @@ export function ListToolbar({
           type="button"
           onClick={onToggleAssistant}
           aria-label="Toggle the assistant"
-          className={cn(toolbarButton, "px-0 w-8 justify-center")}
+          className={cn(
+            toolbarButton,
+            "w-8 justify-center border-blue-600 bg-blue-600 px-0 text-white hover:border-blue-700 hover:bg-blue-700 hover:text-white dark:border-blue-700 dark:bg-blue-700 dark:hover:border-blue-800 dark:hover:bg-blue-800",
+          )}
         >
           <SparklesIcon className="size-3.5" />
         </button>


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260831-222924_pr-3448_a6d3b7d6a38d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Simplifies the mail toolbar and makes the assistant action easier to discover.

- Moves the layout shortcut hint into its hover tooltip.
- Applies the established blue action styling to the assistant control.
- Validated with the targeted Ultracite check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout toggle to use a compact icon-only button.
  * Added the keyboard shortcut to the layout toggle’s tooltip.
  * Restyled the assistant button with a blue filled appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->