### PR TITLE
mail: Add standard default inbox splits

### DIFF
--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -1,17 +1,12 @@
 import { Client } from "pg";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "vitest";
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
 import {
   ActionType,
   MailSplitKind,
   SystemType,
 } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
 
@@ -19,18 +14,9 @@ describe.skipIf(!RUN_DB_TESTS)(
   "default mail splits (real database)",
   { timeout: 30_000 },
   () => {
-    let prisma: typeof import("@/utils/prisma").default;
-    let seedDefaultMailSplits: typeof import("@/utils/mail/default-splits.server").seedDefaultMailSplits;
     let emailAccountId: string;
 
     const accountEmail = "default-mail-splits-test@example.com";
-
-    beforeAll(async () => {
-      prisma = (await import("@/utils/prisma")).default;
-      ({ seedDefaultMailSplits } = await import(
-        "@/utils/mail/default-splits.server"
-      ));
-    });
 
     beforeEach(async () => {
       await prisma.user.deleteMany({ where: { email: accountEmail } });

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -1,0 +1,129 @@
+import { Client } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import {
+  ActionType,
+  MailSplitKind,
+  SystemType,
+} from "@/generated/prisma/enums";
+
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
+
+describe.skipIf(!RUN_DB_TESTS)(
+  "default mail splits (real database)",
+  { timeout: 30_000 },
+  () => {
+    let prisma: typeof import("@/utils/prisma").default;
+    let seedDefaultMailSplits: typeof import("@/utils/mail/default-splits.server").seedDefaultMailSplits;
+    let emailAccountId: string;
+
+    const accountEmail = "default-mail-splits-test@example.com";
+
+    beforeAll(async () => {
+      prisma = (await import("@/utils/prisma")).default;
+      ({ seedDefaultMailSplits } = await import(
+        "@/utils/mail/default-splits.server"
+      ));
+    });
+
+    beforeEach(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+
+      const user = await prisma.user.create({ data: { email: accountEmail } });
+      const account = await prisma.account.create({
+        data: {
+          userId: user.id,
+          provider: "google",
+          providerAccountId: accountEmail,
+          type: "oauth",
+        },
+      });
+      const emailAccount = await prisma.emailAccount.create({
+        data: { email: accountEmail, userId: user.id, accountId: account.id },
+      });
+      emailAccountId = emailAccount.id;
+    });
+
+    afterAll(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+    });
+
+    test("preserves a saved split created while default initialization waits", async () => {
+      const lockClient = new Client({
+        connectionString: process.env.DATABASE_URL,
+      });
+      await lockClient.connect();
+      await lockClient.query("BEGIN");
+
+      try {
+        await lockClient.query(
+          "SELECT pg_advisory_xact_lock(742931, hashtext($1))",
+          [emailAccountId],
+        );
+        await lockClient.query(
+          `INSERT INTO "MailSplit" (
+            "id", "createdAt", "updatedAt", "name", "kind", "order", "emailAccountId"
+          ) VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, $3, 0, $4)`,
+          [
+            "concurrent-saved-split",
+            "Saved",
+            MailSplitKind.UNREAD,
+            emailAccountId,
+          ],
+        );
+
+        const seeding = seedDefaultMailSplits({
+          emailAccountId,
+          rules: [
+            {
+              systemType: SystemType.RECEIPT,
+              actions: [{ type: ActionType.LABEL, labelId: "receipt-label" }],
+            },
+          ],
+        });
+
+        await waitForSeederLock(lockClient);
+        await lockClient.query("COMMIT");
+        await seeding;
+      } catch (error) {
+        await lockClient.query("ROLLBACK");
+        throw error;
+      } finally {
+        await lockClient.end();
+      }
+
+      const splits = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+      });
+
+      expect(splits).toHaveLength(1);
+      expect(splits[0]?.id).toBe("concurrent-saved-split");
+    });
+  },
+);
+
+async function waitForSeederLock(client: Client) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const result = await client.query<{ waiting: boolean }>(`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND wait_event_type = 'Lock'
+          AND wait_event = 'advisory'
+          AND query LIKE '%pg_advisory_xact_lock(742931%'
+      ) AS waiting
+    `);
+    if (result.rows[0]?.waiting) return;
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error("Default split seeder did not wait for the account lock");
+}

