### PR TITLE
cron: schedule the weekly summary email

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -113,6 +113,10 @@
       "schedule": "0 8 * * *"
     },
     {
+      "path": "/api/resend/summary/all",
+      "schedule": "0 9 * * 1"
+    },
+    {
       "path": "/api/meeting-briefs",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-093006_pr-3466_a68958c22105/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The weekly summary email route (`/api/resend/summary/all`) exists and fans out per-account sends through the queue, but it was never listed in the Vercel cron config, so no summary has been sent to any account for well over a year. Users with the weekly setting (the default) never receive the archived-emails recap that is meant to surface what automation hid from them.

- Add `/api/resend/summary/all` to the cron list, Mondays at 09:00 UTC
- No route changes: the per-account route already skips accounts sent within the last 7 days, so a weekly trigger is the natural cadence

Validation: JSON parses; rendered the summary template locally to confirm the email still renders with its archived, follow-up, and cold-email sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a weekly automated summary delivery scheduled for Mondays at 9:00 AM UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->