### PR TITLE
mcp: add server logs for auth-url rejections and connect failures

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
@@ -93,6 +93,7 @@ export function IntegrationRow({
       analytics.captureAction("integration_connect_failed", {
         integration: integration.name,
         reason: "auth_url_error",
+        error_message: error instanceof Error ? error.message : undefined,
       });
       console.error(
         `Failed to initiate ${integration.name} connection:`,

--- a/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
@@ -93,7 +93,8 @@ export function IntegrationRow({
       analytics.captureAction("integration_connect_failed", {
         integration: integration.name,
         reason: "auth_url_error",
-        error_message: error instanceof Error ? error.message : undefined,
+        error_message:
+          error instanceof Error && error.message ? error.message : undefined,
       });
       console.error(
         `Failed to initiate ${integration.name} connection:`,

--- a/apps/web/app/api/mcp/[integration]/auth-url/route.ts
+++ b/apps/web/app/api/mcp/[integration]/auth-url/route.ts
@@ -41,12 +41,10 @@ export const GET = withEmailAccount(
       },
     });
 
-    if (
-      !hasTierAccess({
-        tier: getUserTier(user?.premium),
-        minimumTier: "PLUS_MONTHLY",
-      })
-    ) {
+    const tier = getUserTier(user?.premium);
+
+    if (!hasTierAccess({ tier, minimumTier: "PLUS_MONTHLY" })) {
+      logger.warn("MCP auth URL rejected: tier too low", { tier });
       throw new SafeError(
         "Integrations require a Plus plan or higher. Please upgrade to continue.",
       );
@@ -55,10 +53,14 @@ export const GET = withEmailAccount(
     const integrationConfig = findIntegration(integration);
 
     if (!integrationConfig) {
+      logger.warn("MCP auth URL rejected: unknown integration");
       throw new SafeError(`Integration ${integration} not found`);
     }
 
     if (integrationConfig.authType !== "oauth") {
+      logger.warn("MCP auth URL rejected: integration is not OAuth", {
+        authType: integrationConfig.authType,
+      });
       throw new SafeError(`Integration ${integration} does not support OAuth`);
     }
 
@@ -76,6 +78,8 @@ export const GET = withEmailAccount(
         redirectUri,
         state,
       });
+
+      logger.info("Generated MCP auth URL");
 
       // Set secure cookies for state and PKCE verifier
       const response = NextResponse.json<GetMcpAuthUrlResponse>({ url });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-224022_pr-3464_0cb68884c44f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Connect attempts for MCP integrations that failed before the OAuth redirect left no server-side trace: the auth-url route threw SafeErrors that the middleware returns silently, and the client analytics event only recorded a generic reason. Recent client events show several such failures with no way to diagnose them from logs.

- Log a warn with the user's tier when the auth-url route rejects for insufficient plan, plus warns for unknown or non-OAuth integrations
- Log an info line when an auth URL is generated so successful starts are visible alongside the existing callback logs
- Include the error message in the client `integration_connect_failed` analytics event

Validation: biome check and format pass on both files. Logging only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration connection error reporting by capturing meaningful error details more accurately.
  * Enhanced diagnostic logging for MCP authorization requests, including access restrictions, unsupported integrations, non-OAuth integrations, and successfully generated authorization links.
  * Authorization behavior remains unchanged, while troubleshooting information is now clearer and more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->