### PR TITLE
desktop: detect hosted web app updates

### DIFF
--- a/apps/web/providers/GlobalProviders.tsx
+++ b/apps/web/providers/GlobalProviders.tsx
@@ -4,6 +4,13 @@ import type React from "react";
 import { useEffect } from "react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { SerwistProvider, useSerwist } from "@serwist/next/react";
+import { toast } from "sonner";
+import {
+  getInboxZeroDesktopApp,
+  shouldCheckForDesktopWebUpdate,
+} from "@/utils/desktop-app";
+
+const DESKTOP_WEB_UPDATE_TOAST_ID = "desktop-web-update";
 
 export function GlobalProviders(props: { children: React.ReactNode }) {
   return (
@@ -16,7 +23,7 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
       cacheOnNavigation={false}
       disable={process.env.NODE_ENV !== "production"}
     >
-      <RegisterServiceWorker />
+      <ManageServiceWorker />
       <NuqsAdapter>{props.children}</NuqsAdapter>
     </SerwistProvider>
   );
@@ -25,11 +32,78 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
 // SerwistProvider's own register drops the promise, so the failures that come
 // with crawlers, webviews and private browsing surface as unhandled rejections.
 // The worker is precache-only, so swallowing them is safe.
-function RegisterServiceWorker() {
+function ManageServiceWorker() {
   const { serwist } = useSerwist();
 
   useEffect(() => {
-    serwist?.register().catch(() => {});
+    if (!serwist) return;
+
+    const isDesktopApp = Boolean(getInboxZeroDesktopApp());
+    let hadController = Boolean(navigator.serviceWorker.controller);
+    let lastCheckedAt: number | null = null;
+    let registration: ServiceWorkerRegistration | undefined;
+
+    const notifyAboutUpdate = () => {
+      if (hadController && isDesktopApp) {
+        toast.info("Update available", {
+          action: {
+            label: "Reload",
+            onClick: () => window.location.reload(),
+          },
+          description: "Reload Inbox Zero to use the latest version.",
+          duration: Number.POSITIVE_INFINITY,
+          id: DESKTOP_WEB_UPDATE_TOAST_ID,
+        });
+      }
+      hadController = true;
+    };
+
+    const checkForUpdate = async () => {
+      const now = Date.now();
+      if (
+        !shouldCheckForDesktopWebUpdate({
+          isDesktopApp,
+          isOnline: navigator.onLine,
+          isVisible: document.visibilityState === "visible",
+          lastCheckedAt,
+          now,
+        })
+      ) {
+        return;
+      }
+
+      lastCheckedAt = now;
+      try {
+        registration ??= await navigator.serviceWorker.getRegistration();
+        await registration?.update();
+      } catch {
+        // Update checks are best-effort and should never interrupt the app.
+      }
+    };
+
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      notifyAboutUpdate,
+    );
+    document.addEventListener("visibilitychange", checkForUpdate);
+    window.addEventListener("online", checkForUpdate);
+
+    serwist
+      .register()
+      .then((serviceWorkerRegistration) => {
+        registration ??= serviceWorkerRegistration;
+        return checkForUpdate();
+      })
+      .catch(() => {});
+
+    return () => {
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        notifyAboutUpdate,
+      );
+      document.removeEventListener("visibilitychange", checkForUpdate);
+      window.removeEventListener("online", checkForUpdate);
+    };
   }, [serwist]);
 
   return null;

--- a/apps/web/utils/desktop-app.test.ts
+++ b/apps/web/utils/desktop-app.test.ts
@@ -69,4 +69,16 @@ describe("shouldCheckForDesktopWebUpdate", () => {
       }),
     ).toBe(true);
   });
+
+  it("checks when the previous timestamp is ahead of the current clock", () => {
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: true,
+        isVisible: true,
+        lastCheckedAt: now + 1,
+        now,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/web/utils/desktop-app.test.ts
+++ b/apps/web/utils/desktop-app.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS,
+  shouldCheckForDesktopWebUpdate,
+} from "./desktop-app";
+
+describe("shouldCheckForDesktopWebUpdate", () => {
+  const now = 1_000_000;
+
+  it("checks when the desktop app is first visible", () => {
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: true,
+        isVisible: true,
+        lastCheckedAt: null,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not check in a browser or while the app is hidden", () => {
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: false,
+        isOnline: true,
+        isVisible: true,
+        lastCheckedAt: null,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: true,
+        isVisible: false,
+        lastCheckedAt: null,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: false,
+        isVisible: true,
+        lastCheckedAt: null,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("checks again only after the interval has elapsed", () => {
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: true,
+        isVisible: true,
+        lastCheckedAt: now - DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS + 1,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCheckForDesktopWebUpdate({
+        isDesktopApp: true,
+        isOnline: true,
+        isVisible: true,
+        lastCheckedAt: now - DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS,
+        now,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/utils/desktop-app.ts
+++ b/apps/web/utils/desktop-app.ts
@@ -36,6 +36,7 @@ export function shouldCheckForDesktopWebUpdate({
   if (!isDesktopApp || !isOnline || !isVisible) return false;
   return (
     lastCheckedAt === null ||
+    now < lastCheckedAt ||
     now - lastCheckedAt >= DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS
   );
 }

--- a/apps/web/utils/desktop-app.ts
+++ b/apps/web/utils/desktop-app.ts
@@ -1,5 +1,7 @@
 export type DesktopAuthProvider = "apple" | "google" | "microsoft";
 
+export const DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
 export type InboxZeroDesktopApi = {
   startAuth: (
     provider: DesktopAuthProvider,
@@ -16,4 +18,24 @@ declare global {
 export function getInboxZeroDesktopApp(): InboxZeroDesktopApi | undefined {
   if (typeof window === "undefined") return;
   return window.inboxZeroDesktop;
+}
+
+export function shouldCheckForDesktopWebUpdate({
+  isDesktopApp,
+  isOnline,
+  isVisible,
+  lastCheckedAt,
+  now,
+}: {
+  isDesktopApp: boolean;
+  isOnline: boolean;
+  isVisible: boolean;
+  lastCheckedAt: number | null;
+  now: number;
+}): boolean {
+  if (!isDesktopApp || !isOnline || !isVisible) return false;
+  return (
+    lastCheckedAt === null ||
+    now - lastCheckedAt >= DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS
+  );
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260902-212125_pr-3490_60321bec90e4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Automatically checks for a newer hosted web deployment when the desktop app returns to the foreground after the check interval.

- Shows a persistent reload action only after a new service worker takes control.
- Skips browser, hidden, and offline checks and never forces a reload over unsaved work.
- Adds focused coverage for initial, throttled, hidden, browser, and offline checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop app users are now notified when a web update is available.
  - A persistent “Update available” notification includes an option to reload and apply the update.
  - Updates are checked when the app starts, returns to visibility, or reconnects online, with checks limited to periodic intervals.
  - Update checks are performed only when the app is online and visible, helping avoid unnecessary interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->