### PR TITLE
mail: Hide system category labels

### DIFF
--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -5,6 +5,24 @@ import {
 } from "./EmailMessageCellLabels";
 
 describe("getEmailMessageCellLabels", () => {
+  it("hides Gmail system categories while keeping user labels", () => {
+    const labels = getEmailMessageCellLabels({
+      labelIds: ["CATEGORY_PERSONAL", "label-calendar"],
+      userLabels: {
+        CATEGORY_PERSONAL: {
+          id: "CATEGORY_PERSONAL",
+          name: "CATEGORY_PERSONAL",
+        },
+        "label-calendar": {
+          id: "label-calendar",
+          name: "Calendar",
+        },
+      },
+    });
+
+    expect(labels).toEqual([{ id: "label-calendar", name: "Calendar" }]);
+  });
+
   it("does not infer Outlook sent mail as archived just because it is outside the inbox", () => {
     const labels = getEmailMessageCellLabels({
       labelIds: ["SENT", "Awaiting Reply"],

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -29,7 +29,8 @@ export function getEmailMessageCellLabels({
   provider?: string | null;
 }): EmailMessageCellLabel[] | undefined {
   const labels = labelIds
-    ?.map((idOrName) => {
+    ?.filter((labelId) => !GMAIL_CATEGORY_LABELS.has(labelId))
+    .map((idOrName) => {
       const label =
         userLabels[idOrName] ??
         Object.values(userLabels).find(
@@ -76,7 +77,7 @@ export function getEmailThreadLabels({
     ...new Set(
       [...messages].reverse().flatMap((message) => message.labelIds ?? []),
     ),
-  ].filter((labelId) => !GMAIL_CATEGORY_LABELS.has(labelId));
+  ];
 
   return getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260831-230001_pr-3452_9ca7c590e986/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Hides built-in category labels from shared email label rendering while preserving user-created labels.

- Applies consistently across history, mail lists, and reader surfaces
- Adds focused regression coverage and passes the targeted unit test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gmail system category labels are now excluded from email message labels.
  * User-created labels continue to display correctly.
  * Label handling is now consistent when viewing individual messages and threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->