### PR TITLE
mail: improve reader actions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -2,7 +2,11 @@ import { expect } from "@playwright/test";
 import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 test("starts mailbox warming from the app shell before mail opens", async ({
   page,
@@ -151,6 +155,65 @@ test("opening a conversation issues one detail request", async ({ page }) => {
     page.getByText("First message in the reader conversation."),
   ).toBeVisible();
   expect(threadDetailRequestCount).toBe(1);
+});
+
+test("waits for a direct reader snapshot before marking it read", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  const releaseThreadDetail = Promise.withResolvers<void>();
+  let threadDetailRequestCount = 0;
+
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+  });
+  await page.route(
+    "**/api/threads/thr_playwright_reader?includeDrafts=true",
+    async (route) => {
+      threadDetailRequestCount += 1;
+      const response = await route.fetch();
+      const data = (await response.json()) as {
+        thread: { messages: Array<{ labelIds?: string[] | null }> };
+      };
+      data.thread.messages = data.thread.messages.map((message) => ({
+        ...message,
+        labelIds: [...new Set([...(message.labelIds ?? []), "UNREAD"])],
+      }));
+      await releaseThreadDetail.promise;
+      await route.fulfill({ json: data });
+    },
+  );
+
+  await page.goto(
+    `/${emailAccountId}/mail?labelId=Label_project&thread-id=thr_playwright_reader`,
+  );
+  await expect.poll(() => threadDetailRequestCount).toBe(1);
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "set_read_state",
+        threadId: "thr_playwright_reader",
+      }),
+    )
+    .toBeUndefined();
+
+  releaseThreadDetail.resolve();
+  await expect(
+    page.getByText("First message in the reader conversation."),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "set_read_state",
+        threadId: "thr_playwright_reader",
+      }),
+    )
+    .toMatchObject({ payload: { read: true }, status: "pending" });
 });
 
 test("filters the mail list by state, category, and label", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -28,6 +28,7 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
   const archiveButton = page.getByRole("button", { name: /^Archive/ });
   await expect(archiveButton.locator("kbd")).toHaveCount(0);
   await archiveButton.hover();
+  await page.waitForTimeout(250);
   await expect(page.getByRole("tooltip")).toHaveCount(0);
   await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-toolbar");
 
@@ -35,13 +36,18 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
     response.url().includes("/api/user/stats/newsletters"),
   );
   await page.getByRole("button", { name: /^More actions/ }).click();
+  const actionsMenu = page.getByRole("menu");
   await expect(
-    page.getByRole("menuitem", { name: "Auto archive future emails" }),
+    actionsMenu.getByRole("menuitem", {
+      name: "Auto archive future emails",
+    }),
   ).toBeVisible();
   await expect(
-    page.getByRole("menuitem", { name: "Mark as spam" }),
+    actionsMenu.getByRole("menuitem", { name: "Mark as spam" }),
   ).toBeVisible();
-  await expect(page.getByRole("menuitem").last()).toHaveText(/Open in Gmail/);
+  await expect(actionsMenu.getByRole("menuitem").last()).toHaveText(
+    /Open in Gmail/,
+  );
   expect((await senderStatsResponse).ok()).toBe(true);
   await capturePlaywrightCheckpoint(
     page,

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -26,14 +26,10 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
   ).toHaveCount(0);
 
   const archiveButton = page.getByRole("button", { name: /^Archive/ });
-  await expect(archiveButton.locator("kbd")).toBeHidden();
+  await expect(archiveButton.locator("kbd")).toHaveCount(0);
   await archiveButton.hover();