--- a/apps/web/prisma/migrations/20260901010000_seed_default_mail_splits/migration.sql
+++ b/apps/web/prisma/migrations/20260901010000_seed_default_mail_splits/migration.sql
@@ -1,0 +1,76 @@
+WITH "standardRuleLabels" AS (
+  SELECT DISTINCT ON (r."emailAccountId", r."systemType")
+    r."id" AS "ruleId",
+    r."emailAccountId",
+    r."systemType",
+    COALESCE(a."label", r."name") AS "name",
+    a."labelId" AS "value",
+    CASE r."systemType"
+      WHEN 'TO_REPLY' THEN 0
+      WHEN 'NEWSLETTER' THEN 1
+      WHEN 'MARKETING' THEN 2
+      WHEN 'CALENDAR' THEN 3
+      WHEN 'RECEIPT' THEN 4
+      WHEN 'NOTIFICATION' THEN 5
+      WHEN 'COLD_EMAIL' THEN 6
+    END AS "standardOrder"
+  FROM "Rule" AS r
+  INNER JOIN "Action" AS a
+    ON a."ruleId" = r."id"
+    AND a."emailAccountId" = r."emailAccountId"
+  WHERE r."systemType" IN (
+    'TO_REPLY',
+    'NEWSLETTER',
+    'MARKETING',
+    'CALENDAR',
+    'RECEIPT',
+    'NOTIFICATION',
+    'COLD_EMAIL'
+  )
+    AND r."enabled" = true
+    AND a."type" = 'LABEL'
+    AND a."labelId" IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "Action" AS moves_out_of_inbox
+      WHERE moves_out_of_inbox."ruleId" = r."id"
+        AND moves_out_of_inbox."emailAccountId" = r."emailAccountId"
+        AND moves_out_of_inbox."type" IN ('ARCHIVE', 'MOVE_FOLDER')
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "MailSplit" AS existing
+      WHERE existing."emailAccountId" = r."emailAccountId"
+    )
+  ORDER BY r."emailAccountId", r."systemType", a."createdAt"
+),
+"rankedSplits" AS (
+  SELECT
+    *,
+    (ROW_NUMBER() OVER (
+      PARTITION BY "emailAccountId"
+      ORDER BY "standardOrder"
+    ) - 1)::integer AS "splitOrder"
+  FROM "standardRuleLabels"
+)
+INSERT INTO "MailSplit" (
+  "id",
+  "createdAt",
+  "updatedAt",
+  "name",
+  "kind",
+  "value",
+  "order",
+  "emailAccountId"
+)
+SELECT
+  CONCAT('default-split-', "ruleId"),
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  "name",
+  'LABEL'::"MailSplitKind",
+  "value",
+  "splitOrder",
+  "emailAccountId"
+FROM "rankedSplits"
+ON CONFLICT DO NOTHING;

