### PR TITLE
INB-343: Show Outlook thread messages chronologically

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -123,6 +123,40 @@ describe("OutlookProvider.getThread", () => {
   });
 });
 
+describe("OutlookProvider.getThreadsWithLabel", () => {
+  it("returns messages chronologically while using the newest snippet", async () => {
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({
+          id: "newest",
+          receivedDateTime: "2026-01-02T00:00:00.000Z",
+          bodyPreview: "Newest preview",
+        }),
+        createMessage({
+          id: "oldest",
+          receivedDateTime: "2026-01-01T00:00:00.000Z",
+          bodyPreview: "Oldest preview",
+        }),
+      ]),
+    );
+    vi.spyOn(provider, "getLabelById").mockResolvedValue({
+      id: "label-1",
+      name: "Follow up",
+      type: "user",
+    });
+
+    const [thread] = await provider.getThreadsWithLabel({
+      labelId: "label-1",
+    });
+
+    expect(thread?.messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "newest",
+    ]);
+    expect(thread?.snippet).toBe("Newest preview");
+  });
+});
+
 describe("OutlookProvider.getLatestMessageInThread", () => {
   it("uses converted date fallback when receivedDateTime is missing", async () => {
     vi.useFakeTimers();

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -96,6 +96,33 @@ describe("OutlookProvider.sendEmail", () => {
   });
 });
 
+describe("OutlookProvider.getThread", () => {
+  it("returns messages chronologically while using the newest snippet", async () => {
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({
+          id: "newest",
+          receivedDateTime: "2026-01-02T00:00:00.000Z",
+          bodyPreview: "Newest preview",
+        }),
+        createMessage({
+          id: "oldest",
+          receivedDateTime: "2026-01-01T00:00:00.000Z",
+          bodyPreview: "Oldest preview",
+        }),
+      ]),
+    );
+
+    const thread = await provider.getThread("thread-1");
+
+    expect(thread.messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "newest",
+    ]);
+    expect(thread.snippet).toBe("Newest preview");
+  });
+});
+
 describe("OutlookProvider.getLatestMessageInThread", () => {
   it("uses converted date fallback when receivedDateTime is missing", async () => {
     vi.useFakeTimers();
@@ -1029,6 +1056,7 @@ function createMessage(input: {
   id: string;
   conversationId?: string;
   receivedDateTime?: string | undefined;
+  bodyPreview?: string;
   isDraft?: boolean;
   bodyContentType?: "text" | "html";
   bodyContent?: string;
@@ -1039,6 +1067,7 @@ function createMessage(input: {
   const {
     id,
     conversationId = "thread-1",
+    bodyPreview = "",
     isDraft = false,
     bodyContentType = "text",
     bodyContent = "",
@@ -1056,7 +1085,7 @@ function createMessage(input: {
     conversationIndex: null,
     internetMessageId: `<${id}@example.com>`,
     subject: "Subject",
-    bodyPreview: "",
+    bodyPreview,
     from: {
       emailAddress: {
         name: "Sender",

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -149,7 +149,7 @@ export class OutlookProvider implements EmailProvider {
       return {
         id: threadId,
         messages,
-        snippet: messages[0]?.snippet || "",
+        snippet: messages.at(-1)?.snippet || "",
       };
     } catch (error) {
       const context = {
@@ -1334,7 +1334,7 @@ export class OutlookProvider implements EmailProvider {
         threads.push({
           id: conversationId,
           messages,
-          snippet: messages[0]?.snippet || "",
+          snippet: messages.at(-1)?.snippet || "",
         });
       } catch (error) {
         this.logger.warn("Failed to fetch thread messages for conversationId", {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1399,7 +1399,7 @@ export class OutlookProvider implements EmailProvider {
         messages: messages.sort(
           (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
         ),
-        snippet: messages[0]?.snippet || "",
+        snippet: messages.at(-1)?.snippet || "",
       }),
     );
   }

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -242,6 +242,7 @@ export interface EmailProvider {
     maxResults?: number;
   }): Promise<EmailThread[]>;
   getSignatures(): Promise<EmailSignature[]>;
+  // Thread messages are returned in chronological order (oldest first).
   getThread(threadId: string): Promise<EmailThread>;
   getThreadMessages(threadId: string): Promise<ParsedMessage[]>;
   getThreadMessagesInInbox(threadId: string): Promise<ParsedMessage[]>;

--- a/apps/web/utils/outlook/thread.test.ts
+++ b/apps/web/utils/outlook/thread.test.ts
@@ -1,7 +1,31 @@
 import { describe, expect, it, vi } from "vitest";
-import { getThreadsWithNextPageToken } from "@/utils/outlook/thread";
+import { getThread, getThreadsWithNextPageToken } from "@/utils/outlook/thread";
 import type { OutlookClient } from "@/utils/outlook/client";
 import { createTestLogger } from "@/__tests__/helpers";
+
+describe("getThread", () => {
+  it("returns messages in chronological order", async () => {
+    const api = vi.fn().mockReturnValue(
+      createMessagesRequest([
+        { id: "newest", receivedDateTime: "2026-01-03T00:00:00.000Z" },
+        { id: "oldest", receivedDateTime: "2026-01-01T00:00:00.000Z" },
+        { id: "middle", receivedDateTime: "2026-01-02T00:00:00.000Z" },
+      ]),
+    );
+
+    const messages = await getThread(
+      "thread-1",
+      createOutlookClient(api),
+      createTestLogger(),
+    );
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+    ]);
+  });
+});
 
 describe("getThreadsWithNextPageToken", () => {
   it("does not use opaque page tokens as Graph paths", async () => {
@@ -10,7 +34,7 @@ describe("getThreadsWithNextPageToken", () => {
     await getThreadsWithNextPageToken({
       client: createOutlookClient(api),
       pageToken: "opaque-token",
-      logger: createLogger(),
+      logger: createTestLogger(),
     });
 
     expect(api).toHaveBeenCalledWith("/me/messages");
@@ -23,7 +47,7 @@ describe("getThreadsWithNextPageToken", () => {
       getThreadsWithNextPageToken({
         client: createOutlookClient(api),
         pageToken: "prefix-https://169.254.169.254/latest",
-        logger: createLogger(),
+        logger: createTestLogger(),
       }),
     ).rejects.toThrow("Invalid Outlook page token");
 
@@ -37,16 +61,15 @@ function createOutlookClient(api: ReturnType<typeof vi.fn>) {
   } as unknown as OutlookClient;
 }
 
-function createMessagesRequest() {
+function createMessagesRequest(
+  messages: Array<{ id: string; receivedDateTime: string }> = [],
+) {
   const request = {
     top: vi.fn(() => request),
     select: vi.fn(() => request),
+    expand: vi.fn(() => request),
     filter: vi.fn(() => request),
-    get: vi.fn().mockResolvedValue({ value: [] }),
+    get: vi.fn().mockResolvedValue({ value: messages }),
   };
   return request;
-}
-
-function createLogger() {
-  return createTestLogger();
 }

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -38,7 +38,7 @@ export async function getThread(
     return messages.value.sort((a, b) => {
       const dateA = new Date(a.receivedDateTime || 0).getTime();
       const dateB = new Date(b.receivedDateTime || 0).getTime();
-      return dateB - dateA; // desc order (newest first)
+      return dateA - dateB;
     });
   } catch (error) {
     // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -158,8 +158,8 @@ async function fetchThreadAndConversationMessages(
   threadMessages: ParsedMessage[];
   previousConversationMessages: ParsedMessage[] | null;
 }> {
-  // Normalize provider-specific ordering (Outlook returns newest-first).
-  // Downstream drafting logic expects chronological order (oldest -> newest).
+  // Providers return chronological order; sort defensively since drafting
+  // logic breaks silently if messages arrive out of order.
   const threadMessages = (await client.getThreadMessages(threadId)).sort(
     sortByInternalDate("asc"),
   );


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260901-203314_pr-3456_c0508b85890f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Outlook thread messages now follow the provider contract by returning oldest first, fixing reversed display order. Thread previews continue to use the newest message.

- Sort Microsoft Graph thread messages chronologically and document the provider contract.
- Preserve newest-message snippets for direct, participant, and label-filtered thread fetches.
- Tests: `pnpm --filter inbox-zero-ai test --run utils/outlook/thread.test.ts utils/email/microsoft.test.ts` (45 passed).
- Formatting: `pnpm exec ultracite check` on all six changed files.
- Performance: Reverses the comparator in the existing in-memory O(n log n) sort (up to 100 messages) and adds constant-time tail access; no extra database or network calls; low hot-path risk.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-343/thread-messages-displayed-in-reverse-chronological-order-for-outlook

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email threads now display messages chronologically, from oldest to newest.
  * Thread previews now reflect the latest message instead of the earliest one.
* **Documentation**
  * Clarified the expected chronological ordering of messages in email threads.
* **Tests**
  * Added coverage for thread ordering and latest-message previews across Outlook and Microsoft email providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->