### PR TITLE
Improve mail reader actions menu

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -35,10 +35,14 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
     "mail-reader-toolbar-shortcut-hover",
   );
 
+  const senderStatsResponse = page.waitForResponse((response) =>
+    response.url().includes("/api/user/stats/newsletters"),
+  );
   await page.getByRole("button", { name: /^More actions/ }).click();
   await expect(
     page.getByRole("menuitem", { name: "Auto archive future emails" }),
   ).toBeVisible();
+  expect((await senderStatsResponse).ok()).toBe(true);
   await capturePlaywrightCheckpoint(
     page,
     testInfo,

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -25,6 +25,27 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
     ),
   ).toHaveCount(0);
 
+  const archiveButton = page.getByRole("button", { name: /^Archive/ });
+  await expect(archiveButton.locator("kbd")).toBeHidden();
+  await archiveButton.hover();
+  await expect(archiveButton.locator("kbd")).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-reader-toolbar-shortcut-hover",
+  );
+
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "Auto archive future emails" }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-reader-sender-actions",
+  );
+  await page.keyboard.press("Escape");
+
   const attachmentPreview = page.getByRole("img", {
     name: "reader-preview.png",
   });

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -86,15 +86,29 @@ export function ReaderToolbar({
       </div>
 
       <div className="ml-auto flex flex-wrap items-center gap-1.5">
-        <Button onClick={onArchive} size="xs-2" variant="outline">
+        <Button
+          className="group"
+          onClick={onArchive}
+          size="xs-2"
+          variant="outline"
+        >
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
-          <Kbd className="ml-1.5">{getShortcutHint("archive")}</Kbd>
+          <Kbd className="ml-1.5 hidden group-hover:inline-flex group-focus-visible:inline-flex">
+            {getShortcutHint("archive")}
+          </Kbd>
         </Button>
-        <Button onClick={onReply} size="xs-2" variant="outline">
+        <Button
+          className="group"
+          onClick={onReply}
+          size="xs-2"
+          variant="outline"
+        >
           <ReplyIcon className="mr-1.5 size-3.5" />
           Reply
-          <Kbd className="ml-1.5">{getShortcutHint("reply")}</Kbd>
+          <Kbd className="ml-1.5 hidden group-hover:inline-flex group-focus-visible:inline-flex">
+            {getShortcutHint("reply")}
+          </Kbd>
         </Button>
         <Button
           aria-label={`Delete (${getShortcutHint("delete")})`}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -94,7 +94,7 @@ export function ReaderToolbar({
         >
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
-          <Kbd className="ml-1.5 hidden group-hover:inline-flex group-focus-visible:inline-flex">
+          <Kbd className="invisible ml-1.5 inline-flex group-hover:visible group-focus-visible:visible">
             {getShortcutHint("archive")}
           </Kbd>
         </Button>
@@ -106,7 +106,7 @@ export function ReaderToolbar({
         >
           <ReplyIcon className="mr-1.5 size-3.5" />
           Reply
-          <Kbd className="ml-1.5 hidden group-hover:inline-flex group-focus-visible:inline-flex">
+          <Kbd className="invisible ml-1.5 inline-flex group-hover:visible group-focus-visible:visible">
             {getShortcutHint("reply")}
           </Kbd>
         </Button>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -120,7 +120,7 @@ export function ThreadActionsMenu({
                 Matched reason
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
-                <DropdownMenuSubContent className="w-[min(24rem,calc(100vw-1rem))] p-0">
+                <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto p-0">
                   {plans.map((plan) => (
                     <RuleAttribution
                       key={plan.id}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -2,11 +2,13 @@
 
 import type { ComponentProps } from "react";
 import {
+  ArchiveRestoreIcon,
   ExternalLinkIcon,
   MailXIcon,
   MailIcon,
   MailOpenIcon,
   MoreHorizontalIcon,
+  SparklesIcon,
 } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
@@ -19,7 +21,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
@@ -69,8 +75,13 @@ export function ThreadActionsMenu({
 }: ThreadActionsMenuProps) {
   const hint = getShortcutHint("moreActions");
   const { provider, userEmail } = useAccount();
-  const { canUnsubscribe, onUnsubscribe, PremiumModal } =
-    useUnsubscribeSender(message);
+  const {
+    canAutoArchive,
+    canUnsubscribe,
+    onAutoArchive,
+    onUnsubscribe,
+    PremiumModal,
+  } = useUnsubscribeSender(message, { loadStoredLink: Boolean(open) });
   const ReadIcon = isUnread ? MailOpenIcon : MailIcon;
   const openUrl = message
     ? getEmailMessageCellActions({
@@ -102,15 +113,27 @@ export function ThreadActionsMenu({
           className="w-[min(24rem,calc(100vw-1rem))]"
           onEscapeKeyDown={(event) => event.stopPropagation()}
         >
-          {plans.map((plan) => (
-            <RuleAttribution
-              key={plan.id}
-              message={message}
-              plan={plan}
-              setChatInput={setChatInput}
-              showFixWithChat={showFixWithChat}
-            />
-          ))}
+          {plans.length > 0 ? (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <SparklesIcon className="mr-2 size-4" />
+                Matched reason
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent className="w-[min(24rem,calc(100vw-1rem))] p-0">
+                  {plans.map((plan) => (
+                    <RuleAttribution
+                      key={plan.id}
+                      message={message}
+                      plan={plan}
+                      setChatInput={setChatInput}
+                      showFixWithChat={showFixWithChat}
+                    />
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          ) : null}
 
           {plans.length > 0 ? <DropdownMenuSeparator /> : null}
 
@@ -131,7 +154,14 @@ export function ThreadActionsMenu({
           {canUnsubscribe ? (
             <DropdownMenuItem onSelect={onUnsubscribe}>
               <MailXIcon className="mr-2 size-4" />
-              Unsubscribe
+              Unsubscribe from sender
+            </DropdownMenuItem>
+          ) : null}
+
+          {canAutoArchive ? (
+            <DropdownMenuItem onSelect={onAutoArchive}>
+              <ArchiveRestoreIcon className="mr-2 size-4" />
+              Auto archive future emails
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuContent>

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import useSWR from "swr";
 import { toast } from "sonner";
 import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
@@ -45,11 +45,11 @@ export function useUnsubscribeSender(
   const { hasUnsubscribeAccess, mutate: refetchPremium } = usePremium();
   const { PremiumModal, openModal } = usePremiumModal();
   const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
+  const [autoArchivedSender, setAutoArchivedSender] = useState<string | null>(
+    null,
+  );
 
   const listUnsubscribeHeader = message?.headers["list-unsubscribe"] ?? null;
-  const headerUnsubscribeLink = getUserFacingUnsubscribeLink({
-    listUnsubscribeHeader,
-  });
   const from = message?.headers.from ?? "";
   const senderEmail = extractEmailAddress(from);
   const senderName = extractNameFromEmail(from);
@@ -57,22 +57,23 @@ export function useUnsubscribeSender(
     ? `/api/user/stats/newsletters?${createSearchParams({
         types: [],
         search: senderEmail,
+        orderBy: "emails",
+        orderDirection: "desc",
         includeMissingUnsubscribe: true,
       })}`
     : null;
   const { data: senderStats } = useSWR<NewsletterStatsResponse>(
-    loadStoredLink && !headerUnsubscribeLink && senderStatsUrl
-      ? [senderStatsUrl, emailAccountId]
-      : null,
+    loadStoredLink && senderStatsUrl ? [senderStatsUrl, emailAccountId] : null,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
     },
   );
   const canonicalSenderEmail = canonicalizeEmailAddress(senderEmail);
-  const unsubscribeLink = senderStats?.newsletters.find(
+  const sender = senderStats?.newsletters.find(
     (sender) => sender.name === canonicalSenderEmail,
-  )?.unsubscribeLink;
+  );
+  const unsubscribeLink = sender?.unsubscribeLink;
   const httpLink = getHttpUnsubscribeLink({
     unsubscribeLink,
     listUnsubscribeHeader,
@@ -82,7 +83,12 @@ export function useUnsubscribeSender(
     listUnsubscribeHeader,
   });
   const canUnsubscribe = Boolean(senderEmail && userFacingLink);
-  const canAutoArchive = Boolean(senderEmail);
+  const canAutoArchive = Boolean(
+    senderEmail &&
+      senderStats &&
+      autoArchivedSender !== canonicalSenderEmail &&
+      sender?.status !== NewsletterStatus.AUTO_ARCHIVED,
+  );
 
   const onUnsubscribe = useCallback(async () => {
     if (!(canUnsubscribe && userFacingLink)) return;
@@ -166,6 +172,7 @@ export function useUnsubscribeSender(
         status: NewsletterStatus.AUTO_ARCHIVED,
       });
       assertActionSucceeded(result);
+      setAutoArchivedSender(canonicalSenderEmail);
       await decrementUnsubscribeCreditAction();
       await queueArchiveSenders({ senders: [senderEmail] });
       await refetchPremium();
@@ -180,6 +187,7 @@ export function useUnsubscribeSender(
     }
   }, [
     canAutoArchive,
+    canonicalSenderEmail,
     emailAccountId,
     hasUnsubscribeAccess,
     openModal,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
@@ -87,7 +87,7 @@ export function useUnsubscribeSender(
     senderEmail &&
       senderStats &&
       autoArchivedSender !== canonicalSenderEmail &&
-      sender?.status !== NewsletterStatus.AUTO_ARCHIVED,
+      senderStats.searchedSenderStatus !== NewsletterStatus.AUTO_ARCHIVED,
   );
 
   const onUnsubscribe = useCallback(async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-unsubscribe-sender.ts
@@ -1,43 +1,88 @@
 "use client";
 
 import { useCallback } from "react";
+import useSWR from "swr";
 import { toast } from "sonner";
 import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
+import type { NewsletterStatsResponse } from "@/app/api/user/stats/newsletters/route";
 import { usePremium } from "@/hooks/usePremium";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { useArchiveSenderQueueActions } from "@/store/archive-sender-queue";
 import { decrementUnsubscribeCreditAction } from "@/utils/actions/premium";
-import { unsubscribeSenderAction } from "@/utils/actions/unsubscriber";
-import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
+import {
+  setSenderStatusAction,
+  unsubscribeSenderAction,
+} from "@/utils/actions/unsubscriber";
+import {
+  canonicalizeEmailAddress,
+  extractEmailAddress,
+  extractNameFromEmail,
+} from "@/utils/email";
+import { assertActionSucceeded, captureException } from "@/utils/error";
+import { NewsletterStatus } from "@/generated/prisma/enums";
 import {
   getHttpUnsubscribeLink,
   getUserFacingUnsubscribeLink,
 } from "@/utils/parse/unsubscribe";
 import type { ParsedMessage } from "@/utils/types";
+import { createSearchParams } from "@/utils/url";
 
 /**
  * Unsubscribing from a single message, for the reader.
  *
- * Only the sender's own `List-Unsubscribe` header is trusted here: the bulk
- * page can fall back to a link scraped out of the body, but that scrape happens
- * server-side while indexing senders and isn't available on an open thread.
+ * The message's `List-Unsubscribe` header is available immediately. When the
+ * menu opens, the reader also checks the sender stats used by bulk unsubscribe
+ * so a previously indexed link from the message body remains available here.
  *
  * A one-click header is unsubscribed server-side and the sender is marked; when
  * that fails, or when the sender only offers a mailto, the user gets the link.
  */
-export function useUnsubscribeSender(message: ParsedMessage | null) {
+export function useUnsubscribeSender(
+  message: ParsedMessage | null,
+  { loadStoredLink = false }: { loadStoredLink?: boolean } = {},
+) {
   const { emailAccountId } = useAccount();
   const { hasUnsubscribeAccess, mutate: refetchPremium } = usePremium();
   const { PremiumModal, openModal } = usePremiumModal();
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
 
   const listUnsubscribeHeader = message?.headers["list-unsubscribe"] ?? null;
-  const httpLink = getHttpUnsubscribeLink({ listUnsubscribeHeader });
-  const userFacingLink = getUserFacingUnsubscribeLink({
+  const headerUnsubscribeLink = getUserFacingUnsubscribeLink({
     listUnsubscribeHeader,
   });
   const from = message?.headers.from ?? "";
   const senderEmail = extractEmailAddress(from);
   const senderName = extractNameFromEmail(from);
+  const senderStatsUrl = senderEmail
+    ? `/api/user/stats/newsletters?${createSearchParams({
+        types: [],
+        search: senderEmail,
+        includeMissingUnsubscribe: true,
+      })}`
+    : null;
+  const { data: senderStats } = useSWR<NewsletterStatsResponse>(
+    loadStoredLink && !headerUnsubscribeLink && senderStatsUrl
+      ? [senderStatsUrl, emailAccountId]
+      : null,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
+  const canonicalSenderEmail = canonicalizeEmailAddress(senderEmail);
+  const unsubscribeLink = senderStats?.newsletters.find(
+    (sender) => sender.name === canonicalSenderEmail,
+  )?.unsubscribeLink;
+  const httpLink = getHttpUnsubscribeLink({
+    unsubscribeLink,
+    listUnsubscribeHeader,
+  });
+  const userFacingLink = getUserFacingUnsubscribeLink({
+    unsubscribeLink,
+    listUnsubscribeHeader,
+  });
   const canUnsubscribe = Boolean(senderEmail && userFacingLink);
+  const canAutoArchive = Boolean(senderEmail);
 
   const onUnsubscribe = useCallback(async () => {
     if (!(canUnsubscribe && userFacingLink)) return;
@@ -69,6 +114,7 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
     try {
       const result = await unsubscribeSenderAction(emailAccountId, {
         senderEmail,
+        unsubscribeLink,
         listUnsubscribeHeader,
       });
       if (!result?.data?.unsubscribe.success) {
@@ -81,6 +127,8 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
     }
 
     toast.success(`Unsubscribed from ${senderName}`, { id: toastId });
+
+    queueArchiveSenders({ senders: [senderEmail] }).catch(() => {});
 
     // Metering happens after the fact, and neither half changes what the user
     // just saw: a failure here must not read as a failed unsubscribe.
@@ -97,10 +145,57 @@ export function useUnsubscribeSender(message: ParsedMessage | null) {
     refetchPremium,
     senderEmail,
     senderName,
+    unsubscribeLink,
     userFacingLink,
+    queueArchiveSenders,
   ]);
 
-  return { canUnsubscribe, onUnsubscribe, PremiumModal };
+  const onAutoArchive = useCallback(async () => {
+    if (!canAutoArchive) return;
+
+    if (!hasUnsubscribeAccess) {
+      openModal();
+      return;
+    }
+
+    const toastId = toast.loading(`Enabling auto archive for ${senderName}`);
+
+    try {
+      const result = await setSenderStatusAction(emailAccountId, {
+        senderEmail,
+        status: NewsletterStatus.AUTO_ARCHIVED,
+      });
+      assertActionSucceeded(result);
+      await decrementUnsubscribeCreditAction();
+      await queueArchiveSenders({ senders: [senderEmail] });
+      await refetchPremium();
+      toast.success(`Future emails from ${senderName} will be archived`, {
+        id: toastId,
+      });
+    } catch (error) {
+      captureException(error);
+      toast.error(`Couldn't enable auto archive for ${senderName}`, {
+        id: toastId,
+      });
+    }
+  }, [
+    canAutoArchive,
+    emailAccountId,
+    hasUnsubscribeAccess,
+    openModal,
+    queueArchiveSenders,
+    refetchPremium,
+    senderEmail,
+    senderName,
+  ]);
+
+  return {
+    canAutoArchive,
+    canUnsubscribe,
+    onAutoArchive,
+    onUnsubscribe,
+    PremiumModal,
+  };
 }
 
 function openUnsubscribePage(link: string) {

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -93,11 +93,15 @@ async function getEmailMessages(
       status: findNewsletterStatus(newsletterStatuses, from),
     };
   });
+  const searchedSenderStatus = options.search
+    ? findNewsletterStatus(newsletterStatuses, options.search)
+    : undefined;
 
-  if (!options.filters?.length) return { newsletters };
+  if (!options.filters?.length) return { newsletters, searchedSenderStatus };
 
   return {
     newsletters: filterNewsletters(newsletters, options.filters),
+    searchedSenderStatus,
   };
 }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-095148_pr-3479_ea602c57daa6/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves the mail reader action menu with sender cleanup actions and a compact rule attribution submenu.

- Reuses existing unsubscribe and auto-archive workflows.
- Shows toolbar shortcut hints only on hover or keyboard focus.
- Adds focused browser coverage for the updated reader states.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Auto archive future emails” action to sender controls.
  - Added a “Matched reason” submenu for viewing rule-based message details.
  - Unsubscribing from a sender now queues future messages for archiving.
  - Renamed the unsubscribe option to “Unsubscribe from sender.”

- **UI Improvements**
  - Keyboard shortcut hints for Archive and Reply appear on hover or keyboard focus instead of displaying by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->