--- a/apps/web/prisma/migrations/20260901010000_seed_default_mail_splits/migration.sql
+++ b/apps/web/prisma/migrations/20260901010000_seed_default_mail_splits/migration.sql
@@ -1,3 +1,50 @@
+BEGIN;
+
+CREATE TEMP TABLE "DefaultMailSplitAccount" ON COMMIT DROP AS
+SELECT DISTINCT r."emailAccountId"
+FROM "Rule" AS r
+INNER JOIN "Action" AS a
+  ON a."ruleId" = r."id"
+  AND a."emailAccountId" = r."emailAccountId"
+WHERE r."systemType" IN (
+  'TO_REPLY',
+  'NEWSLETTER',
+  'MARKETING',
+  'CALENDAR',
+  'RECEIPT',
+  'NOTIFICATION',
+  'COLD_EMAIL'
+)
+  AND r."enabled" = true
+  AND a."type" = 'LABEL'
+  AND a."labelId" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "Action" AS moves_out_of_inbox
+    WHERE moves_out_of_inbox."ruleId" = r."id"
+      AND moves_out_of_inbox."emailAccountId" = r."emailAccountId"
+      AND moves_out_of_inbox."type" IN ('ARCHIVE', 'MOVE_FOLDER')
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "MailSplit" AS existing
+    WHERE existing."emailAccountId" = r."emailAccountId"
+  );
+
+-- Serialize the backfill with live split creation for each eligible account.
+DO $$
+DECLARE
+  account RECORD;
+BEGIN
+  FOR account IN
+    SELECT "emailAccountId"
+    FROM "DefaultMailSplitAccount"
+    ORDER BY "emailAccountId"
+  LOOP
+    PERFORM pg_advisory_xact_lock(742931, hashtext(account."emailAccountId"));
+  END LOOP;
+END $$;
+
 WITH "standardRuleLabels" AS (
   SELECT DISTINCT ON (r."emailAccountId", r."systemType")
     r."id" AS "ruleId",
@@ -15,6 +62,8 @@ WITH "standardRuleLabels" AS (
       WHEN 'COLD_EMAIL' THEN 6
     END AS "standardOrder"
   FROM "Rule" AS r
+  INNER JOIN "DefaultMailSplitAccount" AS target
+    ON target."emailAccountId" = r."emailAccountId"
   INNER JOIN "Action" AS a
     ON a."ruleId" = r."id"
     AND a."emailAccountId" = r."emailAccountId"
@@ -74,3 +123,5 @@ SELECT
   "emailAccountId"
 FROM "rankedSplits"
 ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -15,6 +15,7 @@ import {
 } from "@/utils/actions/mail-split.validation";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
+import { lockMailSplits } from "@/utils/mail/split-lock";
 
 const MAX_SPLITS = 12;
 
@@ -193,13 +194,4 @@ async function createMailSplit({
   ]);
 
   return results[0];
-}
-
-function lockMailSplits(emailAccountId: string) {
-  return prisma.$queryRaw`
-    SELECT true AS locked
-    FROM (
-      SELECT pg_advisory_xact_lock(742931, hashtext(${emailAccountId}))
-    ) lock
-  `;
 }

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -43,6 +43,7 @@ import {
   getSystemRuleActionTypes,
   getCategoryAction,
   getActionTypesForCategoryAction,
+  STANDARD_CATEGORY_SYSTEM_TYPES,
 } from "@/utils/rule/consts";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
 import { assertRuleIsNotOrgManaged } from "@/utils/organizations/rules";
@@ -59,6 +60,7 @@ import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
 import { toCreateOrUpdateRuleCondition } from "@/utils/rule/create-rule-condition";
+import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
@@ -347,6 +349,7 @@ export const createRulesOnboardingAction = actionClient
       if (!emailAccount) throw new SafeError("User not found");
 
       const promises: Promise<unknown>[] = [];
+      const systemRulePromises: Array<ReturnType<typeof upsertSystemRule>> = [];
 
       const isSet = (
         value: string | undefined | null,
@@ -391,6 +394,7 @@ export const createRulesOnboardingAction = actionClient
           });
         })();
 
+        systemRulePromises.push(promise);
         promises.push(promise);
       }
 
@@ -411,17 +415,7 @@ export const createRulesOnboardingAction = actionClient
       }
 
       // Process system rules
