### PR TITLE
mail: Refine split tab focus handling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -43,22 +43,21 @@ export function SplitTabs({
   className,
 }: SplitTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
+  const activeTabRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const tabs = tabsRef.current;
     const focusedTab = document.activeElement;
     if (
+      !activeSplitId ||
       !(focusedTab instanceof HTMLButtonElement) ||
       !tabs?.contains(focusedTab) ||
-      !focusedTab.hasAttribute("data-split-id")
+      !focusedTab.hasAttribute("data-split-tab")
     ) {
       return;
     }
 
-    const activeTab = Array.from(
-      tabs.querySelectorAll<HTMLButtonElement>("button[data-split-id]"),
-    ).find((tab) => tab.dataset.splitId === activeSplitId);
-    activeTab?.focus({ preventScroll: true });
+    activeTabRef.current?.focus({ preventScroll: true });
   }, [activeSplitId]);
 
   return (
@@ -87,7 +86,8 @@ export function SplitTabs({
           >
             <button
               type="button"
-              data-split-id={split.id}
+              ref={active ? activeTabRef : undefined}
+              data-split-tab
               onClick={() => onSelect(split.id)}
               aria-current={active ? "true" : undefined}
               className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-105952_pr-3483_91abcd5c4613/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Replace the DOM tab scan with a direct React ref for the active split tab.

- Preserve keyboard focus when cycling split tabs
- Keep focus changes scoped to split-tab controls
- Validate with the focused browser test suite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved focus restoration when switching between split-tab views.
  - Keyboard focus now reliably returns to the active tab after navigation or UI updates.
  - Prevented focus handling from running when no active split tab is selected or when focus is outside the tab interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->