-  await expect(archiveButton.locator("kbd")).toBeVisible();
-  await capturePlaywrightCheckpoint(
-    page,
-    testInfo,
-    "mail-reader-toolbar-shortcut-hover",
-  );
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-toolbar");
 
   const senderStatsResponse = page.waitForResponse((response) =>
     response.url().includes("/api/user/stats/newsletters"),
@@ -42,6 +38,10 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
   await expect(
     page.getByRole("menuitem", { name: "Auto archive future emails" }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Mark as spam" }),
+  ).toBeVisible();
+  await expect(page.getByRole("menuitem").last()).toHaveText(/Open in Gmail/);
   expect((await senderStatsResponse).ok()).toBe(true);
   await capturePlaywrightCheckpoint(
     page,

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -336,7 +336,7 @@ export function MailShell() {
 
   const orderedIds = useMemo(() => threads.map(getListThreadKey), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, markRead, setReadState, snooze, undo } =
+  const { archive, trash, markRead, markSpam, setReadState, snooze, undo } =
     useThreadActions({
       emailAccountId,
       threads,
@@ -598,6 +598,10 @@ export function MailShell() {
     [archive, runOn],
   );
   const trashTargets = useCallback(() => runOn(trash, true), [runOn, trash]);
+  const markSpamTargets = useCallback(
+    () => runOn(markSpam, true),
+    [markSpam, runOn],
+  );
   const markReadTargets = useCallback(
     () => runOn(markRead, false),
     [markRead, runOn],
@@ -1130,6 +1134,7 @@ export function MailShell() {
                   message={openMessages.at(-1) ?? null}
                   setChatInput={setChatInput}
                   isUnread={isOpenThreadUnread}
+                  onMarkSpam={markSpamTargets}
                   onToggleRead={() => {
                     if (!resolvedOpenThreadKey) return;
                     setReadState([resolvedOpenThreadKey], isOpenThreadUnread);

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -336,11 +336,6 @@ export function MailShell() {
 
   const orderedIds = useMemo(() => threads.map(getListThreadKey), [threads]);
   const selection = useThreadSelection(orderedIds);
-  const { archive, trash, markRead, markSpam, setReadState, snooze, undo } =
-    useThreadActions({
-      emailAccountId,
-      threads,
-    });
 
   const clampIndex = useCallback(
     (index: number) =>
@@ -411,6 +406,29 @@ export function MailShell() {
   const openMessages = readerSelectionSettled
     ? (openThreadData?.thread.messages ?? NO_MESSAGES)
     : NO_MESSAGES;
+  const readerTarget = useMemo(() => {
+    if (!openThreadKey || !openThreadSelection || !readerSelectionSettled)
+      return;
+    const messageIds = [...new Set(openMessages.map((message) => message.id))];
+    if (!messageIds.length) return;
+    return {
+      emailAccountId: openThreadSelection.emailAccountId,
+      key: openThreadKey,
+      messageIds,
+      threadId: openThreadSelection.threadId,
+    };
+  }, [
+    openMessages,
+    openThreadKey,
+    openThreadSelection,
+    readerSelectionSettled,
+  ]);
+  const { archive, trash, markRead, markSpam, setReadState, snooze, undo } =
+    useThreadActions({
+      emailAccountId,
+      readerTarget,
+      threads,
+    });
   const requestReaderReply = useCallback(() => {
     const messageId = openMessages.at(-1)?.id;
     if (messageId) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -365,9 +365,6 @@ export function MailShell() {
   const openThread = openThreadKey
     ? threads.find((thread) => getListThreadKey(thread) === openThreadKey)
     : undefined;
-  const resolvedOpenThreadKey = openThread
-    ? getListThreadKey(openThread)
-    : null;
   const readAttemptedForOpenThread = useRef<string | null>(null);
 
   // Defer the pair as one value: rendering a new id with the previous account
@@ -591,26 +588,21 @@ export function MailShell() {
       return;
     }
     if (
-      !resolvedOpenThreadKey ||
-      readAttemptedForOpenThread.current === resolvedOpenThreadKey
+      !openThreadKey ||
+      readAttemptedForOpenThread.current === openThreadKey
     ) {
       return;
     }
     if (!isOpenThreadUnread) {
-      readAttemptedForOpenThread.current = resolvedOpenThreadKey;
+      readAttemptedForOpenThread.current = openThreadKey;
       return;
     }
 
     // Remember the durable attempt so this reader doesn't queue duplicates
     // while the outbox is waiting for connectivity or provider recovery.
-    readAttemptedForOpenThread.current = resolvedOpenThreadKey;
-    markRead([resolvedOpenThreadKey]);
-  }, [
-    isOpenThreadUnread,
-    markRead,
-    openReaderThreadKey,
-    resolvedOpenThreadKey,
-  ]);
+    readAttemptedForOpenThread.current = openThreadKey;
+    markRead([openThreadKey]);
+  }, [isOpenThreadUnread, markRead, openReaderThreadKey, openThreadKey]);
   const archiveTargets = useCallback(
     () => runOn(archive, true, true),
     [archive, runOn],
@@ -1154,8 +1146,8 @@ export function MailShell() {
                   isUnread={isOpenThreadUnread}
                   onMarkSpam={markSpamTargets}
                   onToggleRead={() => {
-                    if (!resolvedOpenThreadKey) return;
-                    setReadState([resolvedOpenThreadKey], isOpenThreadUnread);
+                    if (!openThreadKey) return;
+                    setReadState([openThreadKey], isOpenThreadUnread);
                   }}
                   showFixWithChat={
                     !isAllAccounts ||

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -589,6 +589,8 @@ export function MailShell() {
     }
     if (
       !openThreadKey ||
+      !readerSelectionSettled ||
+      !openMessages.length ||
       readAttemptedForOpenThread.current === openThreadKey
     ) {
       return;
@@ -602,7 +604,14 @@ export function MailShell() {
     // while the outbox is waiting for connectivity or provider recovery.
     readAttemptedForOpenThread.current = openThreadKey;
     markRead([openThreadKey]);
-  }, [isOpenThreadUnread, markRead, openReaderThreadKey, openThreadKey]);
+  }, [
+    isOpenThreadUnread,
+    markRead,
+    openMessages.length,
+    openReaderThreadKey,
+    openThreadKey,
+    readerSelectionSettled,
+  ]);
   const archiveTargets = useCallback(
     () => runOn(archive, true, true),
     [archive, runOn],

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -10,7 +10,6 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
-import { Kbd } from "@/components/Kbd";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
@@ -90,29 +89,13 @@ export function ReaderToolbar({
         className="ml-auto flex flex-wrap items-center gap-1.5"
         role="group"
       >
-        <Button
-          className="group"
-          onClick={onArchive}
-          size="xs-2"
-          variant="outline"
-        >
+        <Button onClick={onArchive} size="xs-2" variant="outline">
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
-          <Kbd className="invisible ml-1.5 inline-flex group-hover:visible group-focus-visible:visible">
-            {getShortcutHint("archive")}
-          </Kbd>
         </Button>
-        <Button
-          className="group"
-          onClick={onReply}
-          size="xs-2"
-          variant="outline"
-        >
+        <Button onClick={onReply} size="xs-2" variant="outline">
           <ReplyIcon className="mr-1.5 size-3.5" />
           Reply
-          <Kbd className="invisible ml-1.5 inline-flex group-hover:visible group-focus-visible:visible">
-            {getShortcutHint("reply")}
-          </Kbd>
         </Button>
         <Button
           aria-label={`Delete (${getShortcutHint("delete")})`}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -8,6 +8,7 @@ import {
   MailIcon,
   MailOpenIcon,
   MoreHorizontalIcon,
+  ShieldAlertIcon,
   SparklesIcon,
 } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
@@ -52,6 +53,7 @@ export type ThreadActionsMenuProps = {
   /** `setInput` from `useChat()`: the fix flow seeds the assistant with it. */
   setChatInput: (input: string) => void;
   isUnread: boolean;
+  onMarkSpam: () => void;
   onToggleRead: () => void;
   /** Chat remains scoped to the route account, so cross-account rows hide it. */
   showFixWithChat?: boolean;
@@ -68,6 +70,7 @@ export function ThreadActionsMenu({
   message,
   setChatInput,
   isUnread,
+  onMarkSpam,
   onToggleRead,
   showFixWithChat = true,
   open,
@@ -110,7 +113,7 @@ export function ThreadActionsMenu({
 
         <DropdownMenuContent
           align="end"
-          className="w-[min(24rem,calc(100vw-1rem))]"
+          className="w-56"
           onEscapeKeyDown={(event) => event.stopPropagation()}
         >
           {plans.length > 0 ? (
@@ -137,18 +140,14 @@ export function ThreadActionsMenu({
 
           {plans.length > 0 ? <DropdownMenuSeparator /> : null}
 
-          {openUrl ? (
-            <DropdownMenuItem asChild>
-              <a href={openUrl} rel="noopener noreferrer" target="_blank">
-                <ExternalLinkIcon className="mr-2 size-4" />
-                Open in {isMicrosoftProvider(provider) ? "Outlook" : "Gmail"}
-              </a>
-            </DropdownMenuItem>
-          ) : null}
-
           <DropdownMenuItem onSelect={onToggleRead}>
             <ReadIcon className="mr-2 size-4" />
             {isUnread ? "Mark as read" : "Mark as unread"}
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onSelect={onMarkSpam}>
+            <ShieldAlertIcon className="mr-2 size-4" />
+            Mark as spam
           </DropdownMenuItem>
 
           {canUnsubscribe ? (
@@ -162,6 +161,15 @@ export function ThreadActionsMenu({
             <DropdownMenuItem onSelect={onAutoArchive}>
               <ArchiveRestoreIcon className="mr-2 size-4" />
               Auto archive future emails
+            </DropdownMenuItem>
+          ) : null}
+
+          {openUrl ? (
+            <DropdownMenuItem asChild>
+              <a href={openUrl} rel="noopener noreferrer" target="_blank">
+                <ExternalLinkIcon className="mr-2 size-4" />
+                Open in {isMicrosoftProvider(provider) ? "Outlook" : "Gmail"}
+              </a>
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuContent>

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -253,6 +253,36 @@ describe("useThreadActions durable mutations", () => {
     ]);
   });
 
+  it("clears a fetched reader snapshot when the reader closes", async () => {
+    const readerTarget = {
+      emailAccountId: "account",
+      key: "reader-thread",
+      messageIds: ["reader-message"],
+      threadId: "reader-thread",
+    };
+    const { result, rerender } = renderHook(
+      ({ target }) =>
+        useThreadActions({
+          emailAccountId: "account",
+          readerTarget: target,
+          threads: [],
+        }),
+      {
+        initialProps: {
+          target: readerTarget as typeof readerTarget | undefined,
+        },
+      },
+    );
+
+    rerender({ target: undefined });
+    await act(() => result.current.markSpam(["reader-thread"]));
+
+    expect(outbox.enqueueBatch).not.toHaveBeenCalled();
+    expect(notifications.error).toHaveBeenCalledWith(
+      "Couldn't queue marking as spam",
+    );
+  });
+
   it("retains the opened snapshot after the durable overlay hides its row", async () => {
     const thread = createThread(["INBOX", "UNREAD"]);
     const { result, rerender } = renderHook(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -230,6 +230,29 @@ describe("useThreadActions durable mutations", () => {
     expect(notifications.success).toHaveBeenCalledWith("Marked as spam");
   });
 
+  it("queues a fetched reader snapshot that is absent from the list", async () => {
+    const { result } = renderActions({
+      threads: [],
+      readerTarget: {
+        emailAccountId: "account",
+        key: "reader-thread",
+        messageIds: ["reader-message"],
+        threadId: "reader-thread",
+      },
+    });
+
+    await act(() => result.current.markSpam(["reader-thread"]));
+
+    expect(outbox.enqueueBatch).toHaveBeenCalledWith([
+      {
+        emailAccountId: "account",
+        kind: "spam",
+        messageIds: ["reader-message"],
+        threadId: "reader-thread",
+      },
+    ]);
+  });
+
   it("retains the opened snapshot after the durable overlay hides its row", async () => {
     const thread = createThread(["INBOX", "UNREAD"]);
     const { result, rerender } = renderHook(
@@ -333,12 +356,20 @@ describe("useThreadActions durable mutations", () => {
 
 function renderActions({
   threads = [createThread(["INBOX", "UNREAD"])],
+  readerTarget,
 }: {
   threads?: ListThread[];
+  readerTarget?: {
+    emailAccountId: string;
+    key: string;
+    messageIds: string[];
+    threadId: string;
+  };
 } = {}) {
   return renderHook(() =>
     useThreadActions({
       emailAccountId: "account",
+      readerTarget,
       threads,
     }),
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.test.ts
@@ -214,6 +214,22 @@ describe("useThreadActions durable mutations", () => {
     ]);
   });
 
+  it("queues spam snapshots for durable removal", async () => {
+    const { result } = renderActions();
+
+    await act(() => result.current.markSpam(["thread"]));
+
+    expect(outbox.enqueueBatch).toHaveBeenCalledWith([
+      {
+        emailAccountId: "account",
+        kind: "spam",
+        messageIds: ["message-one", "message-two"],
+        threadId: "thread",
+      },
+    ]);
+    expect(notifications.success).toHaveBeenCalledWith("Marked as spam");
+  });
+
   it("retains the opened snapshot after the durable overlay hides its row", async () => {
     const thread = createThread(["INBOX", "UNREAD"]);
     const { result, rerender } = renderHook(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -28,6 +28,8 @@ type ThreadSnapshot = {
   threadId: string;
 };
 
+type ThreadActionTarget = Omit<ThreadSnapshot, "mutationId">;
+
 type UndoableBatch = {
   action: UndoableAction;
   snapshots: ThreadSnapshot[];
@@ -36,42 +38,42 @@ type UndoableBatch = {
 
 export function useThreadActions({
   emailAccountId,
+  readerTarget,
   threads,
 }: {
   emailAccountId: string;
+  readerTarget?: ThreadActionTarget;
   threads: ListThread[];
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
   const retainedEmailAccountId = useRef(emailAccountId);
-  const threadsByKey = useRef(new Map<string, ListThread>());
+  const targetsByKey = useRef(new Map<string, ThreadActionTarget>());
   if (retainedEmailAccountId.current !== emailAccountId) {
     retainedEmailAccountId.current = emailAccountId;
-    threadsByKey.current.clear();
+    targetsByKey.current.clear();
     lastAction.current = null;
   }
+  if (readerTarget?.messageIds.length) {
+    targetsByKey.current.set(readerTarget.key, readerTarget);
+  }
   for (const thread of threads) {
-    threadsByKey.current.set(getListThreadKey(thread), thread);
+    const messageIds = [...new Set(getListThreadMessageIds(thread))];
+    if (!messageIds.length) continue;
+    const key = getListThreadKey(thread);
+    targetsByKey.current.set(key, {
+      emailAccountId: getListThreadEmailAccountId(thread, emailAccountId),
+      key,
+      messageIds,
+      threadId: thread.id,
+    });
   }
 
   const resolveTargets = useCallback(
     (threadKeys: string[]) =>
       threadKeys
-        .map((key) => {
-          const thread = threadsByKey.current.get(key);
-          if (!thread) return;
-          const messageIds = [...new Set(getListThreadMessageIds(thread))];
-          if (!messageIds.length) return;
-          return {
-            emailAccountId: getListThreadEmailAccountId(thread, emailAccountId),
-            key,
-            messageIds,
-            threadId: thread.id,
-          };
-        })
-        .filter((target): target is Omit<ThreadSnapshot, "mutationId"> =>
-          Boolean(target),
-        ),
-    [emailAccountId],
+        .map((key) => targetsByKey.current.get(key))
+        .filter((target): target is ThreadActionTarget => Boolean(target)),
+    [],
   );
 
   const enqueueTargets = useCallback(

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
@@ -47,31 +47,40 @@ export function useThreadActions({
 }) {
   const lastAction = useRef<UndoableBatch | null>(null);
   const retainedEmailAccountId = useRef(emailAccountId);
-  const targetsByKey = useRef(new Map<string, ThreadActionTarget>());
-  if (retainedEmailAccountId.current !== emailAccountId) {
-    retainedEmailAccountId.current = emailAccountId;
-    targetsByKey.current.clear();
-    lastAction.current = null;
-  }
-  if (readerTarget?.messageIds.length) {
-    targetsByKey.current.set(readerTarget.key, readerTarget);
-  }
-  for (const thread of threads) {
-    const messageIds = [...new Set(getListThreadMessageIds(thread))];
-    if (!messageIds.length) continue;
-    const key = getListThreadKey(thread);
-    targetsByKey.current.set(key, {
-      emailAccountId: getListThreadEmailAccountId(thread, emailAccountId),
-      key,
-      messageIds,
-      threadId: thread.id,
-    });
-  }
+  const listTargetsByKey = useRef(new Map<string, ThreadActionTarget>());
+  const activeReaderTarget = useRef<ThreadActionTarget | undefined>(undefined);
+  useEffect(() => {
+    if (retainedEmailAccountId.current !== emailAccountId) {
+      retainedEmailAccountId.current = emailAccountId;
+      listTargetsByKey.current.clear();
+      lastAction.current = null;
+    }
+    activeReaderTarget.current = readerTarget?.messageIds.length
+      ? readerTarget
+      : undefined;
+    for (const thread of threads) {
+      const messageIds = [...new Set(getListThreadMessageIds(thread))];
+      if (!messageIds.length) continue;
+      const key = getListThreadKey(thread);
+      listTargetsByKey.current.set(key, {
+        emailAccountId: getListThreadEmailAccountId(thread, emailAccountId),
+        key,
+        messageIds,
+        threadId: thread.id,
+      });
+    }
+  }, [emailAccountId, readerTarget, threads]);
 
   const resolveTargets = useCallback(
     (threadKeys: string[]) =>
       threadKeys
-        .map((key) => targetsByKey.current.get(key))
+        .map((key) => {
+          const listTarget = listTargetsByKey.current.get(key);
+          if (listTarget) return listTarget;
+          return activeReaderTarget.current?.key === key
+            ? activeReaderTarget.current
+            : undefined;
+        })
         .filter((target): target is ThreadActionTarget => Boolean(target)),
     [],
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -252,6 +252,30 @@ export function useThreadActions({
     [enqueueTargets, resolveTargets],
   );
 
+  const markSpam = useCallback(
+    async (threadKeys: string[]) => {
+      const targets = resolveTargets(threadKeys);
+      const snapshots = await enqueueTargets(targets, { kind: "spam" });
+      const failedCount = threadKeys.length - snapshots.length;
+      if (snapshots.length) {
+        toast.success(
+          snapshots.length === 1
+            ? "Marked as spam"
+            : `Marked ${snapshots.length} conversations as spam`,
+        );
+      }
+      if (failedCount) {
+        toast.error(
+          failedCount === threadKeys.length
+            ? "Couldn't queue marking as spam"
+            : `Couldn't queue ${failedCount} of ${threadKeys.length} as spam`,
+        );
+      }
+      return snapshots.map((snapshot) => snapshot.key);
+    },
+    [enqueueTargets, resolveTargets],
+  );
+
   return {
     archive: useCallback(
       (threadKeys: string[]) => runUndoable("archive", threadKeys),
@@ -265,6 +289,7 @@ export function useThreadActions({
       (threadKeys: string[]) => setReadState(threadKeys, true, false),
       [setReadState],
     ),
+    markSpam,
     setReadState,
     snooze,
     undo,

--- a/apps/web/utils/actions/mail-mutation.test.ts
+++ b/apps/web/utils/actions/mail-mutation.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   cancelSnooze: vi.fn(),
   createEmailProvider: vi.fn(),
   prepareSnooze: vi.fn(),
+  markSpam: vi.fn(),
   sendEmailWithHtml: vi.fn(),
   unarchiveMessages: vi.fn(),
 }));
@@ -47,10 +48,12 @@ describe("executeMailMutationAction", () => {
     );
     mocks.createEmailProvider.mockResolvedValue({
       archiveMessages: mocks.archiveMessages,
+      markSpam: mocks.markSpam,
       sendEmailWithHtml: mocks.sendEmailWithHtml,
       unarchiveMessages: mocks.unarchiveMessages,
     });
     mocks.archiveMessages.mockResolvedValue(undefined);
+    mocks.markSpam.mockResolvedValue(undefined);
     mocks.unarchiveMessages.mockResolvedValue(undefined);
     mocks.prepareSnooze.mockResolvedValue({
       created: true,
@@ -76,6 +79,18 @@ describe("executeMailMutationAction", () => {
       ["one", "two"],
       undefined,
     );
+  });
+
+  it("marks the captured thread as spam", async () => {
+    const result = await executeMailMutationAction("account-1", {
+      kind: "spam",
+      mutationId,
+      threadId: "thread",
+      messageIds: ["one", "two"],
+    });
+
+    expect(result?.data).toEqual({ status: "applied" });
+    expect(mocks.markSpam).toHaveBeenCalledWith("thread");
   });
 
   it("applies a durable archive batch with one provider operation", async () => {

--- a/apps/web/utils/actions/mail-mutation.ts
+++ b/apps/web/utils/actions/mail-mutation.ts
@@ -88,6 +88,9 @@ export const executeMailMutationAction = actionClient
         case "untrash":
           await emailProvider.untrashMessages(parsedInput.messageIds);
           break;
+        case "spam":
+          await emailProvider.markSpam(parsedInput.threadId);
+          break;
         case "set_read_state":
           await emailProvider.markMessagesReadState(
             parsedInput.messageIds,

--- a/apps/web/utils/actions/mail-mutation.validation.ts
+++ b/apps/web/utils/actions/mail-mutation.validation.ts
@@ -19,6 +19,7 @@ export const executeMailMutationBody = z.discriminatedUnion("kind", [
   snapshot.extend({ kind: z.literal("unarchive") }),
   snapshot.extend({ kind: z.literal("trash") }),
   snapshot.extend({ kind: z.literal("untrash") }),
+  snapshot.extend({ kind: z.literal("spam") }),
   snapshot.extend({ kind: z.literal("set_read_state"), read: z.boolean() }),
   snapshot.extend({
     kind: z.literal("snooze"),

--- a/apps/web/utils/email-cache/database.ts
+++ b/apps/web/utils/email-cache/database.ts
@@ -66,6 +66,7 @@ export type StoredMailMutation = {
     | "unarchive"
     | "trash"
     | "untrash"
+    | "spam"
     | "set_read_state"
     | "snooze"
     | "cancel_snooze"

--- a/apps/web/utils/email-cache/mail-mutation-overlay.test.ts
+++ b/apps/web/utils/email-cache/mail-mutation-overlay.test.ts
@@ -72,13 +72,23 @@ describe("mail mutation overlay", () => {
       }),
     ).toBe(false);
   });
+
+  it("hides messages marked as spam", () => {
+    const result = applyMailMutationOverlayToMessages({
+      emailAccountId: "account",
+      messages: [message("spam", "thread", ["INBOX"])],
+      mutations: [mutation({ id: "spam", kind: "spam", messageIds: ["spam"] })],
+    });
+
+    expect(result).toEqual([]);
+  });
 });
 
 function mutation(
   value:
     | {
         id: string;
-        kind: "archive" | "unarchive";
+        kind: "archive" | "unarchive" | "spam";
         messageIds: string[];
       }
     | {

--- a/apps/web/utils/email-cache/mail-mutation-overlay.ts
+++ b/apps/web/utils/email-cache/mail-mutation-overlay.ts
@@ -3,6 +3,7 @@ import type { MailMutation } from "./mail-mutations";
 
 const HIDE_KINDS = new Set<MailMutation["kind"]>([
   "archive",
+  "spam",
   "trash",
   "snooze",
 ]);

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -12,6 +12,7 @@ export type MailMutationPayload =
   | { kind: "unarchive" }
   | { kind: "trash" }
   | { kind: "untrash" }
+  | { kind: "spam" }
   | { kind: "set_read_state"; read: boolean }
   | { kind: "snooze"; scheduledFor: string }
   | { kind: "cancel_snooze"; snoozeMutationId: string }

--- a/apps/web/utils/outlook/spam.ts
+++ b/apps/web/utils/outlook/spam.ts
@@ -36,6 +36,7 @@ export async function markSpam(
         ),
       failureMessage: "Failed to move message to spam",
       continueOnError: true,
+      throwIfAllFail: true,
     });
   } catch (error) {
     // If the filter fails, try a different approach
@@ -60,6 +61,7 @@ export async function markSpam(
           ),
         noMessagesMessage:
           "No messages found for conversationId, skipping spam move",
+        throwIfAllFail: true,
       });
     } catch (directError) {
       logger.error("Failed to mark message as spam", {

--- a/apps/web/utils/outlook/thread-helpers.test.ts
+++ b/apps/web/utils/outlook/thread-helpers.test.ts
@@ -48,7 +48,7 @@ describe("runThreadMessageMutation", () => {
   });
 
   it("throws the provider error when every attempted mutation fails", async () => {
-    const messageHandler = vi.fn().mockRejectedValue(new Error("move failed"));
+    const messageHandler = vi.fn().mockRejectedValue("move failed");
 
     await expect(
       runThreadMessageMutation({
@@ -60,7 +60,7 @@ describe("runThreadMessageMutation", () => {
         throwIfAllFail: true,
         messageHandler,
       }),
-    ).rejects.toThrow("move failed");
+    ).rejects.toEqual(new Error("move failed"));
 
     expect(messageHandler).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/utils/outlook/thread-helpers.test.ts
+++ b/apps/web/utils/outlook/thread-helpers.test.ts
@@ -39,9 +39,28 @@ describe("runThreadMessageMutation", () => {
         logger: createTestLogger(),
         failureMessage: "Failed to mutate message",
         continueOnError: true,
+        throwIfAllFail: true,
         messageHandler,
       }),
     ).resolves.toBeUndefined();
+
+    expect(messageHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws the provider error when every attempted mutation fails", async () => {
+    const messageHandler = vi.fn().mockRejectedValue(new Error("move failed"));
+
+    await expect(
+      runThreadMessageMutation({
+        messageIds: ["msg1", "msg2"],
+        threadId: "conv1",
+        logger: createTestLogger(),
+        failureMessage: "Failed to mutate message",
+        continueOnError: true,
+        throwIfAllFail: true,
+        messageHandler,
+      }),
+    ).rejects.toThrow("move failed");
 
     expect(messageHandler).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/utils/outlook/thread-helpers.ts
+++ b/apps/web/utils/outlook/thread-helpers.ts
@@ -46,11 +46,16 @@ export async function runThreadMessageMutation({
     });
   }
 
-  if (!continueOnError && failures.length > 0) {
-    throw failures[0].result.reason;
+  const firstFailure = failures[0];
+  if (!firstFailure) return;
+  const reason = firstFailure.result.reason;
+  const error = reason instanceof Error ? reason : new Error(String(reason));
+
+  if (!continueOnError) {
+    throw error;
   }
   if (throwIfAllFail && failures.length === messageIds.length) {
-    throw failures[0].result.reason;
+    throw error;
   }
 }
 

--- a/apps/web/utils/outlook/thread-helpers.ts
+++ b/apps/web/utils/outlook/thread-helpers.ts
@@ -11,6 +11,7 @@ export async function runThreadMessageMutation({
   messageHandler,
   failureMessage,
   continueOnError = false,
+  throwIfAllFail = false,
 }: {
   messageIds: string[];
   threadId: string;
@@ -18,6 +19,7 @@ export async function runThreadMessageMutation({
   messageHandler: (messageId: string) => Promise<unknown>;
   failureMessage: string;
   continueOnError?: boolean;
+  throwIfAllFail?: boolean;
 }) {
   if (messageIds.length === 0) return;
 
@@ -47,6 +49,9 @@ export async function runThreadMessageMutation({
   if (!continueOnError && failures.length > 0) {
     throw failures[0].result.reason;
   }
+  if (throwIfAllFail && failures.length === messageIds.length) {
+    throw failures[0].result.reason;
+  }
 }
 
 /**
@@ -59,12 +64,14 @@ export async function processThreadMessagesFallback({
   logger,
   messageHandler,
   noMessagesMessage,
+  throwIfAllFail = false,
 }: {
   client: OutlookClient;
   threadId: string;
   logger: Logger;
   messageHandler: (messageId: string) => Promise<unknown>;
   noMessagesMessage: string;
+  throwIfAllFail?: boolean;
 }) {
   const messages = await client
     .getClient()
@@ -85,6 +92,7 @@ export async function processThreadMessagesFallback({
       messageHandler,
       failureMessage: "Failed to process message in thread fallback",
       continueOnError: true,
+      throwIfAllFail,
     });
   } else {
     logger.warn(noMessagesMessage, { threadId });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260902-172109_pr-3487_2789cdca4b49/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improves email reader actions and menu behavior.

- add durable spam handling through the existing mail mutation flow
- refine reader action controls and menu sizing and order
- add focused mutation and browser coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Mark as spam” action to the thread actions menu.
  * Spam-marked messages are removed from the visible mail list.
  * Added success and error notifications for spam actions.
  * Spam actions now work reliably for open email threads.

* **UI Updates**
  * Archive and Reply buttons no longer display keyboard shortcut hints.
  * Standardized the thread actions menu width.
  * Reordered external mailbox actions.

* **Bug Fixes**
  * Spam actions now report errors when all updates fail.
  * Threads are marked as read only after reader content finishes loading.

* **Tests**
  * Added coverage for spam actions, visibility, and menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->