-      const systemRules = [
-        SystemType.TO_REPLY,
-        SystemType.NEWSLETTER,
-        SystemType.MARKETING,
-        SystemType.CALENDAR,
-        SystemType.RECEIPT,
-        SystemType.NOTIFICATION,
-        SystemType.COLD_EMAIL,
-      ];
-
-      for (const type of systemRules) {
+      for (const type of STANDARD_CATEGORY_SYSTEM_TYPES) {
         const config = systemCategoryMap.get(type);
         if (config && isSet(config.action)) {
           createSystemRuleForOnboarding(type, config.action);
@@ -484,6 +478,18 @@ export const createRulesOnboardingAction = actionClient
       }
 
       await Promise.allSettled(promises);
+
+      const systemRuleResults = await Promise.allSettled(systemRulePromises);
+      try {
+        await seedDefaultMailSplits({
+          emailAccountId,
+          rules: systemRuleResults.flatMap((result) =>
+            result.status === "fulfilled" ? [result.value] : [],
+          ),
+        });
+      } catch (error) {
+        logger.error("Error creating default mail splits", { error });
+      }
 
       after(() =>
         bulkProcessInboxEmails({

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -349,7 +349,9 @@ export const createRulesOnboardingAction = actionClient
       if (!emailAccount) throw new SafeError("User not found");
 
       const promises: Promise<unknown>[] = [];
-      const systemRulePromises: Array<ReturnType<typeof upsertSystemRule>> = [];
+      const defaultSplitRulePromises: Array<
+        ReturnType<typeof upsertSystemRule>
+      > = [];
 
       const isSet = (
         value: string | undefined | null,
@@ -394,8 +396,9 @@ export const createRulesOnboardingAction = actionClient
           });
         })();
 
-        systemRulePromises.push(promise);
         promises.push(promise);
+
+        return promise;
       }
 
       async function deleteRule(
@@ -418,7 +421,9 @@ export const createRulesOnboardingAction = actionClient
       for (const type of STANDARD_CATEGORY_SYSTEM_TYPES) {
         const config = systemCategoryMap.get(type);
         if (config && isSet(config.action)) {
-          createSystemRuleForOnboarding(type, config.action);
+          defaultSplitRulePromises.push(
+            createSystemRuleForOnboarding(type, config.action),
+          );
         } else {
           deleteRule(type, emailAccountId);
         }
@@ -479,13 +484,11 @@ export const createRulesOnboardingAction = actionClient
 
       await Promise.allSettled(promises);
 
-      const systemRuleResults = await Promise.allSettled(systemRulePromises);
       try {
+        const systemRules = await Promise.all(defaultSplitRulePromises);
         await seedDefaultMailSplits({
           emailAccountId,
-          rules: systemRuleResults.flatMap((result) =>
-            result.status === "fulfilled" ? [result.value] : [],
-          ),
+          rules: systemRules,
         });
       } catch (error) {
         logger.error("Error creating default mail splits", { error });

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ActionType,
+  MailSplitKind,
+  SystemType,
+} from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
+
+vi.mock("@/utils/prisma");
+
+describe("seedDefaultMailSplits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("seeds standard rule labels for an account without saved splits", async () => {
+    prisma.mailSplit.count.mockResolvedValue(0);
+
+    await seedDefaultMailSplits({
+      emailAccountId: "account-id",
+      rules: [rule(SystemType.RECEIPT, "receipt-label")],
+    });
+
+    expect(prisma.mailSplit.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          emailAccountId: "account-id",
+          name: "Receipt",
+          kind: MailSplitKind.LABEL,
+          value: "receipt-label",
+          order: 0,
+        },
+      ],
+      skipDuplicates: true,
+    });
+  });
+
+  it("preserves an account's existing split configuration", async () => {
+    prisma.mailSplit.count.mockResolvedValue(1);
+
+    await seedDefaultMailSplits({
+      emailAccountId: "account-id",
+      rules: [rule(SystemType.RECEIPT, "receipt-label")],
+    });
+
+    expect(prisma.mailSplit.createMany).not.toHaveBeenCalled();
+  });
+});
+
+function rule(systemType: SystemType, labelId: string) {
+  return {
+    systemType,
+    actions: [{ type: ActionType.LABEL, labelId }],
+  };
+}

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ActionType,
-  MailSplitKind,
-  SystemType,
-} from "@/generated/prisma/enums";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
 
@@ -15,36 +11,39 @@ describe("seedDefaultMailSplits", () => {
   });
 
   it("seeds standard rule labels for an account without saved splits", async () => {
-    prisma.mailSplit.count.mockResolvedValue(0);
+    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
 
     await seedDefaultMailSplits({
       emailAccountId: "account-id",
       rules: [rule(SystemType.RECEIPT, "receipt-label")],
     });
 
-    expect(prisma.mailSplit.createMany).toHaveBeenCalledWith({
-      data: [
-        {
-          emailAccountId: "account-id",
-          name: "Receipt",
-          kind: MailSplitKind.LABEL,
-          value: "receipt-label",
-          order: 0,
-        },
-      ],
-      skipDuplicates: true,
-    });
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining("pg_advisory_xact_lock"),
+      ]),
+      "account-id",
+    );
+    expect(prisma.$executeRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining("WHERE NOT EXISTS")]),
+      "account-id",
+      expect.any(String),
+      "account-id",
+    );
   });
 
