### PR TITLE
rules: tell the rule picker what each candidate rule will do

### DIFF
--- a/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
+++ b/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
@@ -157,6 +157,13 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule (categorization data)", () => {
   const dataset = loadDataset(shouldRunEval ? datasetPaths : []);
   const cases = sampleStratified(dataset.cases, readSampleSize());
 
+  // A broken or empty dataset must not produce a green run with no records.
+  test("dataset loaded and mapped to at least one case", () => {
+    const fileLevelIssues = dataset.issues.filter((issue) => !issue.caseId);
+    expect(fileLevelIssues).toEqual([]);
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
   describeEvalMatrix("choose-rule categorization", (model, emailAccount) => {
     for (const variant of ruleContextVariants) {
       for (const evalCase of cases) {
@@ -269,6 +276,9 @@ function loadDataset(filePaths: string[]): Dataset {
     // parseCsv rejects the whole file on a field-count mismatch, so a
     // structurally broken overlay is skipped as a unit rather than per row.
     const rawRows = readCsvRows(file);
+    // Later roots may override earlier ones by case_id, but a repeated id
+    // inside one file is a data error, not an overlay.
+    const seenInFile = new Set<string>();
     if (!rawRows.ok) {
       issues.push({ file, caseId: null, message: rawRows.message });
       continue;
@@ -290,6 +300,15 @@ function loadDataset(filePaths: string[]): Dataset {
         });
         continue;
       }
+      if (seenInFile.has(parsed.data.case_id)) {
+        issues.push({
+          file,
+          caseId: parsed.data.case_id,
+          message: "duplicate case_id within the same file; later copy ignored",
+        });
+        continue;
+      }
+      seenInFile.add(parsed.data.case_id);
       rowsById.set(parsed.data.case_id, parsed.data);
     }
   }

--- a/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
+++ b/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
@@ -1,0 +1,428 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { afterAll, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
+import type { Action } from "@/generated/prisma/client";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { getEvalDataDirs } from "@/__tests__/eval/harness/load-cases";
+import { parseCsv } from "@/__tests__/eval/harness/parse-csv";
+import { aiChooseRule } from "@/utils/ai/choose-rule/ai-choose-rule";
+import { CONVERSATION_TRACKING_INSTRUCTIONS } from "@/utils/ai/choose-rule/run-rules";
+import { getRuleConfig } from "@/utils/rule/consts";
+import { getEmail, getRule } from "@/__tests__/helpers";
+import { createScopedLogger } from "@/utils/logger";
+
+// Runs the rule picker over the external categorization dataset, once with each
+// rule's actions in the prompt (what ships) and once with actions stripped (the
+// prompt before actions were added). Only the "with actions" arm asserts.
+//
+// EVAL_DATA_DIRS=/path/to/inbox-zero-evals/datasets pnpm test-ai eval/choose-rule-categorization-data
+// Bounded: EVAL_SAMPLES=100 EVAL_DATA_DIRS=... pnpm test-ai eval/choose-rule-categorization-data
+// Multi-model: EVAL_MODELS=all EVAL_DATA_DIRS=... pnpm test-ai eval/choose-rule-categorization-data
+
+const DATASET_RELATIVE_PATH = path.join("categorization", "persona-v1.csv");
+const SAMPLE_SEED = "choose-rule-categorization-v1";
+const TIMEOUT = 180_000;
+vi.setConfig({ maxConcurrency: 3 });
+const logger = createScopedLogger("eval-choose-rule-categorization-data");
+
+const datasetPath = findDatasetPath(getEvalDataDirs());
+const shouldRunEval = shouldRunEvalTests() && datasetPath !== null;
+
+if (!datasetPath) {
+  logger.info(
+    `Skipped: no ${DATASET_RELATIVE_PATH} found under EVAL_DATA_DIRS. The dataset is not part of this repository.`,
+  );
+}
+
+const datasetRowSchema = z.object({
+  case_id: z.string().min(1),
+  from: z.string(),
+  subject: z.string(),
+  body: z.string(),
+  gold: z.string().min(1),
+  difficulty: z.string(),
+  language: z.string(),
+  audit_label: z.string(),
+  audit_status: z.string(),
+  audit_ambiguous: z.string(),
+  audit_alternative: z.string(),
+});
+
+const HIDING_ACTION_TYPES = new Set<ActionType>([
+  ActionType.ARCHIVE,
+  ActionType.MOVE_FOLDER,
+  ActionType.DELETE,
+  ActionType.MARK_SPAM,
+]);
+
+// Same candidate set as choose-rule.test.ts: the default system rules with the
+// actions they ship with, plus the collapsed "Conversations" meta-rule.
+const systemRule = (type: SystemType) => {
+  const config = getRuleConfig(type);
+  const actions = [{ type: ActionType.LABEL, label: config.label }];
+  if (config.categoryAction === "label_archive") {
+    actions.push({ type: ActionType.ARCHIVE, label: null });
+  }
+  return getRule(config.instructions, actions as Action[], config.name);
+};
+
+const CONVERSATIONS_RULE_NAME = "Conversations";
+
+const rules = [
+  systemRule(SystemType.NEWSLETTER),
+  systemRule(SystemType.MARKETING),
+  systemRule(SystemType.CALENDAR),
+  systemRule(SystemType.RECEIPT),
+  systemRule(SystemType.NOTIFICATION),
+  getRule(CONVERSATION_TRACKING_INSTRUCTIONS, [], CONVERSATIONS_RULE_NAME),
+];
+
+const hidingRuleNames = rules
+  .filter((rule) =>
+    rule.actions.some((action) => HIDING_ACTION_TYPES.has(action.type)),
+  )
+  .map((rule) => rule.name);
+
+// Dataset gold labels are finer-grained than the system rules. The first entry
+// is the rule that should win; the rest are acceptable because the system rule
+// boundaries genuinely overlap there (a shipped-order update reads as either a
+// status notification or a purchase record; recruiter mail is a conversation
+// but interview scheduling is a fair Calendar pick).
+const goldLabelToRuleNames: Record<string, string[]> = {
+  receipt: [getRuleConfig(SystemType.RECEIPT).name],
+  shipping: [
+    getRuleConfig(SystemType.NOTIFICATION).name,
+    getRuleConfig(SystemType.RECEIPT).name,
+  ],
+  newsletter: [getRuleConfig(SystemType.NEWSLETTER).name],
+  marketing: [getRuleConfig(SystemType.MARKETING).name],
+  calendar: [getRuleConfig(SystemType.CALENDAR).name],
+  security: [getRuleConfig(SystemType.NOTIFICATION).name],
+  automated_alert: [getRuleConfig(SystemType.NOTIFICATION).name],
+  personal_request: [CONVERSATIONS_RULE_NAME],
+  support: [CONVERSATIONS_RULE_NAME],
+  recruiting: [
+    CONVERSATIONS_RULE_NAME,
+    getRuleConfig(SystemType.CALENDAR).name,
+  ],
+};
+
+const ruleContextVariants = [
+  { label: "with actions", rules, gate: true },
+  {
+    label: "without actions",
+    rules: rules.map((rule) => ({ ...rule, actions: [] })),
+    gate: false,
+  },
+] as const;
+
+type Outcome = {
+  model: string;
+  variant: string;
+  caseId: string;
+  gold: string;
+  difficulty: string;
+  gated: boolean;
+  expectedRule: string;
+  actualRule: string;
+  pass: boolean;
+  wronglyHidden: boolean;
+};
+
+describe.runIf(shouldRunEval)("Eval: Choose Rule (categorization data)", () => {
+  const evalReporter = createEvalReporter({
+    evalName: "choose-rule-categorization-data",
+  });
+  const outcomes: Outcome[] = [];
+
+  // describe.runIf still runs the collector when skipped, so only read the
+  // dataset when the suite is actually going to run.
+  const dataset = loadDataset(shouldRunEval ? datasetPath : null);
+  const cases = sampleStratified(dataset.cases, readSampleSize());
+
+  describeEvalMatrix("choose-rule categorization", (model, emailAccount) => {
+    for (const variant of ruleContextVariants) {
+      for (const evalCase of cases) {
+        const testName = `${variant.label} | ${evalCase.id}`;
+        test.concurrent(
+          testName,
+          async () => {
+            const result = await aiChooseRule({
+              email: evalCase.email,
+              rules: variant.rules,
+              emailAccount,
+              logger,
+            });
+
+            const primaryRule = result.rules.find((r) => r.isPrimary);
+            const actual =
+              primaryRule?.rule.name ??
+              result.rules[0]?.rule.name ??
+              "no match";
+            const selectedRuleNames = result.rules.map((r) => r.rule.name);
+            const forbiddenSelected = selectedRuleNames.filter((name) =>
+              evalCase.forbiddenRules.includes(name),
+            );
+            const wronglyHidden = forbiddenSelected.length > 0;
+            const pass =
+              evalCase.acceptableRules.includes(actual) && !wronglyHidden;
+
+            evalReporter.record({
+              testName,
+              model: model.label,
+              pass,
+              expected: evalCase.acceptableRules.join(" | "),
+              actual: wronglyHidden
+                ? `${actual} [hidden by ${forbiddenSelected.join(", ")}]`
+                : actual,
+            });
+            outcomes.push({
+              model: model.label,
+              variant: variant.label,
+              caseId: evalCase.id,
+              gold: evalCase.gold,
+              difficulty: evalCase.difficulty,
+              gated: evalCase.gate,
+              expectedRule: evalCase.acceptableRules[0],
+              actualRule: actual,
+              pass,
+              wronglyHidden,
+            });
+
+            if (!variant.gate || !evalCase.gate) return;
+
+            expect(evalCase.acceptableRules).toContain(actual);
+            expect(forbiddenSelected).toEqual([]);
+          },
+          TIMEOUT,
+        );
+      }
+    }
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+    logDatasetSummary(dataset, cases);
+    logOutcomeSummary(outcomes);
+  });
+});
+
+type EvalCase = {
+  id: string;
+  email: ReturnType<typeof getEmail>;
+  gold: string;
+  difficulty: string;
+  language: string;
+  acceptableRules: string[];
+  forbiddenRules: string[];
+  gate: boolean;
+  auditDisagrees: boolean;
+};
+
+type Dataset = {
+  cases: EvalCase[];
+  skippedGoldCounts: Record<string, number>;
+  ruleCounts: Record<string, number>;
+};
+
+function findDatasetPath(roots: string[]): string | null {
+  const candidates = roots
+    .map((root) => path.join(root, DATASET_RELATIVE_PATH))
+    .filter((candidate) => existsSync(candidate));
+  return candidates.at(-1) ?? null;
+}
+
+function loadDataset(filePath: string | null): Dataset {
+  const cases: EvalCase[] = [];
+  const skippedGoldCounts: Record<string, number> = {};
+  const ruleCounts: Record<string, number> = {};
+  if (!filePath) return { cases, skippedGoldCounts, ruleCounts };
+
+  for (const raw of parseCsv(readFileSync(filePath, "utf8"))) {
+    const row = datasetRowSchema.parse(raw);
+    const goldRules = goldLabelToRuleNames[row.gold];
+    if (!goldRules) {
+      skippedGoldCounts[row.gold] = (skippedGoldCounts[row.gold] ?? 0) + 1;
+      continue;
+    }
+
+    // When the audit relabeled the row, either label is a fair answer; the
+    // audit's alternative label is likewise accepted where one was recorded.
+    const auditDisagrees = row.audit_status === "disagree";
+    const acceptableRules = unique([
+      ...goldRules,
+      ...(auditDisagrees ? (goldLabelToRuleNames[row.audit_label] ?? []) : []),
+      ...(goldLabelToRuleNames[row.audit_alternative] ?? []),
+    ]);
+    const forbiddenRules = hidingRuleNames.filter(
+      (name) => !acceptableRules.includes(name),
+    );
+
+    ruleCounts[goldRules[0]] = (ruleCounts[goldRules[0]] ?? 0) + 1;
+    cases.push({
+      id: row.case_id,
+      email: getEmail({
+        from: row.from,
+        subject: row.subject,
+        content: row.body,
+      }),
+      gold: row.gold,
+      difficulty: row.difficulty,
+      language: row.language,
+      acceptableRules,
+      forbiddenRules,
+      gate: row.audit_ambiguous !== "true",
+      auditDisagrees,
+    });
+  }
+
+  return { cases, skippedGoldCounts, ruleCounts };
+}
+
+function readSampleSize(): number | null {
+  const raw = process.env.EVAL_SAMPLES;
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`EVAL_SAMPLES must be a positive integer, got "${raw}"`);
+  }
+  return parsed;
+}
+
+// Proportional allocation per gold label (largest remainder), then a seeded
+// order within each label so the same EVAL_SAMPLES picks the same rows every run.
+function sampleStratified(cases: EvalCase[], size: number | null): EvalCase[] {
+  if (size === null || size >= cases.length) return cases;
+
+  const strata = new Map<string, EvalCase[]>();
+  for (const evalCase of cases) {
+    const stratum = strata.get(evalCase.gold) ?? [];
+    stratum.push(evalCase);
+    strata.set(evalCase.gold, stratum);
+  }
+
+  const allocations = [...strata.entries()].map(([gold, stratum]) => {
+    const exact = (size * stratum.length) / cases.length;
+    return { gold, stratum, take: Math.floor(exact), remainder: exact % 1 };
+  });
+  let remaining = size - allocations.reduce((sum, a) => sum + a.take, 0);
+  for (const allocation of [...allocations].sort(
+    (a, b) => b.remainder - a.remainder || a.gold.localeCompare(b.gold),
+  )) {
+    if (remaining <= 0) break;
+    allocation.take += 1;
+    remaining -= 1;
+  }
+
+  return allocations.flatMap(({ stratum, take }) =>
+    [...stratum]
+      .sort((a, b) => seededKey(a.id).localeCompare(seededKey(b.id)))
+      .slice(0, take),
+  );
+}
+
+function seededKey(id: string): string {
+  return createHash("sha256").update(`${SAMPLE_SEED}:${id}`).digest("hex");
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function logDatasetSummary(dataset: Dataset, cases: EvalCase[]) {
+  const skipped = Object.values(dataset.skippedGoldCounts).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+  logger.info("Dataset summary", {
+    datasetPath,
+    mappedRows: dataset.cases.length,
+    rowsPerRule: dataset.ruleCounts,
+    skippedUnmappableRows: skipped,
+    skippedGoldValues: dataset.skippedGoldCounts,
+    sampledRows: cases.length,
+    sampleSize: readSampleSize() ?? "all",
+    nonGatingAmbiguousRows: cases.filter((c) => !c.gate).length,
+    auditDisagreeRows: cases.filter((c) => c.auditDisagrees).length,
+    byDifficulty: countBy(cases, (c) => c.difficulty),
+    byLanguage: countBy(cases, (c) => c.language),
+  });
+}
+
+function logOutcomeSummary(outcomes: Outcome[]) {
+  if (outcomes.length === 0) return;
+
+  const models = unique(outcomes.map((o) => o.model));
+  const variants = unique(outcomes.map((o) => o.variant));
+
+  for (const model of models) {
+    for (const variant of variants) {
+      const subset = outcomes.filter(
+        (o) => o.model === model && o.variant === variant,
+      );
+      if (subset.length === 0) continue;
+
+      const misses = subset.filter((o) => !o.pass);
+      logger.info("Accuracy", {
+        model,
+        variant,
+        total: subset.length,
+        correct: subset.length - misses.length,
+        accuracy: formatRate(subset.length - misses.length, subset.length),
+        gatedAccuracy: formatRate(
+          subset.filter((o) => o.gated && o.pass).length,
+          subset.filter((o) => o.gated).length,
+        ),
+        wronglyHidden: subset.filter((o) => o.wronglyHidden).length,
+        accuracyByGold: rateBy(subset, (o) => o.gold),
+        accuracyByDifficulty: rateBy(subset, (o) => o.difficulty),
+        confusionOnMisses: countBy(
+          misses,
+          (o) => `${o.gold} (${o.expectedRule}) -> ${o.actualRule}`,
+        ),
+        wronglyHiddenCaseIds: subset
+          .filter((o) => o.wronglyHidden)
+          .map((o) => o.caseId),
+      });
+    }
+  }
+}
+
+function countBy<T>(items: T[], key: (item: T) => string) {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const k = key(item);
+    counts[k] = (counts[k] ?? 0) + 1;
+  }
+  return Object.fromEntries(
+    Object.entries(counts).sort(([, a], [, b]) => b - a),
+  );
+}
+
+function rateBy(outcomes: Outcome[], key: (outcome: Outcome) => string) {
+  const groups = new Map<string, Outcome[]>();
+  for (const outcome of outcomes) {
+    const k = key(outcome);
+    groups.set(k, [...(groups.get(k) ?? []), outcome]);
+  }
+  return Object.fromEntries(
+    [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, group]) => [
+        k,
+        formatRate(group.filter((o) => o.pass).length, group.length),
+      ]),
+  );
+}
+
+function formatRate(numerator: number, denominator: number): string {
+  if (denominator === 0) return "n/a";
+  return `${numerator}/${denominator} (${((100 * numerator) / denominator).toFixed(1)}%)`;
+}

--- a/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
+++ b/apps/web/__tests__/eval/choose-rule-categorization-data.test.ts
@@ -22,6 +22,10 @@ import { createScopedLogger } from "@/utils/logger";
 // rule's actions in the prompt (what ships) and once with actions stripped (the
 // prompt before actions were added). Only the "with actions" arm asserts.
 //
+// The CSV is read from every EVAL_DATA_DIRS root that has it and merged by
+// case_id, later roots overriding earlier ones (same overlay convention as
+// load-cases.ts).
+//
 // EVAL_DATA_DIRS=/path/to/inbox-zero-evals/datasets pnpm test-ai eval/choose-rule-categorization-data
 // Bounded: EVAL_SAMPLES=100 EVAL_DATA_DIRS=... pnpm test-ai eval/choose-rule-categorization-data
 // Multi-model: EVAL_MODELS=all EVAL_DATA_DIRS=... pnpm test-ai eval/choose-rule-categorization-data
@@ -32,10 +36,10 @@ const TIMEOUT = 180_000;
 vi.setConfig({ maxConcurrency: 3 });
 const logger = createScopedLogger("eval-choose-rule-categorization-data");
 
-const datasetPath = findDatasetPath(getEvalDataDirs());
-const shouldRunEval = shouldRunEvalTests() && datasetPath !== null;
+const datasetPaths = findDatasetPaths(getEvalDataDirs());
+const shouldRunEval = shouldRunEvalTests() && datasetPaths.length > 0;
 
-if (!datasetPath) {
+if (datasetPaths.length === 0) {
   logger.info(
     `Skipped: no ${DATASET_RELATIVE_PATH} found under EVAL_DATA_DIRS. The dataset is not part of this repository.`,
   );
@@ -140,11 +144,17 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule (categorization data)", () => {
   const evalReporter = createEvalReporter({
     evalName: "choose-rule-categorization-data",
   });
+  // The stripped-actions arm is reported separately so the headline numbers
+  // and history only reflect the prompt that ships.
+  const baselineReporter = createEvalReporter({
+    evalName: "choose-rule-categorization-data-without-actions",
+    reportPathSuffix: "-without-actions",
+  });
   const outcomes: Outcome[] = [];
 
   // describe.runIf still runs the collector when skipped, so only read the
   // dataset when the suite is actually going to run.
-  const dataset = loadDataset(shouldRunEval ? datasetPath : null);
+  const dataset = loadDataset(shouldRunEval ? datasetPaths : []);
   const cases = sampleStratified(dataset.cases, readSampleSize());
 
   describeEvalMatrix("choose-rule categorization", (model, emailAccount) => {
@@ -174,7 +184,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule (categorization data)", () => {
             const pass =
               evalCase.acceptableRules.includes(actual) && !wronglyHidden;
 
-            evalReporter.record({
+            (variant.gate ? evalReporter : baselineReporter).record({
               testName,
               model: model.label,
               pass,
@@ -209,6 +219,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule (categorization data)", () => {
 
   afterAll(() => {
     evalReporter.printReport();
+    baselineReporter.printReport();
     logDatasetSummary(dataset, cases);
     logOutcomeSummary(outcomes);
   });
@@ -226,27 +237,64 @@ type EvalCase = {
   auditDisagrees: boolean;
 };
 
+type DatasetIssue = {
+  file: string;
+  caseId: string | null;
+  message: string;
+};
+
 type Dataset = {
   cases: EvalCase[];
+  issues: DatasetIssue[];
+  rowsPerFile: Record<string, number>;
   skippedGoldCounts: Record<string, number>;
   ruleCounts: Record<string, number>;
 };
 
-function findDatasetPath(roots: string[]): string | null {
-  const candidates = roots
+function findDatasetPaths(roots: string[]): string[] {
+  return roots
     .map((root) => path.join(root, DATASET_RELATIVE_PATH))
     .filter((candidate) => existsSync(candidate));
-  return candidates.at(-1) ?? null;
 }
 
-function loadDataset(filePath: string | null): Dataset {
+function loadDataset(filePaths: string[]): Dataset {
   const cases: EvalCase[] = [];
+  const issues: DatasetIssue[] = [];
+  const rowsPerFile: Record<string, number> = {};
   const skippedGoldCounts: Record<string, number> = {};
   const ruleCounts: Record<string, number> = {};
-  if (!filePath) return { cases, skippedGoldCounts, ruleCounts };
+  const rowsById = new Map<string, z.infer<typeof datasetRowSchema>>();
 
-  for (const raw of parseCsv(readFileSync(filePath, "utf8"))) {
-    const row = datasetRowSchema.parse(raw);
+  for (const file of filePaths) {
+    // parseCsv rejects the whole file on a field-count mismatch, so a
+    // structurally broken overlay is skipped as a unit rather than per row.
+    const rawRows = readCsvRows(file);
+    if (!rawRows.ok) {
+      issues.push({ file, caseId: null, message: rawRows.message });
+      continue;
+    }
+
+    rowsPerFile[file] = rawRows.rows.length;
+    for (const raw of rawRows.rows) {
+      const parsed = datasetRowSchema.safeParse(raw);
+      if (!parsed.success) {
+        issues.push({
+          file,
+          caseId: raw.case_id || null,
+          message: parsed.error.issues
+            .map(
+              (issue) =>
+                `${issue.path.join(".") || "<root>"}: ${issue.message}`,
+            )
+            .join("; "),
+        });
+        continue;
+      }
+      rowsById.set(parsed.data.case_id, parsed.data);
+    }
+  }
+
+  for (const row of rowsById.values()) {
     const goldRules = goldLabelToRuleNames[row.gold];
     if (!goldRules) {
       skippedGoldCounts[row.gold] = (skippedGoldCounts[row.gold] ?? 0) + 1;
@@ -283,7 +331,22 @@ function loadDataset(filePath: string | null): Dataset {
     });
   }
 
-  return { cases, skippedGoldCounts, ruleCounts };
+  return { cases, issues, rowsPerFile, skippedGoldCounts, ruleCounts };
+}
+
+function readCsvRows(
+  file: string,
+):
+  | { ok: true; rows: Record<string, string>[] }
+  | { ok: false; message: string } {
+  try {
+    return { ok: true, rows: parseCsv(readFileSync(file, "utf8")) };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "unreadable CSV",
+    };
+  }
 }
 
 function readSampleSize(): number | null {
@@ -342,8 +405,17 @@ function logDatasetSummary(dataset: Dataset, cases: EvalCase[]) {
     0,
   );
   logger.info("Dataset summary", {
-    datasetPath,
+    datasetRoots: Object.keys(dataset.rowsPerFile).length,
+    rowsPerFile: dataset.rowsPerFile,
+    mergedRows: dataset.cases.length + skipped,
     mappedRows: dataset.cases.length,
+    skippedInvalidRows: dataset.issues.length,
+    invalidRowReasons: dataset.issues
+      .slice(0, 5)
+      .map(
+        (issue) =>
+          `${issue.file}${issue.caseId ? ` [${issue.caseId}]` : ""}: ${issue.message}`,
+      ),
     rowsPerRule: dataset.ruleCounts,
     skippedUnmappableRows: skipped,
     skippedGoldValues: dataset.skippedGoldCounts,

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -742,6 +742,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
   // and history only reflect the prompt that ships.
   const baselineReporter = createEvalReporter({
     evalName: "choose-rule-without-actions",
+    reportPathSuffix: "-without-actions",
   });
 
   describeEvalMatrix("choose-rule", (model, emailAccount) => {

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -738,6 +738,11 @@ const ruleContextVariants = [
 
 describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
   const evalReporter = createEvalReporter({ evalName: "choose-rule" });
+  // The stripped-actions arm is reported separately so the headline numbers
+  // and history only reflect the prompt that ships.
+  const baselineReporter = createEvalReporter({
+    evalName: "choose-rule-without-actions",
+  });
 
   describeEvalMatrix("choose-rule", (model, emailAccount) => {
     for (const variant of ruleContextVariants) {
@@ -773,7 +778,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
             const pass =
               acceptable.includes(actual) && forbiddenSelected.length === 0;
 
-            evalReporter.record({
+            (variant.gate ? evalReporter : baselineReporter).record({
               testName,
               model: model.label,
               pass,
@@ -909,5 +914,6 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
 
   afterAll(() => {
     evalReporter.printReport();
+    baselineReporter.printReport();
   });
 });

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -748,7 +748,14 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
           const acceptable = Array.isArray(tc.expectedRule)
             ? tc.expectedRule
             : [tc.expectedRule ?? "no match"];
-          const pass = acceptable.includes(actual);
+          const forbiddenSelected = result.rules
+            .map((r) => r.rule.name)
+            .filter(
+              (name) =>
+                "forbiddenRules" in tc && tc.forbiddenRules.includes(name),
+            );
+          const pass =
+            acceptable.includes(actual) && forbiddenSelected.length === 0;
 
           evalReporter.record({
             testName,
@@ -764,12 +771,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
             expect(acceptable).toContain(actual);
           }
 
-          if ("forbiddenRules" in tc) {
-            const selected = result.rules.map((r) => r.rule.name);
-            expect(
-              selected.filter((name) => tc.forbiddenRules.includes(name)),
-            ).toEqual([]);
-          }
+          expect(forbiddenSelected).toEqual([]);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterAll } from "vitest";
+import { afterAll, describe, expect, test, vi } from "vitest";
 import { ActionType, SystemType } from "@/generated/prisma/enums";
 import type { Action } from "@/generated/prisma/client";
 import {
@@ -16,7 +16,8 @@ import { createScopedLogger } from "@/utils/logger";
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/choose-rule
 
 const shouldRunEval = shouldRunEvalTests();
-const TIMEOUT = 60_000;
+const TIMEOUT = 180_000;
+vi.setConfig({ maxConcurrency: 3 });
 const logger = createScopedLogger("eval-choose-rule");
 
 // Default system rules — mirrors what aiChooseRule actually receives in production.
@@ -723,58 +724,76 @@ You are receiving this email because you signed up for Summit Outfitters offers.
   },
 ];
 
+// The single-rule suite runs twice: with each rule's actions in the prompt (what
+// ships) and with actions stripped, which reproduces the prompt before actions
+// were added. The stripped run is a baseline for comparison and never fails.
+const ruleContextVariants = [
+  { label: "with actions", rules, gate: true },
+  {
+    label: "without actions",
+    rules: rules.map((rule) => ({ ...rule, actions: [] })),
+    gate: false,
+  },
+] as const;
+
 describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
   const evalReporter = createEvalReporter({ evalName: "choose-rule" });
 
   describeEvalMatrix("choose-rule", (model, emailAccount) => {
-    for (const tc of testCases) {
-      const expectedLabel = Array.isArray(tc.expectedRule)
-        ? tc.expectedRule.join(" | ")
-        : (tc.expectedRule ?? "no match");
-      const testName = `${tc.email.from} / ${tc.email.subject} → ${expectedLabel}`;
-      test(
-        testName,
-        async () => {
-          const result = await aiChooseRule({
-            email: tc.email,
-            rules,
-            emailAccount,
-            logger,
-          });
+    for (const variant of ruleContextVariants) {
+      for (const tc of testCases) {
+        const expectedLabel = Array.isArray(tc.expectedRule)
+          ? tc.expectedRule.join(" | ")
+          : (tc.expectedRule ?? "no match");
+        const testName = `${variant.label} | ${tc.email.from} / ${tc.email.subject} → ${expectedLabel}`;
+        test.concurrent(
+          testName,
+          async () => {
+            const result = await aiChooseRule({
+              email: tc.email,
+              rules: variant.rules,
+              emailAccount,
+              logger,
+            });
 
-          const primaryRule = result.rules.find((r) => r.isPrimary);
-          const actual =
-            primaryRule?.rule.name ?? result.rules[0]?.rule.name ?? "no match";
-          const acceptable = Array.isArray(tc.expectedRule)
-            ? tc.expectedRule
-            : [tc.expectedRule ?? "no match"];
-          const forbiddenSelected = result.rules
-            .map((r) => r.rule.name)
-            .filter(
-              (name) =>
-                "forbiddenRules" in tc && tc.forbiddenRules.includes(name),
-            );
-          const pass =
-            acceptable.includes(actual) && forbiddenSelected.length === 0;
+            const primaryRule = result.rules.find((r) => r.isPrimary);
+            const actual =
+              primaryRule?.rule.name ??
+              result.rules[0]?.rule.name ??
+              "no match";
+            const acceptable = Array.isArray(tc.expectedRule)
+              ? tc.expectedRule
+              : [tc.expectedRule ?? "no match"];
+            const forbiddenSelected = result.rules
+              .map((r) => r.rule.name)
+              .filter(
+                (name) =>
+                  "forbiddenRules" in tc && tc.forbiddenRules.includes(name),
+              );
+            const pass =
+              acceptable.includes(actual) && forbiddenSelected.length === 0;
 
-          evalReporter.record({
-            testName,
-            model: model.label,
-            pass,
-            expected: expectedLabel,
-            actual,
-          });
+            evalReporter.record({
+              testName,
+              model: model.label,
+              pass,
+              expected: expectedLabel,
+              actual,
+            });
 
-          if (tc.expectedRule === null) {
-            expect(result.rules).toEqual([]);
-          } else {
-            expect(acceptable).toContain(actual);
-          }
+            if (!variant.gate) return;
 
-          expect(forbiddenSelected).toEqual([]);
-        },
-        TIMEOUT,
-      );
+            if (tc.expectedRule === null) {
+              expect(result.rules).toEqual([]);
+            } else {
+              expect(acceptable).toContain(actual);
+            }
+
+            expect(forbiddenSelected).toEqual([]);
+          },
+          TIMEOUT,
+        );
+      }
     }
   });
 

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -704,6 +704,7 @@ Maple Grove PTA President`,
     }),
     // Must not fall into Marketing, which archives. Any label-only rule is acceptable.
     expectedRule: ["Notification", "Newsletter", "Conversations", "Calendar"],
+    forbiddenRules: ["Marketing"],
   },
   {
     email: getEmail({
@@ -761,6 +762,13 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
             expect(result.rules).toEqual([]);
           } else {
             expect(acceptable).toContain(actual);
+          }
+
+          if ("forbiddenRules" in tc) {
+            const selected = result.rules.map((r) => r.rule.name);
+            expect(
+              selected.filter((name) => tc.forbiddenRules.includes(name)),
+            ).toEqual([]);
           }
         },
         TIMEOUT,

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, afterAll } from "vitest";
-import { SystemType } from "@/generated/prisma/enums";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
+import type { Action } from "@/generated/prisma/client";
 import {
   describeEvalMatrix,
   shouldRunEvalTests,
@@ -21,9 +22,15 @@ const logger = createScopedLogger("eval-choose-rule");
 // Default system rules — mirrors what aiChooseRule actually receives in production.
 // Cold email is handled in a prior step and conversation status (to_reply/fyi/etc)
 // is resolved in a later step. Step 2 sees these rules + the collapsed "Conversations" meta-rule.
+// System rules carry their default actions so the picker sees which ones hide
+// the email (Marketing archives) versus only label it.
 const systemRule = (type: SystemType) => {
   const config = getRuleConfig(type);
-  return getRule(config.instructions, [], config.name);
+  const actions = [{ type: ActionType.LABEL, label: config.label }];
+  if (config.categoryAction === "label_archive") {
+    actions.push({ type: ActionType.ARCHIVE, label: null });
+  }
+  return getRule(config.instructions, actions as Action[], config.name);
 };
 
 const newsletter = systemRule(SystemType.NEWSLETTER);
@@ -673,6 +680,43 @@ Customer Experience Team, GreenLeaf
 
 You're receiving this because you purchased from GreenLeaf. Manage preferences or unsubscribe.
 GreenLeaf Goods LLC | 200 Elm Street, Portland, OR 97201`,
+    }),
+    expectedRule: "Marketing",
+  },
+  // --- Archive-sensitive: bulk-looking mail from a community the user belongs to ---
+  {
+    email: getEmail({
+      from: "Dana Whitfield <president@maplegrovepta.example>",
+      to: "undisclosed-recipients:;",
+      subject: "Thank you for a great year - join us again this fall",
+      listUnsubscribe: "<https://maplegrovepta.example/unsubscribe>",
+      content: `Hello everyone!
+
+If you are receiving this you were a PTA member or an active supporter last year. Thank you! We had an incredibly successful year and that was possible because of you.
+
+Membership for the new school year is now open. Dues are $15 per family and go directly to classroom supplies and the fall festival. You can renew at the link below or at the welcome table on the first day of school.
+
+Our first general meeting is Tuesday September 16 at 6:30pm in the library. Childcare will be provided.
+
+Warmly,
+Dana
+Maple Grove PTA President`,
+    }),
+    // Must not fall into Marketing, which archives. Any label-only rule is acceptable.
+    expectedRule: ["Notification", "Newsletter", "Conversations", "Calendar"],
+  },
+  {
+    email: getEmail({
+      from: "Summit Outfitters <deals@summitoutfitters.example>",
+      subject: "Last chance: 30% off all jackets ends tonight",
+      listUnsubscribe: "<https://summitoutfitters.example/unsubscribe>",
+      content: `Our biggest jacket sale of the season ends at midnight.
+
+Save 30% on every jacket, plus free shipping on orders over $75. Use code JACKET30 at checkout.
+
+Shop the sale now before sizes sell out.
+
+You are receiving this email because you signed up for Summit Outfitters offers. Unsubscribe.`,
     }),
     expectedRule: "Marketing",
   },

--- a/apps/web/__tests__/eval/harness/parse-csv.test.ts
+++ b/apps/web/__tests__/eval/harness/parse-csv.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseCsv } from "@/__tests__/eval/harness/parse-csv";
+
+describe("parseCsv", () => {
+  it("keeps commas, escaped quotes, and newlines inside quoted fields", () => {
+    const text = [
+      "id,subject,body",
+      'a,"Hello, world","Line one\nLine two"',
+      'b,"She said ""hi""",plain',
+      "",
+    ].join("\n");
+
+    expect(parseCsv(text)).toEqual([
+      { id: "a", subject: "Hello, world", body: "Line one\nLine two" },
+      { id: "b", subject: 'She said "hi"', body: "plain" },
+    ]);
+  });
+
+  it("accepts CRLF line endings and a UTF-8 BOM", () => {
+    const text = "\uFEFFid,value\r\n1,x\r\n2,\r\n";
+
+    expect(parseCsv(text)).toEqual([
+      { id: "1", value: "x" },
+      { id: "2", value: "" },
+    ]);
+  });
+
+  it("rejects rows whose field count does not match the header", () => {
+    expect(() => parseCsv("id,value\n1,x,extra\n")).toThrow(/row 2/);
+  });
+});

--- a/apps/web/__tests__/eval/harness/parse-csv.test.ts
+++ b/apps/web/__tests__/eval/harness/parse-csv.test.ts
@@ -25,7 +25,24 @@ describe("parseCsv", () => {
     ]);
   });
 
+  it("treats a lone CR as a line terminator", () => {
+    expect(parseCsv("id,value\r1,x\r2,y")).toEqual([
+      { id: "1", value: "x" },
+      { id: "2", value: "y" },
+    ]);
+    expect(parseCsv("id,value\r1,x\r")).toEqual([{ id: "1", value: "x" }]);
+  });
+
+  it("skips blank lines but not single-field rows", () => {
+    expect(parseCsv("id,value\n\n1,x\n\n")).toEqual([{ id: "1", value: "x" }]);
+    expect(() => parseCsv('id,value\n1,x\n""\n')).toThrow(/row 3/);
+  });
+
   it("rejects rows whose field count does not match the header", () => {
     expect(() => parseCsv("id,value\n1,x,extra\n")).toThrow(/row 2/);
+  });
+
+  it("rejects input that ends inside a quoted field", () => {
+    expect(() => parseCsv('id,value\n1,"open')).toThrow(/quoted field/);
   });
 });

--- a/apps/web/__tests__/eval/harness/parse-csv.ts
+++ b/apps/web/__tests__/eval/harness/parse-csv.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal RFC 4180 parser for eval datasets that ship as CSV. Handles quoted
+ * fields containing commas, escaped quotes (""), and embedded newlines, which
+ * email bodies routinely have. Returns one object per data row keyed by the
+ * header row.
+ */
+export function parseCsv(text: string): Record<string, string>[] {
+  const [header, ...rows] = parseCsvRows(text.replace(/^\uFEFF/, ""));
+  if (!header) return [];
+
+  return rows
+    .filter((row) => !(row.length === 1 && row[0] === ""))
+    .map((row, index) => {
+      if (row.length !== header.length) {
+        throw new Error(
+          `CSV row ${index + 2} has ${row.length} fields, expected ${header.length}`,
+        );
+      }
+      return Object.fromEntries(header.map((key, i) => [key, row[i] ?? ""]));
+    });
+}
+
+function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char !== '"') {
+        field += char;
+      } else if (text[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else {
+        inQuotes = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n" || (char === "\r" && text[i + 1] === "\n")) {
+      if (char === "\r") i++;
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}

--- a/apps/web/__tests__/eval/harness/parse-csv.ts
+++ b/apps/web/__tests__/eval/harness/parse-csv.ts
@@ -8,16 +8,14 @@ export function parseCsv(text: string): Record<string, string>[] {
   const [header, ...rows] = parseCsvRows(text.replace(/^\uFEFF/, ""));
   if (!header) return [];
 
-  return rows
-    .filter((row) => !(row.length === 1 && row[0] === ""))
-    .map((row, index) => {
-      if (row.length !== header.length) {
-        throw new Error(
-          `CSV row ${index + 2} has ${row.length} fields, expected ${header.length}`,
-        );
-      }
-      return Object.fromEntries(header.map((key, i) => [key, row[i] ?? ""]));
-    });
+  return rows.map((row, index) => {
+    if (row.length !== header.length) {
+      throw new Error(
+        `CSV row ${index + 2} has ${row.length} fields, expected ${header.length}`,
+      );
+    }
+    return Object.fromEntries(header.map((key, i) => [key, row[i] ?? ""]));
+  });
 }
 
 function parseCsvRows(text: string): string[][] {
@@ -25,6 +23,7 @@ function parseCsvRows(text: string): string[][] {
   let row: string[] = [];
   let field = "";
   let inQuotes = false;
+  let lineStart = 0;
 
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
@@ -46,8 +45,13 @@ function parseCsvRows(text: string): string[][] {
     } else if (char === ",") {
       row.push(field);
       field = "";
-    } else if (char === "\n" || (char === "\r" && text[i + 1] === "\n")) {
-      if (char === "\r") i++;
+    } else if (char === "\n" || char === "\r") {
+      // Only a terminator with nothing before it on the line is a blank line;
+      // a line holding just `""` is a real single-field row.
+      const blankLine = i === lineStart;
+      if (char === "\r" && text[i + 1] === "\n") i++;
+      lineStart = i + 1;
+      if (blankLine) continue;
       row.push(field);
       rows.push(row);
       row = [];
@@ -57,7 +61,11 @@ function parseCsvRows(text: string): string[][] {
     }
   }
 
-  if (field.length > 0 || row.length > 0) {
+  if (inQuotes) {
+    throw new Error("CSV ends inside a quoted field (unterminated quote)");
+  }
+
+  if (text.length > lineStart) {
     row.push(field);
     rows.push(row);
   }

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -85,6 +85,43 @@ describe("eval reporter", () => {
     ).toBe(false);
   });
 
+  it("writes suffixed report paths alongside the primary report", () => {
+    const { workspaceRoot, packageDir } = createTempWorkspace();
+    process.chdir(packageDir);
+    process.env.EVAL_REPORT_PATH = ".context/evals/report.md";
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const reporter = createEvalReporter({ evalName: "example eval" });
+    reporter.record({
+      testName: "example",
+      model: "Gemini 3 Flash",
+      pass: true,
+    });
+    reporter.printReport();
+
+    const baselineReporter = createEvalReporter({
+      evalName: "example eval baseline",
+      reportPathSuffix: "-baseline",
+    });
+    baselineReporter.record({
+      testName: "example",
+      model: "Gemini 3 Flash",
+      pass: false,
+    });
+    baselineReporter.printReport();
+
+    const evalsDir = path.join(workspaceRoot, ".context", "evals");
+    expect(
+      JSON.parse(fs.readFileSync(path.join(evalsDir, "report.json"), "utf8")),
+    ).toEqual([{ testName: "example", model: "Gemini 3 Flash", pass: true }]);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(evalsDir, "report-baseline.json"), "utf8"),
+      ),
+    ).toEqual([{ testName: "example", model: "Gemini 3 Flash", pass: false }]);
+    expect(fs.existsSync(path.join(evalsDir, "report-baseline.md"))).toBe(true);
+  });
+
   it("includes usage cost totals in the markdown report", async () => {
     const { workspaceRoot, packageDir } = createTempWorkspace();
     process.chdir(packageDir);

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -19,6 +19,11 @@ export interface EvalRecord {
 
 export interface EvalReporterOptions {
   evalName?: string;
+  /**
+   * Appended to the `EVAL_REPORT_PATH` basename (before the extension) so a
+   * secondary reporter in the same suite does not overwrite the primary report.
+   */
+  reportPathSuffix?: string;
 }
 
 export interface CachedEvalOptions {
@@ -50,10 +55,12 @@ class EvalReporter {
   private readonly records: EvalRecord[] = [];
   private readonly usageEvents: AiUsageEvent[] = [];
   private readonly evalName: string | undefined;
+  private readonly reportPathSuffix: string | undefined;
   private unsubscribeFromUsage: (() => void) | undefined;
 
   constructor(options: EvalReporterOptions = {}) {
     this.evalName = options.evalName;
+    this.reportPathSuffix = options.reportPathSuffix;
     this.unsubscribeFromUsage = subscribeToAiUsage((event) => {
       this.usageEvents.push(event);
     });
@@ -141,7 +148,12 @@ class EvalReporter {
       console.log(`\n${reportParts.join("\n\n")}`);
 
       if (process.env.EVAL_REPORT_PATH) {
-        this.writeReport(resolveEvalReportPath(process.env.EVAL_REPORT_PATH));
+        this.writeReport(
+          appendReportPathSuffix(
+            resolveEvalReportPath(process.env.EVAL_REPORT_PATH),
+            this.reportPathSuffix,
+          ),
+        );
       }
 
       this.writeHistoryReport();
@@ -579,6 +591,15 @@ function resolveEvalReportPath(filePath: string): string {
   if (path.isAbsolute(filePath)) return filePath;
 
   return path.join(findWorkspaceRoot(process.cwd()), filePath);
+}
+
+function appendReportPathSuffix(
+  filePath: string,
+  suffix: string | undefined,
+): string {
+  if (!suffix) return filePath;
+  const extension = path.extname(filePath);
+  return `${filePath.slice(0, filePath.length - extension.length)}${suffix}${extension}`;
 }
 
 type EvalResultCacheMode = "off" | "readonly" | "readwrite" | "refresh";

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ActionType } from "@/generated/prisma/enums";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { stringifyEmail } from "@/utils/stringify-email";
 import { isDefined, type EmailForLLM } from "@/utils/types";
@@ -8,7 +9,12 @@ import {
   appendOllamaOnlySystemGuidance,
   isOllamaProvider,
 } from "@/utils/llms/ollama-guidance";
-import { getUserInfoPrompt, getUserRulesPrompt } from "@/utils/ai/helpers";
+import {
+  formatRuleActions,
+  getUserInfoPrompt,
+  getUserRulesPrompt,
+  type RuleActionSummary,
+} from "@/utils/ai/helpers";
 import { sortRulesByCanonicalOrder } from "@/utils/rule/sort";
 import type { Logger } from "@/utils/logger";
 import type { ClassificationFeedbackItem } from "@/utils/rule/classification-feedback";
@@ -16,13 +22,23 @@ import type { ClassificationFeedbackItem } from "@/utils/rule/classification-fee
 type GetAiResponseOptions = {
   email: EmailForLLM;
   emailAccount: EmailAccountWithAI;
-  rules: { name: string; instructions: string; systemType?: string | null }[];
+  rules: {
+    name: string;
+    instructions: string;
+    systemType?: string | null;
+    actions?: RuleActionSummary[];
+  }[];
   modelType?: ModelType;
   classificationFeedback?: ClassificationFeedbackItem[] | null;
 };
 
 export async function aiChooseRule<
-  T extends { name: string; instructions: string; systemType?: string | null },
+  T extends {
+    name: string;
+    instructions: string;
+    systemType?: string | null;
+    actions?: RuleActionSummary[];
+  },
 >({
   email,
   rules,
@@ -166,6 +182,7 @@ async function getAiResponseSingleRule({
   - When multiple rules match, choose the more specific one that best matches the email's content.
   - Rules about requiring replies should be prioritized when the email clearly needs a response.
   ${METADATA_GUIDELINE}
+  ${getActionAwarenessGuideline(rules)}
   </guidelines>
 </instructions>
 
@@ -239,10 +256,10 @@ async function getAiResponseMultiRule({
   classificationFeedback?: ClassificationFeedbackItem[] | null;
 }) {
   const rulesSection = rules
-    .map(
-      (rule) =>
-        `<rule>\n<name>${rule.name}</name>\n<instructions>${rule.instructions}</instructions>\n</rule>`,
-    )
+    .map((rule) => {
+      const actions = formatRuleActions(rule.actions);
+      return `<rule>\n<name>${rule.name}</name>\n<instructions>${rule.instructions}</instructions>${actions ? `\n<actions>${actions}</actions>` : ""}\n</rule>`;
+    })
     .join("\n");
 
   const system = `You are an AI assistant that helps people manage their emails.
@@ -266,6 +283,7 @@ async function getAiResponseMultiRule({
   - Do not be greedy - only select rules that add meaningful context.
   - Be concise in your reasoning - avoid repetitive explanations.
   ${METADATA_GUIDELINE}
+  ${getActionAwarenessGuideline(rules)}
   </guidelines>
 </instructions>
 
@@ -350,6 +368,25 @@ ${stringifyEmail(email, 500)}
 
 const METADATA_GUIDELINE =
   "- Consider email metadata (e.g. List-Unsubscribe headers) alongside content.";
+
+const HIDING_ACTION_TYPES = new Set<ActionType>([
+  ActionType.ARCHIVE,
+  ActionType.MOVE_FOLDER,
+  ActionType.DELETE,
+  ActionType.MARK_SPAM,
+]);
+
+// Only worth the prompt space when a wrong pick would actually hide the email.
+function getActionAwarenessGuideline(
+  rules: { actions?: RuleActionSummary[] }[],
+) {
+  const hasHidingRule = rules.some((rule) =>
+    rule.actions?.some((action) => HIDING_ACTION_TYPES.has(action.type)),
+  );
+  if (!hasHidingRule) return "";
+
+  return "- Each rule lists the actions it takes. Rules that archive, move, delete, or mark as spam hide the email from the user, so reserve them for promotional or automated bulk mail. Mailings from groups the user is part of (their school, club, team, or local community) are not promotional even when sent in bulk with an unsubscribe link: prefer a rule that only labels over one that hides them.";
+}
 
 function logAiChooseRuleResult<
   T extends { name: string; systemType?: string | null },

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -369,6 +369,28 @@ ${stringifyEmail(email, 500)}
 const METADATA_GUIDELINE =
   "- Consider email metadata (e.g. List-Unsubscribe headers) alongside content.";
 
+function formatClassificationFeedback(
+  feedback: ClassificationFeedbackItem[] | null | undefined,
+): string {
+  if (!feedback?.length) return "";
+
+  const lines = feedback.map((entry) => {
+    const subject = entry.subject
+      ? `"${entry.subject}"`
+      : "(email no longer available)";
+    if (entry.eventType === "LABEL_ADDED") {
+      return `- ${subject} → ${entry.ruleName}`;
+    }
+    return `- ${subject} removed from ${entry.ruleName}`;
+  });
+
+  return `<classification_feedback>
+User has manually classified emails from this sender into these rules:
+${lines.join("\n")}
+These are hints from past user actions. Still evaluate the current email on its own merits.
+</classification_feedback>`;
+}
+
 const HIDING_ACTION_TYPES = new Set<ActionType>([
   ActionType.ARCHIVE,
   ActionType.MOVE_FOLDER,
@@ -448,28 +470,6 @@ function logAiChooseRuleResult<
 
 function joinLogValues(values: (string | null | undefined)[]) {
   return values.filter(isDefined).join(", ");
-}
-
-function formatClassificationFeedback(
-  feedback: ClassificationFeedbackItem[] | null | undefined,
-): string {
-  if (!feedback?.length) return "";
-
-  const lines = feedback.map((entry) => {
-    const subject = entry.subject
-      ? `"${entry.subject}"`
-      : "(email no longer available)";
-    if (entry.eventType === "LABEL_ADDED") {
-      return `- ${subject} → ${entry.ruleName}`;
-    }
-    return `- ${subject} removed from ${entry.ruleName}`;
-  });
-
-  return `<classification_feedback>
-User has manually classified emails from this sender into these rules:
-${lines.join("\n")}
-These are hints from past user actions. Still evaluate the current email on its own merits.
-</classification_feedback>`;
 }
 
 const OLLAMA_MULTI_RULE_SELECTION_GUIDANCE = [

--- a/apps/web/utils/ai/helpers.test.ts
+++ b/apps/web/utils/ai/helpers.test.ts
@@ -1,3 +1,4 @@
+import { ActionType } from "@/generated/prisma/enums";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   getUserInfoPrompt,
@@ -77,6 +78,34 @@ describe("getUserInfoPrompt", () => {
 });
 
 describe("getUserRulesPrompt", () => {
+  it("lists what a rule will do when actions are provided", () => {
+    const result = getUserRulesPrompt({
+      rules: [
+        {
+          name: "Marketing",
+          instructions: "Promotional emails",
+          actions: [
+            { type: ActionType.LABEL, label: "Marketing" },
+            { type: ActionType.ARCHIVE },
+          ],
+        },
+        { name: "Receipts", instructions: "Receipts", actions: [] },
+      ],
+    });
+
+    expect(result).toBe(`<user_rules>
+<rule>
+  <name>Marketing</name>
+  <criteria>Promotional emails</criteria>
+  <actions>label as "Marketing", archive (removes it from the inbox)</actions>
+</rule>
+<rule>
+  <name>Receipts</name>
+  <criteria>Receipts</criteria>
+</rule>
+</user_rules>`);
+  });
+
   it("should format single rule", () => {
     const rules = [
       {

--- a/apps/web/utils/ai/helpers.test.ts
+++ b/apps/web/utils/ai/helpers.test.ts
@@ -106,6 +106,39 @@ describe("getUserRulesPrompt", () => {
 </user_rules>`);
   });
 
+  it("omits actions that do not change what the user sees", () => {
+    const result = getUserRulesPrompt({
+      rules: [
+        {
+          name: "Job hunt",
+          instructions: "Recruiter emails",
+          actions: [
+            { type: ActionType.LABEL, label: "Job hunt" },
+            { type: ActionType.STAR },
+            { type: ActionType.NOTIFY_MESSAGING_CHANNEL },
+            { type: ActionType.DIGEST },
+          ],
+        },
+        {
+          name: "Alerts",
+          instructions: "Server alerts",
+          actions: [
+            { type: ActionType.NOTIFY_MESSAGING_CHANNEL },
+            { type: ActionType.CALL_WEBHOOK },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toContain('<actions>label as "Job hunt"</actions>');
+    expect(result).not.toContain("notification");
+    expect(result).not.toContain("digest");
+    expect(result).not.toContain("star");
+    expect(result).not.toMatch(
+      /<name>Alerts<\/name>\n {2}<criteria>Server alerts<\/criteria>\n {2}<actions>/,
+    );
+  });
+
   it("should format single rule", () => {
     const rules = [
       {

--- a/apps/web/utils/ai/helpers.ts
+++ b/apps/web/utils/ai/helpers.ts
@@ -1,6 +1,13 @@
+import { ActionType } from "@/generated/prisma/enums";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { stringifyEmail } from "@/utils/stringify-email";
 import type { EmailForLLM } from "@/utils/types";
+
+export type RuleActionSummary = {
+  type: ActionType;
+  label?: string | null;
+  folderName?: string | null;
+};
 
 export function getTodayForLLM(date: Date = new Date()) {
   return `Today's date and time is: ${date.toISOString()}.`;
@@ -37,15 +44,20 @@ ${info.map((i) => `<${i.label}>${i.value}</${i.label}>`).join("\n")}
 export const getUserRulesPrompt = ({
   rules,
 }: {
-  rules: { name: string; instructions: string }[];
+  rules: {
+    name: string;
+    instructions: string;
+    actions?: RuleActionSummary[];
+  }[];
 }) => `<user_rules>
 ${rules
-  .map(
-    (rule) => `<rule>
+  .map((rule) => {
+    const actions = formatRuleActions(rule.actions);
+    return `<rule>
   <name>${rule.name}</name>
-  <criteria>${rule.instructions}</criteria>
-</rule>`,
-  )
+  <criteria>${rule.instructions}</criteria>${actions ? `\n  <actions>${actions}</actions>` : ""}
+</rule>`;
+  })
   .join("\n")}
 </user_rules>`;
 
@@ -64,3 +76,41 @@ export const getEmailListPrompt = ({
     .map((email) => `<email>${stringifyEmail(email, messageMaxLength)}</email>`)
     .join("\n");
 };
+
+const ACTION_DESCRIPTIONS: Record<ActionType, string> = {
+  [ActionType.ARCHIVE]: "archive (removes it from the inbox)",
+  [ActionType.LABEL]: "label",
+  [ActionType.REPLY]: "send a reply",
+  [ActionType.SEND_EMAIL]: "send an email",
+  [ActionType.FORWARD]: "forward",
+  [ActionType.DRAFT_EMAIL]: "draft a reply",
+  [ActionType.DRAFT_MESSAGING_CHANNEL]: "draft a reply in chat",
+  [ActionType.NOTIFY_MESSAGING_CHANNEL]: "send a chat notification",
+  [ActionType.MARK_SPAM]: "mark as spam",
+  [ActionType.CALL_WEBHOOK]: "call a webhook",
+  [ActionType.MARK_READ]: "mark as read",
+  [ActionType.STAR]: "star",
+  [ActionType.DELETE]: "delete",
+  [ActionType.DIGEST]: "add to the digest",
+  [ActionType.MOVE_FOLDER]: "move to a folder",
+  [ActionType.NOTIFY_SENDER]: "notify the sender",
+  [ActionType.INTEGRATION]: "run an integration action",
+};
+
+// Tells the rule picker what a match will do, so it can be more careful with
+// rules that hide the email than with rules that only label it.
+export function formatRuleActions(actions?: RuleActionSummary[] | null) {
+  if (!actions?.length) return "";
+
+  return actions
+    .map((action) => {
+      if (action.type === ActionType.LABEL && action.label) {
+        return `label as "${action.label}"`;
+      }
+      if (action.type === ActionType.MOVE_FOLDER && action.folderName) {
+        return `move to folder "${action.folderName}"`;
+      }
+      return ACTION_DESCRIPTIONS[action.type];
+    })
+    .join(", ");
+}

--- a/apps/web/utils/ai/helpers.ts
+++ b/apps/web/utils/ai/helpers.ts
@@ -1,13 +1,11 @@
+import type { Action } from "@/generated/prisma/client";
 import { ActionType } from "@/generated/prisma/enums";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { stringifyEmail } from "@/utils/stringify-email";
 import type { EmailForLLM } from "@/utils/types";
 
-export type RuleActionSummary = {
-  type: ActionType;
-  label?: string | null;
-  folderName?: string | null;
-};
+export type RuleActionSummary = Pick<Action, "type"> &
+  Partial<Pick<Action, "label" | "folderName">>;
 
 export function getTodayForLLM(date: Date = new Date()) {
   return `Today's date and time is: ${date.toISOString()}.`;

--- a/apps/web/utils/ai/helpers.ts
+++ b/apps/web/utils/ai/helpers.ts
@@ -77,7 +77,7 @@ export const getEmailListPrompt = ({
 
 // Only actions that change what the user sees, or that send something on their
 // behalf, affect how careful the picker should be. Notifications, digests,
-// webhooks, stars, and integrations are left out on purpose.
+// chat drafts, webhooks, stars, and integrations are left out on purpose.
 const ACTION_DESCRIPTIONS: Partial<Record<ActionType, string>> = {
   [ActionType.LABEL]: "label",
   [ActionType.ARCHIVE]: "archive (removes it from the inbox)",
@@ -88,6 +88,7 @@ const ACTION_DESCRIPTIONS: Partial<Record<ActionType, string>> = {
   [ActionType.REPLY]: "send a reply",
   [ActionType.SEND_EMAIL]: "send an email",
   [ActionType.FORWARD]: "forward",
+  [ActionType.DRAFT_EMAIL]: "draft a reply",
 };
 
 // Tells the rule picker what a match will do, so it can be more careful with

--- a/apps/web/utils/ai/helpers.ts
+++ b/apps/web/utils/ai/helpers.ts
@@ -2,7 +2,7 @@ import type { Action } from "@/generated/prisma/client";
 import { ActionType } from "@/generated/prisma/enums";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { stringifyEmail } from "@/utils/stringify-email";
-import type { EmailForLLM } from "@/utils/types";
+import { type EmailForLLM, isDefined } from "@/utils/types";
 
 export type RuleActionSummary = Pick<Action, "type"> &
   Partial<Pick<Action, "label" | "folderName">>;
@@ -75,24 +75,19 @@ export const getEmailListPrompt = ({
     .join("\n");
 };
 
-const ACTION_DESCRIPTIONS: Record<ActionType, string> = {
-  [ActionType.ARCHIVE]: "archive (removes it from the inbox)",
+// Only actions that change what the user sees, or that send something on their
+// behalf, affect how careful the picker should be. Notifications, digests,
+// webhooks, stars, and integrations are left out on purpose.
+const ACTION_DESCRIPTIONS: Partial<Record<ActionType, string>> = {
   [ActionType.LABEL]: "label",
+  [ActionType.ARCHIVE]: "archive (removes it from the inbox)",
+  [ActionType.MOVE_FOLDER]: "move to a folder",
+  [ActionType.MARK_READ]: "mark as read",
+  [ActionType.MARK_SPAM]: "mark as spam",
+  [ActionType.DELETE]: "delete",
   [ActionType.REPLY]: "send a reply",
   [ActionType.SEND_EMAIL]: "send an email",
   [ActionType.FORWARD]: "forward",
-  [ActionType.DRAFT_EMAIL]: "draft a reply",
-  [ActionType.DRAFT_MESSAGING_CHANNEL]: "draft a reply in chat",
-  [ActionType.NOTIFY_MESSAGING_CHANNEL]: "send a chat notification",
-  [ActionType.MARK_SPAM]: "mark as spam",
-  [ActionType.CALL_WEBHOOK]: "call a webhook",
-  [ActionType.MARK_READ]: "mark as read",
-  [ActionType.STAR]: "star",
-  [ActionType.DELETE]: "delete",
-  [ActionType.DIGEST]: "add to the digest",
-  [ActionType.MOVE_FOLDER]: "move to a folder",
-  [ActionType.NOTIFY_SENDER]: "notify the sender",
-  [ActionType.INTEGRATION]: "run an integration action",
 };
 
 // Tells the rule picker what a match will do, so it can be more careful with
@@ -110,5 +105,6 @@ export function formatRuleActions(actions?: RuleActionSummary[] | null) {
       }
       return ACTION_DESCRIPTIONS[action.type];
     })
+    .filter(isDefined)
     .join(", ");
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260901-233523_pr-3471_d3034b48b36f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

The rule picker chose between rules by name and instructions only. It had no idea that picking "Marketing" archives the email while picking "Newsletter" only labels it, so a borderline call between the two carried a hidden cost. In a recent case this archived a personal community mailing from someone the user knows.

- Each candidate rule in the choose-rule prompt now lists its actions in plain words (for example `label as "Marketing", archive (removes it from the inbox)`), in both the single-rule and multi-rule prompts. `getUserRulesPrompt` renders the line only when actions are provided, so other callers are unaffected
- When at least one candidate rule archives, moves, deletes, or marks as spam, a guideline is added telling the model to reserve those rules for promotional or automated bulk mail and to prefer a label-only rule for mailings from groups the user belongs to. The guideline is omitted when no candidate hides email, so rule sets without such actions see no prompt change
- Eval: system rules in the choose-rule eval now carry their default actions (Marketing archives), and two cases were added: a school parent-group mailing with an unsubscribe link must land on a label-only rule, and a retailer sale must still land on Marketing

Prompt and tool-description changes are disclosed above; no new tools or parameters.

Eval results with the default eval model:
- Baseline on main: 39/39
- First attempt (unconditional guideline): the new community case still went to Marketing, and a no-actions stress case regressed from "no match" to a label rule, which is why the guideline is now conditional
- Final: 40/41. Both new cases pass. The one failure was a pre-existing case that passed 3/3 on immediate rerun, so it is model nondeterminism rather than this change

Unit tests: helpers and choose-rule suites pass (134 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * AI-powered email rule selection now considers configured actions such as labeling, archiving, moving, deleting, and marking messages as spam.
  * Promotional and automated bulk emails are better distinguished from group or membership communications.
  * Rule details now provide clearer descriptions of configured actions, including labels and destination folders.
* **Tests**
  * Added coverage for action-aware rule guidance and prompts.
  * Added classification scenarios for membership communications and promotional sales emails.
  * Added baseline comparisons to verify classification behavior with and without action details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->