### PR TITLE
Mail: improve split label controls

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -1,5 +1,10 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import { Client } from "pg";
 import { getEmailAccountId } from "../account-test-helpers";
+
+const DEFAULT_SPLIT_RULE_ID = "playwright-default-split-rule";
+const DEFAULT_SPLIT_ACTION_ID = "playwright-default-split-action";
+const DEFAULT_SPLIT_LABEL_ID = "Label_project";
 
 export async function openMail(page: Page) {
   const emailAccountId = await getEmailAccountId(page);
@@ -121,4 +126,60 @@ export function clearMailMutations(
       }),
     expected,
   );
+}
+
+export async function seedDefaultSplitRule(emailAccountId: string) {
+  await withClient(async (client) => {
+    await deleteDefaultSplitRule(client, emailAccountId);
+    await client.query(
+      `INSERT INTO "Rule"
+        (id, name, enabled, automate, "runOnThreads", "systemType",
+         "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, 'Calendar', true, true, false, 'CALENDAR', $2,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [DEFAULT_SPLIT_RULE_ID, emailAccountId],
+    );
+    await client.query(
+      `INSERT INTO "Action"
+        (id, type, "ruleId", "emailAccountId", label, "labelId",
+         "createdAt", "updatedAt")
+       VALUES ($1, 'LABEL', $2, $3, 'Project Alpha', $4,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        DEFAULT_SPLIT_ACTION_ID,
+        DEFAULT_SPLIT_RULE_ID,
+        emailAccountId,
+        DEFAULT_SPLIT_LABEL_ID,
+      ],
+    );
+  });
+}
+
+export async function cleanupDefaultSplitRule(emailAccountId: string) {
+  await withClient((client) => deleteDefaultSplitRule(client, emailAccountId));
+}
+
+async function deleteDefaultSplitRule(client: Client, emailAccountId: string) {
+  await client.query(
+    `DELETE FROM "MailSplit"
+     WHERE "emailAccountId" = $1
+       AND kind = 'LABEL'
+       AND value = $2
+       AND name = 'Calendar'`,
+    [emailAccountId, DEFAULT_SPLIT_LABEL_ID],
+  );
+  await client.query(
+    `DELETE FROM "Rule" WHERE id = $1 AND "emailAccountId" = $2`,
+    [DEFAULT_SPLIT_RULE_ID, emailAccountId],
+  );
+}
+
+async function withClient<T>(callback: (client: Client) => Promise<T>) {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    return await callback(client);
+  } finally {
+    await client.end();
+  }
 }

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -1,7 +1,21 @@
 import { expect } from "@playwright/test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import { getEmailAccountId } from "../account-test-helpers";
+import {
+  cleanupDefaultSplitRule,
+  conversationWithSubject,
+  openMail,
+  seedDefaultSplitRule,
+} from "./mail-test-helpers";
+
+let defaultSplitEmailAccountId: string | undefined;
+
+test.afterEach(async () => {
+  if (!defaultSplitEmailAccountId) return;
+  await cleanupDefaultSplitRule(defaultSplitEmailAccountId);
+  defaultSplitEmailAccountId = undefined;
+});
 
 test("shows a combined picker and creates a matching split", async ({
   page,
@@ -69,4 +83,45 @@ test("shows a combined picker and creates a matching split", async ({
     .getByRole("button", { name: "Remove the Promotions split" })
     .click();
   await expect(promotionsSplit).toHaveCount(0);
+});
+
+test("organizes split choices and manages all rule labels", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await getEmailAccountId(page);
+  defaultSplitEmailAccountId = emailAccountId;
+  await seedDefaultSplitRule(emailAccountId);
+  await openMail(page);
+
+  await page.getByRole("button", { name: "New split" }).click();
+
+  await expect(page.getByText("State", { exact: true })).toHaveCount(0);
+  const headingElements = page.locator("[cmdk-group-heading]");
+  await expect(headingElements.filter({ hasText: /^Labels/ })).toBeVisible();
+  await expect(
+    headingElements.filter({ hasText: /^Categories$/ }),
+  ).toBeVisible();
+  const groupHeadings = await headingElements.allTextContents();
+  expect(
+    groupHeadings.findIndex((heading) => heading.startsWith("Labels")),
+  ).toBeLessThan(
+    groupHeadings.findIndex((heading) => heading.startsWith("Categories")),
+  );
+
+  await page.getByRole("option", { name: "Add all" }).click();
+  const calendarSplit = page.getByRole("button", {
+    name: "Calendar",
+    exact: true,
+  });
+  await expect(calendarSplit).toBeVisible();
+  await page.getByRole("button", { name: "New split" }).click();
+  await expect(page.getByRole("option", { name: "Remove all" })).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-rule-label-splits-added",
+  );
+
+  await page.getByRole("option", { name: "Remove all" }).click();
+  await expect(calendarSplit).toHaveCount(0);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -89,8 +89,8 @@ test("organizes split choices and manages all rule labels", async ({
   page,
 }, testInfo) => {
   const emailAccountId = await getEmailAccountId(page);
-  defaultSplitEmailAccountId = emailAccountId;
   await seedDefaultSplitRule(emailAccountId);
+  defaultSplitEmailAccountId = emailAccountId;
   await openMail(page);
 
   await page.getByRole("button", { name: "New split" }).click();

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -156,6 +156,8 @@ export function MailShell() {
   const [activeSplitId, setActiveSplitId] = useQueryState("split", {
     defaultValue: "all",
   });
+  const activeSplitIdRef = useRef(activeSplitId);
+  activeSplitIdRef.current = activeSplitId;
   const [accountScope, setAccountScope] = useQueryState("accountScope");
   const [scopeType, setScopeType] = useQueryState("type");
   const [scopeLabelId, setScopeLabelId] = useQueryState("labelId");
@@ -214,19 +216,12 @@ export function MailShell() {
         // the UI showing a preference the server never accepted.
         if (result?.serverError || result?.validationErrors)
           throw new Error(getActionErrorMessage(result));
-        return {
-          layout: next,
-          splits: current?.splits ?? [],
-          defaultSplits: current?.defaultSplits ?? [],
-        };
+        return current ? { ...current, layout: next } : undefined;
       },
       {
-        optimisticData: (current) => ({
-          layout: next,
-          splits: current?.splits ?? [],
-          defaultSplits: current?.defaultSplits ?? [],
-        }),
-        revalidate: false,
+        optimisticData: (current) =>
+          current ? { ...current, layout: next } : undefined,
+        revalidate: settings === undefined,
         rollbackOnError: true,
       },
     ).catch((error) => {
@@ -234,7 +229,7 @@ export function MailShell() {
         error instanceof Error ? error.message : "Couldn't save that",
       );
     });
-  }, [emailAccountId, layout, mutateSettings]);
+  }, [emailAccountId, layout, mutateSettings, settings]);
 
   // A sidebar selection scopes the whole list, which replaces the split tabs —
   // splits are a way of slicing the inbox, not of slicing an arbitrary view.
@@ -293,8 +288,15 @@ export function MailShell() {
         defaultLabelIds.has(split.value),
     );
   }, [settings?.defaultSplits, settings?.splits]);
