### PR TITLE
INB-349: Show Outlook drafts in mail thread view

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -121,6 +121,29 @@ describe("OutlookProvider.getThread", () => {
     ]);
     expect(thread.snippet).toBe("Newest preview");
   });
+
+  it("includes drafts in the thread view", async () => {
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({ id: "received-message" }),
+        createMessage({
+          id: "draft-reply",
+          isDraft: true,
+          parentFolderId: "drafts-folder-id",
+          receivedDateTime: "2026-01-02T00:00:00.000Z",
+        }),
+      ]),
+      createTestLogger(),
+    );
+
+    const thread = await provider.getThread("thread-1");
+
+    expect(thread.messages.map((message) => message.id)).toEqual([
+      "received-message",
+      "draft-reply",
+    ]);
+    expect(thread.messages.at(-1)?.labelIds).toContain("DRAFT");
+  });
 });
 
 describe("OutlookProvider.getThreadsWithLabel", () => {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -130,7 +130,7 @@ describe("OutlookProvider.getThread", () => {
           id: "draft-reply",
           isDraft: true,
           parentFolderId: "drafts-folder-id",
-          receivedDateTime: "2026-01-02T00:00:00.000Z",
+          receivedDateTime: undefined,
         }),
       ]),
       createTestLogger(),

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -149,7 +149,14 @@ export class OutlookProvider implements EmailProvider {
 
   async getThread(threadId: string): Promise<EmailThread> {
     try {
-      const messages = await this.getThreadMessages(threadId);
+      const messages = await getThreadMessages(
+        threadId,
+        this.client,
+        this.logger,
+        {
+          includeDrafts: true,
+        },
+      );
 
       return {
         id: threadId,

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -251,6 +251,7 @@ export interface EmailProvider {
   }): Promise<EmailThread[]>;
   getSignatures(): Promise<EmailSignature[]>;
   // Thread messages are returned in chronological order (oldest first).
+  // getThread includes draft messages; getThreadMessages excludes them.
   getThread(threadId: string): Promise<EmailThread>;
   getThreadMessages(threadId: string): Promise<ParsedMessage[]>;
   getThreadMessagesInInbox(threadId: string): Promise<ParsedMessage[]>;

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -36,8 +36,14 @@ export async function getThread(
 
     // Sort in memory to avoid "restriction or sort order is too complex" error
     return messages.value.sort((a, b) => {
-      const dateA = new Date(a.receivedDateTime || 0).getTime();
-      const dateB = new Date(b.receivedDateTime || 0).getTime();
+      const dateA =
+        a.isDraft && !a.receivedDateTime
+          ? Number.POSITIVE_INFINITY
+          : new Date(a.receivedDateTime || 0).getTime();
+      const dateB =
+        b.isDraft && !b.receivedDateTime
+          ? Number.POSITIVE_INFINITY
+          : new Date(b.receivedDateTime || 0).getTime();
       return dateA - dateB;
     });
   } catch (error) {

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -223,14 +223,15 @@ export async function getThreadMessages(
   threadId: string,
   client: OutlookClient,
   logger: Logger,
+  { includeDrafts = false }: { includeDrafts?: boolean } = {},
 ): Promise<ParsedMessage[]> {
   const [messages, folderIds, categoryMap] = await Promise.all([
     getThread(threadId, client, logger),
-    getFolderIds(client, logger, { includeDrafts: false }),
+    getFolderIds(client, logger, { includeDrafts }),
     getCategoryMap(client, logger),
   ]);
 
   return messages
-    .filter((msg) => !msg.isDraft)
+    .filter((msg) => includeDrafts || !msg.isDraft)
     .map((msg) => convertMessage(msg, folderIds, categoryMap));
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260902-003534_pr-3472_605e5519ac7d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Show Outlook draft replies in the mail thread view while preserving draft exclusion for background thread-message consumers. This aligns the visible Outlook thread behavior with the existing provider contract.

- Add opt-in draft inclusion to Outlook thread message loading.
- Preserve draft filtering for `getThreadMessages` callers.
- Add regression coverage for draft visibility and the `DRAFT` label.
- Tests: focused provider suite (43 passed) and Ultracite checks on all changed files.
- Performance: no database work; existing Outlook fetches are retained, with at most a one-time Drafts folder-ID request when uncached; filtering remains linear and low risk for the thread-view hot path.

Linear: https://linear.app/inbox-zero-ai/issue/INB-349/outlook-auto-generated-drafts-not-displayed-in-mail-thread-view


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outlook email threads now include draft messages alongside received messages.
  * Drafts are clearly labeled and positioned appropriately when they lack a received timestamp.

* **Bug Fixes**
  * Fixed thread views omitting draft messages.

* **Tests**
  * Added coverage confirming draft inclusion, ordering, and labeling across Outlook email threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->