### PR TITLE
mail: Preserve auto-advance in filtered views

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -80,12 +80,12 @@ test("advances the split reader after archiving an open conversation", async ({
   let restoreSucceeded: boolean | undefined;
   try {
     await page.getByRole("button", { name: "Archive", exact: true }).click();
+    archived = true;
     await expect(
       page
         .getByRole("region", { name: "Notifications alt+T" })
         .getByText("Archived", { exact: true }),
     ).toBeVisible();
-    archived = true;
 
     await expect(conversations).toBeVisible();
     await expect

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -64,7 +64,6 @@ test("advances the split reader after archiving an open conversation", async ({
 }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
   await page.getByRole("button", { name: "Switch list or split view" }).click();
-  await page.getByRole("button", { name: "Unread", exact: true }).click();
   const conversation = conversationWithSubject(
     page,
     conversations,
@@ -74,25 +73,33 @@ test("advances the split reader after archiving an open conversation", async ({
   await expect(
     page.getByRole("heading", { name: "Second Unread Command Message" }),
   ).toBeVisible();
+  await page.getByRole("button", { name: "Unread", exact: true }).click();
   await expect(conversation).toHaveCount(0);
 
   try {
     await page.getByRole("button", { name: "Archive", exact: true }).click();
 
     await expect(conversations).toBeVisible();
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("thread-id"))
+      .not.toBe("thr_playwright_3");
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("thread-id"))
+      .not.toBeNull();
     await expect(
-      page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+      page.getByRole("button", { name: "Archive", exact: true }),
     ).toBeVisible();
-    await expect(page).toHaveURL(/thread-id=thr_playwright_reader/);
     await capturePlaywrightCheckpoint(
       page,
       testInfo,
       "split-reader-after-archive",
     );
   } finally {
-    await page.request.post("/api/threads/thr_playwright_3/unarchive", {
-      headers: { "X-Email-Account-ID": emailAccountId },
-    });
+    const restoreResponse = await page.request.post(
+      "/api/threads/thr_playwright_3/unarchive",
+      { headers: { "X-Email-Account-ID": emailAccountId } },
+    );
+    expect(restoreResponse.ok()).toBeTruthy();
   }
 });
 

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
@@ -62,9 +63,19 @@ test("deletes an open conversation and returns to the list", async ({
 test("advances the split reader after archiving an open conversation", async ({
   page,
 }, testInfo) => {
+  const settingsResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      new URL(response.url()).pathname === "/api/mail/settings",
+  );
   const { conversations, emailAccountId } = await openMail(page);
+  const settingsResponse = await settingsResponsePromise;
+  expect(settingsResponse.ok()).toBeTruthy();
+  const settings = (await settingsResponse.json()) as MailSettingsResponse;
   const emptyReader = page.getByText("Nothing selected", { exact: true });
-  if (!(await emptyReader.isVisible())) {
+  if (settings.layout === "SPLIT") {
+    await expect(emptyReader).toBeVisible();
+  } else {
     await page
       .getByRole("button", { name: "Switch list or split view" })
       .click();

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
@@ -56,6 +57,43 @@ test("deletes an open conversation and returns to the list", async ({
     { headers: { "X-Email-Account-ID": emailAccountId } },
   );
   expect(restoreResponse.ok()).toBeTruthy();
+});
+
+test("advances the split reader after archiving an open conversation", async ({
+  page,
+}, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  await page.getByRole("button", { name: "Switch list or split view" }).click();
+  await page.getByRole("button", { name: "Unread", exact: true }).click();
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Second Unread Command Message",
+  );
+  await conversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Second Unread Command Message" }),
+  ).toBeVisible();
+  await expect(conversation).toHaveCount(0);
+
+  try {
+    await page.getByRole("button", { name: "Archive", exact: true }).click();
+
+    await expect(conversations).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Re: Reader Navigation Message" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/thread-id=thr_playwright_reader/);
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "split-reader-after-archive",
+    );
+  } finally {
+    await page.request.post("/api/threads/thr_playwright_3/unarchive", {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    });
+  }
 });
 
 test("selects ranges and opens conversations with the keyboard", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -76,8 +76,16 @@ test("advances the split reader after archiving an open conversation", async ({
   await page.getByRole("button", { name: "Unread", exact: true }).click();
   await expect(conversation).toHaveCount(0);
 
+  let archived = false;
+  let restoreSucceeded: boolean | undefined;
   try {
     await page.getByRole("button", { name: "Archive", exact: true }).click();
+    await expect(
+      page
+        .getByRole("region", { name: "Notifications alt+T" })
+        .getByText("Archived", { exact: true }),
+    ).toBeVisible();
+    archived = true;
 
     await expect(conversations).toBeVisible();
     await expect
@@ -95,12 +103,17 @@ test("advances the split reader after archiving an open conversation", async ({
       "split-reader-after-archive",
     );
   } finally {
-    const restoreResponse = await page.request.post(
-      "/api/threads/thr_playwright_3/unarchive",
-      { headers: { "X-Email-Account-ID": emailAccountId } },
-    );
-    expect(restoreResponse.ok()).toBeTruthy();
+    if (archived) {
+      restoreSucceeded = (
+        await page.request
+          .post("/api/threads/thr_playwright_3/unarchive", {
+            headers: { "X-Email-Account-ID": emailAccountId },
+          })
+          .catch(() => undefined)
+      )?.ok();
+    }
   }
+  expect(restoreSucceeded).toBe(true);
 });
 
 test("selects ranges and opens conversations with the keyboard", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -63,7 +63,13 @@ test("advances the split reader after archiving an open conversation", async ({
   page,
 }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
-  await page.getByRole("button", { name: "Switch list or split view" }).click();
+  const emptyReader = page.getByText("Nothing selected", { exact: true });
+  if (!(await emptyReader.isVisible())) {
+    await page
+      .getByRole("button", { name: "Switch list or split view" })
+      .click();
+    await expect(emptyReader).toBeVisible();
+  }
   const conversation = conversationWithSubject(
     page,
     conversations,
@@ -73,7 +79,26 @@ test("advances the split reader after archiving an open conversation", async ({
   await expect(
     page.getByRole("heading", { name: "Second Unread Command Message" }),
   ).toBeVisible();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await page.getByRole("menuitem", { name: "Mark as unread" }).click();
+  await expect(
+    page.getByText("Marked as unread", { exact: true }),
+  ).toBeVisible();
+
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Read Command Message",
+  ).click();
+  await expect(
+    page.getByRole("heading", { name: "Read Command Message" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "Unread", exact: true }).click();
+  await expect(conversation).toBeVisible();
+  await conversation.click();
+  await expect(
+    page.getByRole("heading", { name: "Second Unread Command Message" }),
+  ).toBeVisible();
   await expect(conversation).toHaveCount(0);
 
   let archived = false;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -461,6 +461,7 @@ export function MailShell() {
           const nextThread = getNextThreadAfterRemoval({
             threadIds: orderedIds,
             currentThreadId: openThreadKey,
+            currentThreadIndex: focusedIndex,
             removedThreadIds: queuedThreadKeys,
           });
           setFocusedIndex(nextThread?.index ?? 0);
@@ -486,6 +487,7 @@ export function MailShell() {
     },
     [
       focusedThread,
+      focusedIndex,
       openThreadKey,
       orderedIds,
       selection,

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -68,6 +68,7 @@ describe("getNextThreadAfterRemoval", () => {
       getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three"],
         currentThreadId: "two",
+        currentThreadIndex: 1,
         removedThreadIds: ["two"],
       }),
     ).toEqual({ id: "three", index: 1 });
@@ -78,6 +79,7 @@ describe("getNextThreadAfterRemoval", () => {
       getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three", "four"],
         currentThreadId: "two",
+        currentThreadIndex: 1,
         removedThreadIds: ["two", "three"],
       }),
     ).toEqual({ id: "four", index: 1 });
@@ -88,6 +90,7 @@ describe("getNextThreadAfterRemoval", () => {
       getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three", "four"],
         currentThreadId: "three",
+        currentThreadIndex: 2,
         removedThreadIds: ["one", "three"],
       }),
     ).toEqual({ id: "four", index: 1 });
@@ -98,9 +101,32 @@ describe("getNextThreadAfterRemoval", () => {
       getNextThreadAfterRemoval({
         threadIds: ["one", "two", "three"],
         currentThreadId: "three",
+        currentThreadIndex: 2,
         removedThreadIds: ["two", "three"],
       }),
     ).toEqual({ id: "one", index: 0 });
+  });
+
+  it("uses the last known index when the open thread already left the list", () => {
+    expect(
+      getNextThreadAfterRemoval({
+        threadIds: ["one", "three", "four"],
+        currentThreadId: "two",
+        currentThreadIndex: 1,
+        removedThreadIds: ["two"],
+      }),
+    ).toEqual({ id: "three", index: 1 });
+  });
+
+  it("uses the previous thread when the missing open thread was last", () => {
+    expect(
+      getNextThreadAfterRemoval({
+        threadIds: ["one", "two"],
+        currentThreadId: "three",
+        currentThreadIndex: 2,
+        removedThreadIds: ["three"],
+      }),
+    ).toEqual({ id: "two", index: 1 });
   });
 
   it("closes the reader when every thread is removed", () => {
@@ -108,6 +134,7 @@ describe("getNextThreadAfterRemoval", () => {
       getNextThreadAfterRemoval({
         threadIds: ["one", "two"],
         currentThreadId: "one",
+        currentThreadIndex: 0,
         removedThreadIds: ["one", "two"],
       }),
     ).toBeNull();

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -38,18 +38,21 @@ export function getThreadActionTargetIds({
 export function getNextThreadAfterRemoval({
   threadIds,
   currentThreadId,
+  currentThreadIndex,
   removedThreadIds,
 }: {
   threadIds: string[];
   currentThreadId: string;
+  currentThreadIndex: number;
   removedThreadIds: string[];
 }): { id: string; index: number } | null {
   const currentIndex = threadIds.indexOf(currentThreadId);
-  if (currentIndex < 0) return null;
 
   const removed = new Set(removedThreadIds);
   let nextThreadId: string | undefined;
-  for (let index = currentIndex + 1; index < threadIds.length; index++) {
+  const nextIndex =
+    currentIndex >= 0 ? currentIndex + 1 : Math.max(0, currentThreadIndex);
+  for (let index = nextIndex; index < threadIds.length; index++) {
     const threadId = threadIds[index];
     if (threadId && !removed.has(threadId)) {
       nextThreadId = threadId;
@@ -57,7 +60,11 @@ export function getNextThreadAfterRemoval({
     }
   }
   if (!nextThreadId) {
-    for (let index = currentIndex - 1; index >= 0; index--) {
+    const previousIndex =
+      currentIndex >= 0
+        ? currentIndex - 1
+        : Math.min(currentThreadIndex - 1, threadIds.length - 1);
+    for (let index = previousIndex; index >= 0; index--) {
       const threadId = threadIds[index];
       if (threadId && !removed.has(threadId)) {
         nextThreadId = threadId;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-113544_pr-3478_1c950b8e0626/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Fixes reader auto-advance when the open conversation has already left a filtered list.

- Retains the last known row index to choose the next surviving conversation.
- Adds focused unit and emulated browser regression coverage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation navigation after archiving or removing the open conversation in split view.
  - The reader now advances to the appropriate next conversation, including when the current conversation is no longer in the list.
  - Improved handling when the removed conversation was the last item or its position cannot be determined.

- **Tests**
  - Added coverage for split-view archiving and conversation navigation scenarios, including archive confirmation and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->