### PR TITLE
fix(cli): use valid Gemini model IDs

### DIFF
--- a/packages/cli/src/llm.test.ts
+++ b/packages/cli/src/llm.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultLlmModels } from "./llm";
+
+describe("getDefaultLlmModels", () => {
+  it("should return valid Google Gemini model IDs", () => {
+    expect(getDefaultLlmModels("google")).toEqual({
+      default: "gemini-3-flash-preview",
+      economy: "gemini-2.5-flash",
+    });
+  });
+});

--- a/packages/cli/src/llm.ts
+++ b/packages/cli/src/llm.ts
@@ -42,7 +42,10 @@ const DEFAULT_MODELS = {
     economy: "claude-haiku-4-5-20251001",
   },
   openai: { default: "gpt-5.4-mini", economy: "gpt-5.4-nano" },
-  google: { default: "gemini-3-flash", economy: "gemini-2-5-flash" },
+  google: {
+    default: "gemini-3-flash-preview",
+    economy: "gemini-2.5-flash",
+  },
   openrouter: {
     default: "anthropic/claude-sonnet-4.6",
     economy: "anthropic/claude-haiku-4.5",


### PR DESCRIPTION
## Summary

* Use `gemini-3-flash-preview` as the default Google Gemini model.
* Fix the `gemini-2-5-flash` typo to `gemini-2.5-flash`.
* Add regression coverage for the Google CLI model defaults.

## Testing

* `npx --yes pnpm@11.19.0 --filter @inbox-zero/cli test`
* `npx --yes pnpm@11.19.0 check`

Fixes #3440


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the default Google Gemini model to `gemini-3-flash-preview`.
  - Updated the economy Google Gemini model to `gemini-2.5-flash`.
  - Google model selections now use the latest configured model identifiers when defaults are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->