### PR TITLE
mail: Improve inline draft interactions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -355,9 +355,7 @@ test("opens and sends a reply from the reader with Enter", async ({
   await expect(
     page.locator("[data-email-preserved-kind='quote']"),
   ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: "Show quoted message" }),
-  ).toBeVisible();
+  await expect(page.getByLabel("Show quoted message")).toBeVisible();
   await expect(page.getByText("Quoted message", { exact: true })).toHaveCount(
     0,
   );

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -355,11 +355,24 @@ test("opens and sends a reply from the reader with Enter", async ({
   await expect(
     page.locator("[data-email-preserved-kind='quote']"),
   ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Show quoted message" }),
+  ).toBeVisible();
+  await expect(page.getByText("Quoted message", { exact: true })).toHaveCount(
+    0,
+  );
+  await expect(
+    page.getByRole("button", { name: "Remove quoted message" }),
+  ).toHaveCount(0);
   const replyBody = `A reply sent through the mail reader. ${testInfo.retry}`;
   await replyEditor.pressSequentially(replyBody);
   await expect(replyEditor).toContainText(replyBody);
+  const sendButton = page.getByRole("button", { name: "Send", exact: true });
+  await expect(sendButton).toHaveText("Send");
+  await sendButton.hover();
+  await expect(page.getByRole("tooltip")).toHaveText(/(?:⌘|Ctrl)\+Enter/);
   await capturePlaywrightCheckpoint(page, testInfo, "protected-quoted-reply");
-  await page.getByRole("button", { name: /^Send/ }).click();
+  await sendButton.click();
 
   await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
   await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -45,13 +45,13 @@ import type {
 } from "@/app/api/user/contacts/route";
 import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
 import { Input, Label } from "@/components/Input";
-import { ButtonLoader, LoadingMiniSpinner } from "@/components/Loading";
+import { ButtonLoader } from "@/components/Loading";
 import { LoadingContent } from "@/components/LoadingContent";
+import { Tooltip } from "@/components/Tooltip";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CommandShortcut } from "@/components/ui/command";
 import {
   Select,
   SelectContent,
@@ -110,7 +110,6 @@ type ComposeEmailFormProps = {
   onSuccess?: (messageId: string, threadId: string) => void;
   onClose?: () => void;
   onDiscard?: () => void;
-  isDiscarding?: boolean;
 };
 
 type ComposeAttachment = EmailComposerAttachment & {
@@ -164,7 +163,6 @@ function ComposeEmailFormContent({
   onSuccess,
   onClose,
   onDiscard,
-  isDiscarding,
 }: ComposeEmailFormProps & {
   accountProvider: string;
   accountSignatureHtml: string;
@@ -838,21 +836,24 @@ function ComposeEmailFormContent({
         )}
       >
         <div className="flex items-center">
-          <Button
-            className={cn(
-              isComposeWindow &&
-                "h-9 px-0 font-semibold text-foreground hover:bg-transparent hover:text-foreground",
-            )}
-            disabled={isSubmitting}
-            type="submit"
-            variant={isComposeWindow ? "ghost" : "default"}
-          >
-            {isSubmitting && <ButtonLoader />}
-            Send
-            {!isComposeWindow && (
-              <CommandShortcut className="ml-2">{symbol}+Enter</CommandShortcut>
-            )}
-          </Button>
+          {isComposeWindow ? (
+            <Button
+              className="h-9 px-0 font-semibold text-foreground hover:bg-transparent hover:text-foreground"
+              disabled={isSubmitting}
+              type="submit"
+              variant="ghost"
+            >
+              {isSubmitting && <ButtonLoader />}
+              Send
+            </Button>
+          ) : (
+            <Tooltip content={`${symbol}+Enter`}>
+              <Button disabled={isSubmitting} type="submit" variant="gradient">
+                {isSubmitting && <ButtonLoader />}
+                Send
+              </Button>
+            </Tooltip>
+          )}
         </div>
 
         <div className="flex items-center gap-0.5 text-muted-foreground">
@@ -904,18 +905,14 @@ function ComposeEmailFormContent({
                 isComposeWindow &&
                   "text-muted-foreground hover:text-foreground",
               )}
-              disabled={isSubmitting || isDiscarding}
+              disabled={isSubmitting}
               onClick={onDiscard}
               size={isComposeWindow ? "iconSm" : "icon"}
               title="Discard draft"
               type="button"
               variant="ghost"
             >
-              {isDiscarding ? (
-                <LoadingMiniSpinner />
-              ) : (
-                <TrashIcon className="size-4" />
-              )}
+              <TrashIcon className="size-4" />
             </Button>
           )}
         </div>

--- a/apps/web/components/email-list/EmailMessage.test.tsx
+++ b/apps/web/components/email-list/EmailMessage.test.tsx
@@ -11,10 +11,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailMessage } from "@/components/email-list/EmailMessage";
 
-const actions = vi.hoisted(() => ({ executeAsync: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  executeAsync: vi.fn(),
+  toastError: vi.fn(),
+}));
 
 vi.mock("next-safe-action/hooks", () => ({
-  useAction: () => actions,
+  useAction: () => ({ executeAsync: mocks.executeAsync }),
 }));
 vi.mock("swr", () => ({
   default: () => ({ data: undefined }),
@@ -42,7 +45,7 @@ vi.mock("@/components/email-list/EmailAttachments", () => ({
 vi.mock("@/components/email-list/EmailDetails", () => ({
   EmailDetails: () => null,
 }));
-vi.mock("@/components/Toast", () => ({ toastError: vi.fn() }));
+vi.mock("@/components/Toast", () => ({ toastError: mocks.toastError }));
 vi.mock("@/utils/actions/mail", () => ({ deleteDraftAction: vi.fn() }));
 vi.mock("@/utils/actions/generate-reply", () => ({
   generateNudgeReplyAction: vi.fn(),
@@ -73,11 +76,12 @@ describe("EmailMessage draft recovery", () => {
 
   it("keeps a newer compose mode open when an earlier discard fails", async () => {
     let rejectDiscard: (error: Error) => void = () => {};
-    actions.executeAsync.mockReturnValue(
+    mocks.executeAsync.mockReturnValue(
       new Promise((_, reject) => {
         rejectDiscard = reject;
       }),
     );
+    const refetch = vi.fn();
 
     render(
       <EmailMessage
@@ -86,7 +90,7 @@ describe("EmailMessage draft recovery", () => {
         expanded
         message={createMessage("message-1")}
         onSendSuccess={vi.fn()}
-        refetch={vi.fn()}
+        refetch={refetch}
         showReplyButton
       />,
     );
@@ -103,6 +107,10 @@ describe("EmailMessage draft recovery", () => {
     });
 
     expect(screen.getByTestId("composer").textContent).toContain("forward");
+    expect(mocks.toastError).toHaveBeenCalledWith({
+      description: "Failed to discard draft",
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/components/email-list/EmailMessage.test.tsx
+++ b/apps/web/components/email-list/EmailMessage.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadMessage } from "@/components/email-list/types";
+import { EmailMessage } from "@/components/email-list/EmailMessage";
+
+const actions = vi.hoisted(() => ({ executeAsync: vi.fn() }));
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => actions,
+}));
+vi.mock("swr", () => ({
+  default: () => ({ data: undefined }),
+}));
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => ({
+    emailAccount: undefined,
+    emailAccountId: "account-1",
+    userEmail: "user@example.com",
+  }),
+}));
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_CONTACTS_ENABLED: false },
+}));
+vi.mock("@/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/email-list/EmailContents", () => ({
+  HtmlEmail: () => null,
+  PlainEmail: () => null,
+}));
+vi.mock("@/components/email-list/EmailAttachments", () => ({
+  EmailAttachments: () => null,
+}));
+vi.mock("@/components/email-list/EmailDetails", () => ({
+  EmailDetails: () => null,
+}));
+vi.mock("@/components/Toast", () => ({ toastError: vi.fn() }));
+vi.mock("@/utils/actions/mail", () => ({ deleteDraftAction: vi.fn() }));
+vi.mock("@/utils/actions/generate-reply", () => ({
+  generateNudgeReplyAction: vi.fn(),
+}));
+vi.mock("@/app/(app)/[emailAccountId]/compose/ComposeEmailFormLazy", () => ({
+  ComposeEmailFormLazy: ({
+    onDiscard,
+    replyingToEmail,
+  }: {
+    onDiscard: () => void;
+    replyingToEmail?: { to?: string };
+  }) => (
+    <div data-testid="composer">
+      <span>{replyingToEmail?.to ? "reply" : "forward"}</span>
+      <button onClick={onDiscard} type="button">
+        Discard draft
+      </button>
+    </div>
+  ),
+}));
+
+describe("EmailMessage draft recovery", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps a newer compose mode open when an earlier discard fails", async () => {
+    let rejectDiscard: (error: Error) => void = () => {};
+    actions.executeAsync.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectDiscard = reject;
+      }),
+    );
+
+    render(
+      <EmailMessage
+        defaultShowReply
+        draftMessage={createMessage("draft-1")}
+        expanded
+        message={createMessage("message-1")}
+        onSendSuccess={vi.fn()}
+        refetch={vi.fn()}
+        showReplyButton
+      />,
+    );
+
+    expect(screen.getByTestId("composer").textContent).toContain("reply");
+    fireEvent.click(screen.getByRole("button", { name: "Discard draft" }));
+    expect(screen.queryByTestId("composer")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Forward" }));
+    expect(screen.getByTestId("composer").textContent).toContain("forward");
+
+    await act(async () => {
+      rejectDiscard(new Error("Request failed"));
+    });
+
+    expect(screen.getByTestId("composer").textContent).toContain("forward");
+  });
+});
+
+function createMessage(id: string) {
+  return {
+    date: "2026-01-01T00:00:00.000Z",
+    headers: {
+      date: "2026-01-01T00:00:00.000Z",
+      from: "sender@example.com",
+      subject: "Subject",
+      to: "user@example.com",
+    },
+    historyId: "history-1",
+    id,
+    inline: [],
+    snippet: "Preview",
+    subject: "Subject",
+    textPlain: "Message body",
+    threadId: "thread-1",
+  } as ThreadMessage;
+}

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -128,7 +128,7 @@ export function EmailMessage({
               generateNudge={generateNudge}
               message={message}
               onCloseCompose={onCloseCompose}
-              onOpenCompose={onReply}
+              onOpenCompose={showReply ? onReply : onForward}
               onSendSuccess={onSendSuccess}
               refetch={refetch}
               showReply={showReply}

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -440,30 +440,34 @@ function ReplyPanel({
     return prepareForwardingEmail(message);
   }, [showReply, message, draftMessage, reply]);
 
-  const { execute: discardDraft, isExecuting: isDiscardingDraft } = useAction(
+  const { executeAsync: discardDraft } = useAction(
     deleteDraftAction.bind(null, emailAccountId),
-    {
-      onSuccess: () => {
-        refetch();
-        onCloseCompose();
-      },
-      onError: (error) => {
-        toastError({
-          description: getActionErrorMessage(error.error, {
-            prefix: "Failed to discard draft",
-          }),
-        });
-      },
-    },
   );
 
-  const onDiscard = useCallback(() => {
+  const onDiscard = useCallback(async () => {
     if (!draftMessage) {
       onCloseCompose();
       return;
     }
-    discardDraft({ draftMessageId: draftMessage.id });
-  }, [draftMessage, discardDraft, onCloseCompose]);
+
+    const discardPromise = discardDraft({ draftMessageId: draftMessage.id });
+    onCloseCompose();
+
+    try {
+      const result = await discardPromise;
+      if (result?.serverError || result?.validationErrors) {
+        toastError({
+          description: getActionErrorMessage(result, {
+            prefix: "Failed to discard draft",
+          }),
+        });
+      }
+    } catch {
+      toastError({ description: "Failed to discard draft" });
+    } finally {
+      refetch();
+    }
+  }, [draftMessage, discardDraft, onCloseCompose, refetch]);
 
   return (
     <Card className="mt-6 rounded-xl p-3" ref={replyRef}>
@@ -484,7 +488,6 @@ function ReplyPanel({
         </div>
       ) : (
         <ComposeEmailFormLazy
-          isDiscarding={isDiscardingDraft}
           onClose={onCloseCompose}
           onDiscard={onDiscard}
           onSuccess={(messageId: string, threadId: string) => {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -75,14 +75,38 @@ export function EmailMessage({
 
   const [showDetails, setShowDetails] = useState(false);
   const [showForward, setShowForward] = useState(false);
+  const composeSessionRef = useRef(0);
 
-  const onReply = useCallback(() => setReplyOverride(true), []);
-  const onForward = useCallback(() => setShowForward(true), []);
+  const onReply = useCallback(() => {
+    composeSessionRef.current += 1;
+    setReplyOverride(true);
+    setShowForward(false);
+  }, []);
+  const onForward = useCallback(() => {
+    composeSessionRef.current += 1;
+    setReplyOverride(false);
+    setShowForward(true);
+  }, []);
 
   const onCloseCompose = useCallback(() => {
     setReplyOverride(false);
     setShowForward(false);
   }, []);
+
+  const onStartDiscard = useCallback(() => {
+    const composeSession = composeSessionRef.current;
+    onCloseCompose();
+    return composeSession;
+  }, [onCloseCompose]);
+
+  const onRestoreCompose = useCallback(
+    (composeSession: number) => {
+      if (composeSessionRef.current !== composeSession) return;
+      if (showReply) onReply();
+      else onForward();
+    },
+    [onForward, onReply, showReply],
+  );
 
   const toggleDetails = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -128,8 +152,9 @@ export function EmailMessage({
               generateNudge={generateNudge}
               message={message}
               onCloseCompose={onCloseCompose}
-              onOpenCompose={showReply ? onReply : onForward}
+              onRestoreCompose={onRestoreCompose}
               onSendSuccess={onSendSuccess}
+              onStartDiscard={onStartDiscard}
               refetch={refetch}
               showReply={showReply}
             />
@@ -351,7 +376,8 @@ function ReplyPanel({
   refetch,
   onSendSuccess,
   onCloseCompose,
-  onOpenCompose,
+  onRestoreCompose,
+  onStartDiscard,
   defaultShowReply,
   showReply,
   draftMessage,
@@ -361,7 +387,8 @@ function ReplyPanel({
   refetch: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
   onCloseCompose: () => void;
-  onOpenCompose: () => void;
+  onRestoreCompose: (composeSession: number) => void;
+  onStartDiscard: () => number;
   defaultShowReply?: boolean;
   showReply: boolean;
   draftMessage?: ThreadMessage;
@@ -454,7 +481,7 @@ function ReplyPanel({
     }
 
     const discardPromise = discardDraft({ draftMessageId: draftMessage.id });
-    onCloseCompose();
+    const composeSession = onStartDiscard();
 
     try {
       const result = await discardPromise;
@@ -464,15 +491,22 @@ function ReplyPanel({
             prefix: "Failed to discard draft",
           }),
         });
-        onOpenCompose();
+        onRestoreCompose(composeSession);
       }
     } catch {
       toastError({ description: "Failed to discard draft" });
-      onOpenCompose();
+      onRestoreCompose(composeSession);
     } finally {
       refetch();
     }
-  }, [draftMessage, discardDraft, onCloseCompose, onOpenCompose, refetch]);
+  }, [
+    draftMessage,
+    discardDraft,
+    onCloseCompose,
+    onRestoreCompose,
+    onStartDiscard,
+    refetch,
+  ]);
 
   return (
     <Card className="mt-6 rounded-xl p-3" ref={replyRef}>

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -128,6 +128,7 @@ export function EmailMessage({
               generateNudge={generateNudge}
               message={message}
               onCloseCompose={onCloseCompose}
+              onOpenCompose={onReply}
               onSendSuccess={onSendSuccess}
               refetch={refetch}
               showReply={showReply}
@@ -350,6 +351,7 @@ function ReplyPanel({
   refetch,
   onSendSuccess,
   onCloseCompose,
+  onOpenCompose,
   defaultShowReply,
   showReply,
   draftMessage,
@@ -359,6 +361,7 @@ function ReplyPanel({
   refetch: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
   onCloseCompose: () => void;
+  onOpenCompose: () => void;
   defaultShowReply?: boolean;
   showReply: boolean;
   draftMessage?: ThreadMessage;
@@ -461,13 +464,15 @@ function ReplyPanel({
             prefix: "Failed to discard draft",
           }),
         });
+        onOpenCompose();
       }
     } catch {
       toastError({ description: "Failed to discard draft" });
+      onOpenCompose();
     } finally {
       refetch();
     }
-  }, [draftMessage, discardDraft, onCloseCompose, refetch]);
+  }, [draftMessage, discardDraft, onCloseCompose, onOpenCompose, refetch]);
 
   return (
     <Card className="mt-6 rounded-xl p-3" ref={replyRef}>

--- a/packages/email-editor/src/web/preserved-block.tsx
+++ b/packages/email-editor/src/web/preserved-block.tsx
@@ -26,21 +26,32 @@ export function PreservedBlockDetails({
       open={open}
       onToggle={(event) => setOpen(event.currentTarget.open)}
     >
-      <summary className={styles.preservedSummary}>
+      <summary
+        aria-label={
+          block.kind === "quote"
+            ? `${open ? "Hide" : "Show"} quoted message`
+            : undefined
+        }
+        className={styles.preservedSummary}
+      >
         <span aria-hidden>{block.kind === "quote" ? "⋯" : "—"}</span>
-        <span>{title}</span>
-        <button
-          aria-label={`Remove ${title.toLowerCase()}`}
-          className={styles.removePreservedButton}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onRemove();
-          }}
-          type="button"
-        >
-          ×
-        </button>
+        {block.kind === "signature" && (
+          <>
+            <span>{title}</span>
+            <button
+              aria-label={`Remove ${title.toLowerCase()}`}
+              className={styles.removePreservedButton}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onRemove();
+              }}
+              type="button"
+            >
+              ×
+            </button>
+          </>
+        )}
       </summary>
       <iframe
         className={


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-110106_pr-3477_31a1a9319b32/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves inline draft deletion feedback and simplifies reply composer controls.

- Closes discarded drafts optimistically while preserving error recovery and refresh behavior.
- Updates quoted-content and send controls, with browser assertions for accessibility and shortcut behavior.
- Validated with formatting checks, focused draft-action tests, and email-editor typechecks and tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quoted messages in replies are collapsed by default and can be expanded when needed.
  - The Send button provides clearer keyboard shortcut guidance and adapts to the compose window layout.
  - Signature blocks and quoted messages now have distinct controls and presentation.

- **Bug Fixes**
  - Discarding a draft closes the composer promptly, reports failures clearly, refreshes the message view reliably, and reopens the correct reply or forward mode when needed.
  - Reply and send interactions now provide more precise behavior and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->