### PR TITLE
INB-347: Add mark as unread actions to mail toolbars

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -9,7 +9,14 @@ import {
 } from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
-let readStateCleanup: { emailAccountId: string; threadId: string } | undefined;
+let readStateCleanup:
+  | {
+      emailAccountId: string;
+      listQuery: string;
+      subject: string;
+      threadId: string;
+    }
+  | undefined;
 
 test.afterEach(async ({ page }) => {
   const cleanup = readStateCleanup;
@@ -78,6 +85,8 @@ test("marks selected conversations as unread", async ({ page }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
   readStateCleanup = {
     emailAccountId,
+    listQuery: "type=inbox",
+    subject: "Read Command Message",
     threadId: "thr_playwright_2",
   };
   const conversation = conversationWithSubject(
@@ -115,6 +124,8 @@ test("marks an open conversation as unread", async ({ page }, testInfo) => {
   await stubMailboxSync(page, emailAccountId, "thr_playwright_label");
   readStateCleanup = {
     emailAccountId,
+    listQuery: "type=label&labelId=Label_project",
+    subject: "Project Label Message",
     threadId: "thr_playwright_label",
   };
   await page.goto(
@@ -232,24 +243,49 @@ function allRowsAreSelected(rows: Locator, selected: boolean) {
 
 async function restoreReadState(
   page: Page,
-  { emailAccountId, threadId }: { emailAccountId: string; threadId: string },
+  {
+    emailAccountId,
+    listQuery,
+    subject,
+    threadId,
+  }: {
+    emailAccountId: string;
+    listQuery: string;
+    subject: string;
+    threadId: string;
+  },
 ) {
-  await page.goto(`/${emailAccountId}/mail?type=sent&thread-id=${threadId}`);
-  await page.getByRole("button", { name: /^More actions/ }).click();
-  const markRead = page.getByRole("menuitem", { name: "Mark as read" });
-  const markUnread = page.getByRole("menuitem", { name: "Mark as unread" });
-  await expect(markRead.or(markUnread)).toBeVisible();
-  if (!(await markRead.isVisible())) {
-    await page.keyboard.press("Escape");
+  await page.goto(`/${emailAccountId}/mail?${listQuery}`);
+  const conversations = page.getByRole("listbox", { name: "Conversations" });
+  await expect(conversations).toBeVisible();
+  await conversationWithSubject(page, conversations, subject).click();
+  await expect(page.getByRole("heading", { name: subject })).toBeVisible();
+  await expect
+    .poll(() => isThreadUnread(page, emailAccountId, threadId), {
+      timeout: 60_000,
+    })
+    .toBe(false);
+}
+
+async function isThreadUnread(
+  page: Page,
+  emailAccountId: string,
+  threadId: string,
+) {
+  try {
+    const response = await page.request.get(`/api/threads/${threadId}`, {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    });
+    if (!response.ok()) return;
+    const { thread } = (await response.json()) as {
+      thread: { messages: { labelIds?: string[] }[] };
+    };
+    return thread.messages.some((message) =>
+      message.labelIds?.includes("UNREAD"),
+    );
+  } catch {
     return;
   }
-
-  await markRead.click();
-  await expectReadStateMutation(page, {
-    emailAccountId,
-    threadId,
-    read: true,
-  });
 }
 
 function stubMailboxSync(page: Page, emailAccountId: string, threadId: string) {

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,6 +1,11 @@
-import { expect, type Locator } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
 
@@ -56,6 +61,81 @@ test("deletes an open conversation and returns to the list", async ({
     { headers: { "X-Email-Account-ID": emailAccountId } },
   );
   expect(restoreResponse.ok()).toBeTruthy();
+});
+
+test("marks selected conversations as unread", async ({ page }, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Read Command Message",
+  );
+
+  await conversation
+    .getByRole("checkbox", { name: "Select conversation with Bob Example" })
+    .click();
+  const markUnread = page.getByRole("button", {
+    name: "Mark as unread",
+    exact: true,
+  });
+  await expect(markUnread).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-selection-mark-unread",
+  );
+
+  await markUnread.click();
+
+  await expect(page.getByText("1 selected", { exact: true })).toBeHidden();
+  await expectReadStateMutation(page, {
+    emailAccountId,
+    threadId: "thr_playwright_2",
+    read: false,
+  });
+
+  await conversation.click();
+  await expectReadStateMutation(page, {
+    emailAccountId,
+    threadId: "thr_playwright_2",
+    read: true,
+  });
+});
+
+test("marks an open conversation as unread", async ({ page }, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Project Label Message",
+  );
+  await conversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Project Label Message" }),
+  ).toBeVisible();
+
+  const markUnread = page.getByRole("button", {
+    name: "Mark as unread",
+    exact: true,
+  });
+  await expect(markUnread).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-mark-unread");
+
+  await markUnread.click();
+
+  await expectReadStateMutation(page, {
+    emailAccountId,
+    threadId: "thr_playwright_label",
+    read: false,
+  });
+
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await page.getByRole("menuitem", { name: "Mark as read" }).click();
+  await expectReadStateMutation(page, {
+    emailAccountId,
+    threadId: "thr_playwright_label",
+    read: true,
+  });
 });
 
 test("selects ranges and opens conversations with the keyboard", async ({
@@ -116,6 +196,25 @@ test("selects every conversation with Command A", async ({ page }) => {
   await expect(options).toHaveCount(conversationCount);
   await expect.poll(() => allRowsAreSelected(options, true)).toBe(true);
 });
+
+function expectReadStateMutation(
+  page: Page,
+  {
+    emailAccountId,
+    threadId,
+    read,
+  }: { emailAccountId: string; threadId: string; read: boolean },
+) {
+  return expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "set_read_state",
+        threadId,
+      }),
+    )
+    .toMatchObject({ payload: { read } });
+}
 
 function allRowsAreSelected(rows: Locator, selected: boolean) {
   return rows.evaluateAll(

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import {
@@ -8,6 +9,14 @@ import {
 } from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
+let readStateCleanup: { emailAccountId: string; threadId: string } | undefined;
+
+test.afterEach(async ({ page }) => {
+  const cleanup = readStateCleanup;
+  readStateCleanup = undefined;
+  if (!cleanup || page.isClosed()) return;
+  await restoreReadState(page, cleanup);
+});
 
 test("archives a selected conversation and restores it with undo", async ({
   page,
@@ -64,7 +73,13 @@ test("deletes an open conversation and returns to the list", async ({
 });
 
 test("marks selected conversations as unread", async ({ page }, testInfo) => {
+  const accountId = await getEmailAccountId(page);
+  await stubMailboxSync(page, accountId, "thr_playwright_2");
   const { conversations, emailAccountId } = await openMail(page);
+  readStateCleanup = {
+    emailAccountId,
+    threadId: "thr_playwright_2",
+  };
   const conversation = conversationWithSubject(
     page,
     conversations,
@@ -93,23 +108,18 @@ test("marks selected conversations as unread", async ({ page }, testInfo) => {
     threadId: "thr_playwright_2",
     read: false,
   });
-
-  await conversation.click();
-  await expectReadStateMutation(page, {
-    emailAccountId,
-    threadId: "thr_playwright_2",
-    read: true,
-  });
 });
 
 test("marks an open conversation as unread", async ({ page }, testInfo) => {
-  const { conversations, emailAccountId } = await openMail(page);
-  const conversation = conversationWithSubject(
-    page,
-    conversations,
-    "Project Label Message",
+  const emailAccountId = await getEmailAccountId(page);
+  await stubMailboxSync(page, emailAccountId, "thr_playwright_label");
+  readStateCleanup = {
+    emailAccountId,
+    threadId: "thr_playwright_label",
+  };
+  await page.goto(
+    `/${emailAccountId}/mail?type=sent&thread-id=thr_playwright_label`,
   );
-  await conversation.click();
   await expect(
     page.getByRole("heading", { name: "Project Label Message" }),
   ).toBeVisible();
@@ -127,14 +137,6 @@ test("marks an open conversation as unread", async ({ page }, testInfo) => {
     emailAccountId,
     threadId: "thr_playwright_label",
     read: false,
-  });
-
-  await page.getByRole("button", { name: /^More actions/ }).click();
-  await page.getByRole("menuitem", { name: "Mark as read" }).click();
-  await expectReadStateMutation(page, {
-    emailAccountId,
-    threadId: "thr_playwright_label",
-    read: true,
   });
 });
 
@@ -206,14 +208,16 @@ function expectReadStateMutation(
   }: { emailAccountId: string; threadId: string; read: boolean },
 ) {
   return expect
-    .poll(() =>
-      readLatestMailMutation(page, {
-        emailAccountId,
-        kind: "set_read_state",
-        threadId,
-      }),
+    .poll(
+      () =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "set_read_state",
+          threadId,
+        }),
+      { timeout: 60_000 },
     )
-    .toMatchObject({ payload: { read } });
+    .toMatchObject({ payload: { read }, status: "succeeded" });
 }
 
 function allRowsAreSelected(rows: Locator, selected: boolean) {
@@ -224,4 +228,51 @@ function allRowsAreSelected(rows: Locator, selected: boolean) {
       ),
     selected,
   );
+}
+
+async function restoreReadState(
+  page: Page,
+  { emailAccountId, threadId }: { emailAccountId: string; threadId: string },
+) {
+  await page.goto(`/${emailAccountId}/mail?type=sent&thread-id=${threadId}`);
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  const markRead = page.getByRole("menuitem", { name: "Mark as read" });
+  const markUnread = page.getByRole("menuitem", { name: "Mark as unread" });
+  await expect(markRead.or(markUnread)).toBeVisible();
+  if (!(await markRead.isVisible())) {
+    await page.keyboard.press("Escape");
+    return;
+  }
+
+  await markRead.click();
+  await expectReadStateMutation(page, {
+    emailAccountId,
+    threadId,
+    read: true,
+  });
+}
+
+function stubMailboxSync(page: Page, emailAccountId: string, threadId: string) {
+  return page.route("**/api/mobile/mailbox-sync", async (route) => {
+    const response = await page.request.get(`/api/threads/${threadId}`, {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    });
+    expect(response.ok()).toBeTruthy();
+    const { thread } = (await response.json()) as {
+      thread: { messages: unknown[] };
+    };
+
+    await route.fulfill({
+      body: JSON.stringify({
+        accountId: emailAccountId,
+        cursor: "playwright-triage-actions-sync",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: false,
+        upsertedMessages: thread.messages,
+      }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1032,6 +1032,7 @@ export function MailShell() {
                 onSelectRangeTo={selection.selectRangeTo}
                 onArchiveSelected={archiveTargets}
                 onDeleteSelected={trashTargets}
+                onMarkUnreadSelected={markUnreadTargets}
                 onClearSelection={selection.clear}
                 showLoadMore={hasMore}
                 isLoadingMore={isLoadingMore}
@@ -1067,6 +1068,7 @@ export function MailShell() {
               onBackToInbox={closeReader}
               onArchive={archiveTargets}
               onDelete={trashTargets}
+              onMarkUnread={markUnreadTargets}
               onReply={requestReaderReply}
               onToggleFocusMode={() => setIsFocusMode((on) => !on)}
               showSidebarToggle={!isMailSidebarOpen}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -312,11 +312,6 @@ export function MailShell() {
 
   const orderedIds = useMemo(() => threads.map(getListThreadKey), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, markRead, setReadState, snooze, undo } =
-    useThreadActions({
-      emailAccountId,
-      threads,
-    });
 
   const clampIndex = useCallback(
     (index: number) =>
@@ -346,9 +341,6 @@ export function MailShell() {
   const openThread = openThreadKey
     ? threads.find((thread) => getListThreadKey(thread) === openThreadKey)
     : undefined;
-  const resolvedOpenThreadKey = openThread
-    ? getListThreadKey(openThread)
-    : null;
   const readAttemptedForOpenThread = useRef<string | null>(null);
 
   // Defer the pair as one value: rendering a new id with the previous account
@@ -387,6 +379,37 @@ export function MailShell() {
   const openMessages = readerSelectionSettled
     ? (openThreadData?.thread.messages ?? NO_MESSAGES)
     : NO_MESSAGES;
+  const readerTarget = useMemo(() => {
+    if (
+      !readerSelectionSettled ||
+      !openThreadSelection ||
+      !openThreadKey ||
+      !openThreadData?.thread
+    ) {
+      return null;
+    }
+
+    return {
+      emailAccountId: openThreadSelection.emailAccountId,
+      key: openThreadKey,
+      messageIds: openThreadData.thread.messages.map((message) => message.id),
+      threadId: openThreadData.thread.id,
+    };
+  }, [
+    openThreadData?.thread,
+    openThreadKey,
+    openThreadSelection,
+    readerSelectionSettled,
+  ]);
+  const { archive, trash, markRead, setReadState, snooze, undo } =
+    useThreadActions({
+      emailAccountId,
+      readerTarget,
+      threads,
+    });
+  const resolvedOpenThreadKey = openThread
+    ? getListThreadKey(openThread)
+    : readerTarget?.key;
   const requestReaderReply = useCallback(() => {
     const messageId = openMessages.at(-1)?.id;
     if (messageId) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import {
   ArchiveIcon,
   ArrowLeftIcon,
+  MailIcon,
   MaximizeIcon,
   MinimizeIcon,
   ReplyIcon,
@@ -28,6 +29,7 @@ type ReaderToolbarProps = {
   isFocusMode: boolean;
   onBackToInbox: () => void;
   onArchive: () => void;
+  onMarkUnread: () => void;
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
@@ -46,6 +48,7 @@ export function ReaderToolbar({
   isFocusMode,
   onBackToInbox,
   onArchive,
+  onMarkUnread,
   onReply,
   onDelete,
   onToggleFocusMode,
@@ -90,6 +93,10 @@ export function ReaderToolbar({
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
           <Kbd className="ml-1.5">{getShortcutHint("archive")}</Kbd>
+        </Button>
+        <Button onClick={onMarkUnread} size="xs-2" variant="outline">
+          <MailIcon className="mr-1.5 size-3.5" />
+          Mark as unread
         </Button>
         <Button onClick={onReply} size="xs-2" variant="outline">
           <ReplyIcon className="mr-1.5 size-3.5" />

--- a/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
@@ -11,6 +11,7 @@ import { getShortcutHint } from "@/lib/shortcuts/registry";
 export type SelectionBarProps = {
   selectedCount: number;
   onArchive: () => void;
+  onMarkUnread: () => void;
   onDelete: () => void;
   onClear: () => void;
 };
@@ -19,6 +20,7 @@ export type SelectionBarProps = {
 export function SelectionBar({
   selectedCount,
   onArchive,
+  onMarkUnread,
   onDelete,
   onClear,
 }: SelectionBarProps) {
@@ -41,6 +43,9 @@ export function SelectionBar({
         </TooltipTrigger>
         <TooltipContent>Archive ({getShortcutHint("archive")})</TooltipContent>
       </Tooltip>
+      <Button onClick={onMarkUnread} size="xs-2" variant="outline">
+        Mark as unread
+      </Button>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -33,6 +33,7 @@ export type ThreadListProps = {
   onToggleSelect: (index: number) => void;
   onSelectRangeTo: (index: number) => void;
   onArchiveSelected: () => void;
+  onMarkUnreadSelected: () => void;
   onDeleteSelected: () => void;
   onClearSelection: () => void;
   showLoadMore: boolean;
@@ -56,6 +57,7 @@ export function ThreadList({
   onToggleSelect,
   onSelectRangeTo,
   onArchiveSelected,
+  onMarkUnreadSelected,
   onDeleteSelected,
   onClearSelection,
   showLoadMore,
@@ -129,6 +131,7 @@ export function ThreadList({
           onArchive={onArchiveSelected}
           onClear={onClearSelection}
           onDelete={onDeleteSelected}
+          onMarkUnread={onMarkUnreadSelected}
           selectedCount={selectedCount}
         />
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -45,6 +45,7 @@ export type ThreadReaderProps = {
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
+  onMarkUnread: () => void;
   onReply: () => void;
   onDelete: () => void;
   onToggleFocusMode: () => void;
@@ -74,6 +75,7 @@ export function ThreadReader({
   onRemoveLabel,
   onBackToInbox,
   onArchive,
+  onMarkUnread,
   onReply,
   onDelete,
   onToggleFocusMode,
@@ -150,6 +152,7 @@ export function ThreadReader({
             onArchive={onArchive}
             onBackToInbox={onBackToInbox}
             onDelete={onDelete}
+            onMarkUnread={onMarkUnread}
             onRemoveLabel={onRemoveLabel}
             onReply={onReply}
             onToggleFocusMode={onToggleFocusMode}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -115,6 +115,29 @@ describe("useThreadActions durable mutations", () => {
     expect(outbox.enqueueBatch).not.toHaveBeenCalled();
   });
 
+  it("queues a fetched reader target that has no retained list row", async () => {
+    const { result } = renderActions({
+      threads: [],
+      readerTarget: {
+        emailAccountId: "account",
+        key: "reader-thread",
+        messageIds: ["reader-message-one", "reader-message-two"],
+        threadId: "reader-thread",
+      },
+    });
+
+    await act(() => result.current.setReadState(["reader-thread"], false));
+
+    expect(outbox.enqueueBatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        emailAccountId: "account",
+        messageIds: ["reader-message-one", "reader-message-two"],
+        read: false,
+        threadId: "reader-thread",
+      }),
+    ]);
+  });
+
   it("counts unresolved rows in partial-action feedback", async () => {
     const { result } = renderActions();
 
@@ -317,12 +340,20 @@ describe("useThreadActions durable mutations", () => {
 
 function renderActions({
   threads = [createThread(["INBOX", "UNREAD"])],
+  readerTarget,
 }: {
   threads?: ListThread[];
+  readerTarget?: {
+    emailAccountId: string;
+    key: string;
+    messageIds: string[];
+    threadId: string;
+  };
 } = {}) {
   return renderHook(() =>
     useThreadActions({
       emailAccountId: "account",
+      readerTarget,
       threads,
     }),
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -116,15 +116,8 @@ describe("useThreadActions durable mutations", () => {
   });
 
   it("queues a fetched reader target that has no retained list row", async () => {
-    const { result } = renderActions({
-      threads: [],
-      readerTarget: {
-        emailAccountId: "account",
-        key: "reader-thread",
-        messageIds: ["reader-message-one", "reader-message-two"],
-        threadId: "reader-thread",
-      },
-    });
+    const readerTarget = createReaderTarget();
+    const { result } = renderActions({ threads: [], readerTarget });
 
     await act(() => result.current.setReadState(["reader-thread"], false));
 
@@ -136,6 +129,31 @@ describe("useThreadActions durable mutations", () => {
         threadId: "reader-thread",
       }),
     ]);
+  });
+
+  it("does not retain a direct reader target after the reader closes", async () => {
+    const readerTarget = createReaderTarget();
+    const { result, rerender } = renderHook(
+      ({
+        activeReaderTarget,
+      }: {
+        activeReaderTarget: typeof readerTarget | null;
+      }) =>
+        useThreadActions({
+          emailAccountId: "account",
+          readerTarget: activeReaderTarget,
+          threads: [],
+        }),
+      { initialProps: { activeReaderTarget: readerTarget } },
+    );
+
+    rerender({ activeReaderTarget: null });
+    await act(() => result.current.setReadState(["reader-thread"], false));
+
+    expect(outbox.enqueueBatch).not.toHaveBeenCalled();
+    expect(notifications.error).toHaveBeenCalledWith(
+      "Couldn't queue marking as unread",
+    );
   });
 
   it("counts unresolved rows in partial-action feedback", async () => {
@@ -357,6 +375,15 @@ function renderActions({
       threads,
     }),
   );
+}
+
+function createReaderTarget() {
+  return {
+    emailAccountId: "account",
+    key: "reader-thread",
+    messageIds: ["reader-message-one", "reader-message-two"],
+    threadId: "reader-thread",
+  };
 }
 
 function createThread(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -28,6 +28,8 @@ type ThreadSnapshot = {
   threadId: string;
 };
 
+type ThreadActionTarget = Omit<ThreadSnapshot, "mutationId">;
+
 type UndoableBatch = {
   action: UndoableAction;
   snapshots: ThreadSnapshot[];
@@ -36,42 +38,41 @@ type UndoableBatch = {
 
 export function useThreadActions({
   emailAccountId,
+  readerTarget,
   threads,
 }: {
   emailAccountId: string;
+  readerTarget?: ThreadActionTarget | null;
   threads: ListThread[];
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
   const retainedEmailAccountId = useRef(emailAccountId);
-  const threadsByKey = useRef(new Map<string, ListThread>());
+  const targetsByKey = useRef(new Map<string, ThreadActionTarget>());
   if (retainedEmailAccountId.current !== emailAccountId) {
     retainedEmailAccountId.current = emailAccountId;
-    threadsByKey.current.clear();
+    targetsByKey.current.clear();
     lastAction.current = null;
   }
   for (const thread of threads) {
-    threadsByKey.current.set(getListThreadKey(thread), thread);
+    const target = getThreadActionTarget(thread, emailAccountId);
+    if (target) targetsByKey.current.set(target.key, target);
+  }
+  if (readerTarget) {
+    const messageIds = [...new Set(readerTarget.messageIds)];
+    if (messageIds.length) {
+      targetsByKey.current.set(readerTarget.key, {
+        ...readerTarget,
+        messageIds,
+      });
+    }
   }
 
   const resolveTargets = useCallback(
     (threadKeys: string[]) =>
       threadKeys
-        .map((key) => {
-          const thread = threadsByKey.current.get(key);
-          if (!thread) return;
-          const messageIds = [...new Set(getListThreadMessageIds(thread))];
-          if (!messageIds.length) return;
-          return {
-            emailAccountId: getListThreadEmailAccountId(thread, emailAccountId),
-            key,
-            messageIds,
-            threadId: thread.id,
-          };
-        })
-        .filter((target): target is Omit<ThreadSnapshot, "mutationId"> =>
-          Boolean(target),
-        ),
-    [emailAccountId],
+        .map((key) => targetsByKey.current.get(key))
+        .filter((target): target is ThreadActionTarget => Boolean(target)),
+    [],
   );
 
   const enqueueTargets = useCallback(
@@ -273,4 +274,19 @@ export function useThreadActions({
 
 function summarise(verb: string, count: number) {
   return count === 1 ? verb : `${verb} ${count} conversations`;
+}
+
+function getThreadActionTarget(
+  thread: ListThread,
+  currentEmailAccountId: string,
+): ThreadActionTarget | undefined {
+  const messageIds = [...new Set(getListThreadMessageIds(thread))];
+  if (!messageIds.length) return;
+
+  return {
+    emailAccountId: getListThreadEmailAccountId(thread, currentEmailAccountId),
+    key: getListThreadKey(thread),
+    messageIds,
+    threadId: thread.id,
+  };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -47,32 +47,37 @@ export function useThreadActions({
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
   const retainedEmailAccountId = useRef(emailAccountId);
-  const targetsByKey = useRef(new Map<string, ThreadActionTarget>());
+  const readerTargetRef = useRef<ThreadActionTarget | null>(null);
+  const threadsByKey = useRef(new Map<string, ListThread>());
   if (retainedEmailAccountId.current !== emailAccountId) {
     retainedEmailAccountId.current = emailAccountId;
-    targetsByKey.current.clear();
+    readerTargetRef.current = null;
+    threadsByKey.current.clear();
     lastAction.current = null;
   }
   for (const thread of threads) {
-    const target = getThreadActionTarget(thread, emailAccountId);
-    if (target) targetsByKey.current.set(target.key, target);
+    threadsByKey.current.set(getListThreadKey(thread), thread);
   }
-  if (readerTarget) {
-    const messageIds = [...new Set(readerTarget.messageIds)];
-    if (messageIds.length) {
-      targetsByKey.current.set(readerTarget.key, {
-        ...readerTarget,
-        messageIds,
-      });
-    }
-  }
+  readerTargetRef.current = readerTarget ?? null;
 
   const resolveTargets = useCallback(
     (threadKeys: string[]) =>
       threadKeys
-        .map((key) => targetsByKey.current.get(key))
+        .map((key) => {
+          const activeReaderTarget = readerTargetRef.current;
+          if (activeReaderTarget?.key === key) {
+            const messageIds = [...new Set(activeReaderTarget.messageIds)];
+            if (!messageIds.length) return;
+            return { ...activeReaderTarget, messageIds };
+          }
+
+          const thread = threadsByKey.current.get(key);
+          return thread
+            ? getThreadActionTarget(thread, emailAccountId)
+            : undefined;
+        })
         .filter((target): target is ThreadActionTarget => Boolean(target)),
-    [],
+    [emailAccountId],
   );
 
   const enqueueTargets = useCallback(


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-211414_pr-3463_67fc307c1cbe/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a primary Mark as unread action for selected conversations and the open mail reader. The new controls reuse the existing optimistic read-state mutation path.

- Wire selection and reader toolbars to the existing unread action.
- Add emulated Playwright coverage and visual checkpoints for both placements.
- Test: `pnpm -F inbox-zero-ai test:playwright:emulated mail/triage-actions.spec.ts` (7 passed).
- Performance: no new steady-state work, database calls, or network call types; clicks reuse the existing mutation path, so hot-path risk is low.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-347/add-mark-as-unread-action-to-selected-emails-and-reading-panel-in-mail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Mark as unread” action to the mail reading toolbar.
  * Added support for marking selected messages or threads as unread from the selection bar.
  * Connected the action across mail list and reader views.
  * Marking as unread now works for messages opened directly through a link, even when they are not visible in the mail list.

* **Tests**
  * Added coverage verifying unread actions across list and reader views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->