-  const canAddDefaultSplits =
-    savedDefaultSplits.length < (settings?.defaultSplits.length ?? 0);
+  const canAddDefaultSplits = (settings?.defaultSplits ?? []).some(
+    (defaultSplit) =>
+      !(settings?.splits ?? []).some(
+        (split) =>
+          split.name === defaultSplit.name ||
+          (split.kind === MailSplitKind.LABEL &&
+            split.value === defaultSplit.value),
+      ),
+  );
   const canRemoveDefaultSplits = savedDefaultSplits.length > 0;
 
   const query: ThreadsQuery = useMemo(() => {
@@ -785,10 +787,6 @@ export function MailShell() {
 
   const onSetDefaultSplits = useCallback(
     async (enabled: boolean) => {
-      const shouldResetActiveSplit =
-        !enabled &&
-        savedDefaultSplits.some((split) => split.id === activeSplitId);
-
       const result = await setDefaultMailSplitsAction(emailAccountId, {
         enabled,
       });
@@ -797,16 +795,17 @@ export function MailShell() {
         return false;
       }
       await mutateSettings();
-      if (shouldResetActiveSplit) setActiveSplitId("all");
+      if (
+        !enabled &&
+        savedDefaultSplits.some(
+          (split) => split.id === activeSplitIdRef.current,
+        )
+      ) {
+        setActiveSplitId("all");
+      }
       return true;
     },
-    [
-      activeSplitId,
-      emailAccountId,
-      mutateSettings,
-      savedDefaultSplits,
-      setActiveSplitId,
-    ],
+    [emailAccountId, mutateSettings, savedDefaultSplits, setActiveSplitId],
   );
 
   const onCreateLabel = useCallback(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -86,6 +86,7 @@ import {
   createMailSplitAction,
   createMailSplitFromPromptAction,
   deleteMailSplitAction,
+  setDefaultMailSplitsAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 import {
@@ -279,6 +280,20 @@ export function MailShell() {
   const activeCombinedLabelName = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
   )?.labelName;
+  const savedDefaultSplits = useMemo(() => {
+    const defaultLabelIds = new Set(
+      (settings?.defaultSplits ?? []).map((split) => split.value),
+    );
+    return (settings?.splits ?? []).filter(
+      (split) =>
+        split.kind === MailSplitKind.LABEL &&
+        split.value &&
+        defaultLabelIds.has(split.value),
+    );
+  }, [settings?.defaultSplits, settings?.splits]);
+  const canAddDefaultSplits =
+    savedDefaultSplits.length < (settings?.defaultSplits.length ?? 0);
+  const canRemoveDefaultSplits = savedDefaultSplits.length > 0;
 
   const query: ThreadsQuery = useMemo(() => {
     // Search overrides split/scope and covers the whole mailbox, matching
@@ -766,6 +781,34 @@ export function MailShell() {
     [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
   );
 
+  const onSetDefaultSplits = useCallback(
+    async (enabled: boolean) => {
+      if (
+        !enabled &&
+        savedDefaultSplits.some((split) => split.id === activeSplitId)
+      ) {
+        setActiveSplitId("all");
+      }
+
+      const result = await setDefaultMailSplitsAction(emailAccountId, {
+        enabled,
+      });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return false;
+      }
+      await mutateSettings();
+      return true;
+    },
+    [
+      activeSplitId,
+      emailAccountId,
+      mutateSettings,
+      savedDefaultSplits,
+      setActiveSplitId,
+    ],
+  );
+
   const onCreateLabel = useCallback(
     async (name: string) => {
       const result = await createLabelAction(emailAccountId, { name });
@@ -1005,6 +1048,9 @@ export function MailShell() {
                 newSplitOptions={newSplitOptions}
                 onCreateSplit={onCreateSplit}
                 onCreateSplitFromPrompt={onCreateSplitFromPrompt}
+                canAddDefaultSplits={canAddDefaultSplits}
+                canRemoveDefaultSplits={canRemoveDefaultSplits}
+                onSetDefaultSplits={onSetDefaultSplits}
                 canCreateSplits={!isAllAccounts}
               />
             )}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -785,12 +785,9 @@ export function MailShell() {
 
   const onSetDefaultSplits = useCallback(
     async (enabled: boolean) => {
-      if (
+      const shouldResetActiveSplit =
         !enabled &&
-        savedDefaultSplits.some((split) => split.id === activeSplitId)
-      ) {
-        setActiveSplitId("all");
-      }
+        savedDefaultSplits.some((split) => split.id === activeSplitId);
 
       const result = await setDefaultMailSplitsAction(emailAccountId, {
         enabled,
@@ -800,6 +797,7 @@ export function MailShell() {
         return false;
       }
       await mutateSettings();
+      if (shouldResetActiveSplit) setActiveSplitId("all");
       return true;
     },
     [

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -205,7 +205,10 @@ export function MailShell() {
   // Written through the SWR cache rather than mirrored in local state, so the
   // preference has one source of truth and every reader sees the new value.
   const toggleLayout = useCallback(() => {
+    if (!settings) return;
+
     const next = layout === "split" ? MailLayout.LIST : MailLayout.SPLIT;
+    const loadedSettings = settings;
 
     mutateSettings(
       async (current) => {
@@ -216,12 +219,14 @@ export function MailShell() {
         // the UI showing a preference the server never accepted.
         if (result?.serverError || result?.validationErrors)
           throw new Error(getActionErrorMessage(result));
-        return current ? { ...current, layout: next } : undefined;
+        return { ...(current ?? loadedSettings), layout: next };
       },
       {
-        optimisticData: (current) =>
-          current ? { ...current, layout: next } : undefined,
-        revalidate: settings === undefined,
+        optimisticData: (current) => ({
+          ...(current ?? loadedSettings),
+          layout: next,
+        }),
+        revalidate: false,
         rollbackOnError: true,
       },
     ).catch((error) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -217,12 +217,14 @@ export function MailShell() {
         return {
           layout: next,
           splits: current?.splits ?? [],
+          defaultSplits: current?.defaultSplits ?? [],
         };
       },
       {
         optimisticData: (current) => ({
           layout: next,
           splits: current?.splits ?? [],
+          defaultSplits: current?.defaultSplits ?? [],
         }),
         revalidate: false,
         rollbackOnError: true,

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -44,12 +44,15 @@ export type NewSplitPopoverProps = {
   onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
 };
 
-const GROUPS: { group: NewSplitOptionGroup; title?: string }[] = [
-  { group: "state" },
+const GROUPS = [
+  { group: "state", title: undefined },
   { group: "label", title: "Labels" },
   { group: "inbox", title: "Inbox" },
   { group: "category", title: "Categories" },
-];
+] as const satisfies readonly {
+  group: NewSplitOptionGroup;
+  title?: string;
+}[];
 
 export function NewSplitPopover({
   options,

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -16,7 +16,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-/** Display grouping only — "To reply" is a LABEL split that belongs under State. */
 export type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
 
 export type NewSplitOption = {
@@ -40,27 +39,34 @@ export type NewSplitPopoverProps = {
   onCreate: (draft: NewSplitDraft) => void;
   /** Resolves a free-text description into a split. Returns whether it succeeded. */
   onCreateFromPrompt: (prompt: string) => Promise<boolean>;
+  canAddDefaultSplits: boolean;
+  canRemoveDefaultSplits: boolean;
+  onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
 };
 
-const GROUP_TITLES: { group: NewSplitOptionGroup; title: string }[] = [
-  { group: "state", title: "State" },
+const GROUPS: { group: NewSplitOptionGroup; title?: string }[] = [
+  { group: "state" },
+  { group: "label", title: "Labels" },
   { group: "inbox", title: "Inbox" },
-  { group: "category", title: "Category" },
-  { group: "label", title: "Label" },
+  { group: "category", title: "Categories" },
 ];
 
 export function NewSplitPopover({
   options,
   onCreate,
   onCreateFromPrompt,
+  canAddDefaultSplits,
+  canRemoveDefaultSplits,
+  onSetDefaultSplits,
 }: NewSplitPopoverProps) {
   const [open, setOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [isCreating, setIsCreating] = useState(false);
+  const [isUpdatingDefaults, setIsUpdatingDefaults] = useState(false);
   const trimmedPrompt = prompt.trim();
   const normalizedPrompt = trimmedPrompt.toLowerCase();
   const hasMatchingOption = options.some((option) => {
-    const groupTitle = GROUP_TITLES.find(
+    const groupTitle = GROUPS.find(
       ({ group }) => group === option.group,
     )?.title;
     return `${option.name} ${groupTitle ?? ""}`
@@ -92,6 +98,17 @@ export function NewSplitPopover({
       value: option.value,
     });
     changeOpen(false);
+  };
+
+  const updateDefaultSplits = async (enabled: boolean) => {
+    if (isUpdatingDefaults) return;
+    setIsUpdatingDefaults(true);
+    try {
+      const updated = await onSetDefaultSplits(enabled);
+      if (updated) changeOpen(false);
+    } finally {
+      setIsUpdatingDefaults(false);
+    }
   };
 
   return (
@@ -135,19 +152,44 @@ export function NewSplitPopover({
               </CommandGroup>
             )}
 
-            {GROUP_TITLES.map(({ group, title }) => {
+            {GROUPS.map(({ group, title }) => {
               const groupOptions = options.filter(
                 (option) => option.group === group,
               );
-              if (!groupOptions.length) return null;
+              const showDefaultControls =
+                group === "label" &&
+                (canAddDefaultSplits || canRemoveDefaultSplits);
+              if (!groupOptions.length && !showDefaultControls) return null;
 
               return (
                 <CommandGroup key={group} heading={title}>
+                  {canAddDefaultSplits && group === "label" && (
+                    <CommandItem
+                      value="default-labels:add"
+                      keywords={["Add all", "Labels"]}
+                      onSelect={() => updateDefaultSplits(true)}
+                      disabled={isUpdatingDefaults}
+                      className="text-primary text-xs"
+                    >
+                      Add all
+                    </CommandItem>
+                  )}
+                  {canRemoveDefaultSplits && group === "label" && (
+                    <CommandItem
+                      value="default-labels:remove"
+                      keywords={["Remove all", "Labels"]}
+                      onSelect={() => updateDefaultSplits(false)}
+                      disabled={isUpdatingDefaults}
+                      className="text-primary text-xs"
+                    >
+                      Remove all
+                    </CommandItem>
+                  )}
                   {groupOptions.map((option) => (
                     <CommandItem
                       key={option.id}
                       value={option.id}
-                      keywords={[option.name, title]}
+                      keywords={title ? [option.name, title] : [option.name]}
                       onSelect={() => createFromOption(option)}
                       disabled={isCreating}
                       className="text-xs"

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -66,16 +66,20 @@ export function NewSplitPopover({
   const [prompt, setPrompt] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [isUpdatingDefaults, setIsUpdatingDefaults] = useState(false);
+  const isBusy = isCreating || isUpdatingDefaults;
   const trimmedPrompt = prompt.trim();
   const normalizedPrompt = trimmedPrompt.toLowerCase();
-  const hasMatchingOption = options.some((option) => {
-    const groupTitle = GROUPS.find(
-      ({ group }) => group === option.group,
-    )?.title;
-    return `${option.name} ${groupTitle ?? ""}`
-      .toLowerCase()
-      .includes(normalizedPrompt);
-  });
+  const hasMatchingOption =
+    options.some((option) => {
+      const groupTitle = GROUPS.find(
+        ({ group }) => group === option.group,
+      )?.title;
+      return `${option.name} ${groupTitle ?? ""}`
+        .toLowerCase()
+        .includes(normalizedPrompt);
+    }) ||
+    (canAddDefaultSplits && "add all labels".includes(normalizedPrompt)) ||
+    (canRemoveDefaultSplits && "remove all labels".includes(normalizedPrompt));
 
   const changeOpen = (next: boolean) => {
     setOpen(next);
@@ -83,7 +87,7 @@ export function NewSplitPopover({
   };
 
   const createFromPrompt = async () => {
-    if (!trimmedPrompt || isCreating) return;
+    if (!trimmedPrompt || isBusy) return;
     setIsCreating(true);
     try {
       const created = await onCreateFromPrompt(trimmedPrompt);
@@ -94,7 +98,7 @@ export function NewSplitPopover({
   };
 
   const createFromOption = (option: NewSplitOption) => {
-    if (isCreating) return;
+    if (isBusy) return;
     onCreate({
       name: option.name,
       kind: option.kind,
@@ -104,7 +108,7 @@ export function NewSplitPopover({
   };
 
   const updateDefaultSplits = async (enabled: boolean) => {
-    if (isUpdatingDefaults) return;
+    if (isBusy) return;
     setIsUpdatingDefaults(true);
     try {
       const updated = await onSetDefaultSplits(enabled);
@@ -130,7 +134,7 @@ export function NewSplitPopover({
             placeholder="Search or describe a split"
             aria-label="Search or describe a split"
             maxLength={300}
-            disabled={isCreating}
+            disabled={isBusy}
             className="h-9 text-xs"
           />
           <CommandList className="max-h-56">
@@ -140,7 +144,7 @@ export function NewSplitPopover({
                   forceMount
                   value={`create:${trimmedPrompt}`}
                   onSelect={createFromPrompt}
-                  disabled={isCreating}
+                  disabled={isBusy}
                   className="gap-2 text-xs"
                 >
                   {isCreating ? (
@@ -171,7 +175,7 @@ export function NewSplitPopover({
                       value="default-labels:add"
                       keywords={["Add all", "Labels"]}
                       onSelect={() => updateDefaultSplits(true)}
-                      disabled={isUpdatingDefaults}
+                      disabled={isBusy}
                       className="text-primary text-xs"
                     >
                       Add all
@@ -182,7 +186,7 @@ export function NewSplitPopover({
                       value="default-labels:remove"
                       keywords={["Remove all", "Labels"]}
                       onSelect={() => updateDefaultSplits(false)}
-                      disabled={isUpdatingDefaults}
+                      disabled={isBusy}
                       className="text-primary text-xs"
                     >
                       Remove all
@@ -194,7 +198,7 @@ export function NewSplitPopover({
                       value={option.id}
                       keywords={title ? [option.name, title] : [option.name]}
                       onSelect={() => createFromOption(option)}
-                      disabled={isCreating}
+                      disabled={isBusy}
                       className="text-xs"
                     >
                       {option.name}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -25,6 +25,9 @@ export type SplitTabsProps = {
   newSplitOptions: NewSplitOption[];
   onCreateSplit: (draft: NewSplitDraft) => void;
   onCreateSplitFromPrompt: (prompt: string) => Promise<boolean>;
+  canAddDefaultSplits: boolean;
+  canRemoveDefaultSplits: boolean;
+  onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
   /** Split creation stays account-scoped, so it is hidden in All accounts. */
   canCreateSplits: boolean;
   className?: string;
@@ -38,6 +41,9 @@ export function SplitTabs({
   newSplitOptions,
   onCreateSplit,
   onCreateSplitFromPrompt,
+  canAddDefaultSplits,
+  canRemoveDefaultSplits,
+  onSetDefaultSplits,
   canCreateSplits,
   className,
 }: SplitTabsProps) {
@@ -91,6 +97,9 @@ export function SplitTabs({
           options={newSplitOptions}
           onCreate={onCreateSplit}
           onCreateFromPrompt={onCreateSplitFromPrompt}
+          canAddDefaultSplits={canAddDefaultSplits}
+          canRemoveDefaultSplits={canRemoveDefaultSplits}
+          onSetDefaultSplits={onSetDefaultSplits}
         />
       )}
 

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,25 +1,36 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
+import { getDefaultMailSplitDraftsForAccount } from "@/utils/mail/default-splits.server";
 
 export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
 
 async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
-  const emailAccount = await prisma.emailAccount.findUnique({
-    where: { id: emailAccountId },
-    select: {
-      mailLayout: true,
-      mailSplits: {
-        // createdAt breaks ties so tab order can't shuffle between requests
-        orderBy: [{ order: "asc" }, { createdAt: "asc" }],
-        select: { id: true, name: true, kind: true, value: true, order: true },
+  const [emailAccount, defaultSplits] = await Promise.all([
+    prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: {
+        mailLayout: true,
+        mailSplits: {
+          // createdAt breaks ties so tab order can't shuffle between requests
+          orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+          select: {
+            id: true,
+            name: true,
+            kind: true,
+            value: true,
+            order: true,
+          },
+        },
       },
-    },
-  });
+    }),
+    getDefaultMailSplitDraftsForAccount(emailAccountId),
+  ]);
 
   return {
     layout: emailAccount?.mailLayout ?? null,
     splits: emailAccount?.mailSplits ?? [],
+    defaultSplits,
   };
 }
 

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Prisma } from "@/generated/prisma/client";
-import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  MailLayout,
+  MailSplitKind,
+  SystemType,
+} from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   createMailSplitAction,
   createMailSplitFromPromptAction,
   renameMailSplitAction,
+  setDefaultMailSplitsAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
@@ -185,6 +191,29 @@ describe("mail split actions", () => {
     });
 
     expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+
+  it("returns a user-safe error instead of partially adding defaults", async () => {
+    prisma.rule.findMany.mockResolvedValue([
+      {
+        systemType: SystemType.RECEIPT,
+        actions: [{ type: ActionType.LABEL, labelId: "receipt-label" }],
+      },
+      {
+        systemType: SystemType.NEWSLETTER,
+        actions: [{ type: ActionType.LABEL, labelId: "newsletter-label" }],
+      },
+    ] as never);
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [{ availableCount: 1, missingCount: 2 }],
+    ] as never);
+
+    const result = await setDefaultMailSplitsAction(EMAIL_ACCOUNT_ID, {
+      enabled: true,
+    });
+
+    expect(result?.serverError).toBe("You can only have 12 splits.");
   });
 
   it("persists the selected mail layout", async () => {

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -11,13 +11,17 @@ import {
   createMailSplitFromPromptBody,
   deleteMailSplitBody,
   renameMailSplitBody,
+  setDefaultMailSplitsBody,
   updateMailPreferencesBody,
 } from "@/utils/actions/mail-split.validation";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { lockMailSplits } from "@/utils/mail/split-lock";
-
-const MAX_SPLITS = 12;
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
+import {
+  getDefaultMailSplitDraftsForAccount,
+  setDefaultMailSplits,
+} from "@/utils/mail/default-splits.server";
 
 export const createMailSplitAction = actionClient
   .metadata({ name: "createMailSplit" })
@@ -94,6 +98,19 @@ export const deleteMailSplitAction = actionClient
     await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
   });
 
+export const setDefaultMailSplitsAction = actionClient
+  .metadata({ name: "setDefaultMailSplits" })
+  .inputSchema(setDefaultMailSplitsBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { enabled } }) => {
+    const defaultSplits =
+      await getDefaultMailSplitDraftsForAccount(emailAccountId);
+    await setDefaultMailSplits({
+      emailAccountId,
+      defaultSplits,
+      enabled,
+    });
+  });
+
 export const updateMailPreferencesAction = actionClient
   .metadata({ name: "updateMailPreferences" })
   .inputSchema(updateMailPreferencesBody)
@@ -117,7 +134,7 @@ async function createMailSplitOrThrow(
       if (result.status === "duplicate") {
         throw new SafeError(`You already have a "${data.name}" split.`);
       }
-      throw new SafeError(`You can only have ${MAX_SPLITS} splits.`);
+      throw new SafeError(`You can only have ${MAX_MAIL_SPLITS} splits.`);
     }
 
     const { status: _, ...split } = result;
@@ -177,7 +194,7 @@ async function createMailSplit({
           split_state.next_order,
           ${emailAccountId}
         FROM split_state
-        WHERE split_state.count < ${MAX_SPLITS}
+        WHERE split_state.count < ${MAX_MAIL_SPLITS}
           AND NOT split_state.name_exists
         RETURNING *
       )

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -104,11 +104,14 @@ export const setDefaultMailSplitsAction = actionClient
   .action(async ({ ctx: { emailAccountId }, parsedInput: { enabled } }) => {
     const defaultSplits =
       await getDefaultMailSplitDraftsForAccount(emailAccountId);
-    await setDefaultMailSplits({
+    const result = await setDefaultMailSplits({
       emailAccountId,
       defaultSplits,
       enabled,
     });
+    if (result?.status === "limit") {
+      throw new SafeError(`You can only have ${MAX_MAIL_SPLITS} splits.`);
+    }
   });
 
 export const updateMailPreferencesAction = actionClient

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -50,6 +50,9 @@ export type RenameMailSplitBody = z.infer<typeof renameMailSplitBody>;
 export const deleteMailSplitBody = z.object({ id: z.string() });
 export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 
+export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
+export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
+
 export const updateMailPreferencesBody = z.object({
   layout: z.nativeEnum(MailLayout),
 });

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -112,6 +112,32 @@ describe("seedDefaultMailSplits", () => {
       },
     });
   });
+
+  it("does not partially add defaults when the account has too few slots", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [{ availableCount: 1, missingCount: 2 }],
+    ] as never);
+
+    await expect(
+      setDefaultMailSplits({
+        emailAccountId: "account-id",
+        defaultSplits: [
+          {
+            name: "Receipt",
+            kind: MailSplitKind.LABEL,
+            value: "receipt-label",
+          },
+          {
+            name: "Newsletter",
+            kind: MailSplitKind.LABEL,
+            value: "newsletter-label",
+          },
+        ],
+        enabled: true,
+      }),
+    ).resolves.toEqual({ status: "limit" });
+  });
 });
 
 function rule(systemType: SystemType, labelId: string) {

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ActionType, SystemType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  MailSplitKind,
+  SystemType,
+} from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
-import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
+import {
+  getDefaultMailSplitDraftsForAccount,
+  seedDefaultMailSplits,
+  setDefaultMailSplits,
+} from "@/utils/mail/default-splits.server";
 
 vi.mock("@/utils/prisma");
 
@@ -44,6 +52,92 @@ describe("seedDefaultMailSplits", () => {
     });
 
     expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("loads the enabled standard rules that can provide default splits", async () => {
+    prisma.rule.findMany.mockResolvedValue([
+      rule(SystemType.RECEIPT, "receipt-label"),
+    ] as never);
+
+    await expect(
+      getDefaultMailSplitDraftsForAccount("account-id"),
+    ).resolves.toEqual([
+      {
+        name: "Receipt",
+        kind: MailSplitKind.LABEL,
+        value: "receipt-label",
+      },
+    ]);
+    expect(prisma.rule.findMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-id",
+        enabled: true,
+        systemType: { in: expect.arrayContaining([SystemType.RECEIPT]) },
+      },
+      select: {
+        systemType: true,
+        actions: { select: { type: true, labelId: true } },
+      },
+    });
+  });
+
+  it("adds missing default splits without replacing saved splits", async () => {
+    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
+
+    await setDefaultMailSplits({
+      emailAccountId: "account-id",
+      defaultSplits: [
+        {
+          name: "Receipt",
+          kind: MailSplitKind.LABEL,
+          value: "receipt-label",
+        },
+      ],
+      enabled: true,
+    });
+
+    expect(prisma.$executeRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining('existing."value" = defaults."value"'),
+      ]),
+      "account-id",
+      expect.any(String),
+      "account-id",
+      expect.any(Number),
+      "account-id",
+    );
+  });
+
+  it("removes every split backed by a default rule label", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      { count: 2 },
+    ] as never);
+
+    await setDefaultMailSplits({
+      emailAccountId: "account-id",
+      defaultSplits: [
+        {
+          name: "Receipt",
+          kind: MailSplitKind.LABEL,
+          value: "receipt-label",
+        },
+        {
+          name: "Newsletter",
+          kind: MailSplitKind.LABEL,
+          value: "newsletter-label",
+        },
+      ],
+      enabled: false,
+    });
+
+    expect(prisma.mailSplit.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-id",
+        kind: MailSplitKind.LABEL,
+        value: { in: ["receipt-label", "newsletter-label"] },
+      },
+    });
   });
 });
 

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -81,33 +81,6 @@ describe("seedDefaultMailSplits", () => {
     });
   });
 
-  it("adds missing default splits without replacing saved splits", async () => {
-    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
-
-    await setDefaultMailSplits({
-      emailAccountId: "account-id",
-      defaultSplits: [
-        {
-          name: "Receipt",
-          kind: MailSplitKind.LABEL,
-          value: "receipt-label",
-        },
-      ],
-      enabled: true,
-    });
-
-    expect(prisma.$executeRaw).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.stringContaining('existing."value" = defaults."value"'),
-      ]),
-      "account-id",
-      expect.any(String),
-      "account-id",
-      expect.any(Number),
-      "account-id",
-    );
-  });
-
   it("removes every split backed by a default rule label", async () => {
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -6,8 +6,6 @@ import { lockMailSplits } from "@/utils/mail/split-lock";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import { STANDARD_CATEGORY_SYSTEM_TYPES } from "@/utils/rule/consts";
 
-type DefaultMailSplit = ReturnType<typeof getDefaultMailSplitDrafts>[number];
-
 export async function getDefaultMailSplitDraftsForAccount(
   emailAccountId: string,
 ) {
@@ -87,7 +85,7 @@ export async function setDefaultMailSplits({
   enabled,
 }: {
   emailAccountId: string;
-  defaultSplits: DefaultMailSplit[];
+  defaultSplits: ReturnType<typeof getDefaultMailSplitDrafts>;
   enabled: boolean;
 }) {
   if (defaultSplits.length === 0) return;

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -1,7 +1,30 @@
 import { randomUUID } from "node:crypto";
+import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
 import { lockMailSplits } from "@/utils/mail/split-lock";
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
+import { STANDARD_CATEGORY_SYSTEM_TYPES } from "@/utils/rule/consts";
+
+type DefaultMailSplit = ReturnType<typeof getDefaultMailSplitDrafts>[number];
+
+export async function getDefaultMailSplitDraftsForAccount(
+  emailAccountId: string,
+) {
+  const rules = await prisma.rule.findMany({
+    where: {
+      emailAccountId,
+      enabled: true,
+      systemType: { in: [...STANDARD_CATEGORY_SYSTEM_TYPES] },
+    },
+    select: {
+      systemType: true,
+      actions: { select: { type: true, labelId: true } },
+    },
+  });
+
+  return getDefaultMailSplitDrafts(rules);
+}
 
 export async function seedDefaultMailSplits({
   emailAccountId,
@@ -53,6 +76,102 @@ export async function seedDefaultMailSplits({
         FROM "MailSplit"
         WHERE "emailAccountId" = ${emailAccountId}
       )
+      ON CONFLICT DO NOTHING
+    `,
+  ]);
+}
+
+export async function setDefaultMailSplits({
+  emailAccountId,
+  defaultSplits,
+  enabled,
+}: {
+  emailAccountId: string;
+  defaultSplits: DefaultMailSplit[];
+  enabled: boolean;
+}) {
+  if (defaultSplits.length === 0) return;
+
+  if (!enabled) {
+    await prisma.$transaction([
+      lockMailSplits(emailAccountId),
+      prisma.mailSplit.deleteMany({
+        where: {
+          emailAccountId,
+          kind: MailSplitKind.LABEL,
+          value: { in: defaultSplits.map((split) => split.value) },
+        },
+      }),
+    ]);
+    return;
+  }
+
+  const rows = defaultSplits.map((split, order) => ({
+    id: randomUUID(),
+    ...split,
+    order,
+  }));
+
+  await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$executeRaw`
+      WITH split_state AS (
+        SELECT
+          COUNT(*)::integer AS count,
+          COALESCE(MAX("order"), -1)::integer + 1 AS next_order
+        FROM "MailSplit"
+        WHERE "emailAccountId" = ${emailAccountId}
+      ),
+      missing_defaults AS (
+        SELECT
+          defaults.*,
+          (ROW_NUMBER() OVER (ORDER BY defaults."order") - 1)::integer AS offset
+        FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb) AS defaults(
+          "id" text,
+          "name" text,
+          "kind" text,
+          "value" text,
+          "order" integer
+        )
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM "MailSplit" AS existing
+          WHERE existing."emailAccountId" = ${emailAccountId}
+            AND (
+              existing."name" = defaults."name"
+              OR (
+                existing."kind" = 'LABEL'::"MailSplitKind"
+                AND existing."value" = defaults."value"
+              )
+            )
+        )
+        ORDER BY defaults."order"
+        LIMIT (
+          SELECT GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)
+          FROM split_state
+        )
+      )
+      INSERT INTO "MailSplit" (
+        "id",
+        "createdAt",
+        "updatedAt",
+        "name",
+        "kind",
+        "value",
+        "order",
+        "emailAccountId"
+      )
+      SELECT
+        missing_defaults."id",
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP,
+        missing_defaults."name",
+        missing_defaults."kind"::"MailSplitKind",
+        missing_defaults."value",
+        split_state.next_order + missing_defaults.offset,
+        ${emailAccountId}
+      FROM missing_defaults
+      CROSS JOIN split_state
       ON CONFLICT DO NOTHING
     `,
   ]);

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -101,7 +101,7 @@ export async function setDefaultMailSplits({
         },
       }),
     ]);
-    return;
+    return { status: "success" as const };
   }
 
   const rows = defaultSplits.map((split, order) => ({
@@ -110,9 +110,9 @@ export async function setDefaultMailSplits({
     order,
   }));
 
-  await prisma.$transaction([
+  const [, results] = await prisma.$transaction([
     lockMailSplits(emailAccountId),
-    prisma.$executeRaw`
+    prisma.$queryRaw<Array<{ availableCount: number; missingCount: number }>>`
       WITH split_state AS (
         SELECT
           COUNT(*)::integer AS count,
@@ -144,33 +144,48 @@ export async function setDefaultMailSplits({
             )
         )
         ORDER BY defaults."order"
-        LIMIT (
-          SELECT GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)
-          FROM split_state
+      ),
+      inserted_defaults AS (
+        INSERT INTO "MailSplit" (
+          "id",
+          "createdAt",
+          "updatedAt",
+          "name",
+          "kind",
+          "value",
+          "order",
+          "emailAccountId"
         )
-      )
-      INSERT INTO "MailSplit" (
-        "id",
-        "createdAt",
-        "updatedAt",
-        "name",
-        "kind",
-        "value",
-        "order",
-        "emailAccountId"
+        SELECT
+          missing_defaults."id",
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP,
+          missing_defaults."name",
+          missing_defaults."kind"::"MailSplitKind",
+          missing_defaults."value",
+          split_state.next_order + missing_defaults.offset,
+          ${emailAccountId}
+        FROM missing_defaults
+        CROSS JOIN split_state
+        WHERE (
+          SELECT COUNT(*) FROM missing_defaults
+        ) <= GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)
+        ON CONFLICT DO NOTHING
+        RETURNING "id"
       )
       SELECT
-        missing_defaults."id",
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP,
-        missing_defaults."name",
-        missing_defaults."kind"::"MailSplitKind",
-        missing_defaults."value",
-        split_state.next_order + missing_defaults.offset,
-        ${emailAccountId}
-      FROM missing_defaults
-      CROSS JOIN split_state
-      ON CONFLICT DO NOTHING
+        (SELECT COUNT(*)::integer FROM missing_defaults) AS "missingCount",
+        GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)::integer
+          AS "availableCount"
+      FROM split_state
     `,
   ]);
+
+  const result = results[0];
+  return {
+    status:
+      result && result.missingCount > result.availableCount
+        ? ("limit" as const)
+        : ("success" as const),
+  };
 }

--- a/apps/web/utils/mail/split-constants.ts
+++ b/apps/web/utils/mail/split-constants.ts
@@ -1,0 +1,1 @@
+export const MAX_MAIL_SPLITS = 12;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-110143_pr-3481_a3cb313851c6/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves the split picker hierarchy and adds bulk management for eligible rule-backed label tabs.

- Reorders picker groups and removes the redundant state heading.
- Adds account-scoped add/remove controls while preserving saved splits and enforcing the shared limit.
- Covers server behavior and the browser flow with focused tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for enabling or removing default mail splits.
  - Added “Add all” and “Remove all” controls for default label splits.
  - Default splits are added without replacing existing saved splits and are limited to 12 total splits.
  - Split options are grouped under Labels, Inbox, and Categories.

- **Bug Fixes**
  - Prevented duplicate default splits and preserved existing split ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->