### PR TITLE
mail: Keep split focus synchronized

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -3,6 +3,25 @@ import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
+test("moves focus with the active split when cycling by keyboard", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+
+  const activeSplit = page.locator('button[aria-current="true"]');
+  await expect(activeSplit).toBeVisible();
+  await activeSplit.click();
+
+  await page.keyboard.press("Tab");
+
+  await expect(activeSplit).toBeFocused();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-split-keyboard-focus",
+  );
+});
+
 test("shows a combined picker and creates a matching split", async ({
   page,
 }, testInfo) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { XIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
 import {
   type NewSplitDraft,
   type NewSplitOption,
@@ -41,8 +42,28 @@ export function SplitTabs({
   canCreateSplits,
   className,
 }: SplitTabsProps) {
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const tabs = tabsRef.current;
+    const focusedTab = document.activeElement;
+    if (
+      !(focusedTab instanceof HTMLButtonElement) ||
+      !tabs?.contains(focusedTab) ||
+      !focusedTab.hasAttribute("data-split-id")
+    ) {
+      return;
+    }
+
+    const activeTab = Array.from(
+      tabs.querySelectorAll<HTMLButtonElement>("button[data-split-id]"),
+    ).find((tab) => tab.dataset.splitId === activeSplitId);
+    activeTab?.focus({ preventScroll: true });
+  }, [activeSplitId]);
+
   return (
     <div
+      ref={tabsRef}
       className={cn(
         // Padded to sit under the toolbar's search field rather than against
         // the column edge, and ruled off so the tabs read as a header for the
@@ -66,6 +87,7 @@ export function SplitTabs({
           >
             <button
               type="button"
+              data-split-id={split.id}
               onClick={() => onSelect(split.id)}
               aria-current={active ? "true" : undefined}
               className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-102112_pr-3482_abcfd318d8b3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Keep keyboard focus aligned with the active mail split during shortcut navigation.

- move focus when cycling from a focused split
- add emulated browser regression coverage
- verify the focused split suite and shortcut tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->