### PR TITLE
mail: Choose accounts for combined mailbox

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
@@ -17,7 +17,24 @@ test("chooses which accounts appear in All Accounts", async ({
       .getByRole("button", { name: /playwright-test\+/i })
       .last()
       .click();
-    await page.getByRole("menuitem", { name: "Choose accounts" }).click();
+    const chooseAccountsMenuItem = page.getByRole("menuitem", {
+      name: "Choose accounts",
+    });
+    await expect(chooseAccountsMenuItem).toBeVisible();
+
+    await page.locator("nextjs-portal").evaluateAll((portals) => {
+      for (const portal of portals) portal.remove();
+    });
+    const menuScreenshot = await page.screenshot({
+      animations: "disabled",
+      path: testInfo.outputPath("all-accounts-menu.png"),
+    });
+    await testInfo.attach("all-accounts-menu", {
+      body: menuScreenshot,
+      contentType: "image/png",
+    });
+
+    await chooseAccountsMenuItem.click();
 
     const dialog = page.getByRole("dialog", { name: "Choose accounts" });
     await expect(dialog).toBeVisible();
@@ -28,9 +45,6 @@ test("chooses which accounts appear in All Accounts", async ({
       dialog.getByRole("checkbox", { name: new RegExp(secondAccount.name) }),
     ).toBeChecked();
 
-    await page.locator("nextjs-portal").evaluateAll((portals) => {
-      for (const portal of portals) portal.remove();
-    });
     const screenshot = await page.screenshot({
       animations: "disabled",
       path: testInfo.outputPath("all-accounts-selection.png"),

--- a/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import {
+  createSecondEmailAccount,
+  deleteSecondEmailAccount,
+} from "./account-test-helpers";
+import { openMail } from "./mail-test-helpers";
+
+test("chooses which accounts appear in All Accounts", async ({
+  page,
+}, testInfo) => {
+  const { emailAccountId } = await openMail(page);
+  const secondAccount = await createSecondEmailAccount(emailAccountId);
+
+  try {
+    await page.reload();
+    await page
+      .getByRole("button", { name: /playwright-test\+/i })
+      .last()
+      .click();
+    await page.getByRole("menuitem", { name: "Choose accounts" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Choose accounts" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Choose accounts" }),
+    ).toBeHidden();
+    await expect(
+      dialog.getByRole("checkbox", { name: new RegExp(secondAccount.name) }),
+    ).toBeChecked();
+
+    await page.locator("nextjs-portal").evaluateAll((portals) => {
+      for (const portal of portals) portal.remove();
+    });
+    const screenshot = await page.screenshot({
+      animations: "disabled",
+      path: testInfo.outputPath("all-accounts-selection.png"),
+    });
+    await testInfo.attach("all-accounts-selection", {
+      body: screenshot,
+      contentType: "image/png",
+    });
+
+    await dialog
+      .getByRole("checkbox", { name: new RegExp(secondAccount.name) })
+      .uncheck();
+    await dialog.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("All Accounts updated", { exact: true }),
+    ).toBeVisible();
+
+    await expect
+      .poll(async () => {
+        const response = await page.request.get("/api/user/email-accounts");
+        const data = (await response.json()) as {
+          emailAccounts: Array<{
+            id: string;
+            includeInAllAccounts: boolean;
+          }>;
+        };
+        return data.emailAccounts.find(
+          (emailAccount) => emailAccount.id === secondAccount.id,
+        )?.includeInAllAccounts;
+      })
+      .toBe(false);
+  } finally {
+    await deleteSecondEmailAccount(secondAccount.accountId);
+  }
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { useAction } from "next-safe-action/hooks";
+import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
+import { ProfileImage } from "@/components/ProfileImage";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { updateAllAccountsSelectionAction } from "@/utils/actions/all-accounts";
+import { getActionErrorMessage } from "@/utils/error";
+
+export function AllAccountsSelectionDialog({
+  emailAccounts,
+  onClose,
+  onSaved,
+}: {
+  emailAccounts: GetEmailAccountsResponse["emailAccounts"];
+  onClose: () => void;
+  onSaved: () => Promise<unknown>;
+}) {
+  const [selectedAccountIds, setSelectedAccountIds] = useState(
+    () =>
+      new Set(
+        emailAccounts
+          .filter((emailAccount) => emailAccount.includeInAllAccounts)
+          .map((emailAccount) => emailAccount.id),
+      ),
+  );
+  const { execute, isExecuting } = useAction(updateAllAccountsSelectionAction, {
+    onSuccess: async () => {
+      await onSaved();
+      toastSuccess({ description: "All Accounts updated" });
+      onClose();
+    },
+    onError: (error) => {
+      toastError({
+        description: getActionErrorMessage(error.error, {
+          prefix: "Couldn't update All Accounts",
+        }),
+      });
+    },
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Choose accounts</DialogTitle>
+          <DialogDescription>
+            Select which inboxes appear in All Accounts. You can still open any
+            account separately. Keep at least one selected.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid max-h-[50vh] gap-1 overflow-y-auto py-2">
+          {emailAccounts.map((emailAccount) => {
+            const checked = selectedAccountIds.has(emailAccount.id);
+            const isOnlySelected = checked && selectedAccountIds.size === 1;
+
+            return (
+              <label
+                className="flex cursor-pointer items-center gap-3 rounded-lg p-2 hover:bg-muted has-[:disabled]:cursor-default has-[:disabled]:opacity-60"
+                htmlFor={`all-accounts-${emailAccount.id}`}
+                key={emailAccount.id}
+              >
+                <Checkbox
+                  id={`all-accounts-${emailAccount.id}`}
+                  checked={checked}
+                  disabled={isExecuting || isOnlySelected}
+                  onCheckedChange={(nextChecked) => {
+                    setSelectedAccountIds((current) => {
+                      const next = new Set(current);
+                      if (nextChecked === true) {
+                        next.add(emailAccount.id);
+                      } else {
+                        next.delete(emailAccount.id);
+                      }
+                      return next;
+                    });
+                  }}
+                />
+                <ProfileImage
+                  className="size-9"
+                  image={emailAccount.image}
+                  label={emailAccount.name || emailAccount.email}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium text-sm">
+                    {emailAccount.name || emailAccount.email}
+                  </span>
+                  {emailAccount.name ? (
+                    <span className="block truncate text-muted-foreground text-xs">
+                      {emailAccount.email}
+                    </span>
+                  ) : null}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isExecuting}>
+            Cancel
+          </Button>
+          <Button
+            loading={isExecuting}
+            onClick={() =>
+              execute({ emailAccountIds: [...selectedAccountIds] })
+            }
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog.tsx
@@ -56,8 +56,7 @@ export function AllAccountsSelectionDialog({
         <DialogHeader>
           <DialogTitle>Choose accounts</DialogTitle>
           <DialogDescription>
-            Select which inboxes appear in All Accounts. You can still open any
-            account separately. Keep at least one selected.
+            Choose which accounts appear in All Accounts.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import Link from "next/link";
-import { ChevronsUpDownIcon, PlusIcon } from "lucide-react";
+import {
+  ChevronsUpDownIcon,
+  PlusIcon,
+  SlidersHorizontalIcon,
+} from "lucide-react";
 import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
+import { AllAccountsSelectionDialog } from "@/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog";
 import { ProfileImage } from "@/components/ProfileImage";
 import {
   DropdownMenu,
@@ -26,8 +31,9 @@ export function MailAccountSwitcher({
   onSelectAll: () => void;
   variant: "compact" | "sidebar";
 }) {
-  const { data } = useAccounts();
+  const { data, mutate } = useAccounts();
   const { emailAccount } = useAccount();
+  const [isSelectionOpen, setIsSelectionOpen] = useState(false);
 
   if (!data) return null;
 
@@ -93,13 +99,25 @@ export function MailAccountSwitcher({
           sideOffset={8}
         >
           {data.emailAccounts.length > 1 ? (
-            <DropdownMenuItem
-              className="gap-3 rounded-xl p-3"
-              onSelect={onSelectAll}
-            >
-              <AllAccountsIcon />
-              <span className="font-medium">All accounts</span>
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem
+                className="gap-3 rounded-xl p-3"
+                onSelect={onSelectAll}
+              >
+                <AllAccountsIcon />
+                <span className="font-medium">All accounts</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-3 rounded-xl px-3 py-2 text-muted-foreground"
+                onSelect={() => setIsSelectionOpen(true)}
+              >
+                <span className="flex size-8 items-center justify-center">
+                  <SlidersHorizontalIcon className="size-4" />
+                </span>
+                <span className="font-medium text-sm">Choose accounts</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
           ) : null}
           {data.emailAccounts.map((account) => (
             <AccountItem account={account} key={account.id} />
@@ -117,6 +135,13 @@ export function MailAccountSwitcher({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      {isSelectionOpen ? (
+        <AllAccountsSelectionDialog
+          emailAccounts={data.emailAccounts}
+          onClose={() => setIsSelectionOpen(false)}
+          onSaved={mutate}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -17,6 +17,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useAccounts } from "@/hooks/useAccounts";
 import { cn } from "@/utils";
@@ -100,22 +105,27 @@ export function MailAccountSwitcher({
         >
           {data.emailAccounts.length > 1 ? (
             <>
-              <DropdownMenuItem
-                className="gap-3 rounded-xl p-3"
-                onSelect={onSelectAll}
-              >
-                <AllAccountsIcon />
-                <span className="font-medium">All accounts</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="gap-3 rounded-xl px-3 py-2 text-muted-foreground"
-                onSelect={() => setIsSelectionOpen(true)}
-              >
-                <span className="flex size-8 items-center justify-center">
-                  <SlidersHorizontalIcon className="size-4" />
-                </span>
-                <span className="font-medium text-sm">Choose accounts</span>
-              </DropdownMenuItem>
+              <div className="flex items-stretch gap-1">
+                <DropdownMenuItem
+                  className="min-w-0 flex-1 gap-3 rounded-xl p-3"
+                  onSelect={onSelectAll}
+                >
+                  <AllAccountsIcon />
+                  <span className="font-medium">All accounts</span>
+                </DropdownMenuItem>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuItem
+                      aria-label="Choose accounts"
+                      className="w-10 justify-center rounded-xl p-0 text-muted-foreground"
+                      onSelect={() => setIsSelectionOpen(true)}
+                    >
+                      <SlidersHorizontalIcon />
+                    </DropdownMenuItem>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">Choose accounts</TooltipContent>
+                </Tooltip>
+              </div>
               <DropdownMenuSeparator />
             </>
           ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -182,12 +182,18 @@ export function MailShell() {
   );
   const combinedAccounts = useMemo(
     () =>
-      (accountsData?.emailAccounts ?? []).map(({ id, email, name, image }) => ({
-        id,
-        email,
-        name,
-        image,
-      })),
+      (accountsData?.emailAccounts ?? [])
+        .filter(
+          (emailAccount) =>
+            emailAccount.includeInAllAccounts &&
+            emailAccount.account.disconnectedAt === null,
+        )
+        .map(({ id, email, name, image }) => ({
+          id,
+          email,
+          name,
+          image,
+        })),
     [accountsData?.emailAccounts],
   );
   const accountLayout: MailLayoutMode =

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -109,10 +109,11 @@ export function useCombinedMailThreads({
     () =>
       createThreadListCacheKey({
         scope: "combined",
+        accountIdentity,
         isUnread: isUnread || undefined,
         labelName,
       }),
-    [isUnread, labelName],
+    [accountIdentity, isUnread, labelName],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
   const { fetcher } = useSWRConfig();
@@ -126,6 +127,7 @@ export function useCombinedMailThreads({
         return null;
       }
       const params = createSearchParams({
+        accountSet: accountIdentity,
         limit: COMBINED_PAGE_SIZE,
         isUnread: isUnread || undefined,
         labelName,
@@ -133,7 +135,7 @@ export function useCombinedMailThreads({
       });
       return `/api/threads/all?${params.toString()}`;
     },
-    [enabled, isUnread, labelName],
+    [accountIdentity, enabled, isUnread, labelName],
   );
   const fetchCombinedPage = useCallback(
     async (key: string) => {

--- a/apps/web/app/api/threads/all/route.test.ts
+++ b/apps/web/app/api/threads/all/route.test.ts
@@ -78,6 +78,7 @@ describe("GET /api/threads/all", () => {
 
     expect(getConnectedEmailAccountsMock).toHaveBeenCalledWith({
       userId: "user-1",
+      includeInAllAccounts: true,
     });
     expect(createEmailProviderMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -29,6 +29,7 @@ export const GET = withAuth("threads/all", async (request) => {
   );
   const accounts = await getConnectedEmailAccounts({
     userId: request.auth.userId,
+    includeInAllAccounts: true,
   });
   const result = await loadCombinedThreads({
     accounts,

--- a/apps/web/app/api/user/email-accounts/route.ts
+++ b/apps/web/app/api/user/email-accounts/route.ts
@@ -27,6 +27,7 @@ async function getEmailAccounts({ userId }: { userId: string }) {
       accountId: true,
       name: true,
       image: true,
+      includeInAllAccounts: true,
       account: {
         select: {
           disconnectedAt: true,

--- a/apps/web/prisma/migrations/20260901000000_add_all_accounts_preference/migration.sql
+++ b/apps/web/prisma/migrations/20260901000000_add_all_accounts_preference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN "includeInAllAccounts" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -159,6 +159,8 @@ model EmailAccount {
 
   mailLayout MailLayout @default(LIST)
 
+  includeInAllAccounts Boolean @default(true)
+
   meetingBriefingsEnabled       Boolean @default(false)
   meetingBriefingsMinutesBefore Int     @default(240) // 4 hours in minutes
   meetingBriefsSendEmail        Boolean @default(true)

--- a/apps/web/utils/actions/all-accounts.test.ts
+++ b/apps/web/utils/actions/all-accounts.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { updateAllAccountsSelectionAction } from "./all-accounts";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+describe("updateAllAccountsSelectionAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findMany.mockResolvedValue([
+      { id: "account-1" },
+      { id: "account-2" },
+      { id: "account-3" },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.emailAccount.updateMany.mockResolvedValue({ count: 1 });
+    prisma.$transaction.mockResolvedValue([]);
+  });
+
+  it("includes only the selected accounts owned by the user", async () => {
+    const result = await updateAllAccountsSelectionAction({
+      emailAccountIds: ["account-1", "account-3"],
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.emailAccount.updateMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        userId: "user-1",
+        id: { in: ["account-1", "account-3"] },
+      },
+      data: { includeInAllAccounts: true },
+    });
+    expect(prisma.emailAccount.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        userId: "user-1",
+        id: { notIn: ["account-1", "account-3"] },
+      },
+      data: { includeInAllAccounts: false },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an account that does not belong to the user", async () => {
+    const result = await updateAllAccountsSelectionAction({
+      emailAccountIds: ["account-1", "another-user-account"],
+    });
+
+    expect(result?.serverError).toBe("Email account not found");
+    expect(prisma.emailAccount.updateMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("requires at least one account", async () => {
+    const result = await updateAllAccountsSelectionAction({
+      emailAccountIds: [],
+    });
+
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.emailAccount.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/all-accounts.ts
+++ b/apps/web/utils/actions/all-accounts.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { actionClientUser } from "@/utils/actions/safe-action";
+import { updateAllAccountsSelectionBody } from "@/utils/actions/all-accounts.validation";
+import { SafeError } from "@/utils/error";
+import prisma from "@/utils/prisma";
+
+export const updateAllAccountsSelectionAction = actionClientUser
+  .metadata({ name: "updateAllAccountsSelection" })
+  .inputSchema(updateAllAccountsSelectionBody)
+  .action(async ({ ctx: { userId }, parsedInput: { emailAccountIds } }) => {
+    const emailAccounts = await prisma.emailAccount.findMany({
+      where: { userId },
+      select: { id: true },
+    });
+    const ownedAccountIds = new Set(
+      emailAccounts.map((emailAccount) => emailAccount.id),
+    );
+
+    if (emailAccountIds.some((id) => !ownedAccountIds.has(id))) {
+      throw new SafeError("Email account not found");
+    }
+
+    await prisma.$transaction([
+      prisma.emailAccount.updateMany({
+        where: { userId, id: { in: emailAccountIds } },
+        data: { includeInAllAccounts: true },
+      }),
+      prisma.emailAccount.updateMany({
+        where: { userId, id: { notIn: emailAccountIds } },
+        data: { includeInAllAccounts: false },
+      }),
+    ]);
+  });

--- a/apps/web/utils/actions/all-accounts.validation.ts
+++ b/apps/web/utils/actions/all-accounts.validation.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const updateAllAccountsSelectionBody = z.object({
+  emailAccountIds: z.array(z.string()).min(1),
+});

--- a/apps/web/utils/email/connected-accounts.test.ts
+++ b/apps/web/utils/email/connected-accounts.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { getConnectedEmailAccounts } from "./connected-accounts";
+
+vi.mock("@/utils/prisma");
+
+describe("getConnectedEmailAccounts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findMany.mockResolvedValue([]);
+  });
+
+  it("loads only accounts included in the combined mailbox", async () => {
+    await getConnectedEmailAccounts({
+      userId: "user-1",
+      includeInAllAccounts: true,
+    });
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user-1",
+          includeInAllAccounts: true,
+          account: { disconnectedAt: null },
+        },
+      }),
+    );
+  });
+
+  it("allows a specific account lookup regardless of the combined mailbox preference", async () => {
+    await getConnectedEmailAccounts({
+      userId: "user-1",
+      accountId: "account-1",
+    });
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "account-1",
+          userId: "user-1",
+          account: { disconnectedAt: null },
+        },
+      }),
+    );
+  });
+});

--- a/apps/web/utils/email/connected-accounts.ts
+++ b/apps/web/utils/email/connected-accounts.ts
@@ -3,13 +3,16 @@ import prisma from "@/utils/prisma";
 export async function getConnectedEmailAccounts({
   userId,
   accountId,
+  includeInAllAccounts,
 }: {
   userId: string;
   accountId?: string;
+  includeInAllAccounts?: boolean;
 }) {
   const accounts = await prisma.emailAccount.findMany({
     where: {
       ...(accountId ? { id: accountId } : {}),
+      ...(includeInAllAccounts ? { includeInAllAccounts: true } : {}),
       userId,
       account: { disconnectedAt: null },
     },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260831-232945_pr-3449_a8377616f4a9/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a persisted account selection for the combined mailbox while keeping direct account switching unchanged.

- Adds a compact account-selection dialog and a default-on database preference.
- Applies the selection to server fetching and local cache identities.
- Validated with focused tests, lint, Prisma validation, and the server-action export check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added account selection for the “All Accounts” mailbox.
  - Users can choose which connected email accounts appear in the combined view.
  - Added save confirmation and error feedback when updating selections.

- **Bug Fixes**
  - Disconnected or excluded accounts no longer appear in the combined mailbox.
  - Combined mailbox results refresh correctly after selection changes.
  - Prevented users from deselecting the final included account.
  - Account selections now persist reliably across mailbox views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->