### PR TITLE
email: Limit draft messages to the mail reader

### DIFF
--- a/apps/web/app/api/threads/[id]/route.test.ts
+++ b/apps/web/app/api/threads/[id]/route.test.ts
@@ -73,10 +73,29 @@ describe("GET /api/threads/[id]", () => {
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: "Failed to fetch thread" });
   });
+
+  it.each([
+    ["without drafts by default", "", false],
+    ["with drafts when requested", "?includeDrafts=true", true],
+  ])("loads the thread %s", async (_description, query, includeDrafts) => {
+    mockGetThread.mockResolvedValue({
+      id: "thread-id",
+      messages: [],
+      snippet: "",
+    });
+
+    const response = await getThread(query);
+
+    expect(response.status).toBe(200);
+    expect(mockGetThread).toHaveBeenCalledWith("thread-id", { includeDrafts });
+  });
 });
 
-function getThread() {
-  return GET(new NextRequest("http://localhost:3000/api/threads/thread-id"), {
-    params: Promise.resolve({ id: "thread-id" }),
-  });
+function getThread(query = "") {
+  return GET(
+    new NextRequest(`http://localhost:3000/api/threads/thread-id${query}`),
+    {
+      params: Promise.resolve({ id: "thread-id" }),
+    },
+  );
 }

--- a/apps/web/app/api/threads/[id]/route.ts
+++ b/apps/web/app/api/threads/[id]/route.ts
@@ -16,12 +16,9 @@ async function getThread(
   parseReplies: boolean,
   emailProvider: EmailProvider,
 ) {
-  const thread = await emailProvider.getThread(id);
+  const thread = await emailProvider.getThread(id, { includeDrafts });
 
-  let filteredMessages = includeDrafts
-    ? thread.messages
-    : thread.messages.filter((msg) => !msg.labelIds?.includes("DRAFT"));
-
+  let filteredMessages = thread.messages;
   if (parseReplies) {
     filteredMessages = filteredMessages.map(parseMessageReply);
   }

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -94,7 +94,7 @@ function CommandPaletteContent({
   const { emailAccountId } = useAccount();
   const { threadId, showEmail } = displayedEmail;
   const { data: displayedThread, isLoading: isDisplayedThreadLoading } =
-    useThread({ id: threadId }, { includeDrafts: true });
+    useThread({ id: threadId });
   const { onOpen: onOpenComposeModal } = useComposeModal();
   const { commands, isLoading } = useCommandPaletteCommands({
     enabled: !mailCommandContext,

--- a/apps/web/components/EmailViewer.tsx
+++ b/apps/web/components/EmailViewer.tsx
@@ -56,12 +56,7 @@ export function ThreadContent({
   topRightComponent?: React.ReactNode;
   onSendSuccess?: (messageId: string, threadId: string) => void;
 }) {
-  const { data, isLoading, error, mutate } = useThread(
-    { id: threadId },
-    {
-      includeDrafts: true,
-    },
-  );
+  const { data, isLoading, error, mutate } = useThread({ id: threadId });
 
   return (
     <ErrorBoundary extra={{ component: "ThreadContent", threadId }}>

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -268,6 +268,42 @@ describe("GmailProvider.getThread", () => {
       snippet: "Thread preview",
     });
   });
+
+  it("excludes drafts by default and includes them when requested", async () => {
+    const threadGet = vi.fn().mockResolvedValue({
+      data: {
+        id: "thread-1",
+        messages: [
+          {
+            id: "message-1",
+            labelIds: [GmailLabel.INBOX],
+            payload: { body: {}, headers: [], mimeType: "text/plain" },
+            threadId: "thread-1",
+          },
+          {
+            id: "draft-1",
+            labelIds: [GmailLabel.DRAFT],
+            payload: { body: {}, headers: [], mimeType: "text/plain" },
+            threadId: "thread-1",
+          },
+        ],
+      },
+    });
+    const provider = new GmailProvider({
+      users: { threads: { get: threadGet } },
+    } as unknown as gmail_v1.Gmail);
+
+    const thread = await provider.getThread("thread-1");
+    const threadWithDrafts = await provider.getThread("thread-1", {
+      includeDrafts: true,
+    });
+
+    expect(thread.messages.map((message) => message.id)).toEqual(["message-1"]);
+    expect(threadWithDrafts.messages.map((message) => message.id)).toEqual([
+      "message-1",
+      "draft-1",
+    ]);
+  });
 });
 
 describe("GmailProvider.getLatestMessageInThread", () => {

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -96,6 +96,7 @@ import type {
   BulkArchiveThread,
   BulkArchiveResult,
   EmailLabelUpdate,
+  GetThreadOptions,
 } from "@/utils/email/types";
 import type { SendEmailBody } from "@/utils/types/mail";
 import { createScopedLogger, type Logger } from "@/utils/logger";
@@ -146,16 +147,23 @@ export class GmailProvider implements EmailProvider {
     });
   }
 
-  async getThread(threadId: string): Promise<EmailThread> {
+  async getThread(
+    threadId: string,
+    options?: GetThreadOptions,
+  ): Promise<EmailThread> {
     return this.withRateLimitTracking("get-thread", async () => {
       const response = await this.client.users.threads.get({
         userId: "me",
         id: threadId,
       });
 
-      const messages = (response.data.messages || []).map((message) =>
-        parseMessage(message as MessageWithPayload),
-      );
+      const messages = (response.data.messages || [])
+        .map((message) => parseMessage(message as MessageWithPayload))
+        .filter(
+          (message) =>
+            options?.includeDrafts ||
+            !message.labelIds?.includes(GmailLabel.DRAFT),
+        );
 
       return {
         id: threadId,

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -122,7 +122,7 @@ describe("OutlookProvider.getThread", () => {
     expect(thread.snippet).toBe("Newest preview");
   });
 
-  it("includes drafts in the thread view", async () => {
+  it("excludes drafts by default", async () => {
     const provider = new OutlookProvider(
       createMockOutlookClient([
         createMessage({ id: "received-message" }),
@@ -137,6 +137,29 @@ describe("OutlookProvider.getThread", () => {
     );
 
     const thread = await provider.getThread("thread-1");
+
+    expect(thread.messages.map((message) => message.id)).toEqual([
+      "received-message",
+    ]);
+  });
+
+  it("includes drafts when requested", async () => {
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({ id: "received-message" }),
+        createMessage({
+          id: "draft-reply",
+          isDraft: true,
+          parentFolderId: "drafts-folder-id",
+          receivedDateTime: undefined,
+        }),
+      ]),
+      createTestLogger(),
+    );
+
+    const thread = await provider.getThread("thread-1", {
+      includeDrafts: true,
+    });
 
     expect(thread.messages.map((message) => message.id)).toEqual([
       "received-message",

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -78,6 +78,7 @@ import type {
   BulkArchiveThread,
   BulkArchiveResult,
   EmailLabelUpdate,
+  GetThreadOptions,
 } from "@/utils/email/types";
 import type { SendEmailBody } from "@/utils/types/mail";
 import { getOutlookCategoryPreset } from "@/utils/outlook/category-colors";
@@ -147,15 +148,16 @@ export class OutlookProvider implements EmailProvider {
     }));
   }
 
-  async getThread(threadId: string): Promise<EmailThread> {
+  async getThread(
+    threadId: string,
+    options?: GetThreadOptions,
+  ): Promise<EmailThread> {
     try {
       const messages = await getThreadMessages(
         threadId,
         this.client,
         this.logger,
-        {
-          includeDrafts: true,
-        },
+        options,
       );
 
       return {

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -95,6 +95,10 @@ type DraftReference = {
   version?: string;
 };
 
+export type GetThreadOptions = {
+  includeDrafts?: boolean;
+};
+
 export interface EmailProvider {
   archiveMessage(messageId: string): Promise<void>;
   archiveMessages(messageIds: string[], labelId?: string): Promise<void>;
@@ -250,9 +254,8 @@ export interface EmailProvider {
     maxResults?: number;
   }): Promise<EmailThread[]>;
   getSignatures(): Promise<EmailSignature[]>;
-  // Thread messages are returned in chronological order (oldest first).
-  // getThread includes draft messages; getThreadMessages excludes them.
-  getThread(threadId: string): Promise<EmailThread>;
+  // Thread messages are returned in chronological order with drafts excluded unless requested.
+  getThread(threadId: string, options?: GetThreadOptions): Promise<EmailThread>;
   getThreadMessages(threadId: string): Promise<ParsedMessage[]>;
   getThreadMessagesInInbox(threadId: string): Promise<ParsedMessage[]>;
   getThreads(folderId?: string): Promise<EmailThread[]>;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚠️ **Browser QA could not complete** · [QA report](https://qa.getinboxzero.com/20260902-135315_pr-3485_e249c25e42ab/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Limit thread draft loading to explicit callers so background consumers and shared views receive only sent and received messages.

- Make thread draft inclusion opt-in across email providers and forward the existing API option.
- Keep draft inclusion in the mail reader and its prefetch path while removing it from shared surfaces.
- Add provider and API regression coverage for default exclusion and explicit inclusion.
- Tests: 101 focused unit tests passed; Ultracite passed on all changed files.
- Browser QA: attempted, but local authentication setup was blocked by unavailable test database credentials before feature tests ran.
- Performance: no new database or network calls; default thread processing handles fewer messages, with only a linear draft filter for one provider.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email threads now exclude draft messages by default for a clearer conversation view.
  * Draft messages can still be included when explicitly requested.
  * Thread loading behavior is now consistent across Gmail and Outlook integrations.

* **Tests**
  * Added coverage confirming default draft exclusion and optional draft inclusion across supported email providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->