### PR TITLE
rules: do not learn sender exclusions from bulk label removals

### DIFF
--- a/apps/web/utils/rule/record-label-removal-learning.test.ts
+++ b/apps/web/utils/rule/record-label-removal-learning.test.ts
@@ -1,11 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GroupItemSource, SystemType } from "@/generated/prisma/enums";
 import { saveLearnedPattern } from "@/utils/rule/learned-patterns";
-import { recordLabelRemovalLearning } from "./record-label-removal-learning";
+import prisma from "@/utils/prisma";
+import {
+  BULK_LABEL_REMOVAL_THRESHOLD,
+  getBulkRemovedLabelIds,
+  recordLabelRemovalLearning,
+} from "./record-label-removal-learning";
 import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/rule/learned-patterns", () => ({
   saveLearnedPattern: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    classificationFeedback: {
+      count: vi.fn().mockResolvedValue(0),
+    },
+  },
 }));
 
 const logger = createTestLogger();
@@ -14,6 +27,7 @@ describe("recordLabelRemovalLearning", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(saveLearnedPattern).mockResolvedValue(undefined);
+    vi.mocked(prisma.classificationFeedback.count).mockResolvedValue(0);
   });
 
   it("skips when sender is missing", async () => {
@@ -66,5 +80,67 @@ describe("recordLabelRemovalLearning", () => {
       reason: "Label removed",
       source: GroupItemSource.LABEL_REMOVED,
     });
+  });
+  it("skips when the removal was part of a bulk action in the same batch", async () => {
+    await recordLabelRemovalLearning({
+      sender: "sender@example.com",
+      ruleId: "rule-1",
+      systemType: SystemType.NEWSLETTER,
+      messageId: "message-1",
+      threadId: "thread-1",
+      emailAccountId: "email-account-1",
+      isBulkRemoval: true,
+      logger,
+    });
+
+    expect(saveLearnedPattern).not.toHaveBeenCalled();
+    expect(prisma.classificationFeedback.count).not.toHaveBeenCalled();
+  });
+
+  it("skips when the rule already saw many removals in the recent window", async () => {
+    vi.mocked(prisma.classificationFeedback.count).mockResolvedValue(
+      BULK_LABEL_REMOVAL_THRESHOLD,
+    );
+
+    await recordLabelRemovalLearning({
+      sender: "sender@example.com",
+      ruleId: "rule-1",
+      systemType: SystemType.NEWSLETTER,
+      messageId: "message-1",
+      threadId: "thread-1",
+      emailAccountId: "email-account-1",
+      logger,
+    });
+
+    expect(prisma.classificationFeedback.count).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        emailAccountId: "email-account-1",
+        ruleId: "rule-1",
+        eventType: "LABEL_REMOVED",
+      }),
+    });
+    expect(saveLearnedPattern).not.toHaveBeenCalled();
+  });
+});
+
+describe("getBulkRemovedLabelIds", () => {
+  it("flags only labels removed from many messages in one history page", () => {
+    const labelsRemoved = [
+      ...Array.from({ length: BULK_LABEL_REMOVAL_THRESHOLD }, (_, i) => ({
+        labelIds: ["label-bulk", i === 0 ? "label-single" : "INBOX"],
+      })),
+      { labelIds: ["label-few"] },
+      { labelIds: ["label-few"] },
+    ];
+
+    const bulk = getBulkRemovedLabelIds(labelsRemoved);
+
+    expect(bulk.has("label-bulk")).toBe(true);
+    expect(bulk.has("label-few")).toBe(false);
+    expect(bulk.has("label-single")).toBe(false);
+  });
+
+  it("ignores entries without label ids", () => {
+    expect(getBulkRemovedLabelIds([{ labelIds: null }, {}]).size).toBe(0);
   });
 });