-  it("preserves an account's existing split configuration", async () => {
-    prisma.mailSplit.count.mockResolvedValue(1);
-
+  it("does not access the database when no rule can produce an inbox split", async () => {
     await seedDefaultMailSplits({
       emailAccountId: "account-id",
-      rules: [rule(SystemType.RECEIPT, "receipt-label")],
+      rules: [
+        {
+          systemType: SystemType.RECEIPT,
+          actions: [{ type: ActionType.MOVE_FOLDER, labelId: null }],
+        },
+      ],
     });
 
-    expect(prisma.mailSplit.createMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -1,0 +1,27 @@
+import prisma from "@/utils/prisma";
+import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
+
+export async function seedDefaultMailSplits({
+  emailAccountId,
+  rules,
+}: {
+  emailAccountId: string;
+  rules: Parameters<typeof getDefaultMailSplitDrafts>[0];
+}) {
+  const defaultSplits = getDefaultMailSplitDrafts(rules);
+  if (defaultSplits.length === 0) return;
+
+  const existingSplitCount = await prisma.mailSplit.count({
+    where: { emailAccountId },
+  });
+  if (existingSplitCount > 0) return;
+
+  await prisma.mailSplit.createMany({
+    data: defaultSplits.map((split, order) => ({
+      ...split,
+      emailAccountId,
+      order,
+    })),
+    skipDuplicates: true,
+  });
+}

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "node:crypto";
 import prisma from "@/utils/prisma";
 import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
+import { lockMailSplits } from "@/utils/mail/split-lock";
 
 export async function seedDefaultMailSplits({
   emailAccountId,
@@ -11,17 +13,47 @@ export async function seedDefaultMailSplits({
   const defaultSplits = getDefaultMailSplitDrafts(rules);
   if (defaultSplits.length === 0) return;
 
-  const existingSplitCount = await prisma.mailSplit.count({
-    where: { emailAccountId },
-  });
-  if (existingSplitCount > 0) return;
+  const rows = defaultSplits.map((split, order) => ({
+    id: randomUUID(),
+    ...split,
+    order,
+  }));
 
-  await prisma.mailSplit.createMany({
-    data: defaultSplits.map((split, order) => ({
-      ...split,
-      emailAccountId,
-      order,
-    })),
-    skipDuplicates: true,
-  });
+  await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$executeRaw`
+      INSERT INTO "MailSplit" (
+        "id",
+        "createdAt",
+        "updatedAt",
+        "name",
+        "kind",
+        "value",
+        "order",
+        "emailAccountId"
+      )
+      SELECT
+        defaults."id",
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP,
+        defaults."name",
+        defaults."kind"::"MailSplitKind",
+        defaults."value",
+        defaults."order",
+        ${emailAccountId}
+      FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb) AS defaults(
+        "id" text,
+        "name" text,
+        "kind" text,
+        "value" text,
+        "order" integer
+      )
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM "MailSplit"
+        WHERE "emailAccountId" = ${emailAccountId}
+      )
+      ON CONFLICT DO NOTHING
+    `,
+  ]);
 }

--- a/apps/web/utils/mail/default-splits.test.ts
+++ b/apps/web/utils/mail/default-splits.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  ActionType,
+  MailSplitKind,
+  SystemType,
+} from "@/generated/prisma/enums";
+import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
+
+describe("getDefaultMailSplitDrafts", () => {
+  it("creates label splits for the standard category rules in their standard order", () => {
+    const rules = [
+      rule(SystemType.RECEIPT, "receipt-label"),
+      rule(SystemType.FYI, "fyi-label"),
+      rule(SystemType.TO_REPLY, "reply-label"),
+      rule(SystemType.NEWSLETTER, "newsletter-label"),
+      rule(null, "custom-label"),
+    ];
+
+    expect(getDefaultMailSplitDrafts(rules)).toEqual([
+      {
+        name: "To Reply",
+        kind: MailSplitKind.LABEL,
+        value: "reply-label",
+      },
+      {
+        name: "Newsletter",
+        kind: MailSplitKind.LABEL,
+        value: "newsletter-label",
+      },
+      {
+        name: "Receipt",
+        kind: MailSplitKind.LABEL,
+        value: "receipt-label",
+      },
+    ]);
+  });
+
+  it("skips standard rules without a resolved inbox label action", () => {
+    const rules = [
+      rule(SystemType.NEWSLETTER, null, ActionType.MOVE_FOLDER),
+      rule(SystemType.RECEIPT, null),
+      {
+        ...rule(SystemType.MARKETING, "marketing-label"),
+        actions: [
+          { type: ActionType.LABEL, labelId: "marketing-label" },
+          { type: ActionType.ARCHIVE, labelId: null },
+        ],
+      },
+      rule(SystemType.NOTIFICATION, "notification-label"),
+    ];
+
+    expect(getDefaultMailSplitDrafts(rules)).toEqual([
+      {
+        name: "Notification",
+        kind: MailSplitKind.LABEL,
+        value: "notification-label",
+      },
+    ]);
+  });
+});
+
+function rule(
+  systemType: SystemType | null,
+  labelId: string | null,
+  type = ActionType.LABEL,
+) {
+  return {
+    systemType,
+    actions: [{ type, labelId }],
+  };
+}

--- a/apps/web/utils/mail/default-splits.ts
+++ b/apps/web/utils/mail/default-splits.ts
@@ -1,0 +1,47 @@
+import {
+  ActionType,
+  MailSplitKind,
+  type SystemType,
+} from "@/generated/prisma/enums";
+import {
+  getRuleLabel,
+  STANDARD_CATEGORY_SYSTEM_TYPES,
+} from "@/utils/rule/consts";
+
+type RuleForDefaultSplit = {
+  systemType: SystemType | null;
+  actions: Array<{
+    type: ActionType;
+    labelId: string | null;
+  }>;
+};
+
+export function getDefaultMailSplitDrafts(rules: RuleForDefaultSplit[]) {
+  const rulesBySystemType = new Map(
+    rules.flatMap((rule) =>
+      rule.systemType ? [[rule.systemType, rule] as const] : [],
+    ),
+  );
+
+  return STANDARD_CATEGORY_SYSTEM_TYPES.flatMap((systemType) => {
+    const rule = rulesBySystemType.get(systemType);
+    const movesOutOfInbox = rule?.actions.some(
+      (action) =>
+        action.type === ActionType.ARCHIVE ||
+        action.type === ActionType.MOVE_FOLDER,
+    );
+    const labelId = rule?.actions.find(
+      (action) => action.type === ActionType.LABEL && action.labelId,
+    )?.labelId;
+
+    return labelId && !movesOutOfInbox
+      ? [
+          {
+            name: getRuleLabel(systemType),
+            kind: MailSplitKind.LABEL,
+            value: labelId,
+          },
+        ]
+      : [];
+  });
+}

--- a/apps/web/utils/mail/split-lock.ts
+++ b/apps/web/utils/mail/split-lock.ts
@@ -1,0 +1,10 @@
+import prisma from "@/utils/prisma";
+
+export function lockMailSplits(emailAccountId: string) {
+  return prisma.$queryRaw`
+    SELECT true AS locked
+    FROM (
+      SELECT pg_advisory_xact_lock(742931, hashtext(${emailAccountId}))
+    ) lock
+  `;
+}

--- a/apps/web/utils/rule/consts.ts
+++ b/apps/web/utils/rule/consts.ts
@@ -3,6 +3,16 @@ import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { ActionType, SystemType } from "@/generated/prisma/enums";
 import { env } from "@/env";
 
+export const STANDARD_CATEGORY_SYSTEM_TYPES = [
+  SystemType.TO_REPLY,
+  SystemType.NEWSLETTER,
+  SystemType.MARKETING,
+  SystemType.CALENDAR,
+  SystemType.RECEIPT,
+  SystemType.NOTIFICATION,
+  SystemType.COLD_EMAIL,
+] as const;
+
 const ruleConfig: Record<
   SystemType,
   {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260831-223411_pr-3450_106c07f40f59/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Seeds default mail splits from enabled standard rules that keep messages in the inbox.

- Preserves existing split configurations and backfills untouched accounts.
- Adds focused coverage for split selection, ordering, and persistence.
- Validated with focused tests, lint, and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic default mail splits for standard categories during account setup.
  * Creates label-based splits for To Reply, Newsletter, Marketing, Calendar, Receipts, Notifications, and Cold Email.
  * Skips rules that archive or move messages out of the inbox.

* **Bug Fixes**
  * Preserves existing custom mail splits.
  * Prevents duplicate defaults during concurrent updates.

* **Tests**
  * Added coverage for creation, ordering, filtering, duplicate prevention, and concurrent preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->