### PR TITLE
test: Stabilize mail browser tests

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -9,6 +9,9 @@ import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
 const MESSAGE_COUNT = 5000;
 const FIRST_LOCAL_SUBJECT = "Local mailbox load test 0";
+const READER_CACHE_BODY =
+  "This sender is reserved for the bulk unsubscribe flow.";
+const READER_CACHE_SUBJECT = "Cleanup Block Candidate";
 const PRIMARY_UNIFIED_SUBJECT = "Primary local unified conversation";
 const SECONDARY_UNIFIED_SUBJECT = "Secondary local unified conversation";
 const THREAD_DETAIL_VARIANT = "drafts:1|replies:0";
@@ -164,7 +167,11 @@ test("renders a cached thread body when the reader request is offline", async ({
   page,
 }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const { readerUrl, threadId } = await openFirstThread(page, conversations);
+  const { readerUrl, threadId } = await openFirstThread(
+    page,
+    conversations,
+    emailAccountId,
+  );
   await leaveThreadReader(page, emailAccountId);
   await page.route(threadDetailRoute(threadId), (route) =>
     route.abort("connectionfailed"),
@@ -185,7 +192,11 @@ test("falls back to the network for an uncached thread body and persists it", as
   page,
 }) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const { threadId } = await openFirstThread(page, conversations);
+  const { threadId } = await openFirstThread(
+    page,
+    conversations,
+    emailAccountId,
+  );
   await clearThreadDetail(page, { emailAccountId, threadId });
 
   await page.route(threadDetailRoute(threadId), async (route) => {
@@ -212,7 +223,11 @@ test("serves cached reader content without revalidating from the network", async
   page,
 }) => {
   const { conversations, emailAccountId } = await openMail(page);
-  const { readerUrl, threadId } = await openFirstThread(page, conversations);
+  const { readerUrl, threadId } = await openFirstThread(
+    page,
+    conversations,
+    emailAccountId,
+  );
   let threadDetailRequestCount = 0;
 
   await leaveThreadReader(page, emailAccountId);
@@ -397,10 +412,20 @@ async function seedUnifiedMailbox(
 async function openFirstThread(
   page: Page,
   conversations: ReturnType<Page["getByRole"]>,
+  emailAccountId: string,
 ) {
-  await conversations.getByRole("option").first().click();
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    READER_CACHE_SUBJECT,
+  );
+  await expect(conversation).toBeVisible();
+  await conversation.click();
   const threadId = new URL(page.url()).searchParams.get("thread-id");
   if (!threadId) throw new Error("Expected an open thread id");
+  await expect
+    .poll(() => readThreadDetailTextPlain(page, { emailAccountId, threadId }))
+    .toBe(READER_CACHE_BODY);
   return { readerUrl: page.url(), threadId };
 }
 

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -86,24 +86,6 @@ test("advances the split reader after archiving an open conversation", async ({
     conversations,
     "Second Unread Command Message",
   );
-  await conversation.click();
-  await expect(
-    page.getByRole("heading", { name: "Second Unread Command Message" }),
-  ).toBeVisible();
-  await page.getByRole("button", { name: /^More actions/ }).click();
-  await page.getByRole("menuitem", { name: "Mark as unread" }).click();
-  await expect(
-    page.getByText("Marked as unread", { exact: true }),
-  ).toBeVisible();
-
-  await conversationWithSubject(
-    page,
-    conversations,
-    "Read Command Message",
-  ).click();
-  await expect(
-    page.getByRole("heading", { name: "Read Command Message" }),
-  ).toBeVisible();
   await page.getByRole("button", { name: "Unread", exact: true }).click();
   await expect(conversation).toBeVisible();
   await conversation.click();
@@ -115,7 +97,7 @@ test("advances the split reader after archiving an open conversation", async ({
   let archived = false;
   let restoreSucceeded: boolean | undefined;
   try {
-    await page.getByRole("button", { name: "Archive", exact: true }).click();
+    await page.getByRole("button", { name: /^Archive/ }).click();
     archived = true;
     await expect(
       page
@@ -130,9 +112,7 @@ test("advances the split reader after archiving an open conversation", async ({
     await expect
       .poll(() => new URL(page.url()).searchParams.get("thread-id"))
       .not.toBeNull();
-    await expect(
-      page.getByRole("button", { name: "Archive", exact: true }),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Archive/ })).toBeVisible();
     await capturePlaywrightCheckpoint(
       page,
       testInfo,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260902-152741_pr-3486_6b4ff325c52f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Stabilizes mailbox browser coverage by removing timing-dependent setup and cache races.

- use deterministic seeded state and resilient action locators
- wait for persistent cache writes before testing cache misses
- validate the complete emulated mail browser suite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved mail reader test reliability by targeting a specific conversation and verifying cached content before continuing.
  - Updated unread-filter and archive-flow coverage to reflect the current user workflow.
  - Made archive button checks resilient to additional label text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->