### PR TITLE
mail: Measure email content before resource load

### DIFF
--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -180,7 +180,7 @@ describe("HtmlEmail", () => {
     );
   });
 
-  it("keeps watching for the email document after a stale load event", async () => {
+  it("keeps watching until the email document replaces the placeholder", async () => {
     vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByTitle } = render(
       <HtmlEmail html="<p>Long email</p>" messageId="message-loading" />,
@@ -206,6 +206,11 @@ describe("HtmlEmail", () => {
     iframe.dispatchEvent(new Event("load"));
 
     expect(animationFrames).not.toHaveLength(0);
+    for (let frame = 0; frame < 10; frame += 1) {
+      act(() => animationFrames.shift()?.callback(frame));
+    }
+    expect(animationFrames).not.toHaveLength(0);
+
     iframeDocument = emailDocument;
     act(() => animationFrames.shift()?.callback(0));
 

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -21,6 +21,7 @@ import { HtmlEmail, PlainEmail } from "./EmailContents";
 (globalThis as { React?: typeof React }).React = React;
 
 let triggerResize: (() => void) | undefined;
+let animationFrameCallbacks: FrameRequestCallback[] = [];
 
 class MockResizeObserver {
   constructor(callback: ResizeObserverCallback) {
@@ -35,7 +36,16 @@ class MockResizeObserver {
 describe("HtmlEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    animationFrameCallbacks = [];
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrameCallbacks.push(callback);
+        return animationFrameCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -154,6 +164,39 @@ describe("HtmlEmail", () => {
 
     contentHeight = 640;
     act(() => triggerResize?.());
+
+    await waitFor(() =>
+      expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(
+        640,
+      ),
+    );
+  });
+
+  it("measures the email document before its resources finish loading", async () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    const { getByTitle } = render(
+      <HtmlEmail html="<p>Long email</p>" messageId="message-loading" />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    let iframeDocument = iframe.contentDocument;
+    const emailDocument = document.implementation.createHTMLDocument("email");
+
+    Object.defineProperty(emailDocument.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(emailDocument.body, "scrollHeight", {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(iframe, "contentDocument", {
+      configurable: true,
+      get: () => iframeDocument,
+    });
+
+    await waitFor(() => expect(animationFrameCallbacks).not.toHaveLength(0));
+    iframeDocument = emailDocument;
+    act(() => animationFrameCallbacks.shift()?.(0));
 
     await waitFor(() =>
       expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -164,6 +164,7 @@ describe("HtmlEmail", () => {
         get: () => contentHeight,
       },
     );
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
 
     iframe.dispatchEvent(new Event("load"));
     await waitFor(() =>
@@ -188,6 +189,7 @@ describe("HtmlEmail", () => {
     const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
     let iframeDocument = iframe.contentDocument;
     const emailDocument = document.implementation.createHTMLDocument("email");
+    addEmailDocumentMarker(iframe, emailDocument);
 
     Object.defineProperty(emailDocument.documentElement, "scrollHeight", {
       configurable: true,
@@ -213,6 +215,7 @@ describe("HtmlEmail", () => {
 
     iframeDocument = emailDocument;
     act(() => animationFrames.shift()?.callback(0));
+    expect(animationFrames).toHaveLength(0);
 
     await waitFor(() =>
       expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(
@@ -294,3 +297,15 @@ describe("PlainEmail", () => {
     expect(container.textContent).not.toContain("&#39;");
   });
 });
+
+function addEmailDocumentMarker(
+  iframe: HTMLIFrameElement,
+  targetDocument: Document | null,
+) {
+  if (!targetDocument) throw new Error("Expected an iframe document");
+  const marker = new DOMParser()
+    .parseFromString(iframe.srcdoc, "text/html")
+    .querySelector('meta[name="inbox-zero-email-document"]');
+  if (!marker) throw new Error("Expected an email document marker");
+  targetDocument.head.append(marker.cloneNode());
+}

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -21,7 +21,8 @@ import { HtmlEmail, PlainEmail } from "./EmailContents";
 (globalThis as { React?: typeof React }).React = React;
 
 let triggerResize: (() => void) | undefined;
-let animationFrameCallbacks: FrameRequestCallback[] = [];
+let animationFrames: Array<{ callback: FrameRequestCallback; id: number }> = [];
+let nextAnimationFrameId = 0;
 
 class MockResizeObserver {
   constructor(callback: ResizeObserverCallback) {
@@ -36,16 +37,23 @@ class MockResizeObserver {
 describe("HtmlEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    animationFrameCallbacks = [];
+    animationFrames = [];
+    nextAnimationFrameId = 0;
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
     vi.stubGlobal(
       "requestAnimationFrame",
       vi.fn((callback: FrameRequestCallback) => {
-        animationFrameCallbacks.push(callback);
-        return animationFrameCallbacks.length;
+        const id = ++nextAnimationFrameId;
+        animationFrames.push({ callback, id });
+        return id;
       }),
     );
-    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => {
+        animationFrames = animationFrames.filter((frame) => frame.id !== id);
+      }),
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -172,7 +180,7 @@ describe("HtmlEmail", () => {
     );
   });
 
-  it("measures the email document before its resources finish loading", async () => {
+  it("keeps watching for the email document after a stale load event", async () => {
     vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByTitle } = render(
       <HtmlEmail html="<p>Long email</p>" messageId="message-loading" />,
@@ -194,9 +202,12 @@ describe("HtmlEmail", () => {
       get: () => iframeDocument,
     });
 
-    await waitFor(() => expect(animationFrameCallbacks).not.toHaveLength(0));
+    await waitFor(() => expect(animationFrames).not.toHaveLength(0));
+    iframe.dispatchEvent(new Event("load"));
+
+    expect(animationFrames).not.toHaveLength(0);
     iframeDocument = emailDocument;
-    act(() => animationFrameCallbacks.shift()?.(0));
+    act(() => animationFrames.shift()?.callback(0));
 
     await waitFor(() =>
       expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -110,7 +110,7 @@ export function HtmlEmail({
     [renderHtml, mainContent, showReplies, isDarkMode],
   );
 
-  const iframeHeight = useIframeHeight(iframeRef);
+  const iframeHeight = useIframeHeight(iframeRef, srcDoc);
 
   return (
     <div className="relative min-w-0 overflow-x-hidden">
@@ -397,20 +397,29 @@ function addDarkModeClass(html: string, isDarkMode: boolean) {
   }
 }
 
-function useIframeHeight(iframeRef: React.RefObject<HTMLIFrameElement | null>) {
+function useIframeHeight(
+  iframeRef: React.RefObject<HTMLIFrameElement | null>,
+  srcDoc: string,
+) {
   const [height, setHeight] = useState(0);
 
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
+    let animationFrameId: number | undefined;
+    let remainingDocumentChecks = 10;
+    let observedRoot: HTMLElement | null = null;
+    const initialRoot = iframe.contentDocument?.documentElement ?? null;
 
     const updateHeight = () => {
       const iframeDocument = iframe.contentDocument;
       if (!iframeDocument) return;
+      const { body, documentElement } = iframeDocument;
+      if (!body || !documentElement) return;
 
       const newHeight = Math.max(
-        iframeDocument.documentElement.scrollHeight,
-        iframeDocument.body.scrollHeight,
+        documentElement.scrollHeight,
+        body.scrollHeight,
       );
       if (newHeight) setHeight(newHeight);
     };
@@ -418,23 +427,57 @@ function useIframeHeight(iframeRef: React.RefObject<HTMLIFrameElement | null>) {
     const resizeObserver = new ResizeObserver(updateHeight);
 
     const observeDocument = () => {
-      resizeObserver.disconnect();
+      if (iframe.srcdoc !== srcDoc) return;
       const iframeDocument = iframe.contentDocument;
       if (!iframeDocument) return;
+      const { body, documentElement: root } = iframeDocument;
+      if (!body || !root) return;
+      if (root === observedRoot) return;
 
+      resizeObserver.disconnect();
+      observedRoot = root;
       updateHeight();
-      resizeObserver.observe(iframeDocument.documentElement);
-      resizeObserver.observe(iframeDocument.body);
+      resizeObserver.observe(root);
+      resizeObserver.observe(body);
     };
 
-    iframe.addEventListener("load", observeDocument);
+    const stopWatchingForDocument = () => {
+      if (animationFrameId === undefined) return;
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = undefined;
+    };
+
+    const watchForDocument = () => {
+      observeDocument();
+      remainingDocumentChecks -= 1;
+      if (
+        (observedRoot && observedRoot !== initialRoot) ||
+        remainingDocumentChecks === 0
+      ) {
+        animationFrameId = undefined;
+        return;
+      }
+      animationFrameId = requestAnimationFrame(watchForDocument);
+    };
+
+    const onLoad = () => {
+      stopWatchingForDocument();
+      observeDocument();
+      updateHeight();
+    };
+
+    iframe.addEventListener("load", onLoad);
     observeDocument();
+    // `load` waits for remote images. Catch the `srcDoc` document swap first so
+    // its parsed layout can be measured while those images are still loading.
+    animationFrameId = requestAnimationFrame(watchForDocument);
 
     return () => {
-      iframe.removeEventListener("load", observeDocument);
+      iframe.removeEventListener("load", onLoad);
+      stopWatchingForDocument();
       resizeObserver.disconnect();
     };
-  }, [iframeRef]);
+  }, [iframeRef, srcDoc]);
 
   return height;
 }

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -22,6 +22,7 @@ import {
 import { splitEmailContent } from "@/utils/email/split-email-content.client";
 
 const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
+const EMAIL_DOCUMENT_MARKER = "inbox-zero-email-document";
 const NO_INLINE_ATTACHMENTS: ParsedMessage["inline"] = [];
 /**
  * Reading size for a message body that brought no styling of its own. Shared by
@@ -99,18 +100,24 @@ export function HtmlEmail({
     [renderHtml],
   );
 
+  const displayedHtml = showReplies ? renderHtml : mainContent;
+  const documentKey = useMemo(
+    () => getIframeDocumentKey(displayedHtml, isDarkMode),
+    [displayedHtml, isDarkMode],
+  );
   const srcDoc = useMemo(
     () =>
       getIframeHtml(
-        showReplies ? renderHtml : mainContent,
+        displayedHtml,
         isDarkMode,
         IMAGE_PROXY_BASE_URL,
         IMAGE_PROXY_ORIGIN,
+        documentKey,
       ),
-    [renderHtml, mainContent, showReplies, isDarkMode],
+    [displayedHtml, isDarkMode, documentKey],
   );
 
-  const iframeHeight = useIframeHeight(iframeRef, srcDoc);
+  const iframeHeight = useIframeHeight(iframeRef, srcDoc, documentKey);
 
   return (
     <div className="relative min-w-0 overflow-x-hidden">
@@ -157,6 +164,7 @@ function getIframeHtml(
   isDarkMode: boolean,
   imageProxyBaseUrl: string | null,
   imageProxyOrigin: string | null,
+  documentKey: string,
 ) {
   // Count style attributes safely
   const styleAttributeCount = (html.match(/style=/g) || []).length;
@@ -289,7 +297,7 @@ function getIframeHtml(
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
   `;
 
-  const headContent = `${securityHeaders}${defaultFontStyles}<base target="_blank" rel="noopener noreferrer">`;
+  const headContent = `<meta name="${EMAIL_DOCUMENT_MARKER}" content="${documentKey}">${securityHeaders}${defaultFontStyles}<base target="_blank" rel="noopener noreferrer">`;
 
   function wrapWithProperStructure(content: string) {
     if (content.indexOf("<html") === -1) {
@@ -400,6 +408,7 @@ function addDarkModeClass(html: string, isDarkMode: boolean) {
 function useIframeHeight(
   iframeRef: React.RefObject<HTMLIFrameElement | null>,
   srcDoc: string,
+  documentKey: string,
 ) {
   const [height, setHeight] = useState(0);
 
@@ -408,7 +417,6 @@ function useIframeHeight(
     if (!iframe) return;
     let animationFrameId: number | undefined;
     let observedRoot: HTMLElement | null = null;
-    const initialRoot = iframe.contentDocument?.documentElement ?? null;
 
     const updateHeight = () => {
       const iframeDocument = iframe.contentDocument;
@@ -426,18 +434,23 @@ function useIframeHeight(
     const resizeObserver = new ResizeObserver(updateHeight);
 
     const observeDocument = () => {
-      if (iframe.srcdoc !== srcDoc) return;
+      if (iframe.srcdoc !== srcDoc) return false;
       const iframeDocument = iframe.contentDocument;
-      if (!iframeDocument) return;
+      if (!iframeDocument) return false;
+      const marker = iframeDocument.querySelector(
+        `meta[name="${EMAIL_DOCUMENT_MARKER}"]`,
+      );
+      if (marker?.getAttribute("content") !== documentKey) return false;
       const { body, documentElement: root } = iframeDocument;
-      if (!body || !root) return;
-      if (root === observedRoot) return;
+      if (!body || !root) return false;
+      if (root === observedRoot) return true;
 
       resizeObserver.disconnect();
       observedRoot = root;
       updateHeight();
       resizeObserver.observe(root);
       resizeObserver.observe(body);
+      return true;
     };
 
     const stopWatchingForDocument = () => {
@@ -447,8 +460,7 @@ function useIframeHeight(
     };
 
     const watchForDocument = () => {
-      observeDocument();
-      if (observedRoot && observedRoot !== initialRoot) {
+      if (observeDocument()) {
         animationFrameId = undefined;
         return;
       }
@@ -456,25 +468,34 @@ function useIframeHeight(
     };
 
     const onLoad = () => {
-      observeDocument();
+      if (!observeDocument()) return;
       updateHeight();
-      if (observedRoot && observedRoot !== initialRoot) {
-        stopWatchingForDocument();
-      }
+      stopWatchingForDocument();
     };
 
     iframe.addEventListener("load", onLoad);
-    observeDocument();
     // `load` waits for remote images. Catch the `srcDoc` document swap first so
     // its parsed layout can be measured while those images are still loading.
-    animationFrameId = requestAnimationFrame(watchForDocument);
+    if (!observeDocument()) {
+      animationFrameId = requestAnimationFrame(watchForDocument);
+    }
 
     return () => {
       iframe.removeEventListener("load", onLoad);
       stopWatchingForDocument();
       resizeObserver.disconnect();
     };
-  }, [iframeRef, srcDoc]);
+  }, [iframeRef, srcDoc, documentKey]);
 
   return height;
+}
+
+function getIframeDocumentKey(html: string, isDarkMode: boolean) {
+  const source = `${isDarkMode ? "1" : "0"}:${html}`;
+  let hash = 2_166_136_261;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `${source.length}-${(hash >>> 0).toString(36)}`;
 }

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -461,9 +461,11 @@ function useIframeHeight(
     };
 
     const onLoad = () => {
-      stopWatchingForDocument();
       observeDocument();
       updateHeight();
+      if (observedRoot && observedRoot !== initialRoot) {
+        stopWatchingForDocument();
+      }
     };
 
     iframe.addEventListener("load", onLoad);

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -407,7 +407,6 @@ function useIframeHeight(
     const iframe = iframeRef.current;
     if (!iframe) return;
     let animationFrameId: number | undefined;
-    let remainingDocumentChecks = 10;
     let observedRoot: HTMLElement | null = null;
     const initialRoot = iframe.contentDocument?.documentElement ?? null;
 
@@ -449,11 +448,7 @@ function useIframeHeight(
 
     const watchForDocument = () => {
       observeDocument();
-      remainingDocumentChecks -= 1;
-      if (
-        (observedRoot && observedRoot !== initialRoot) ||
-        remainingDocumentChecks === 0
-      ) {
+      if (observedRoot && observedRoot !== initialRoot) {
         animationFrameId = undefined;
         return;
       }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260902-165145_pr-3488_1e602cff67b5/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Measure iframe content as soon as the email document replaces its placeholder so the reader does not stay at the browser default height while embedded resources load.

- attach height observation before the iframe load event while retaining the existing fallback
- cover document replacement and early measurement with a regression test

Validation:
- `pnpm test components/email-list/EmailContents.test.tsx`
- `pnpm exec ultracite check apps/web/components/email-list/EmailContents.tsx apps/web/components/email-list/EmailContents.test.tsx`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email preview sizing while content and embedded resources load.
  - Updated preview dimensions when email content changes, reducing clipped content and excess empty space.
  - Improved height tracking when email documents are replaced or refreshed.
  - Prevented outdated loading events from interrupting updates for newly rendered content.
  - Improved sizing reliability as document content becomes available, including taller email previews.
  - Ensured previews continue monitoring content until the replacement document is ready, improving consistency during rapid updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->