### PR TITLE
mail: Stabilize offline reply test

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -206,7 +206,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     await page.reload();
     await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
   } finally {
-    if (!page.isClosed()) await setNavigatorOnline(page, true);
+    await restoreNavigatorOnline(page);
   }
 });
 
@@ -393,6 +393,14 @@ function setNavigatorOnline(page: Page, online: boolean) {
       get: () => localStorage.getItem("playwright-mail-online") !== "false",
     });
   }, online);
+}
+
+async function restoreNavigatorOnline(page: Page) {
+  try {
+    await setNavigatorOnline(page, true);
+  } catch (error) {
+    if (!page.isClosed()) throw error;
+  }
 }
 
 function clearThreadDetails(

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -111,7 +111,10 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
   await setNavigatorOnline(page, false);
 
   try {
-    await page.getByRole("button", { name: /^Reply R$/ }).click();
+    await page
+      .getByRole("group", { name: "Thread actions" })
+      .getByRole("button", { name: "Reply", exact: true })
+      .click();
     const editor = page.locator("[contenteditable='true']");
     await editor.pressSequentially(replyBody);
     await page.getByRole("button", { name: /^Send/ }).click();
@@ -203,7 +206,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
     await page.reload();
     await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
   } finally {
-    await setNavigatorOnline(page, true);
+    if (!page.isClosed()) await setNavigatorOnline(page, true);
   }
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -85,7 +85,11 @@ export function ReaderToolbar({
         </div>
       </div>
 
-      <div className="ml-auto flex flex-wrap items-center gap-1.5">
+      <div
+        aria-label="Thread actions"
+        className="ml-auto flex flex-wrap items-center gap-1.5"
+        role="group"
+      >
         <Button
           className="group"
           onClick={onArchive}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-115129_pr-3484_1abfb6316d53/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stabilizes the offline reply browser flow after reader action labels changed.

- Adds a named action group and scopes the reply lookup to it.
- Prevents cleanup from masking the original test failure.
- Validated with the focused emulated browser flow and formatting checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved semantics for email thread actions by grouping them under a labeled control region.

* **Tests**
  * Updated reply-action testing to use the thread actions group.
  * Improved test cleanup to avoid restoring online state after the page has closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->