### PR TITLE
assistant: reuse numbered labels and show current label names in rule state

### DIFF
--- a/apps/web/utils/ai/assistant/chat-label-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.test.ts
@@ -168,6 +168,33 @@ describe("chat label tools", () => {
     expect(createLabel).not.toHaveBeenCalled();
   });
 
+  it("reuses a numbered label when asked for its unnumbered name", async () => {
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "label-1", name: "1: To Reply", type: "user" },
+      { id: "label-7", name: "7: OG", type: "user" },
+    ]);
+    const createLabel = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({ getLabels, createLabel }),
+    );
+
+    const toolInstance = createOrGetLabelTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({ name: "OG" });
+
+    expect(result).toEqual({
+      created: false,
+      label: { id: "label-7", name: "7: OG", type: "user" },
+    });
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
   it("does not create a Gmail label when its leaf name is ambiguous", async () => {
     const getLabels = vi.fn().mockResolvedValue([
       { id: "label-1", name: "L3/L4", type: "user" },

--- a/apps/web/utils/ai/assistant/chat-label-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.test.ts
@@ -195,6 +195,38 @@ describe("chat label tools", () => {
     expect(createLabel).not.toHaveBeenCalled();
   });
 
+  it("does not create a label when several numbered labels share the name", async () => {
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "label-1", name: "1: OG", type: "user" },
+      { id: "label-7", name: "7: OG", type: "user" },
+      { id: "label-nested", name: "School/OG", type: "user" },
+    ]);
+    const createLabel = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({ getLabels, createLabel }),
+    );
+
+    const toolInstance = createOrGetLabelTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({ name: "OG" });
+
+    expect(result).toEqual({
+      error: 'Multiple labels match "OG". Use the exact name or full path.',
+      labels: [
+        { id: "label-1", name: "1: OG", type: "user" },
+        { id: "label-7", name: "7: OG", type: "user" },
+        { id: "label-nested", name: "School/OG", type: "user" },
+      ],
+    });
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
   it("does not create a Gmail label when its leaf name is ambiguous", async () => {
     const getLabels = vi.fn().mockResolvedValue([
       { id: "label-1", name: "L3/L4", type: "user" },
@@ -219,7 +251,7 @@ describe("chat label tools", () => {
     const result = await (toolInstance.execute as any)({ name: "L4" });
 
     expect(result).toEqual({
-      error: 'Multiple Gmail labels match "L4". Use the full label path.',
+      error: 'Multiple labels match "L4". Use the exact name or full path.',
       labels: [
         { id: "label-1", name: "L3/L4", type: "user" },
         { id: "label-2", name: "Projects/L4", type: "user" },

--- a/apps/web/utils/ai/assistant/chat-label-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.ts
@@ -161,7 +161,10 @@ function buildCreateOrGetTool({
 
         if (candidates.length > 1) {
           return {
-            error: `Multiple ${terms.resourcePlural} match "${input.name}". Use the exact name or full path.`,
+            error:
+              terms.resource === "label"
+                ? `Multiple labels match "${input.name}". Use the exact name or full path.`
+                : `Multiple categories match "${input.name}". Use the exact name.`,
             [terms.resourcePlural]: candidates.map(pickLabelFields),
           };
         }

--- a/apps/web/utils/ai/assistant/chat-label-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { Logger } from "@/utils/logger";
 import { createEmailProvider } from "@/utils/email/provider";
 import { findNestedLabelMatches } from "@/utils/label/find-nested-label-matches";
+import { findOrderPrefixedLabelMatches } from "@/utils/label/find-order-prefixed-label-matches";
 import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
@@ -90,8 +91,8 @@ function buildCreateOrGetTool({
   return tool({
     description:
       terms.resource === "label"
-        ? `Reuse an existing Gmail label by exact path. A leaf name also reuses a uniquely matching nested label; if multiple nested labels share that leaf, this returns their full paths instead of creating a root label. Create the label only when no match exists. Do not call ${listToolName} first — this tool handles resolution and creation in one step.`
-        : `Reuse an existing ${terms.resource} by exact name or create it if it does not exist yet. Do not call ${listToolName} first — this tool handles the check-and-create in one step.`,
+        ? `Reuse an existing Gmail label by exact path. A leaf name also reuses a uniquely matching nested label, and an unnumbered name reuses a uniquely matching numbered label (e.g. "OG" reuses "7: OG"); if multiple labels match, this returns them instead of creating a new one. Create the label only when no match exists. Do not call ${listToolName} first — this tool handles resolution and creation in one step.`
+        : `Reuse an existing ${terms.resource} by exact name (an unnumbered name also reuses a uniquely matching numbered ${terms.resource}) or create it if it does not exist yet. Do not call ${listToolName} first — this tool handles the check-and-create in one step.`,
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: terms.createToolName, email, logger });
@@ -122,6 +123,27 @@ function buildCreateOrGetTool({
           return {
             created: false,
             [terms.resource]: pickLabelFields(existingHidden),
+          };
+        }
+
+        const prefixedMatches = findOrderPrefixedLabelMatches({
+          labels: hiddenAware,
+          name: input.name,
+          getLabelName: (label) => label.name,
+          normalize: normalizeLabelName,
+        });
+
+        if (prefixedMatches.length === 1) {
+          return {
+            created: false,
+            [terms.resource]: pickLabelFields(prefixedMatches[0]),
+          };
+        }
+
+        if (prefixedMatches.length > 1) {
+          return {
+            error: `Multiple ${terms.resourcePlural} match "${input.name}" once numbering prefixes are ignored. Use the exact name.`,
+            [terms.resourcePlural]: prefixedMatches.map(pickLabelFields),
           };
         }
 

--- a/apps/web/utils/ai/assistant/chat-label-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.ts
@@ -126,48 +126,44 @@ function buildCreateOrGetTool({
           };
         }
 
+        // A bare name may match a numbered label ("7: OG") and, for Gmail, a
+        // nested one ("Projects/OG"). Only reuse when the match is unambiguous.
         const prefixedMatches = findOrderPrefixedLabelMatches({
           labels: hiddenAware,
           name: input.name,
           getLabelName: (label) => label.name,
           normalize: normalizeLabelName,
         });
+        const nestedMatches =
+          terms.resource === "label"
+            ? findNestedLabelMatches({
+                labels: hiddenAware,
+                name: input.name,
+                getLabelName: (label) => label.name,
+                normalize: normalizeLabelName,
+              })
+            : [];
+        const candidates = [
+          ...new Map(
+            [...prefixedMatches, ...nestedMatches].map((label) => [
+              label.id,
+              label,
+            ]),
+          ).values(),
+        ];
 
-        if (prefixedMatches.length === 1) {
+        if (candidates.length === 1) {
           return {
             created: false,
-            [terms.resource]: pickLabelFields(prefixedMatches[0]),
+            [terms.resource]: pickLabelFields(candidates[0]),
           };
         }
 
-        if (prefixedMatches.length > 1) {
+        if (candidates.length > 1) {
           return {
-            error: `Multiple ${terms.resourcePlural} match "${input.name}" once numbering prefixes are ignored. Use the exact name.`,
-            [terms.resourcePlural]: prefixedMatches.map(pickLabelFields),
+            error: `Multiple ${terms.resourcePlural} match "${input.name}". Use the exact name or full path.`,
+            [terms.resourcePlural]: candidates.map(pickLabelFields),
           };
-        }
-
-        if (terms.resource === "label") {
-          const nestedMatches = findNestedLabelMatches({
-            labels: hiddenAware,
-            name: input.name,
-            getLabelName: (label) => label.name,
-            normalize: normalizeLabelName,
-          });
-
-          if (nestedMatches.length === 1) {
-            return {
-              created: false,
-              label: pickLabelFields(nestedMatches[0]),
-            };
-          }
-
-          if (nestedMatches.length > 1) {
-            return {
-              error: `Multiple Gmail labels match "${input.name}". Use the full label path.`,
-              labels: nestedMatches.map(pickLabelFields),
-            };
-          }
         }
 
         const created = await emailProvider.createLabel(input.name);

--- a/apps/web/utils/ai/assistant/chat-rule-state.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-state.ts
@@ -111,7 +111,7 @@ export async function loadAssistantRuleSnapshot({
 
   const currentLabelNames = await loadCurrentLabelNames({
     emailAccountId,
-    provider: emailAccount?.account.provider,
+    provider: emailAccount?.account?.provider,
     labelIds: (emailAccount?.rules ?? []).flatMap((rule) =>
       rule.actions.map((action) => action.labelId),
     ),

--- a/apps/web/utils/ai/assistant/chat-rule-state.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-state.ts
@@ -5,8 +5,13 @@ import {
   MessagingRoutePurpose,
 } from "@/generated/prisma/enums";
 import { filterNullProperties } from "@/utils";
+import { createEmailProvider } from "@/utils/email/provider";
+import { createScopedLogger } from "@/utils/logger";
 import { getMessagingProviderName } from "@/utils/messaging/platforms";
 import prisma from "@/utils/prisma";
+import { isDefined } from "@/utils/types";
+
+const logger = createScopedLogger("chat-rule-state");
 
 export type RuleReadState = {
   readAt: number;
@@ -59,6 +64,7 @@ export async function loadAssistantRuleSnapshot({
     select: {
       about: true,
       rulesRevision: true,
+      account: { select: { provider: true } },
       rules: {
         select: {
           name: true,
@@ -75,6 +81,7 @@ export async function loadAssistantRuleSnapshot({
               type: true,
               content: true,
               label: true,
+              labelId: true,
               to: true,
               cc: true,
               bcc: true,
@@ -100,6 +107,14 @@ export async function loadAssistantRuleSnapshot({
         },
       },
     },
+  });
+
+  const currentLabelNames = await loadCurrentLabelNames({
+    emailAccountId,
+    provider: emailAccount?.account.provider,
+    labelIds: (emailAccount?.rules ?? []).flatMap((rule) =>
+      rule.actions.map((action) => action.labelId),
+    ),
   });
 
   const ruleNotificationDestinations = Array.from(
@@ -138,7 +153,10 @@ export async function loadAssistantRuleSnapshot({
         actions: rule.actions.map((action) => ({
           type: action.type,
           fields: filterNullProperties({
-            label: action.label,
+            // Users rename labels in Gmail; the stored name goes stale while the ID stays valid
+            label:
+              (action.labelId && currentLabelNames.get(action.labelId)) ||
+              action.label,
             content: action.content,
             to: action.to,
             cc: action.cc,
@@ -198,4 +216,31 @@ function stripRuleUpdatedAt(
 ): Omit<AssistantRuleSnapshot["rules"][number], "updatedAt"> {
   const { updatedAt: _updatedAt, ...visibleRule } = rule;
   return visibleRule;
+}
+
+async function loadCurrentLabelNames({
+  emailAccountId,
+  provider,
+  labelIds,
+}: {
+  emailAccountId: string;
+  provider: string | undefined;
+  labelIds: (string | null)[];
+}): Promise<Map<string, string>> {
+  if (!provider || !labelIds.some(isDefined)) return new Map();
+
+  try {
+    const emailProvider = await createEmailProvider({
+      emailAccountId,
+      provider,
+      logger,
+    });
+    const labels = await emailProvider.getLabels({ includeHidden: true });
+    return new Map(labels.map((label) => [label.id, label.name]));
+  } catch (error) {
+    logger.warn("Failed to load current label names for rule snapshot", {
+      error,
+    });
+    return new Map();
+  }
 }

--- a/apps/web/utils/label/find-order-prefixed-label-matches.test.ts
+++ b/apps/web/utils/label/find-order-prefixed-label-matches.test.ts
@@ -9,6 +9,8 @@ const labels = [
   { id: "4", name: "OG" },
   { id: "5", name: "2024 Taxes" },
   { id: "6", name: "Receipts" },
+  { id: "7", name: "1: Follow Up" },
+  { id: "8", name: "01 - Follow Up" },
 ];
 
 const find = (name: string) =>
@@ -28,6 +30,10 @@ describe("findOrderPrefixedLabelMatches", () => {
 
   it("does not treat a four digit year as an order prefix", () => {
     expect(find("Taxes")).toEqual([]);
+  });
+
+  it("returns every label that matches once prefixes are ignored", () => {
+    expect(find("Follow Up")).toEqual(["7", "8"]);
   });
 
   it("excludes exact matches and unrelated labels", () => {

--- a/apps/web/utils/label/find-order-prefixed-label-matches.test.ts
+++ b/apps/web/utils/label/find-order-prefixed-label-matches.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { findOrderPrefixedLabelMatches } from "./find-order-prefixed-label-matches";
+import { normalizeLabelName } from "./normalize-label-name";
+
+const labels = [
+  { id: "1", name: "1: To Reply" },
+  { id: "2", name: "7. OG" },
+  { id: "3", name: "04 Archives" },
+  { id: "4", name: "OG" },
+  { id: "5", name: "2024 Taxes" },
+  { id: "6", name: "Receipts" },
+];
+
+const find = (name: string) =>
+  findOrderPrefixedLabelMatches({
+    labels,
+    name,
+    getLabelName: (label) => label.name,
+    normalize: normalizeLabelName,
+  }).map((label) => label.id);
+
+describe("findOrderPrefixedLabelMatches", () => {
+  it("matches labels that only differ by a leading order prefix", () => {
+    expect(find("To Reply")).toEqual(["1"]);
+    expect(find("og")).toEqual(["2"]);
+    expect(find("Archives")).toEqual(["3"]);
+  });
+
+  it("does not treat a four digit year as an order prefix", () => {
+    expect(find("Taxes")).toEqual([]);
+  });
+
+  it("excludes exact matches and unrelated labels", () => {
+    expect(find("Receipts")).toEqual([]);
+    expect(find("Invoices")).toEqual([]);
+  });
+});

--- a/apps/web/utils/label/find-order-prefixed-label-matches.ts
+++ b/apps/web/utils/label/find-order-prefixed-label-matches.ts
@@ -1,0 +1,26 @@
+// Users often number labels to control Gmail's sort order ("1: To Reply",
+// "7. OG", "04 Archives"). Asking for the unnumbered name should reuse them.
+const ORDER_PREFIX = /^\d{1,3}\s*[:)]?\s+/;
+
+export function findOrderPrefixedLabelMatches<T>({
+  labels,
+  name,
+  getLabelName,
+  normalize,
+}: {
+  labels: T[];
+  name: string;
+  getLabelName: (label: T) => string;
+  normalize: (value: string) => string;
+}) {
+  const normalizedSearch = normalize(name);
+  if (!normalizedSearch) return [];
+
+  return labels.filter((label) => {
+    const normalizedLabel = normalize(getLabelName(label));
+    return (
+      normalizedLabel !== normalizedSearch &&
+      normalizedLabel.replace(ORDER_PREFIX, "") === normalizedSearch
+    );
+  });
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-231156_pr-3469_f4826f82dd80/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Two related ways the assistant lost track of a user's labels after they renamed them in Gmail with numeric prefixes ("1: To Reply", "7: OG").

- `createOrGetLabel` now reuses a uniquely matching numbered label when asked for the unnumbered name, instead of creating a duplicate root label. Multiple matches return the candidates rather than guessing. Tool description updated to say so.
- The assistant's rule snapshot resolves each label action's current name from the provider by label ID, falling back to the stored name if the lookup fails. Rules keep working after a rename because they act on IDs, but the assistant previously saw the stale stored names and reported a "mismatch" that led to unnecessary rule rewrites.

Validation: unit tests added for the prefix matcher and the tool behavior; label tool and rule tool suites pass. The snapshot change adds one labels.list call per chat request when any rule has a label action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Labels and categories with order prefixes, such as “7: OG” or “04 Archives,” can now be found by their unnumbered names.
  - Existing matching labels are reused instead of creating duplicates.
  - Rule details now display the current names of associated labels.

- **Bug Fixes**
  - Prevented duplicate creation when multiple matches exist.
  - Ambiguous matches now show matching options and clearer guidance.
  - Improved handling when label names have changed or are temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->