### PR TITLE
Fix mobile premium entitlement resolution

### DIFF
--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -111,7 +111,38 @@ describe("user/me route", () => {
         name: "Example User",
       },
     ]);
+    expect(body.isPremium).toBe(false);
     expect(body.canManageBilling).toBe(true);
+  });
+
+  it("returns authoritative premium access for active admin grants", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      aiProvider: null,
+      aiModel: null,
+      aiApiKey: null,
+      webhookSecret: null,
+      announcementDismissedAt: null,
+      dismissedHints: [],
+      premium: {
+        id: "premium-1",
+        admins: [{ id: "user-1" }],
+        adminGrantExpiresAt: new Date("2036-01-01T00:00:00.000Z"),
+        adminGrantTier: "BUSINESS_PLUS_ANNUALLY",
+        tier: "BUSINESS_PLUS_ANNUALLY",
+      },
+      emailAccounts: [],
+    } as unknown as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/user/me"),
+      {} as never,
+    );
+
+    const body = await response.json();
+
+    expect(body.isPremium).toBe(true);
   });
 
   it("denies billing access to an organization member even when they are a plan admin", async () => {

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -5,6 +5,7 @@ import { SafeError } from "@/utils/error";
 import { auth } from "@/utils/auth";
 import {
   getRemainingUnsubscribeCredits,
+  isPremiumRecord,
   premiumEntitlementSelect,
 } from "@/utils/premium";
 import {
@@ -103,6 +104,7 @@ async function getUser({
     announcementDismissedAt: user.announcementDismissedAt,
     dismissedHints: user.dismissedHints,
     premium,
+    isPremium: isPremiumRecord(user.premium),
     // Resolved here so the client never compares periods against its own clock.
     unsubscribeCreditsRemaining: getRemainingUnsubscribeCredits(
       user.premium ?? {},


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-090351_pr-3454_f5623001b329/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- expose an authoritative `isPremium` boolean from `/api/user/me`
- reuse the backend premium policy for processor subscriptions and admin grants
- add route coverage for free accounts and active admin grants

## Testing

- `pnpm test app/api/user/me/route.test.ts`
- `pnpm --filter inbox-zero-ai exec biome check app/api/user/me/route.ts app/api/user/me/route.test.ts`

## Baseline note

Repository-wide lint currently reports four unrelated formatting errors already present on `main` in marketing/blog files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `isPremium` status to the user profile response.
  - Premium status now accurately reflects active premium access.

- **Tests**
  - Added coverage for non-premium users and users with active premium access.
  - Verified billing management permissions in the user profile response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->