### PR TITLE
mail: Refine thread message counts

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -50,7 +50,7 @@ test("opens a complete conversation and updates its read state", async ({
     readerConversation.getByText("Dana Example, me", { exact: true }),
   ).toBeVisible();
   await expect(
-    readerConversation.getByText("(2)", { exact: true }),
+    readerConversation.getByText("2", { exact: true }),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(
     readerConversation,

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -142,14 +142,14 @@ export const ThreadRow = memo(function ThreadRow({
   const messageCountMarker =
     messageCount > 1 ? (
       <span className="shrink-0 font-normal text-muted-foreground text-xs">
-        ({messageCount})
+        {messageCount}
       </span>
     ) : null;
   const participantLine = (
     <>
       <span
         className={cn(
-          "min-w-0 flex-1 truncate text-foreground text-sm",
+          "min-w-0 truncate text-foreground text-sm",
           isUnread && "font-semibold",
         )}
       >
@@ -191,7 +191,7 @@ export const ThreadRow = memo(function ThreadRow({
 
       {isWide ? (
         <>
-          <div className="flex w-48 shrink-0 items-baseline gap-1.5 overflow-hidden whitespace-nowrap">
+          <div className="flex w-48 shrink-0 items-baseline gap-1 overflow-hidden whitespace-nowrap">
             {participantLine}
           </div>
           <div className="flex min-w-0 flex-1 items-center gap-2.5">
@@ -221,7 +221,7 @@ export const ThreadRow = memo(function ThreadRow({
         </>
       ) : (
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <div className="flex items-baseline gap-1.5">
+          <div className="flex items-baseline gap-1">
             {participantLine}
             <div className="ml-auto shrink-0">{date}</div>
           </div>


### PR DESCRIPTION
Improve thread count presentation in the mail list to align with familiar inbox conventions.

- Display multi-message counts without surrounding punctuation and keep them beside participants
- Update the focused browser assertion and verify the generated screenshot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