--- a/apps/web/utils/rule/record-label-removal-learning.ts
+++ b/apps/web/utils/rule/record-label-removal-learning.ts
@@ -51,6 +51,9 @@ export async function recordLabelRemovalLearning({
     return;
   }
 
+  // Gmail callers record this removal's feedback row first, so the count
+  // includes it. Concurrent webhook pages can still race past this check; the
+  // batch-level isBulkRemoval flag is the primary guard for large sweeps.
   const recentRemovals = await prisma.classificationFeedback.count({
     where: {
       emailAccountId,

--- a/apps/web/utils/rule/record-label-removal-learning.ts
+++ b/apps/web/utils/rule/record-label-removal-learning.ts
@@ -1,7 +1,19 @@
-import { GroupItemSource, type SystemType } from "@/generated/prisma/enums";
+import { subMinutes } from "date-fns/subMinutes";
+import {
+  ClassificationFeedbackEventType,
+  GroupItemSource,
+  type SystemType,
+} from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
 import { shouldLearnFromLabelRemoval } from "@/utils/rule/consts";
 import { saveLearnedPattern } from "@/utils/rule/learned-patterns";
+
+// A user stripping a label from many emails at once is "stop labeling this",
+// not a per-sender correction. Learning an exclusion from each one leaves
+// later emails from those senders matching nothing.
+export const BULK_LABEL_REMOVAL_THRESHOLD = 10;
+const BULK_LABEL_REMOVAL_WINDOW_MINUTES = 15;
 
 export async function recordLabelRemovalLearning({
   sender,
@@ -10,6 +22,7 @@ export async function recordLabelRemovalLearning({
   messageId,
   threadId,
   emailAccountId,
+  isBulkRemoval,
   logger,
 }: {
   sender: string | null;
@@ -18,6 +31,7 @@ export async function recordLabelRemovalLearning({
   messageId: string;
   threadId?: string | null;
   emailAccountId: string;
+  isBulkRemoval?: boolean;
   logger: Logger;
 }) {
   if (!sender) {
@@ -29,6 +43,33 @@ export async function recordLabelRemovalLearning({
     logger.info("Label removal does not match a learnable system rule", {
       systemType,
     });
+    return;
+  }
+
+  if (isBulkRemoval) {
+    logger.info("Skipping learning from bulk label removal", { systemType });
+    return;
+  }
+
+  const recentRemovals = await prisma.classificationFeedback.count({
+    where: {
+      emailAccountId,
+      ruleId,
+      eventType: ClassificationFeedbackEventType.LABEL_REMOVED,
+      createdAt: {
+        gte: subMinutes(new Date(), BULK_LABEL_REMOVAL_WINDOW_MINUTES),
+      },
+    },
+  });
+
+  if (recentRemovals >= BULK_LABEL_REMOVAL_THRESHOLD) {
+    logger.info(
+      "Skipping learning: recent label removals look like a bulk action",
+      {
+        systemType,
+        recentRemovals,
+      },
+    );
     return;
   }
 
@@ -48,4 +89,22 @@ export async function recordLabelRemovalLearning({
     reason: "Label removed",
     source: GroupItemSource.LABEL_REMOVED,
   });
+}
+
+export function getBulkRemovedLabelIds(
+  labelsRemoved: { labelIds?: string[] | null }[],
+) {
+  const counts = new Map<string, number>();
+
+  for (const removal of labelsRemoved) {
+    for (const labelId of removal.labelIds || []) {
+      counts.set(labelId, (counts.get(labelId) ?? 0) + 1);
+    }
+  }
+
+  return new Set(
+    [...counts]
+      .filter(([, count]) => count >= BULK_LABEL_REMOVAL_THRESHOLD)
+      .map(([labelId]) => labelId),
+  );
 }

--- a/apps/web/utils/webhook/google/process-history-item.ts
+++ b/apps/web/utils/webhook/google/process-history-item.ts
@@ -16,6 +16,7 @@ export async function processHistoryItem(
       | gmail_v1.Schema$HistoryMessageAdded
       | gmail_v1.Schema$HistoryLabelAdded
       | gmail_v1.Schema$HistoryLabelRemoved;
+    bulkRemovedLabelIds?: Set<string>;
   },
   options: ProcessHistoryOptions,
   logger: Logger,
@@ -27,7 +28,7 @@ export async function processHistoryItem(
     rules,
     spamLearnedThreadIds,
   } = options;
-  const { type, item } = historyItem;
+  const { type, item, bulkRemovedLabelIds } = historyItem;
   const messageId = item.message?.id;
   const threadId = item.message?.threadId;
   const emailAccountId = emailAccount.id;
@@ -83,6 +84,7 @@ export async function processHistoryItem(
       {
         emailAccount,
         provider,
+        bulkRemovedLabelIds,
       },
       logger,
     );

--- a/apps/web/utils/webhook/google/process-history.ts
+++ b/apps/web/utils/webhook/google/process-history.ts
@@ -224,6 +224,12 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
 
   if (!history?.length) return;
 
+  // Gmail splits one user action across many history records, so count
+  // removals over the whole batch rather than per record.
+  const bulkRemovedLabelIds = getBulkRemovedLabelIds(
+    history.flatMap((h) => h.labelsRemoved || []),
+  );
+
   for (const h of history) {
     const historyMessages = [
       ...(h.messagesAdded || []),
@@ -232,8 +238,6 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
     ];
 
     if (!historyMessages.length) continue;
-
-    const bulkRemovedLabelIds = getBulkRemovedLabelIds(h.labelsRemoved || []);
 
     const allEvents = [
       ...(h.messagesAdded || [])

--- a/apps/web/utils/webhook/google/process-history.ts
+++ b/apps/web/utils/webhook/google/process-history.ts
@@ -20,6 +20,7 @@ import {
   withRateLimitRecording,
 } from "@/utils/email/rate-limit";
 import prisma from "@/utils/prisma";
+import { getBulkRemovedLabelIds } from "@/utils/rule/record-label-removal-learning";
 import type { Logger } from "@/utils/logger";
 import type { gmail_v1 } from "@googleapis/gmail";
 
@@ -232,6 +233,8 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
 
     if (!historyMessages.length) continue;
 
+    const bulkRemovedLabelIds = getBulkRemovedLabelIds(h.labelsRemoved || []);
+
     const allEvents = [
       ...(h.messagesAdded || [])
         .filter((m) => {
@@ -252,6 +255,7 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
       ...(h.labelsRemoved || []).map((m) => ({
         type: HistoryEventType.LABEL_REMOVED,
         item: m,
+        bulkRemovedLabelIds,
       })),
     ];
 

--- a/apps/web/utils/webhook/google/process-label-removed-event.test.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.test.ts
@@ -259,7 +259,7 @@ describe("process-label-removed-event", () => {
       vi.mocked(findRuleByLabelId).mockResolvedValue({
         id: "rule-123",
         systemType: SystemType.NEWSLETTER,
-      } as any);
+      } satisfies NonNullable<Awaited<ReturnType<typeof findRuleByLabelId>>>);
 
       const historyItem = createLabelRemovedHistoryItem("123", "thread-123", [
         "label-2",

--- a/apps/web/utils/webhook/google/process-label-removed-event.test.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.test.ts
@@ -10,7 +10,10 @@ import {
 } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
-import { findRuleByLabelId } from "@/utils/rule/classification-feedback";
+import {
+  findRuleByLabelId,
+  saveClassificationFeedback,
+} from "@/utils/rule/classification-feedback";
 
 const logger = createTestLogger();
 
@@ -22,6 +25,9 @@ vi.mock("@/utils/prisma", () => ({
     },
     groupItem: {
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    classificationFeedback: {
+      count: vi.fn().mockResolvedValue(0),
     },
   },
 }));
@@ -246,6 +252,28 @@ describe("process-label-removed-event", () => {
       );
       expect(saveLearnedPattern).toHaveBeenCalledWith(
         expect.objectContaining({ ruleId: "rule-2" }),
+      );
+    });
+
+    it("records feedback but does not learn an exclusion for a bulk label removal", async () => {
+      vi.mocked(findRuleByLabelId).mockResolvedValue({
+        id: "rule-123",
+        systemType: SystemType.NEWSLETTER,
+      } as any);
+
+      const historyItem = createLabelRemovedHistoryItem("123", "thread-123", [
+        "label-2",
+      ]);
+
+      await handleLabelRemovedEvent(
+        historyItem.item,
+        { ...defaultOptions, bulkRemovedLabelIds: new Set(["label-2"]) },
+        logger,
+      );
+
+      expect(saveLearnedPattern).not.toHaveBeenCalled();
+      expect(saveClassificationFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ ruleId: "rule-123", messageId: "123" }),
       );
     });
 

--- a/apps/web/utils/webhook/google/process-label-removed-event.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.ts
@@ -123,17 +123,9 @@ async function learnFromRemovedLabel({
 
   const rule = await findRuleByLabelId({ labelId, emailAccountId });
 
-  await recordLabelRemovalLearning({
-    sender,
-    ruleId: rule?.id,
-    systemType: rule?.systemType,
-    messageId,
-    threadId,
-    emailAccountId,
-    isBulkRemoval,
-    logger,
-  });
-
+  // Record feedback before learning so the rolling bulk-removal count in
+  // recordLabelRemovalLearning sees this removal and concurrent webhook pages
+  // see each other's rows as early as possible.
   if (rule && sender && isEligibleForClassificationFeedback(rule.systemType)) {
     await saveClassificationFeedback({
       emailAccountId,
@@ -145,6 +137,17 @@ async function learnFromRemovedLabel({
       logger,
     });
   }
+
+  await recordLabelRemovalLearning({
+    sender,
+    ruleId: rule?.id,
+    systemType: rule?.systemType,
+    messageId,
+    threadId,
+    emailAccountId,
+    isBulkRemoval,
+    logger,
+  });
 }
 
 /**

--- a/apps/web/utils/webhook/google/process-label-removed-event.ts
+++ b/apps/web/utils/webhook/google/process-label-removed-event.ts
@@ -23,9 +23,11 @@ export async function handleLabelRemovedEvent(
   {
     emailAccount,
     provider,
+    bulkRemovedLabelIds,
   }: {
     emailAccount: EmailAccountWithAI;
     provider: EmailProvider;
+    bulkRemovedLabelIds?: Set<string>;
   },
   logger: Logger,
 ) {
@@ -87,6 +89,7 @@ export async function handleLabelRemovedEvent(
         messageId,
         threadId,
         emailAccountId,
+        isBulkRemoval: bulkRemovedLabelIds?.has(labelId) ?? false,
         logger,
       });
     } catch (error) {
@@ -105,6 +108,7 @@ async function learnFromRemovedLabel({
   messageId,
   threadId,
   emailAccountId,
+  isBulkRemoval,
   logger,
 }: {
   labelId: string;
@@ -112,6 +116,7 @@ async function learnFromRemovedLabel({
   messageId: string;
   threadId: string;
   emailAccountId: string;
+  isBulkRemoval: boolean;
   logger: Logger;
 }) {
   logger = logger.with({ labelId });
@@ -125,6 +130,7 @@ async function learnFromRemovedLabel({
     messageId,
     threadId,
     emailAccountId,
+    isBulkRemoval,
     logger,
   });
 

--- a/apps/web/utils/webhook/outlook/learn-label-removal.test.ts
+++ b/apps/web/utils/webhook/outlook/learn-label-removal.test.ts
@@ -19,6 +19,9 @@ vi.mock("@/utils/prisma", () => ({
     action: {
       findMany: vi.fn().mockResolvedValue([]),
     },
+    classificationFeedback: {
+      count: vi.fn().mockResolvedValue(0),
+    },
   },
 }));
 


### PR DESCRIPTION
When a user removes one of our labels from a single email, we learn a per-sender exclusion for that rule. When they strip a label from dozens of emails at once, the same code runs for each one and produces dozens of exclusions. In a recent case that created over 90 sender exclusions in a few minutes, after which later newsletters from those senders matched no rule at all.

Gmail delivers such a sweep as several webhooks, each carrying a history batch with anywhere from 1 to 55 removals, so both a batch-level check and a rolling-window check are needed.

- Per batch: if the flattened history for one webhook removes the same label from 10 or more messages, those removals are treated as bulk and no exclusions are learned
- Per rule: before learning, count LABEL_REMOVED feedback rows for that rule in the last 15 minutes; at 10 or more, skip learning. This catches the small trailing batches of a sweep. Feedback is recorded before the learning decision so each removal's own row is included. This backstop only applies to Gmail today because Outlook does not record classification feedback
- Classification feedback rows are still recorded in both cases, so the rule-picker hints keep working
- The thresholds are constants in `utils/rule/record-label-removal-learning.ts` and easy to tune

Validation: unit tests added for the bulk-batch detection, the window skip, and the feedback-still-recorded path; all 44 tests across the Gmail and Outlook label-removal suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bulk label removals to prevent automatic learning from creating inappropriate label exclusions.
  * Added safeguards for repeated removals within a short period, while continuing to record classification feedback.
  * Improved processing across batched email history events for more consistent results.
* **Tests**
  * Added coverage for bulk-removal detection, threshold handling, and incomplete removal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->