### PR TITLE
fix: stabilize label ordering in email rows

### DIFF
--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -140,27 +140,27 @@ describe("getEmailThreadLabels", () => {
     expect(labels).toEqual([{ id: "label-actioned", name: "Actioned" }]);
   });
 
-  it("prioritizes labels from newer messages", () => {
+  it("keeps older message labels in the consistent display order", () => {
     const labels = getEmailThreadLabels({
       messages: [
-        { labelIds: ["label-older"] },
-        { labelIds: ["DRAFT", "label-newer"] },
+        { labelIds: ["label-alpha"] },
+        { labelIds: ["DRAFT", "label-zulu"] },
       ],
       userLabels: {
-        "label-older": {
-          id: "label-older",
-          name: "Older",
+        "label-alpha": {
+          id: "label-alpha",
+          name: "Alpha",
         },
-        "label-newer": {
-          id: "label-newer",
-          name: "Newer",
+        "label-zulu": {
+          id: "label-zulu",
+          name: "Zulu",
         },
       },
     });
 
     expect(labels).toEqual([
-      { id: "label-newer", name: "Newer" },
-      { id: "label-older", name: "Older" },
+      { id: "label-alpha", name: "Alpha" },
+      { id: "label-zulu", name: "Zulu" },
     ]);
   });
 });

--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -76,6 +76,34 @@ describe("getEmailMessageCellLabels", () => {
 });
 
 describe("getEmailThreadLabels", () => {
+  it("orders the same labels consistently regardless of provider order", () => {
+    const userLabels = {
+      "label-actioned": {
+        id: "label-actioned",
+        name: "Actioned",
+      },
+      "label-receipt": {
+        id: "label-receipt",
+        name: "Receipt",
+      },
+    };
+
+    const actionedFirst = getEmailThreadLabels({
+      messages: [{ labelIds: ["label-actioned", "label-receipt"] }],
+      userLabels,
+    });
+    const receiptFirst = getEmailThreadLabels({
+      messages: [{ labelIds: ["label-receipt", "label-actioned"] }],
+      userLabels,
+    });
+
+    expect(actionedFirst).toEqual([
+      { id: "label-actioned", name: "Actioned" },
+      { id: "label-receipt", name: "Receipt" },
+    ]);
+    expect(receiptFirst).toEqual(actionedFirst);
+  });
+
   it("hides Gmail system categories while keeping user labels", () => {
     const categoryIds = [
       "CATEGORY_PERSONAL",

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -8,6 +8,7 @@ import { getRuleLabel } from "@/utils/rule/consts";
 import { SystemType } from "@/generated/prisma/enums";
 import { GMAIL_SYSTEM_LABELS, GmailLabel } from "@/utils/gmail/label";
 import { OutlookLabel } from "@/utils/outlook/constants";
+import { compareLabelsByName } from "@/utils/label/compare-labels";
 
 export type EmailMessageCellLabel = Pick<EmailLabel, "id" | "name" | "color">;
 
@@ -79,7 +80,9 @@ export function getEmailThreadLabels({
     ),
   ];
 
-  return getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];
+  const labels = getEmailMessageCellLabels({ labelIds, userLabels }) ?? [];
+
+  return labels.sort(compareLabelsByName);
 }
 
 function shouldShowArchivedLabel({

--- a/apps/web/hooks/useLabels.ts
+++ b/apps/web/hooks/useLabels.ts
@@ -3,6 +3,7 @@ import useSWR from "swr";
 import type { LabelsResponse } from "@/app/api/labels/route";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { compareLabelsByName } from "@/utils/label/compare-labels";
 
 export type UserLabel = {
   id: string;
@@ -24,16 +25,6 @@ export type OutlookLabel = {
 };
 
 export type GenericLabel = UserLabel | OutlookLabel;
-
-type SortableLabel = {
-  id: string | null | undefined;
-  name: string | null | undefined;
-  type: string | null;
-  color?: {
-    textColor?: string | null;
-    backgroundColor?: string | null;
-  };
-};
 
 function isHidden(label: EmailLabel): boolean {
   return label.labelListVisibility === "labelHide";
@@ -66,7 +57,7 @@ export function useAllLabels() {
 
     return data.labels
       .filter((label) => label.type === "user")
-      .sort(sortLabels);
+      .sort(compareLabelsByName);
   }, [data?.labels]);
 
   return {
@@ -94,7 +85,7 @@ export function useLabels() {
         labelListVisibility: label.labelListVisibility,
         messageListVisibility: label.messageListVisibility,
       }))
-      .sort(sortLabels);
+      .sort(compareLabelsByName);
   }, [data?.labels]);
 
   return {
@@ -134,15 +125,4 @@ export function useSplitLabels() {
     error,
     mutate,
   };
-}
-
-function sortLabels(a: SortableLabel, b: SortableLabel) {
-  const aName = a.name || "";
-  const bName = b.name || "";
-
-  // Order words that start with [ at the end
-  if (aName.startsWith("[") && !bName.startsWith("[")) return 1;
-  if (!aName.startsWith("[") && bName.startsWith("[")) return -1;
-
-  return aName.localeCompare(bName);
 }

--- a/apps/web/utils/label/compare-labels.test.ts
+++ b/apps/web/utils/label/compare-labels.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { compareLabelsByName } from "./compare-labels";
+
+describe("compareLabelsByName", () => {
+  it("uses consistent English collation for non-ASCII labels", () => {
+    const labels = [
+      { id: "label-zulu", name: "Zulu" },
+      { id: "label-angstrom", name: "Ångström" },
+    ];
+
+    expect(labels.sort(compareLabelsByName).map((label) => label.name)).toEqual(
+      ["Ångström", "Zulu"],
+    );
+  });
+});

--- a/apps/web/utils/label/compare-labels.test.ts
+++ b/apps/web/utils/label/compare-labels.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { compareLabelsByName } from "./compare-labels";
 
 describe("compareLabelsByName", () => {
-  it("uses consistent English collation for non-ASCII labels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses English collation when the runtime default is Swedish", () => {
+    const localeCompare = String.prototype.localeCompare;
+    vi.spyOn(String.prototype, "localeCompare").mockImplementation(function (
+      this: string,
+      compareString,
+      locales,
+      options,
+    ) {
+      return localeCompare.call(this, compareString, locales ?? "sv", options);
+    });
+
     const labels = [
       { id: "label-zulu", name: "Zulu" },
       { id: "label-angstrom", name: "Ångström" },

--- a/apps/web/utils/label/compare-labels.ts
+++ b/apps/web/utils/label/compare-labels.ts
@@ -3,6 +3,8 @@ type SortableLabel = {
   name?: string | null;
 };
 
+const LABEL_SORT_LOCALE = "en";
+
 export function compareLabelsByName(a: SortableLabel, b: SortableLabel) {
   const aName = a.name || "";
   const bName = b.name || "";
@@ -10,5 +12,8 @@ export function compareLabelsByName(a: SortableLabel, b: SortableLabel) {
   if (aName.startsWith("[") && !bName.startsWith("[")) return 1;
   if (!aName.startsWith("[") && bName.startsWith("[")) return -1;
 
-  return aName.localeCompare(bName) || (a.id || "").localeCompare(b.id || "");
+  return (
+    aName.localeCompare(bName, LABEL_SORT_LOCALE) ||
+    (a.id || "").localeCompare(b.id || "", LABEL_SORT_LOCALE)
+  );
 }

--- a/apps/web/utils/label/compare-labels.ts
+++ b/apps/web/utils/label/compare-labels.ts
@@ -1,0 +1,14 @@
+type SortableLabel = {
+  id?: string | null;
+  name?: string | null;
+};
+
+export function compareLabelsByName(a: SortableLabel, b: SortableLabel) {
+  const aName = a.name || "";
+  const bName = b.name || "";
+
+  if (aName.startsWith("[") && !bName.startsWith("[")) return 1;
+  if (!aName.startsWith("[") && bName.startsWith("[")) return -1;
+
+  return aName.localeCompare(bName) || (a.id || "").localeCompare(b.id || "");
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-102215_pr-3475_a934c6538879/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensures labels appear in a deterministic order across email rows.

- Reuses a shared label comparator for label lists and thread chips.
- Adds regression coverage for inconsistent provider ordering.
- Validated with focused unit tests and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Labels now appear in a consistent alphabetical order across email threads and label lists.
  - Bracket-prefixed labels are consistently placed after other labels.
  - Labels with identical names are sorted consistently using their identifiers.
  - Label ordering is consistent across supported runtime locales.

- **Tests**
  - Added coverage for deterministic ordering across message and input-label order.
  - Added tests verifying consistent alphabetical collation and tie-breaking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->