### PR TITLE
INB-346: Show all participants in thread list

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -188,10 +188,10 @@ test("Command K acts on highlighted and selected conversations", async ({
   await expect(palette).toBeHidden();
 
   await conversations
-    .getByRole("checkbox", { name: "Select conversation from Alice Example" })
+    .getByRole("checkbox", { name: "Select conversation with Alice Example" })
     .click();
   await conversations
-    .getByRole("checkbox", { name: "Select conversation from Bob Example" })
+    .getByRole("checkbox", { name: "Select conversation with Bob Example" })
     .click();
 
   await page.keyboard.press(`${commandModifier}+KeyK`);
@@ -211,10 +211,10 @@ test("Command K acts on highlighted and selected conversations", async ({
   await palette.getByRole("option", { name: "Mark 2 as read" }).click();
   await expect(palette).toBeHidden();
   await conversations
-    .getByRole("checkbox", { name: "Select conversation from Alice Example" })
+    .getByRole("checkbox", { name: "Select conversation with Alice Example" })
     .click();
   await conversations
-    .getByRole("checkbox", { name: "Select conversation from Bob Example" })
+    .getByRole("checkbox", { name: "Select conversation with Bob Example" })
     .click();
   await page.keyboard.press(`${commandModifier}+KeyK`);
   await expect(
@@ -235,7 +235,7 @@ async function ensureReadState(
   read: boolean,
 ) {
   const checkbox = conversations.getByRole("checkbox", {
-    name: `Select conversation from ${sender}`,
+    name: `Select conversation with ${sender}`,
   });
   await checkbox.click();
   const selectionCount = page.getByText("1 selected", { exact: true });

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -38,7 +38,7 @@ test("starts mailbox warming from the app shell before mail opens", async ({
 
 test("opens a complete conversation and updates its read state", async ({
   page,
-}) => {
+}, testInfo) => {
   const { conversations } = await openMail(page);
   const readerConversation = conversationWithSubject(
     page,
@@ -46,6 +46,17 @@ test("opens a complete conversation and updates its read state", async ({
     "Re: Reader Navigation Message",
   );
   await expect(readerConversation).toBeVisible();
+  await expect(
+    readerConversation.getByText("Dana Example, me", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    readerConversation.getByText("(2)", { exact: true }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    readerConversation,
+    testInfo,
+    "thread-list-participants",
+  );
 
   await readerConversation.click();
 

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -40,7 +40,7 @@ test("keeps a queued archive hidden across reload and replays it after reconnect
 
   try {
     await conversation
-      .getByRole("checkbox", { name: "Select conversation from Erin Example" })
+      .getByRole("checkbox", { name: "Select conversation with Erin Example" })
       .click();
     await page.getByRole("button", { name: "Archive", exact: true }).click();
 

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -15,7 +15,7 @@ test("archives a selected conversation and restores it with undo", async ({
   );
 
   await archiveConversation
-    .getByRole("checkbox", { name: "Select conversation from Erin Example" })
+    .getByRole("checkbox", { name: "Select conversation with Erin Example" })
     .click();
   await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Archive", exact: true }).click();

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -3,6 +3,7 @@
 import { memo, useMemo, type Ref } from "react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
+import { getThreadParticipantNames } from "@/app/(app)/[emailAccountId]/mail/thread-participants";
 import type {
   ListThread,
   MailLayoutMode,
@@ -19,7 +20,6 @@ import {
 import type { EmailLabels } from "@/providers/email-label-types";
 import { cn } from "@/utils";
 import { internalDateToDate } from "@/utils/date";
-import { extractNameFromEmail, participant } from "@/utils/email";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { GmailLabel } from "@/utils/gmail/label";
 
@@ -71,6 +71,13 @@ export const ThreadRow = memo(function ThreadRow({
     [thread.messages, userLabels],
   );
 
+  const account = "account" in thread ? thread.account : null;
+  const accountEmail = account?.email ?? userEmail;
+  const participantSummary = useMemo(
+    () => getThreadParticipantNames(thread.messages, accountEmail).join(", "),
+    [thread.messages, accountEmail],
+  );
+
   if (!message) return null;
 
   const isUnread = isThreadUnread(thread.messages);
@@ -78,10 +85,7 @@ export const ThreadRow = memo(function ThreadRow({
   const isDraft = message.labelIds?.includes(GmailLabel.DRAFT) ?? false;
   const isWide = layout === "list" && !compact;
 
-  const account = "account" in thread ? thread.account : null;
-  const sender = extractNameFromEmail(
-    participant(message, account?.email ?? userEmail),
-  );
+  const messageCount = thread.messages.length;
   const subject = message.headers.subject;
   const snippet = decodeSnippet(thread.snippet || message.snippet);
   const chips = labels.slice(0, isWide ? 3 : 2);
@@ -97,7 +101,7 @@ export const ThreadRow = memo(function ThreadRow({
     <span className={cn("relative size-3.5 shrink-0", !isWide && "mt-0.5")}>
       {selectionEnabled ? (
         <Checkbox
-          aria-label={`Select conversation from ${sender}`}
+          aria-label={`Select conversation with ${participantSummary}`}
           checked={isSelected}
           className={cn(
             "absolute inset-0 size-3.5 rounded border-input transition-opacity [&_svg]:size-2.5",
@@ -135,6 +139,26 @@ export const ThreadRow = memo(function ThreadRow({
   const draftMarker = isDraft ? (
     <span className="shrink-0 text-primary text-sm">Draft</span>
   ) : null;
+  const messageCountMarker =
+    messageCount > 1 ? (
+      <span className="shrink-0 font-normal text-muted-foreground text-xs">
+        ({messageCount})
+      </span>
+    ) : null;
+  const participantLine = (
+    <>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-foreground text-sm",
+          isUnread && "font-semibold",
+        )}
+      >
+        {participantSummary}
+      </span>
+      {draftMarker}
+      {messageCountMarker}
+    </>
+  );
 
   return (
     <div
@@ -168,15 +192,7 @@ export const ThreadRow = memo(function ThreadRow({
       {isWide ? (
         <>
           <div className="flex w-48 shrink-0 items-baseline gap-1.5 overflow-hidden whitespace-nowrap">
-            <span
-              className={cn(
-                "truncate text-foreground text-sm",
-                isUnread && "font-semibold",
-              )}
-            >
-              {sender}
-            </span>
-            {draftMarker}
+            {participantLine}
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2.5">
             {account ? <AccountAvatar account={account} /> : null}
@@ -206,15 +222,7 @@ export const ThreadRow = memo(function ThreadRow({
       ) : (
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <div className="flex items-baseline gap-1.5">
-            <span
-              className={cn(
-                "min-w-0 flex-1 truncate text-foreground text-sm",
-                isUnread && "font-semibold",
-              )}
-            >
-              {sender}
-            </span>
-            {draftMarker}
+            {participantLine}
             <div className="ml-auto shrink-0">{date}</div>
           </div>
           <div

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getThreadParticipantNames } from "./thread-participants";
+
+describe("getThreadParticipantNames", () => {
+  it("lists each sender once and labels the account owner as me", () => {
+    expect(
+      getThreadParticipantNames(
+        [
+          message({
+            from: "Bah <bah@example.com>",
+            to: "owner@example.com",
+          }),
+          message({
+            from: "owner@example.com",
+            to: "Bah <bah@example.com>",
+          }),
+          message({
+            from: "Bah Updated <BAH@example.com>",
+            to: "owner@example.com",
+          }),
+        ],
+        "OWNER@example.com",
+      ),
+    ).toEqual(["Bah", "me"]);
+  });
+
+  it("does not add me to a received-only thread", () => {
+    expect(
+      getThreadParticipantNames(
+        [
+          message({
+            from: "Bah <bah@example.com>",
+            to: "owner@example.com",
+          }),
+        ],
+        "owner@example.com",
+      ),
+    ).toEqual(["Bah"]);
+  });
+
+  it("keeps recipient names for an outgoing-only thread", () => {
+    expect(
+      getThreadParticipantNames(
+        [
+          message({
+            from: "owner@example.com",
+            to: "Jordan <jordan@example.com>, Taylor <taylor@example.com>",
+          }),
+        ],
+        "owner@example.com",
+      ),
+    ).toEqual(["Jordan", "Taylor"]);
+  });
+});
+
+function message({ from, to }: { from: string; to: string }) {
+  return { headers: { from, to } };
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.ts
@@ -1,0 +1,52 @@
+import {
+  canonicalizeEmailAddress,
+  extractNameFromEmail,
+  splitRecipientList,
+} from "@/utils/email";
+import type { ParsedMessageHeaders } from "@/utils/types";
+
+type ParticipantMessage = {
+  headers: Pick<ParsedMessageHeaders, "from" | "to">;
+};
+
+export function getThreadParticipantNames(
+  messages: ParticipantMessage[],
+  userEmail: string,
+) {
+  const normalizedUserEmail = canonicalizeEmailAddress(userEmail);
+  const senders = new Map<string, string>();
+
+  for (const message of messages) {
+    addParticipant(senders, message.headers.from, normalizedUserEmail);
+  }
+
+  const isOutgoingOnly = senders.size === 1 && senders.has(normalizedUserEmail);
+  if (!isOutgoingOnly) return [...senders.values()];
+
+  const recipients = new Map<string, string>();
+  for (const message of messages) {
+    for (const recipient of splitRecipientList(message.headers.to)) {
+      addParticipant(recipients, recipient, normalizedUserEmail);
+    }
+  }
+  // An outgoing-only thread should name the other side, not "me".
+  recipients.delete(normalizedUserEmail);
+
+  return recipients.size ? [...recipients.values()] : [...senders.values()];
+}
+
+function addParticipant(
+  participants: Map<string, string>,
+  header: string,
+  normalizedUserEmail: string,
+) {
+  const email = canonicalizeEmailAddress(header);
+  const key = email || header.trim().toLowerCase();
+  if (!key || participants.has(key)) return;
+
+  const name =
+    email && email === normalizedUserEmail
+      ? "me"
+      : extractNameFromEmail(header) || email;
+  if (name) participants.set(key, name);
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260901-202345_pr-3460_b1ed1b579c3b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Thread rows now list every distinct participant and show a message count for multi-message conversations. Outgoing-only threads continue to identify recipients instead of the current user.

- Derive and deduplicate participant names across thread messages.
- Render the participant summary and message count in wide and compact layouts.
- Tests: focused unit test (3 passed), emulated Playwright specs (19 passed), and Ultracite check (7 files).
- Performance: adds memoized O(messages) client-side work per changed thread row; no database or network calls; low hot-path risk for bounded thread message lists.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-346/thread-list-does-not-show-all-participants

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Conversation lists now show a complete participant summary across all messages, rather than only the latest sender.
  * Your own identity is labeled as “me” for clearer conversation context.
  * Outgoing-only conversations display recipients when appropriate.
  * Participant names are deduplicated for cleaner summaries.
  * Threads with multiple messages now display the total message count.
  * Conversation selection labels are clearer and more consistent across actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->