### PR TITLE
INB-344: Persist draft deletion in mail threads

### DIFF
--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -142,7 +142,7 @@ export function createMockEmailProvider(
     // Drafts and sending
     draftEmail: vi.fn().mockResolvedValue({ draftId: "draft-123" }),
     getDraft: vi.fn().mockResolvedValue(null),
-    getDraftIdForMessage: vi.fn().mockResolvedValue(null),
+    getDraftReferenceForMessage: vi.fn().mockResolvedValue(null),
     deleteDraft: vi.fn().mockResolvedValue(true),
     createDraft: vi.fn().mockResolvedValue({ id: "draft-new" }),
     updateDraft: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -142,6 +142,7 @@ export function createMockEmailProvider(
     // Drafts and sending
     draftEmail: vi.fn().mockResolvedValue({ draftId: "draft-123" }),
     getDraft: vi.fn().mockResolvedValue(null),
+    getDraftIdForMessage: vi.fn().mockResolvedValue(null),
     deleteDraft: vi.fn().mockResolvedValue(undefined),
     createDraft: vi.fn().mockResolvedValue({ id: "draft-new" }),
     updateDraft: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -143,7 +143,7 @@ export function createMockEmailProvider(
     draftEmail: vi.fn().mockResolvedValue({ draftId: "draft-123" }),
     getDraft: vi.fn().mockResolvedValue(null),
     getDraftIdForMessage: vi.fn().mockResolvedValue(null),
-    deleteDraft: vi.fn().mockResolvedValue(undefined),
+    deleteDraft: vi.fn().mockResolvedValue(true),
     createDraft: vi.fn().mockResolvedValue({ id: "draft-new" }),
     updateDraft: vi.fn().mockResolvedValue(undefined),
     sendDraft: vi.fn().mockResolvedValue({ messageId: "msg-sent" }),

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -108,6 +108,7 @@ type ComposeEmailFormProps = {
   replyingToEmail?: ReplyingToEmail;
   refetch?: () => void;
   onSuccess?: (messageId: string, threadId: string) => void;
+  onClose?: () => void;
   onDiscard?: () => void;
   isDiscarding?: boolean;
 };
@@ -161,6 +162,7 @@ function ComposeEmailFormContent({
   onSelectEmailAccount,
   refetch,
   onSuccess,
+  onClose,
   onDiscard,
   isDiscarding,
 }: ComposeEmailFormProps & {
@@ -482,7 +484,7 @@ function ComposeEmailFormContent({
             toastSuccess({
               description: getQueuedEmailDescription(outcome.reason),
             });
-            onDiscard?.();
+            onClose?.();
           } else if (outcome.status === "uncertain") {
             if (outcome.ownsNotification) {
               toastError({
@@ -490,7 +492,7 @@ function ComposeEmailFormContent({
                   "This reply may have sent. Check Sent before retrying.",
               });
             }
-            onDiscard?.();
+            onClose?.();
           } else if (outcome.ownsNotification) {
             toastError({ description: outcome.error });
           }
@@ -520,7 +522,7 @@ function ComposeEmailFormContent({
     },
     [
       initialDraft,
-      onDiscard,
+      onClose,
       onSuccess,
       preservedBlocks,
       refetch,

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -45,7 +45,7 @@ import type {
 } from "@/app/api/user/contacts/route";
 import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
 import { Input, Label } from "@/components/Input";
-import { ButtonLoader } from "@/components/Loading";
+import { ButtonLoader, LoadingMiniSpinner } from "@/components/Loading";
 import { LoadingContent } from "@/components/LoadingContent";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -109,6 +109,7 @@ type ComposeEmailFormProps = {
   refetch?: () => void;
   onSuccess?: (messageId: string, threadId: string) => void;
   onDiscard?: () => void;
+  isDiscarding?: boolean;
 };
 
 type ComposeAttachment = EmailComposerAttachment & {
@@ -161,6 +162,7 @@ function ComposeEmailFormContent({
   refetch,
   onSuccess,
   onDiscard,
+  isDiscarding,
 }: ComposeEmailFormProps & {
   accountProvider: string;
   accountSignatureHtml: string;
@@ -900,14 +902,18 @@ function ComposeEmailFormContent({
                 isComposeWindow &&
                   "text-muted-foreground hover:text-foreground",
               )}
-              disabled={isSubmitting}
+              disabled={isSubmitting || isDiscarding}
               onClick={onDiscard}
               size={isComposeWindow ? "iconSm" : "icon"}
               title="Discard draft"
               type="button"
               variant="ghost"
             >
-              <TrashIcon className="size-4" />
+              {isDiscarding ? (
+                <LoadingMiniSpinner />
+              ) : (
+                <TrashIcon className="size-4" />
+              )}
             </Button>
           )}
         </div>

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState, useRef, useEffect } from "react";
+import { useAction } from "next-safe-action/hooks";
 import useSWR from "swr";
 import {
   ForwardIcon,
@@ -28,6 +29,7 @@ import { cn } from "@/utils";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { GmailLabel } from "@/utils/gmail/label";
 import { generateNudgeReplyAction } from "@/utils/actions/generate-reply";
+import { deleteDraftAction } from "@/utils/actions/mail";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailDetails } from "@/components/email-list/EmailDetails";
 import { HtmlEmail, PlainEmail } from "@/components/email-list/EmailContents";
@@ -38,6 +40,8 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { formatReplySubject } from "@/utils/email/subject";
 import { env } from "@/env";
 import type { ContactsResponse } from "@/app/api/user/contacts/route";
+import { toastError } from "@/components/Toast";
+import { getActionErrorMessage } from "@/utils/error";
 
 export function EmailMessage({
   message,
@@ -436,6 +440,31 @@ function ReplyPanel({
     return prepareForwardingEmail(message);
   }, [showReply, message, draftMessage, reply]);
 
+  const { execute: discardDraft, isExecuting: isDiscardingDraft } = useAction(
+    deleteDraftAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        refetch();
+        onCloseCompose();
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error, {
+            prefix: "Failed to discard draft",
+          }),
+        });
+      },
+    },
+  );
+
+  const onDiscard = useCallback(() => {
+    if (!draftMessage) {
+      onCloseCompose();
+      return;
+    }
+    discardDraft({ draftMessageId: draftMessage.id });
+  }, [draftMessage, discardDraft, onCloseCompose]);
+
   return (
     <Card className="mt-6 rounded-xl p-3" ref={replyRef}>
       {isGeneratingReply ? (
@@ -455,7 +484,8 @@ function ReplyPanel({
         </div>
       ) : (
         <ComposeEmailFormLazy
-          onDiscard={onCloseCompose}
+          isDiscarding={isDiscardingDraft}
+          onDiscard={onDiscard}
           onSuccess={(messageId: string, threadId: string) => {
             onSendSuccess(messageId, threadId);
             onCloseCompose();

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -485,6 +485,7 @@ function ReplyPanel({
       ) : (
         <ComposeEmailFormLazy
           isDiscarding={isDiscardingDraft}
+          onClose={onCloseCompose}
           onDiscard={onDiscard}
           onSuccess={(messageId: string, threadId: string) => {
             onSendSuccess(messageId, threadId);

--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -129,6 +129,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
               <ComposeEmailFormLazy
                 fromAccounts={accountsData?.emailAccounts}
                 layout="window"
+                onClose={closeCompose}
                 onDiscard={closeCompose}
                 onSuccess={closeCompose}
               />

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -108,7 +108,7 @@ export const createMockEmailProvider = (
   markMessagesReadState: vi.fn().mockResolvedValue(undefined),
   getDraft: vi.fn().mockResolvedValue(null),
   getDraftIdForMessage: vi.fn().mockResolvedValue(null),
-  deleteDraft: vi.fn().mockResolvedValue(undefined),
+  deleteDraft: vi.fn().mockResolvedValue(true),
   sendDraft: vi
     .fn()
     .mockResolvedValue({ messageId: "sent-msg1", threadId: "thread1" }),

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -107,7 +107,7 @@ export const createMockEmailProvider = (
   markReadThread: vi.fn().mockResolvedValue(undefined),
   markMessagesReadState: vi.fn().mockResolvedValue(undefined),
   getDraft: vi.fn().mockResolvedValue(null),
-  getDraftIdForMessage: vi.fn().mockResolvedValue(null),
+  getDraftReferenceForMessage: vi.fn().mockResolvedValue(null),
   deleteDraft: vi.fn().mockResolvedValue(true),
   sendDraft: vi
     .fn()

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -107,6 +107,7 @@ export const createMockEmailProvider = (
   markReadThread: vi.fn().mockResolvedValue(undefined),
   markMessagesReadState: vi.fn().mockResolvedValue(undefined),
   getDraft: vi.fn().mockResolvedValue(null),
+  getDraftIdForMessage: vi.fn().mockResolvedValue(null),
   deleteDraft: vi.fn().mockResolvedValue(undefined),
   sendDraft: vi
     .fn()

--- a/apps/web/utils/actions/mail-draft.test.ts
+++ b/apps/web/utils/actions/mail-draft.test.ts
@@ -69,6 +69,18 @@ describe("deleteDraftAction", () => {
     expect(mocks.markTrackedDraftDeleted).not.toHaveBeenCalled();
   });
 
+  it("reports when the provider draft cannot be found", async () => {
+    mocks.getDraftIdForMessage.mockResolvedValue(null);
+
+    const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "message-1",
+    });
+
+    expect(result?.serverError).toBe("Could not find this draft to delete.");
+    expect(mocks.deleteDraft).not.toHaveBeenCalled();
+    expect(mocks.markTrackedDraftDeleted).not.toHaveBeenCalled();
+  });
+
   it("completes deletion when the tracking update fails", async () => {
     mocks.markTrackedDraftDeleted.mockRejectedValue(
       new Error("Database unavailable"),

--- a/apps/web/utils/actions/mail-draft.test.ts
+++ b/apps/web/utils/actions/mail-draft.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { deleteDraftAction } from "@/utils/actions/mail";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+const mocks = vi.hoisted(() => ({
+  createEmailProvider: vi.fn(),
+  deleteDraft: vi.fn(),
+  getDraftIdForMessage: vi.fn(),
+  markTrackedDraftDeleted: vi.fn(),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: mocks.createEmailProvider,
+}));
+vi.mock("@/utils/ai/draft-cleanup", () => ({
+  markTrackedDraftDeleted: mocks.markTrackedDraftDeleted,
+}));
+
+const EMAIL_ACCOUNT_ID = "email-account-1";
+
+describe("deleteDraftAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        email: "user@example.com",
+        userId: "user-1",
+        provider: "google",
+      }),
+    );
+    mocks.createEmailProvider.mockResolvedValue({
+      deleteDraft: mocks.deleteDraft,
+      getDraftIdForMessage: mocks.getDraftIdForMessage,
+    });
+    mocks.getDraftIdForMessage.mockResolvedValue("draft-1");
+    mocks.deleteDraft.mockResolvedValue(true);
+  });
+
+  it("updates tracking after the provider deletes the draft", async () => {
+    const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "message-1",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(mocks.markTrackedDraftDeleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftId: "draft-1",
+        emailAccountId: EMAIL_ACCOUNT_ID,
+      }),
+    );
+  });
+
+  it("preserves tracking when the draft is no longer deletable", async () => {
+    mocks.deleteDraft.mockResolvedValue(false);
+
+    const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "message-1",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(mocks.markTrackedDraftDeleted).not.toHaveBeenCalled();
+  });
+
+  it("completes deletion when the tracking update fails", async () => {
+    mocks.markTrackedDraftDeleted.mockRejectedValue(
+      new Error("Database unavailable"),
+    );
+
+    const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "message-1",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(mocks.deleteDraft).toHaveBeenCalledWith("draft-1");
+  });
+});

--- a/apps/web/utils/actions/mail-draft.test.ts
+++ b/apps/web/utils/actions/mail-draft.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/utils/auth", () => ({
 const mocks = vi.hoisted(() => ({
   createEmailProvider: vi.fn(),
   deleteDraft: vi.fn(),
-  getDraftIdForMessage: vi.fn(),
+  getDraftReferenceForMessage: vi.fn(),
   markTrackedDraftDeleted: vi.fn(),
 }));
 
@@ -38,9 +38,12 @@ describe("deleteDraftAction", () => {
     );
     mocks.createEmailProvider.mockResolvedValue({
       deleteDraft: mocks.deleteDraft,
-      getDraftIdForMessage: mocks.getDraftIdForMessage,
+      getDraftReferenceForMessage: mocks.getDraftReferenceForMessage,
     });
-    mocks.getDraftIdForMessage.mockResolvedValue("draft-1");
+    mocks.getDraftReferenceForMessage.mockResolvedValue({
+      id: "draft-1",
+      version: 'W/"version-1"',
+    });
     mocks.deleteDraft.mockResolvedValue(true);
   });
 
@@ -58,7 +61,7 @@ describe("deleteDraftAction", () => {
     );
   });
 
-  it("preserves tracking when the draft is no longer deletable", async () => {
+  it("preserves tracking when the draft changes before deletion", async () => {
     mocks.deleteDraft.mockResolvedValue(false);
 
     const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
@@ -66,11 +69,12 @@ describe("deleteDraftAction", () => {
     });
 
     expect(result?.serverError).toBeUndefined();
+    expect(mocks.deleteDraft).toHaveBeenCalledWith("draft-1", 'W/"version-1"');
     expect(mocks.markTrackedDraftDeleted).not.toHaveBeenCalled();
   });
 
   it("reports when the provider draft cannot be found", async () => {
-    mocks.getDraftIdForMessage.mockResolvedValue(null);
+    mocks.getDraftReferenceForMessage.mockResolvedValue(null);
 
     const result = await deleteDraftAction(EMAIL_ACCOUNT_ID, {
       draftMessageId: "message-1",
@@ -91,6 +95,6 @@ describe("deleteDraftAction", () => {
     });
 
     expect(result?.serverError).toBeUndefined();
-    expect(mocks.deleteDraft).toHaveBeenCalledWith("draft-1");
+    expect(mocks.deleteDraft).toHaveBeenCalledWith("draft-1", 'W/"version-1"');
   });
 });

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -20,6 +20,7 @@ import {
 import { MailSplitKind } from "@/generated/prisma/enums";
 import { isGmailLabelColor } from "@/utils/gmail/label-colors";
 import { getOutlookCategoryPreset } from "@/utils/outlook/category-colors";
+import { markTrackedDraftDeleted } from "@/utils/ai/draft-cleanup";
 
 const isStatusOk = (status: number) => status >= 200 && status < 300;
 
@@ -413,6 +414,29 @@ export const sendEmailAction = actionClient
         messageId: result.messageId,
         threadId: result.threadId,
       };
+    },
+  );
+
+export const deleteDraftAction = actionClient
+  .metadata({ name: "deleteDraft" })
+  .inputSchema(z.object({ draftMessageId: z.string() }))
+  .action(
+    async ({
+      ctx: { emailAccountId, provider: providerName, logger },
+      parsedInput: { draftMessageId },
+    }) => {
+      const provider = await createEmailProvider({
+        emailAccountId,
+        provider: providerName,
+        logger,
+      });
+      const draftId = await provider.getDraftIdForMessage(draftMessageId);
+      if (!draftId) {
+        throw new SafeError("Could not find this draft to delete.");
+      }
+
+      await provider.deleteDraft(draftId);
+      await markTrackedDraftDeleted({ draftId, emailAccountId });
     },
   );
 

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -435,8 +435,16 @@ export const deleteDraftAction = actionClient
         throw new SafeError("Could not find this draft to delete.");
       }
 
-      await provider.deleteDraft(draftId);
-      await markTrackedDraftDeleted({ draftId, emailAccountId });
+      const wasDeleted = await provider.deleteDraft(draftId);
+      if (!wasDeleted) return;
+
+      try {
+        await markTrackedDraftDeleted({ draftId, emailAccountId, logger });
+      } catch (error) {
+        logger.error("Failed to update tracking after deleting draft", {
+          error,
+        });
+      }
     },
   );
 

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -430,16 +430,20 @@ export const deleteDraftAction = actionClient
         provider: providerName,
         logger,
       });
-      const draftId = await provider.getDraftIdForMessage(draftMessageId);
-      if (!draftId) {
+      const draft = await provider.getDraftReferenceForMessage(draftMessageId);
+      if (!draft) {
         throw new SafeError("Could not find this draft to delete.");
       }
 
-      const wasDeleted = await provider.deleteDraft(draftId);
+      const wasDeleted = await provider.deleteDraft(draft.id, draft.version);
       if (!wasDeleted) return;
 
       try {
-        await markTrackedDraftDeleted({ draftId, emailAccountId, logger });
+        await markTrackedDraftDeleted({
+          draftId: draft.id,
+          emailAccountId,
+          logger,
+        });
       } catch (error) {
         logger.error("Failed to update tracking after deleting draft", {
           error,

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -274,6 +274,7 @@ describe("markTrackedDraftDeleted", () => {
     await markTrackedDraftDeleted({
       draftId: "draft-1",
       emailAccountId: "email-account-1",
+      logger,
     });
 
     expect(mocks.prisma.executedAction.findFirst).toHaveBeenCalledWith({
@@ -300,6 +301,7 @@ describe("markTrackedDraftDeleted", () => {
     await markTrackedDraftDeleted({
       draftId: "draft-untracked",
       emailAccountId: "email-account-1",
+      logger,
     });
 
     expect(mocks.prisma.executedAction.update).not.toHaveBeenCalled();
@@ -315,6 +317,7 @@ describe("markTrackedDraftDeleted", () => {
     await markTrackedDraftDeleted({
       draftId: "draft-1",
       emailAccountId: "email-account-1",
+      logger,
     });
 
     expect(mocks.prisma.executedAction.update).not.toHaveBeenCalled();

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupAIDraftsForAccount,
   cleanupConfiguredAIDrafts,
+  markTrackedDraftDeleted,
 } from "@/utils/ai/draft-cleanup";
 import { createTestLogger } from "@/__tests__/helpers";
 import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
       findMany: vi.fn(),
     },
     executedAction: {
+      findFirst: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
     },
@@ -254,6 +256,68 @@ describe("cleanupAIDraftsForAccount", () => {
       alreadyGone: 1,
       cleanupDays: 14,
     });
+  });
+});
+
+describe("markTrackedDraftDeleted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the tracked draft as cleaned up", async () => {
+    mocks.prisma.executedAction.findFirst.mockResolvedValue({
+      id: "action-1",
+      draftStatus: DraftEmailStatus.PENDING,
+      wasDraftSent: false,
+    });
+
+    await markTrackedDraftDeleted({
+      draftId: "draft-1",
+      emailAccountId: "email-account-1",
+    });
+
+    expect(mocks.prisma.executedAction.findFirst).toHaveBeenCalledWith({
+      where: {
+        draftId: "draft-1",
+        executedRule: { emailAccountId: "email-account-1" },
+        type: ActionType.DRAFT_EMAIL,
+      },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, draftStatus: true, wasDraftSent: true },
+    });
+    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+        wasDraftSent: null,
+      },
+    });
+  });
+
+  it("does nothing when the draft is not tracked", async () => {
+    mocks.prisma.executedAction.findFirst.mockResolvedValue(null);
+
+    await markTrackedDraftDeleted({
+      draftId: "draft-untracked",
+      emailAccountId: "email-account-1",
+    });
+
+    expect(mocks.prisma.executedAction.update).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite terminal draft statuses", async () => {
+    mocks.prisma.executedAction.findFirst.mockResolvedValue({
+      id: "action-sent",
+      draftStatus: DraftEmailStatus.LIKELY_SENT,
+      wasDraftSent: null,
+    });
+
+    await markTrackedDraftDeleted({
+      draftId: "draft-1",
+      emailAccountId: "email-account-1",
+    });
+
+    expect(mocks.prisma.executedAction.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -135,6 +135,37 @@ export async function cleanupAIDraftsForAccount({
   };
 }
 
+export async function markTrackedDraftDeleted({
+  draftId,
+  emailAccountId,
+}: {
+  draftId: string;
+  emailAccountId: string;
+}) {
+  const trackedDraft = await prisma.executedAction.findFirst({
+    where: {
+      draftId,
+      executedRule: { emailAccountId },
+      type: ActionType.DRAFT_EMAIL,
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, draftStatus: true, wasDraftSent: true },
+  });
+  if (!trackedDraft) return;
+
+  const statusData = getDraftCleanupStatusData({
+    draftStatus: trackedDraft.draftStatus,
+    wasDraftSent: trackedDraft.wasDraftSent,
+    status: DraftEmailStatus.CLEANED_UP_UNUSED,
+  });
+  if (statusData) {
+    await prisma.executedAction.update({
+      where: { id: trackedDraft.id },
+      data: statusData,
+    });
+  }
+}
+
 export async function cleanupConfiguredAIDrafts({
   logger,
 }: {

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -4,6 +4,7 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import type { Logger } from "@/utils/logger";
 import { DEFAULT_AI_DRAFT_CLEANUP_DAYS } from "@/utils/ai/draft-cleanup-settings";
+import { withPrismaRetry } from "@/utils/prisma-retry";
 
 export async function cleanupAIDraftsForAccount({
   emailAccountId,
@@ -138,19 +139,25 @@ export async function cleanupAIDraftsForAccount({
 export async function markTrackedDraftDeleted({
   draftId,
   emailAccountId,
+  logger,
 }: {
   draftId: string;
   emailAccountId: string;
+  logger: Logger;
 }) {
-  const trackedDraft = await prisma.executedAction.findFirst({
-    where: {
-      draftId,
-      executedRule: { emailAccountId },
-      type: ActionType.DRAFT_EMAIL,
-    },
-    orderBy: { createdAt: "desc" },
-    select: { id: true, draftStatus: true, wasDraftSent: true },
-  });
+  const trackedDraft = await withPrismaRetry(
+    () =>
+      prisma.executedAction.findFirst({
+        where: {
+          draftId,
+          executedRule: { emailAccountId },
+          type: ActionType.DRAFT_EMAIL,
+        },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, draftStatus: true, wasDraftSent: true },
+      }),
+    { logger },
+  );
   if (!trackedDraft) return;
 
   const statusData = getDraftCleanupStatusData({
@@ -159,10 +166,14 @@ export async function markTrackedDraftDeleted({
     status: DraftEmailStatus.CLEANED_UP_UNUSED,
   });
   if (statusData) {
-    await prisma.executedAction.update({
-      where: { id: trackedDraft.id },
-      data: statusData,
-    });
+    await withPrismaRetry(
+      () =>
+        prisma.executedAction.update({
+          where: { id: trackedDraft.id },
+          data: statusData,
+        }),
+      { logger },
+    );
   }
 }
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -66,7 +66,12 @@ import {
   getThreadsWithNextPageToken,
 } from "@/utils/gmail/thread";
 import { decodeSnippet } from "@/utils/gmail/decode";
-import { getDraft, deleteDraft, sendDraft } from "@/utils/gmail/draft";
+import {
+  getDraft,
+  getDraftIdForMessage,
+  deleteDraft,
+  sendDraft,
+} from "@/utils/gmail/draft";
 import {
   extractErrorInfo,
   isRetryableError,
@@ -868,6 +873,10 @@ export class GmailProvider implements EmailProvider {
 
   async getDraft(draftId: string): Promise<ParsedMessage | null> {
     return getDraft(draftId, this.client);
+  }
+
+  async getDraftIdForMessage(messageId: string): Promise<string | null> {
+    return getDraftIdForMessage(this.client, messageId);
   }
 
   async deleteDraft(draftId: string): Promise<void> {

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -875,8 +875,9 @@ export class GmailProvider implements EmailProvider {
     return getDraft(draftId, this.client);
   }
 
-  async getDraftIdForMessage(messageId: string): Promise<string | null> {
-    return getDraftIdForMessage(this.client, messageId);
+  async getDraftReferenceForMessage(messageId: string) {
+    const draftId = await getDraftIdForMessage(this.client, messageId);
+    return draftId ? { id: draftId } : null;
   }
 
   async deleteDraft(draftId: string): Promise<boolean> {

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -879,8 +879,8 @@ export class GmailProvider implements EmailProvider {
     return getDraftIdForMessage(this.client, messageId);
   }
 
-  async deleteDraft(draftId: string): Promise<void> {
-    await deleteDraft(this.client, draftId);
+  async deleteDraft(draftId: string): Promise<boolean> {
+    return deleteDraft(this.client, draftId);
   }
 
   async sendDraft(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -53,7 +53,12 @@ import {
   getThreadsFromSenderWithSubject,
 } from "@/utils/outlook/thread";
 import { getOutlookAttachment } from "@/utils/outlook/attachment";
-import { getDraft, deleteDraft, sendDraft } from "@/utils/outlook/draft";
+import {
+  getDraft,
+  getDraftReference,
+  deleteDraft,
+  sendDraft,
+} from "@/utils/outlook/draft";
 import {
   getFiltersList,
   createFilter,
@@ -586,15 +591,21 @@ export class OutlookProvider implements EmailProvider {
     return getDraft({ client: this.client, draftId, logger: this.logger });
   }
 
-  async getDraftIdForMessage(messageId: string): Promise<string | null> {
-    // Outlook drafts are addressed by their message id; verify it is still a
-    // draft so a stale caller can't delete a sent message.
-    const draft = await this.getDraft(messageId);
-    return draft ? messageId : null;
+  async getDraftReferenceForMessage(messageId: string) {
+    return getDraftReference({
+      client: this.client,
+      messageId,
+      logger: this.logger,
+    });
   }
 
-  async deleteDraft(draftId: string): Promise<boolean> {
-    return deleteDraft({ client: this.client, draftId, logger: this.logger });
+  async deleteDraft(draftId: string, version?: string): Promise<boolean> {
+    return deleteDraft({
+      client: this.client,
+      draftId,
+      version,
+      logger: this.logger,
+    });
   }
 
   async sendDraft(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -586,6 +586,13 @@ export class OutlookProvider implements EmailProvider {
     return getDraft({ client: this.client, draftId, logger: this.logger });
   }
 
+  async getDraftIdForMessage(messageId: string): Promise<string | null> {
+    // Outlook drafts are addressed by their message id; verify it is still a
+    // draft so a stale caller can't delete a sent message.
+    const draft = await this.getDraft(messageId);
+    return draft ? messageId : null;
+  }
+
   async deleteDraft(draftId: string): Promise<void> {
     await deleteDraft({ client: this.client, draftId, logger: this.logger });
   }

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -600,10 +600,15 @@ export class OutlookProvider implements EmailProvider {
   }
 
   async deleteDraft(draftId: string, version?: string): Promise<boolean> {
+    const draftReference = version
+      ? { id: draftId, version }
+      : await this.getDraftReferenceForMessage(draftId);
+    if (!draftReference) return false;
+
     return deleteDraft({
       client: this.client,
-      draftId,
-      version,
+      draftId: draftReference.id,
+      version: draftReference.version,
       logger: this.logger,
     });
   }

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -593,8 +593,8 @@ export class OutlookProvider implements EmailProvider {
     return draft ? messageId : null;
   }
 
-  async deleteDraft(draftId: string): Promise<void> {
-    await deleteDraft({ client: this.client, draftId, logger: this.logger });
+  async deleteDraft(draftId: string): Promise<boolean> {
+    return deleteDraft({ client: this.client, draftId, logger: this.logger });
   }
 
   async sendDraft(

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -136,7 +136,7 @@ export interface EmailProvider {
     removeLabelIds?: string[];
   }): Promise<{ status: number }>;
   createLabel(name: string, description?: string): Promise<EmailLabel>;
-  deleteDraft(draftId: string): Promise<void>;
+  deleteDraft(draftId: string): Promise<boolean>;
   deleteFilter(id: string): Promise<{ status: number }>;
   deleteFolder(folderId: string): Promise<void>;
   deleteLabel(labelId: string): Promise<void>;

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -90,6 +90,11 @@ export type BulkArchiveResult = {
   failedThreadIds: string[];
 };
 
+type DraftReference = {
+  id: string;
+  version?: string;
+};
+
 export interface EmailProvider {
   archiveMessage(messageId: string): Promise<void>;
   archiveMessages(messageIds: string[], labelId?: string): Promise<void>;
@@ -136,7 +141,7 @@ export interface EmailProvider {
     removeLabelIds?: string[];
   }): Promise<{ status: number }>;
   createLabel(name: string, description?: string): Promise<EmailLabel>;
-  deleteDraft(draftId: string): Promise<boolean>;
+  deleteDraft(draftId: string, version?: string): Promise<boolean>;
   deleteFilter(id: string): Promise<{ status: number }>;
   deleteFolder(folderId: string): Promise<void>;
   deleteLabel(labelId: string): Promise<void>;
@@ -169,7 +174,9 @@ export interface EmailProvider {
     attachmentId: string,
   ): Promise<{ data: string; size: number }>;
   getDraft(draftId: string): Promise<ParsedMessage | null>;
-  getDraftIdForMessage(messageId: string): Promise<string | null>;
+  getDraftReferenceForMessage(
+    messageId: string,
+  ): Promise<DraftReference | null>;
   getDrafts(options?: { maxResults?: number }): Promise<ParsedMessage[]>;
   getFiltersList(): Promise<EmailFilter[]>;
   getFolderCounts(): Promise<EmailFolderCount[]>;

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -169,6 +169,7 @@ export interface EmailProvider {
     attachmentId: string,
   ): Promise<{ data: string; size: number }>;
   getDraft(draftId: string): Promise<ParsedMessage | null>;
+  getDraftIdForMessage(messageId: string): Promise<string | null>;
   getDrafts(options?: { maxResults?: number }): Promise<ParsedMessage[]>;
   getFiltersList(): Promise<EmailFilter[]>;
   getFolderCounts(): Promise<EmailFolderCount[]>;

--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, type Mock } from "vitest";
+import type { gmail_v1 } from "googleapis";
 import {
   deleteDraft,
   getDraft,
@@ -85,22 +86,18 @@ describe("gmail/draft", () => {
       .mockResolvedValueOnce({
         data: { drafts: [{ id: "r-2", message: { id: "m-2" } }] },
       });
-    const gmail = { users: { drafts: { list } } } as any;
+    const gmail = createGmailDraftListClient(list);
 
     await expect(getDraftIdForMessage(gmail, "m-2")).resolves.toBe("r-2");
     expect(list).toHaveBeenCalledTimes(2);
   });
 
   it("getDraftIdForMessage returns null when the draft is absent", async () => {
-    const gmail = {
-      users: {
-        drafts: {
-          list: vi.fn().mockResolvedValue({
-            data: { drafts: [{ id: "r-1", message: { id: "m-1" } }] },
-          }),
-        },
-      },
-    } as any;
+    const gmail = createGmailDraftListClient(
+      vi.fn().mockResolvedValue({
+        data: { drafts: [{ id: "r-1", message: { id: "m-1" } }] },
+      }),
+    );
 
     await expect(getDraftIdForMessage(gmail, "m-2")).resolves.toBeNull();
   });
@@ -109,7 +106,7 @@ describe("gmail/draft", () => {
     const list = vi.fn().mockResolvedValue({
       data: { drafts: [], nextPageToken: "repeated-page" },
     });
-    const gmail = { users: { drafts: { list } } } as any;
+    const gmail = createGmailDraftListClient(list);
 
     await expect(getDraftIdForMessage(gmail, "m-1")).resolves.toBeNull();
     expect(list).toHaveBeenCalledTimes(2);
@@ -120,7 +117,7 @@ describe("gmail/draft", () => {
     const list = vi.fn().mockImplementation(async () => ({
       data: { drafts: [], nextPageToken: `page-${pageNumber++}` },
     }));
-    const gmail = { users: { drafts: { list } } } as any;
+    const gmail = createGmailDraftListClient(list);
 
     await expect(getDraftIdForMessage(gmail, "m-1")).resolves.toBeNull();
     expect(list).toHaveBeenCalledTimes(10);
@@ -180,3 +177,9 @@ describe("gmail/draft", () => {
     expect(draftsDelete).toHaveBeenCalledTimes(1);
   });
 });
+
+function createGmailDraftListClient(
+  list: gmail_v1.Gmail["users"]["drafts"]["list"],
+) {
+  return { users: { drafts: { list } } } as unknown as gmail_v1.Gmail;
+}

--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -105,6 +105,27 @@ describe("gmail/draft", () => {
     await expect(getDraftIdForMessage(gmail, "m-2")).resolves.toBeNull();
   });
 
+  it("getDraftIdForMessage stops when a page token repeats", async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: { drafts: [], nextPageToken: "repeated-page" },
+    });
+    const gmail = { users: { drafts: { list } } } as any;
+
+    await expect(getDraftIdForMessage(gmail, "m-1")).resolves.toBeNull();
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("getDraftIdForMessage bounds the number of pages", async () => {
+    let pageNumber = 0;
+    const list = vi.fn().mockImplementation(async () => ({
+      data: { drafts: [], nextPageToken: `page-${pageNumber++}` },
+    }));
+    const gmail = { users: { drafts: { list } } } as any;
+
+    await expect(getDraftIdForMessage(gmail, "m-1")).resolves.toBeNull();
+    expect(list).toHaveBeenCalledTimes(10);
+  });
+
   it("deleteDraft skips drafts.delete when getDraft returns null", async () => {
     const draftsDelete = vi.fn().mockResolvedValue({ status: 204 });
     const gmail = {
@@ -125,7 +146,7 @@ describe("gmail/draft", () => {
       labelIds: [GmailLabel.SENT],
     });
 
-    await deleteDraft(gmail, "r-1");
+    await expect(deleteDraft(gmail, "r-1")).resolves.toBe(false);
     expect(draftsDelete).not.toHaveBeenCalled();
   });
 
@@ -155,7 +176,7 @@ describe("gmail/draft", () => {
       date: "",
     });
 
-    await deleteDraft(gmail, "r-1");
+    await expect(deleteDraft(gmail, "r-1")).resolves.toBe(true);
     expect(draftsDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, type Mock } from "vitest";
-import type { gmail_v1 } from "googleapis";
+import type { gmail_v1 } from "@googleapis/gmail";
 import {
   deleteDraft,
   getDraft,

--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, type Mock } from "vitest";
-import { deleteDraft, getDraft } from "@/utils/gmail/draft";
+import {
+  deleteDraft,
+  getDraft,
+  getDraftIdForMessage,
+} from "@/utils/gmail/draft";
 import { GmailLabel } from "@/utils/gmail/label";
 
 vi.mock("@/utils/gmail/retry", () => ({
@@ -67,6 +71,38 @@ describe("gmail/draft", () => {
     const result = await getDraft("r-1", gmail);
     expect(result).not.toBeNull();
     expect(result?.labelIds).toEqual([GmailLabel.DRAFT]);
+  });
+
+  it("getDraftIdForMessage finds a draft across pages", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          drafts: [{ id: "r-1", message: { id: "m-1" } }],
+          nextPageToken: "next-page",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { drafts: [{ id: "r-2", message: { id: "m-2" } }] },
+      });
+    const gmail = { users: { drafts: { list } } } as any;
+
+    await expect(getDraftIdForMessage(gmail, "m-2")).resolves.toBe("r-2");
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("getDraftIdForMessage returns null when the draft is absent", async () => {
+    const gmail = {
+      users: {
+        drafts: {
+          list: vi.fn().mockResolvedValue({
+            data: { drafts: [{ id: "r-1", message: { id: "m-1" } }] },
+          }),
+        },
+      },
+    } as any;
+
+    await expect(getDraftIdForMessage(gmail, "m-2")).resolves.toBeNull();
   });
 
   it("deleteDraft skips drafts.delete when getDraft returns null", async () => {

--- a/apps/web/utils/gmail/draft.ts
+++ b/apps/web/utils/gmail/draft.ts
@@ -60,6 +60,33 @@ export async function getDraft(draftId: string, gmail: gmail_v1.Gmail) {
   }
 }
 
+export async function getDraftIdForMessage(
+  gmail: gmail_v1.Gmail,
+  messageId: string,
+): Promise<string | null> {
+  // Gmail draft ids (r-NNN) differ from the draft's message id; drafts.list is
+  // the only way to map one to the other.
+  let pageToken: string | undefined;
+  do {
+    const response = await withGmailRetry(() =>
+      gmail.users.drafts.list({
+        userId: "me",
+        maxResults: 500,
+        pageToken,
+      }),
+    );
+
+    const draft = response.data.drafts?.find(
+      (draft) => draft.message?.id === messageId,
+    );
+    if (draft?.id) return draft.id;
+
+    pageToken = response.data.nextPageToken ?? undefined;
+  } while (pageToken);
+
+  return null;
+}
+
 function isNotFoundError(error: unknown): boolean {
   if (isGmailError(error) && error.code === 404) return true;
   // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape

--- a/apps/web/utils/gmail/draft.ts
+++ b/apps/web/utils/gmail/draft.ts
@@ -7,6 +7,7 @@ import { isGmailError } from "@/utils/error";
 import { withGmailRetry } from "@/utils/gmail/retry";
 
 const logger = createScopedLogger("gmail/draft");
+const MAX_DRAFT_LOOKUP_PAGES = 10;
 
 export async function getDraft(draftId: string, gmail: gmail_v1.Gmail) {
   try {
@@ -67,7 +68,8 @@ export async function getDraftIdForMessage(
   // Gmail draft ids (r-NNN) differ from the draft's message id; drafts.list is
   // the only way to map one to the other.
   let pageToken: string | undefined;
-  do {
+  const seenPageTokens = new Set<string>();
+  for (let pageCount = 0; pageCount < MAX_DRAFT_LOOKUP_PAGES; pageCount++) {
     const response = await withGmailRetry(() =>
       gmail.users.drafts.list({
         userId: "me",
@@ -81,8 +83,15 @@ export async function getDraftIdForMessage(
     );
     if (draft?.id) return draft.id;
 
-    pageToken = response.data.nextPageToken ?? undefined;
-  } while (pageToken);
+    const nextPageToken = response.data.nextPageToken ?? undefined;
+    if (!nextPageToken || seenPageTokens.has(nextPageToken)) return null;
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  logger.warn("Stopped draft lookup after reaching the page limit", {
+    maxPages: MAX_DRAFT_LOOKUP_PAGES,
+  });
 
   return null;
 }
@@ -141,7 +150,10 @@ export async function sendDraft(
   return { messageId, threadId };
 }
 
-export async function deleteDraft(gmail: gmail_v1.Gmail, draftId: string) {
+export async function deleteDraft(
+  gmail: gmail_v1.Gmail,
+  draftId: string,
+): Promise<boolean> {
   // Log detailed info about the draft ID format for debugging
   logger.info("Attempting to delete draft", {
     draftId,
@@ -166,7 +178,7 @@ export async function deleteDraft(gmail: gmail_v1.Gmail, draftId: string) {
       logger.warn("Draft not found or no longer a draft, skipping deletion.", {
         draftId,
       });
-      return;
+      return false;
     }
 
     const response = await withGmailRetry(() =>
@@ -176,17 +188,16 @@ export async function deleteDraft(gmail: gmail_v1.Gmail, draftId: string) {
       }),
     );
     if (response.status !== 200 && response.status !== 204) {
-      logger.error("Unexpected response status from draft deletion", {
-        draftId,
-        status: response.status,
-      });
+      throw new Error(`Unexpected draft deletion status: ${response.status}`);
     }
     logger.info("Successfully deleted draft", { draftId });
+    return true;
   } catch (error) {
     if (isNotFoundError(error)) {
       logger.warn("Draft not found or already deleted, skipping deletion.", {
         draftId,
       });
+      return false;
     } else {
       logger.error("Failed to delete draft", { draftId, error });
       throw error;

--- a/apps/web/utils/outlook/draft.test.ts
+++ b/apps/web/utils/outlook/draft.test.ts
@@ -1,31 +1,77 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import type { OutlookClient } from "@/utils/outlook/client";
-import { deleteDraft } from "@/utils/outlook/draft";
+import { deleteDraft, getDraftReference } from "@/utils/outlook/draft";
+
+const mocks = vi.hoisted(() => ({
+  getFolderIds: vi.fn(),
+}));
 
 vi.mock("@/utils/microsoft/retry", () => ({
   withMicrosoftGraphRetry: (operation: () => Promise<unknown>) => operation(),
   withMicrosoftGraphWriteRetry: (operation: () => Promise<unknown>) =>
     operation(),
 }));
+vi.mock("@/utils/outlook/message", () => ({
+  convertMessage: vi.fn(),
+  getCategoryMap: vi.fn(),
+  getFolderIds: mocks.getFolderIds,
+}));
 
 describe("outlook/draft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getFolderIds.mockResolvedValue({ drafts: "drafts" });
+  });
+
+  it("captures the current draft version", async () => {
+    const client = createOutlookReadClient({
+      id: "draft-1",
+      parentFolderId: "drafts",
+      "@odata.etag": 'W/"version-1"',
+    });
+
+    await expect(
+      getDraftReference({
+        client,
+        messageId: "draft-1",
+        logger: createTestLogger(),
+      }),
+    ).resolves.toEqual({ id: "draft-1", version: 'W/"version-1"' });
+  });
+
   it("returns true when the draft is deleted", async () => {
     const deleteRequest = vi.fn().mockResolvedValue(undefined);
-    const client = createOutlookClient(deleteRequest);
+    const { client, header } = createOutlookClient(deleteRequest);
 
     await expect(
       deleteDraft({
         client,
         draftId: "draft-1",
+        version: 'W/"version-1"',
         logger: createTestLogger(),
       }),
     ).resolves.toBe(true);
+    expect(header).toHaveBeenCalledWith("If-Match", 'W/"version-1"');
+  });
+
+  it("returns false when the draft is sent before conditional deletion", async () => {
+    const deleteRequest = vi.fn().mockRejectedValue({ statusCode: 412 });
+    const { client } = createOutlookClient(deleteRequest);
+
+    await expect(
+      deleteDraft({
+        client,
+        draftId: "draft-1",
+        version: 'W/"version-1"',
+        logger: createTestLogger(),
+      }),
+    ).resolves.toBe(false);
   });
 
   it("returns false when the draft no longer exists", async () => {
     const deleteRequest = vi.fn().mockRejectedValue({ statusCode: 404 });
-    const client = createOutlookClient(deleteRequest);
+    const { client } = createOutlookClient(deleteRequest);
 
     await expect(
       deleteDraft({
@@ -38,9 +84,25 @@ describe("outlook/draft", () => {
 });
 
 function createOutlookClient(deleteRequest: () => Promise<unknown>) {
+  const request = {
+    delete: deleteRequest,
+    header: vi.fn(),
+  };
+  request.header.mockReturnValue(request);
+
+  const client = {
+    getClient: () => ({
+      api: vi.fn(() => request),
+    }),
+  } as unknown as OutlookClient;
+
+  return { client, header: request.header };
+}
+
+function createOutlookReadClient(message: object) {
   return {
     getClient: () => ({
-      api: vi.fn(() => ({ delete: deleteRequest })),
+      api: vi.fn(() => ({ get: vi.fn().mockResolvedValue(message) })),
     }),
   } as unknown as OutlookClient;
 }

--- a/apps/web/utils/outlook/draft.test.ts
+++ b/apps/web/utils/outlook/draft.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import type { OutlookClient } from "@/utils/outlook/client";
+import { deleteDraft } from "@/utils/outlook/draft";
+
+vi.mock("@/utils/microsoft/retry", () => ({
+  withMicrosoftGraphRetry: (operation: () => Promise<unknown>) => operation(),
+  withMicrosoftGraphWriteRetry: (operation: () => Promise<unknown>) =>
+    operation(),
+}));
+
+describe("outlook/draft", () => {
+  it("returns true when the draft is deleted", async () => {
+    const deleteRequest = vi.fn().mockResolvedValue(undefined);
+    const client = createOutlookClient(deleteRequest);
+
+    await expect(
+      deleteDraft({
+        client,
+        draftId: "draft-1",
+        logger: createTestLogger(),
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when the draft no longer exists", async () => {
+    const deleteRequest = vi.fn().mockRejectedValue({ statusCode: 404 });
+    const client = createOutlookClient(deleteRequest);
+
+    await expect(
+      deleteDraft({
+        client,
+        draftId: "draft-1",
+        logger: createTestLogger(),
+      }),
+    ).resolves.toBe(false);
+  });
+});
+
+function createOutlookClient(deleteRequest: () => Promise<unknown>) {
+  return {
+    getClient: () => ({
+      api: vi.fn(() => ({ delete: deleteRequest })),
+    }),
+  } as unknown as OutlookClient;
+}

--- a/apps/web/utils/outlook/draft.test.ts
+++ b/apps/web/utils/outlook/draft.test.ts
@@ -40,6 +40,23 @@ describe("outlook/draft", () => {
     ).resolves.toEqual({ id: "draft-1", version: 'W/"version-1"' });
   });
 
+  it("rejects a draft reference when the Drafts folder is unavailable", async () => {
+    mocks.getFolderIds.mockResolvedValue({});
+    const client = createOutlookReadClient({
+      id: "draft-1",
+      parentFolderId: "drafts",
+      "@odata.etag": 'W/"version-1"',
+    });
+
+    await expect(
+      getDraftReference({
+        client,
+        messageId: "draft-1",
+        logger: createTestLogger(),
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("returns true when the draft is deleted", async () => {
     const deleteRequest = vi.fn().mockResolvedValue(undefined);
     const { client, header } = createOutlookClient(deleteRequest);
@@ -77,6 +94,7 @@ describe("outlook/draft", () => {
       deleteDraft({
         client,
         draftId: "draft-1",
+        version: 'W/"version-1"',
         logger: createTestLogger(),
       }),
     ).resolves.toBe(false);

--- a/apps/web/utils/outlook/draft.ts
+++ b/apps/web/utils/outlook/draft.ts
@@ -48,6 +48,10 @@ export async function getDraftReference({
     logger,
   });
   if (!draft) return null;
+  if (!draft.folderIds.drafts) {
+    logger.warn("Could not verify the Outlook Drafts folder");
+    return null;
+  }
 
   const version = (draft.message as { "@odata.etag"?: string })["@odata.etag"];
   if (!version) {
@@ -107,14 +111,16 @@ export async function deleteDraft({
 }: {
   client: OutlookClient;
   draftId: string;
-  version?: string;
+  version: string;
   logger: Logger;
 }): Promise<boolean> {
   try {
     logger.info("Deleting draft", { draftId });
 
-    const request = client.getClient().api(`/me/messages/${draftId}`);
-    if (version) request.header("If-Match", version);
+    const request = client
+      .getClient()
+      .api(`/me/messages/${draftId}`)
+      .header("If-Match", version);
 
     await withMicrosoftGraphWriteRetry(() => request.delete(), logger);
 

--- a/apps/web/utils/outlook/draft.ts
+++ b/apps/web/utils/outlook/draft.ts
@@ -107,7 +107,7 @@ export async function deleteDraft({
   client: OutlookClient;
   draftId: string;
   logger: Logger;
-}) {
+}): Promise<boolean> {
   try {
     logger.info("Deleting draft", { draftId });
 
@@ -119,10 +119,11 @@ export async function deleteDraft({
     );
 
     logger.info("Draft deleted successfully", { draftId });
+    return true;
   } catch (error) {
     if (isNotFoundError(error)) {
       logger.info("Draft not found or already deleted", { draftId });
-      return;
+      return false;
     }
 
     logger.error("Failed to delete draft", { draftId, error });

--- a/apps/web/utils/outlook/draft.ts
+++ b/apps/web/utils/outlook/draft.ts
@@ -1,7 +1,10 @@
 import type { Message } from "@microsoft/microsoft-graph-types";
 import type { OutlookClient } from "@/utils/outlook/client";
 import type { Logger } from "@/utils/logger";
-import { isNotFoundError } from "@/utils/outlook/errors";
+import {
+  isNotFoundError,
+  isPreconditionFailedError,
+} from "@/utils/outlook/errors";
 import {
   convertMessage,
   getCategoryMap,
@@ -21,40 +24,37 @@ export async function getDraft({
   draftId: string;
   logger: Logger;
 }) {
-  try {
-    const [response, folderIds, categoryMap] = await Promise.all([
-      withMicrosoftGraphRetry(
-        () =>
-          client
-            .getClient()
-            .api(`/me/messages/${draftId}`)
-            .get() as Promise<Message>,
-        logger,
-      ),
-      getFolderIds(client, logger),
-      getCategoryMap(client, logger),
-    ]);
+  const [draft, categoryMap] = await Promise.all([
+    getDraftMessage({ client, draftId, logger }),
+    getCategoryMap(client, logger),
+  ]);
+  if (!draft) return null;
 
-    // Treat drafts NOT in Drafts folder as "deleted" - when a draft is sent or deleted,
-    // it gets moved to another folder (Sent Items, Deleted Items, Outbox, etc.)
-    // For draft cleanup purposes, we only care about drafts in the Drafts folder
-    if (folderIds.drafts && response.parentFolderId !== folderIds.drafts) {
-      logger.info("Draft is no longer in Drafts folder, treating as deleted.", {
-        draftId,
-      });
-      return null;
-    }
+  return convertMessage(draft.message, draft.folderIds, categoryMap);
+}
 
-    const message = convertMessage(response, folderIds, categoryMap);
-    return message;
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      logger.info("Draft not found, returning null.", { draftId });
-      return null;
-    }
+export async function getDraftReference({
+  client,
+  messageId,
+  logger,
+}: {
+  client: OutlookClient;
+  messageId: string;
+  logger: Logger;
+}): Promise<{ id: string; version: string } | null> {
+  const draft = await getDraftMessage({
+    client,
+    draftId: messageId,
+    logger,
+  });
+  if (!draft) return null;
 
-    throw error;
+  const version = (draft.message as { "@odata.etag"?: string })["@odata.etag"];
+  if (!version) {
+    throw new Error("Draft response did not include a version");
   }
+
+  return { id: messageId, version };
 }
 
 export async function sendDraft({
@@ -102,31 +102,71 @@ export async function sendDraft({
 export async function deleteDraft({
   client,
   draftId,
+  version,
   logger,
 }: {
   client: OutlookClient;
   draftId: string;
+  version?: string;
   logger: Logger;
 }): Promise<boolean> {
   try {
     logger.info("Deleting draft", { draftId });
 
-    // DELETE moves the draft to Deleted Items folder (not permanently deleted)
-    // This is fine - getDraft() treats drafts not in Drafts folder as "deleted"
-    await withMicrosoftGraphWriteRetry(
-      () => client.getClient().api(`/me/messages/${draftId}`).delete(),
-      logger,
-    );
+    const request = client.getClient().api(`/me/messages/${draftId}`);
+    if (version) request.header("If-Match", version);
+
+    await withMicrosoftGraphWriteRetry(() => request.delete(), logger);
 
     logger.info("Draft deleted successfully", { draftId });
     return true;
   } catch (error) {
-    if (isNotFoundError(error)) {
-      logger.info("Draft not found or already deleted", { draftId });
+    if (isNotFoundError(error) || isPreconditionFailedError(error)) {
+      logger.info("Draft no longer matches the deletable version", { draftId });
       return false;
     }
 
     logger.error("Failed to delete draft", { draftId, error });
+    throw error;
+  }
+}
+
+async function getDraftMessage({
+  client,
+  draftId,
+  logger,
+}: {
+  client: OutlookClient;
+  draftId: string;
+  logger: Logger;
+}) {
+  try {
+    const [message, folderIds] = await Promise.all([
+      withMicrosoftGraphRetry(
+        () =>
+          client
+            .getClient()
+            .api(`/me/messages/${draftId}`)
+            .get() as Promise<Message>,
+        logger,
+      ),
+      getFolderIds(client, logger),
+    ]);
+
+    if (folderIds.drafts && message.parentFolderId !== folderIds.drafts) {
+      logger.info("Draft is no longer in Drafts folder, treating as deleted.", {
+        draftId,
+      });
+      return null;
+    }
+
+    return { message, folderIds };
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      logger.info("Draft not found, returning null.", { draftId });
+      return null;
+    }
+
     throw error;
   }
 }

--- a/apps/web/utils/outlook/errors.ts
+++ b/apps/web/utils/outlook/errors.ts
@@ -36,3 +36,12 @@ export function isNotFoundError(error: unknown): boolean {
   }
   return false;
 }
+
+export function isPreconditionFailedError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    (error as { statusCode: unknown }).statusCode === 412
+  );
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260901-213400_pr-3457_f6b6a3d9cb46/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Persists draft deletion from mail-thread reply composers across Google and Microsoft providers, and keeps tracked AI draft state in sync. Adds discard progress and error handling so the thread only closes after deletion succeeds.

- Resolve provider draft IDs safely, including bounded paginated Gmail lookup and Outlook draft verification
- Delete provider drafts through an authenticated server action and update tracked cleanup status with retry protection
- Validate with 77 focused and affected unit tests plus Ultracite checks across all changed files
- Linear: https://linear.app/inbox-zero-ai/issue/INB-344/draft-deletion-in-mail-thread-does-not-persist
- Performance: Work runs only on explicit discard; it adds bounded provider lookup/deletion network calls plus one database read and at most one write, with transient database retries. There is no inbox render/list hot-path work, so hot-path risk is low.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to discard saved drafts directly from the email composer.
  - Draft deletion now confirms whether the draft was successfully removed.
  - Composer controls show progress and prevent duplicate discard attempts.

- **Bug Fixes**
  - Improved handling of missing, already deleted, or changed drafts.
  - Safer deletion prevents overwriting newer draft changes.
  - Composer closes appropriately after queued replies or uncertain outcomes.

- **Tests**
  - Expanded coverage for draft deletion, pagination, retries, and cleanup tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->