### PR TITLE
email: Keep credentials after operation-level access errors

### DIFF
--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -138,22 +138,21 @@ describe("provider health", () => {
     );
   });
 
-  it("records Outlook access denied as action-required permission issues", async () => {
+  it("does not disconnect Outlook accounts for item access failures", async () => {
     const logger = createMockLogger();
 
     await recordEmailAccountProviderIssue({
       emailAccountId: "email-account-1",
       provider: "microsoft",
-      error: new Error("Access is denied. Check credentials and try again."),
+      error: new Error(
+        "Access is denied. Check credentials and try again. Cannot save changes made to an item to store.",
+      ),
       logger,
-      operation: "getMessage",
+      operation: "removeThreadLabels",
     });
 
-    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
-      emailAccountId: "email-account-1",
-      reason: "insufficient_permissions",
-      logger,
-    });
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+    expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
   it("does not treat malformed Outlook requests as permanent credential failures", () => {

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -156,13 +156,13 @@ describe("provider health", () => {
     expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
-  it("records Outlook authorization failures as permission issues", async () => {
+  it("records Outlook authorization failures case-insensitively", async () => {
     const logger = createScopedLogger("provider-health-test");
 
     await recordEmailAccountProviderIssue({
       emailAccountId: "email-account-1",
       provider: "microsoft",
-      error: new Error("Access is denied. Check credentials and try again."),
+      error: new Error("ACCESS IS DENIED. CHECK CREDENTIALS AND TRY AGAIN."),
       logger,
       operation: "getMessage",
     });

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -156,6 +156,24 @@ describe("provider health", () => {
     expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
+  it("records Outlook authorization failures as permission issues", async () => {
+    const logger = createScopedLogger("provider-health-test");
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      error: new Error("Access is denied. Check credentials and try again."),
+      logger,
+      operation: "getMessage",
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "insufficient_permissions",
+      logger,
+    });
+  });
+
   it("does not treat malformed Outlook requests as permanent credential failures", () => {
     expect(
       classifyEmailAccountProviderIssue({

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -8,6 +8,7 @@ import {
   claimProviderIssueCleanupInRedis,
   releaseProviderIssueCleanupClaimInRedis,
 } from "@/utils/redis/provider-issue-cleanup";
+import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
   cleanupInvalidTokens: vi.fn(),
@@ -139,7 +140,7 @@ describe("provider health", () => {
   });
 
   it("does not disconnect Outlook accounts for item access failures", async () => {
-    const logger = createMockLogger();
+    const logger = createScopedLogger("provider-health-test");
 
     await recordEmailAccountProviderIssue({
       emailAccountId: "email-account-1",

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -146,7 +146,7 @@ describe("provider health", () => {
       emailAccountId: "email-account-1",
       provider: "microsoft",
       error: new Error(
-        "Access is denied. Check credentials and try again. Cannot save changes made to an item to store.",
+        "Access is denied. Check credentials and try again. CANNOT SAVE CHANGES MADE TO AN ITEM TO STORE.",
       ),
       logger,
       operation: "removeThreadLabels",
@@ -172,6 +172,21 @@ describe("provider health", () => {
       reason: "insufficient_permissions",
       logger,
     });
+  });
+
+  it("does not disconnect Outlook accounts for code-only access denials", async () => {
+    const logger = createScopedLogger("provider-health-test");
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      error: { code: "ErrorAccessDenied" },
+      logger,
+      operation: "getMessage",
+    });
+
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+    expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
   it("does not treat malformed Outlook requests as permanent credential failures", () => {

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -3,6 +3,7 @@ import {
   getErrorMessage,
   isGmailInsufficientPermissionsError,
   isInvalidGrantError,
+  isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import {
@@ -87,6 +88,14 @@ export function classifyEmailAccountProviderIssue({
     provider === "google" &&
     (isGmailInsufficientPermissionsError(error) ||
       message?.includes("Request had insufficient authentication scopes"))
+  ) {
+    return { reason: "insufficient_permissions" };
+  }
+
+  if (
+    provider === "microsoft" &&
+    isOutlookAccessDeniedError(error) &&
+    !message?.includes("Cannot save changes made to an item to store")
   ) {
     return { reason: "insufficient_permissions" };
   }

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -3,7 +3,6 @@ import {
   getErrorMessage,
   isGmailInsufficientPermissionsError,
   isInvalidGrantError,
-  isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import {
@@ -89,10 +88,6 @@ export function classifyEmailAccountProviderIssue({
     (isGmailInsufficientPermissionsError(error) ||
       message?.includes("Request had insufficient authentication scopes"))
   ) {
-    return { reason: "insufficient_permissions" };
-  }
-
-  if (provider === "microsoft" && isOutlookAccessDeniedError(error)) {
     return { reason: "insufficient_permissions" };
   }
 

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -83,6 +83,7 @@ export function classifyEmailAccountProviderIssue({
   provider: "google" | "microsoft";
 }): ProviderIssue | null {
   const message = getErrorMessage(error);
+  const normalizedMessage = message?.toLowerCase() ?? "";
 
   if (
     provider === "google" &&
@@ -95,7 +96,10 @@ export function classifyEmailAccountProviderIssue({
   if (
     provider === "microsoft" &&
     isOutlookAccessDeniedError(error) &&
-    !message?.includes("Cannot save changes made to an item to store")
+    normalizedMessage.includes(
+      "access is denied. check credentials and try again",
+    ) &&
+    !normalizedMessage.includes("cannot save changes made to an item to store")
   ) {
     return { reason: "insufficient_permissions" };
   }

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -3,7 +3,6 @@ import {
   getErrorMessage,
   isGmailInsufficientPermissionsError,
   isInvalidGrantError,
-  isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import {
@@ -95,7 +94,6 @@ export function classifyEmailAccountProviderIssue({
 
   if (
     provider === "microsoft" &&
-    isOutlookAccessDeniedError(error) &&
     normalizedMessage.includes(
       "access is denied. check credentials and try again",
     ) &&


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-214006_pr-3462_cf7d231a4e4b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevents operation-level Microsoft access errors from being classified as missing OAuth consent.

- preserve account credentials when an individual provider operation is denied
- retain verified authentication-failure cleanup and add regression coverage
- validate with focused provider and error unit tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Microsoft Outlook access-denied errors during email operations.
  * Item-specific failures are no longer incorrectly treated as account credential or permission problems.
  * Prevented unnecessary token cleanup and recovery actions when Outlook reports an issue with a specific email item.
  * Preserved existing handling for genuine authentication and permission errors, helping avoid unnecessary account disruption.
  * Improved recognition of Outlook error messages regardless of capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->