### PR TITLE
mail: add custom from-address/domain split inboxes

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -86,6 +86,7 @@ import {
   createMailSplitAction,
   createMailSplitFromPromptAction,
   deleteMailSplitAction,
+  renameMailSplitAction,
   setDefaultMailSplitsAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
@@ -815,6 +816,21 @@ export function MailShell() {
     [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
   );
 
+  const onRenameSplit = useCallback(
+    async (splitId: string, name: string) => {
+      const result = await renameMailSplitAction(emailAccountId, {
+        id: splitId,
+        name,
+      });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return;
+      }
+      mutateSettings();
+    },
+    [emailAccountId, mutateSettings],
+  );
+
   const onSetDefaultSplits = useCallback(
     async (enabled: boolean) => {
       const result = await setDefaultMailSplitsAction(emailAccountId, {
@@ -1074,6 +1090,7 @@ export function MailShell() {
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}
+                onRename={onRenameSplit}
                 newSplitOptions={newSplitOptions}
                 onCreateSplit={onCreateSplit}
                 onCreateSplitFromPrompt={onCreateSplitFromPrompt}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { Loader2Icon, PlusIcon, SparklesIcon } from "lucide-react";
-import type { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import { parseFromSplitInput } from "@/utils/mail/from-split";
 import {
   Command,
   CommandGroup,
@@ -69,6 +70,7 @@ export function NewSplitPopover({
   const isBusy = isCreating || isUpdatingDefaults;
   const trimmedPrompt = prompt.trim();
   const normalizedPrompt = trimmedPrompt.toLowerCase();
+  const fromFilter = parseFromSplitInput(trimmedPrompt);
   const hasMatchingOption =
     options.some((option) => {
       const groupTitle = GROUPS.find(
@@ -138,7 +140,35 @@ export function NewSplitPopover({
             className="h-9 text-xs"
           />
           <CommandList className="max-h-56">
-            {trimmedPrompt && !hasMatchingOption && (
+            {fromFilter && (
+              <CommandGroup forceMount heading="From">
+                <CommandItem
+                  forceMount
+                  value={`from:${fromFilter.value}`}
+                  keywords={[
+                    fromFilter.value,
+                    fromFilter.name,
+                    "from",
+                    "inbox",
+                  ]}
+                  onSelect={() => {
+                    if (isBusy) return;
+                    onCreate({
+                      name: fromFilter.name,
+                      kind: MailSplitKind.FROM,
+                      value: fromFilter.value,
+                    });
+                    changeOpen(false);
+                  }}
+                  disabled={isBusy}
+                  className="text-xs"
+                >
+                  <span className="truncate">{fromFilter.value} in Inbox</span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {trimmedPrompt && !hasMatchingOption && !fromFilter && (
               <CommandGroup forceMount>
                 <CommandItem
                   forceMount

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -126,6 +126,12 @@ function SplitTab({
   const [isEditing, setIsEditing] = useState(false);
   const [draftName, setDraftName] = useState(split.name);
 
+  const startRename = () => {
+    if (!split.deletable) return;
+    setDraftName(split.name);
+    setIsEditing(true);
+  };
+
   const commitRename = () => {
     const next = draftName.trim();
     setIsEditing(false);
@@ -173,10 +179,12 @@ function SplitTab({
           ref={active ? activeTabRef : undefined}
           data-split-tab
           onClick={() => onSelect(split.id)}
-          onDoubleClick={() => {
-            if (!split.deletable) return;
-            setDraftName(split.name);
-            setIsEditing(true);
+          onDoubleClick={startRename}
+          onKeyDown={(event) => {
+            if (event.key === "F2") {
+              event.preventDefault();
+              startRename();
+            }
           }}
           aria-current={active ? "true" : undefined}
           title={split.deletable ? "Double-click to rename" : undefined}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -210,7 +210,9 @@ function SplitTab({
             }
           }}
           aria-current={active ? "true" : undefined}
-          title={split.deletable ? "Double-click to rename" : undefined}
+          title={
+            split.deletable ? "Double-click or press F2 to rename" : undefined
+          }
           className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {split.name}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -125,6 +125,8 @@ function SplitTab({
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [draftName, setDraftName] = useState(split.name);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const wasEditingRef = useRef(false);
 
   const startRename = () => {
     if (!split.deletable) return;
@@ -132,14 +134,35 @@ function SplitTab({
     setIsEditing(true);
   };
 
+  const stopEditing = () => {
+    setIsEditing(false);
+  };
+
   const commitRename = () => {
     const next = draftName.trim();
-    setIsEditing(false);
+    stopEditing();
     if (!next || next === split.name) {
       setDraftName(split.name);
       return;
     }
     onRename(split.id, next.slice(0, 60));
+  };
+
+  // F2 rename unmounts the input; restore focus so keyboard users keep place.
+  useEffect(() => {
+    if (wasEditingRef.current && !isEditing) {
+      buttonRef.current?.focus({ preventScroll: true });
+    }
+    wasEditingRef.current = isEditing;
+  }, [isEditing]);
+
+  const setTabButtonRef = (node: HTMLButtonElement | null) => {
+    buttonRef.current = node;
+    if (active) {
+      (
+        activeTabRef as React.MutableRefObject<HTMLButtonElement | null>
+      ).current = node;
+    }
   };
 
   return (
@@ -164,7 +187,7 @@ function SplitTab({
             if (event.key === "Escape") {
               event.preventDefault();
               setDraftName(split.name);
-              setIsEditing(false);
+              stopEditing();
             }
           }}
           aria-label={`Rename the ${split.name} split`}
@@ -176,7 +199,7 @@ function SplitTab({
       ) : (
         <button
           type="button"
-          ref={active ? activeTabRef : undefined}
+          ref={setTabButtonRef}
           data-split-tab
           onClick={() => onSelect(split.id)}
           onDoubleClick={startRename}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { XIcon } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   type NewSplitDraft,
   type NewSplitOption,
@@ -23,6 +23,7 @@ export type SplitTabsProps = {
   activeSplitId: string | null;
   onSelect: (splitId: string) => void;
   onDelete: (splitId: string) => void;
+  onRename: (splitId: string, name: string) => void;
   newSplitOptions: NewSplitOption[];
   onCreateSplit: (draft: NewSplitDraft) => void;
   onCreateSplitFromPrompt: (prompt: string) => Promise<boolean>;
@@ -39,6 +40,7 @@ export function SplitTabs({
   activeSplitId,
   onSelect,
   onDelete,
+  onRename,
   newSplitOptions,
   onCreateSplit,
   onCreateSplitFromPrompt,
@@ -77,42 +79,17 @@ export function SplitTabs({
         className,
       )}
     >
-      {splits.map((split) => {
-        const active = split.id === activeSplitId;
-
-        return (
-          <div
-            key={split.id}
-            className={cn(
-              "flex items-center gap-1 rounded-full py-0.5 pr-1 pl-2.5 text-xs",
-              active
-                ? "bg-primary/10 font-medium text-primary"
-                : "text-muted-foreground hover:bg-accent hover:text-foreground",
-            )}
-          >
-            <button
-              type="button"
-              ref={active ? activeTabRef : undefined}
-              data-split-tab
-              onClick={() => onSelect(split.id)}
-              aria-current={active ? "true" : undefined}
-              className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              {split.name}
-            </button>
-            {active && split.deletable && (
-              <button
-                type="button"
-                onClick={() => onDelete(split.id)}
-                aria-label={`Remove the ${split.name} split`}
-                className="rounded-full p-0.5 text-primary/60 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <XIcon className="size-3" />
-              </button>
-            )}
-          </div>
-        );
-      })}
+      {splits.map((split) => (
+        <SplitTab
+          key={split.id}
+          split={split}
+          active={split.id === activeSplitId}
+          activeTabRef={activeTabRef}
+          onSelect={onSelect}
+          onDelete={onDelete}
+          onRename={onRename}
+        />
+      ))}
 
       {canCreateSplits && (
         <NewSplitPopover
@@ -127,6 +104,97 @@ export function SplitTabs({
 
       <div className="flex-1" />
       <Kbd title="Next split">{getShortcutHint("nextSplit")}</Kbd>
+    </div>
+  );
+}
+
+function SplitTab({
+  split,
+  active,
+  activeTabRef,
+  onSelect,
+  onDelete,
+  onRename,
+}: {
+  split: MailSplitTab;
+  active: boolean;
+  activeTabRef: React.RefObject<HTMLButtonElement | null>;
+  onSelect: (splitId: string) => void;
+  onDelete: (splitId: string) => void;
+  onRename: (splitId: string, name: string) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftName, setDraftName] = useState(split.name);
+
+  const commitRename = () => {
+    const next = draftName.trim();
+    setIsEditing(false);
+    if (!next || next === split.name) {
+      setDraftName(split.name);
+      return;
+    }
+    onRename(split.id, next.slice(0, 60));
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-full py-0.5 pr-1 pl-2.5 text-xs",
+        active
+          ? "bg-primary/10 font-medium text-primary"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      {isEditing ? (
+        <input
+          value={draftName}
+          onChange={(event) => setDraftName(event.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              commitRename();
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setDraftName(split.name);
+              setIsEditing(false);
+            }
+          }}
+          aria-label={`Rename the ${split.name} split`}
+          maxLength={60}
+          // biome-ignore lint/a11y/noAutofocus: renaming starts from an explicit double-click
+          autoFocus
+          className="w-24 bg-transparent py-0.5 pr-1.5 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      ) : (
+        <button
+          type="button"
+          ref={active ? activeTabRef : undefined}
+          data-split-tab
+          onClick={() => onSelect(split.id)}
+          onDoubleClick={() => {
+            if (!split.deletable) return;
+            setDraftName(split.name);
+            setIsEditing(true);
+          }}
+          aria-current={active ? "true" : undefined}
+          title={split.deletable ? "Double-click to rename" : undefined}
+          className="py-0.5 pr-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {split.name}
+        </button>
+      )}
+      {active && split.deletable && !isEditing && (
+        <button
+          type="button"
+          onClick={() => onDelete(split.id)}
+          aria-label={`Remove the ${split.name} split`}
+          className="rounded-full p-0.5 text-primary/60 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <XIcon className="size-3" />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/prisma/migrations/20260902213000_add_mail_split_from_kind/migration.sql
+++ b/apps/web/prisma/migrations/20260902213000_add_mail_split_from_kind/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "MailSplitKind" ADD VALUE 'FROM';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -237,7 +237,8 @@ model EmailAccount {
 }
 
 // A saved filter shown as a tab above the mail list. `value` holds the label id for
-// LABEL splits and the provider category for CATEGORY splits; it is unused for INBOX/UNREAD.
+// LABEL splits, the provider category for CATEGORY splits, and the sender/domain for
+// FROM splits (always scoped to the inbox); it is unused for INBOX/UNREAD.
 model MailSplit {
   id        String        @id @default(cuid())
   createdAt DateTime      @default(now())
@@ -1965,6 +1966,7 @@ enum MailSplitKind {
   UNREAD
   LABEL
   CATEGORY
+  FROM
 }
 
 enum DraftReplyConfidence {

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -125,6 +125,32 @@ describe("mail split actions", () => {
     expect(result?.serverError).toBe('You already have a "Unread" split.');
   });
 
+  it("creates a from-split directly from a sender/domain prompt without calling the AI", async () => {
+    const split = {
+      id: "split-from-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      name: "getinboxzero.on.crisp.email",
+      kind: MailSplitKind.FROM,
+      value: "@getinboxzero.on.crisp.email",
+      order: 0,
+      emailAccountId: EMAIL_ACCOUNT_ID,
+    };
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [{ status: "created", ...split }],
+    ] as never);
+
+    const result = await createMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
+      prompt:
+        "all emails from @getinboxzero.on.crisp.email that are in the inbox",
+      options: PROMPT_OPTIONS,
+    });
+
+    expect(result?.data).toEqual({ split });
+    expect(aiPromptToSplit).not.toHaveBeenCalled();
+  });
+
   it("creates the split the AI matched from a description", async () => {
     vi.mocked(aiPromptToSplit).mockResolvedValue({
       reasoning: "Receipts filters for what the user described",

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -15,6 +15,8 @@ import {
   updateMailPreferencesBody,
 } from "@/utils/actions/mail-split.validation";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
+import { parseFromSplitInput } from "@/utils/mail/from-split";
+import { MailSplitKind } from "@/generated/prisma/enums";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { lockMailSplits } from "@/utils/mail/split-lock";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
@@ -43,6 +45,17 @@ export const createMailSplitFromPromptAction = actionClient
   .inputSchema(createMailSplitFromPromptBody)
   .action(
     async ({ ctx: { emailAccountId }, parsedInput: { prompt, options } }) => {
+      const fromFilter = parseFromSplitInput(prompt);
+      if (fromFilter) {
+        const split = await createMailSplitOrThrow({
+          emailAccountId,
+          name: fromFilter.name,
+          kind: MailSplitKind.FROM,
+          value: fromFilter.value,
+        });
+        return { split };
+      }
+
       const emailAccount = await getEmailAccountWithAi({ emailAccountId });
       if (!emailAccount) throw new SafeError("Email account not found");
 
@@ -127,8 +140,21 @@ export const updateMailPreferencesAction = actionClient
 async function createMailSplitOrThrow(
   data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">,
 ): Promise<MailSplit> {
+  let splitData = data;
+  if (splitData.kind === MailSplitKind.FROM) {
+    const parsed = parseFromSplitInput(splitData.value ?? "");
+    if (!parsed) {
+      throw new SafeError("From splits need an email address or @domain");
+    }
+    splitData = {
+      ...splitData,
+      name: splitData.name || parsed.name,
+      value: parsed.value,
+    };
+  }
+
   try {
-    const result = await createMailSplit(data);
+    const result = await createMailSplit(splitData);
 
     if (!result) {
       throw new SafeError("Could not create split. Please try again.");

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import { parseFromSplitInput } from "@/utils/mail/from-split";
 
 // LABEL splits carry a provider label id; CATEGORY splits carry a provider category
 // (e.g. CATEGORY_PERSONAL). INBOX and UNREAD need no value.
 const requiresValue = (kind: MailSplitKind) =>
-  kind === MailSplitKind.LABEL || kind === MailSplitKind.CATEGORY;
+  kind === MailSplitKind.LABEL ||
+  kind === MailSplitKind.CATEGORY ||
+  kind === MailSplitKind.FROM;
 
 export const createMailSplitBody = z
   .object({
@@ -13,9 +16,20 @@ export const createMailSplitBody = z
     value: z.string().trim().min(1).nullish(),
   })
   .refine((data) => !requiresValue(data.kind) || !!data.value, {
-    message: "Label and category splits need a value",
+    message: "Label, category, and from splits need a value",
     path: ["value"],
-  });
+  })
+  .refine(
+    (data) =>
+      data.kind !== MailSplitKind.FROM ||
+      !data.value ||
+      parseFromSplitInput(data.value)?.value ===
+        data.value.trim().toLowerCase(),
+    {
+      message: "From splits need an email address or @domain",
+      path: ["value"],
+    },
+  );
 export type CreateMailSplitBody = z.infer<typeof createMailSplitBody>;
 
 // The client sends the account's available options (labels, categories, states)
@@ -29,7 +43,7 @@ const splitPromptOption = z
     value: z.string().trim().min(1).nullish(),
   })
   .refine((data) => !requiresValue(data.kind) || !!data.value, {
-    message: "Label and category splits need a value",
+    message: "Label, category, and from splits need a value",
     path: ["value"],
   });
 

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -352,6 +352,47 @@ describe("synced mailbox cache", () => {
     ]);
   });
 
+  it("matches domain from-filters against sender suffixes", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-24T00:00:00.000Z"),
+      page: {
+        cursor: "cursor",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          getMessage({
+            id: "domain-match",
+            threadId: "domain-thread",
+            from: "Bot <noreply@crisp.email>",
+            internalDate: "2026-08-22T10:00:00.000Z",
+            labelIds: ["INBOX"],
+          }),
+          getMessage({
+            id: "domain-miss",
+            threadId: "other-domain-thread",
+            from: "Other <person@example.com>",
+            internalDate: "2026-08-22T11:00:00.000Z",
+            labelIds: ["INBOX"],
+          }),
+        ],
+      },
+    });
+
+    const snapshot = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: {
+        type: "inbox",
+        fromEmail: "@crisp.email",
+      },
+    });
+
+    expect(snapshot?.threads.map((thread) => thread.id)).toEqual([
+      "domain-thread",
+    ]);
+  });
+
   it("falls back for views the inbox snapshot cannot answer correctly", async () => {
     await applyMailboxSyncPage({
       emailAccountId: "account-1",

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -1,5 +1,6 @@
 import { internalDateToDate, sortByInternalDate } from "@/utils/date";
 import { canonicalizeEmailAddress } from "@/utils/email";
+import { getFromFilterDomain } from "@/utils/mail/from-split";
 import type { MailboxSyncPage } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import type { CombinedListThread } from "@/utils/threads/load-combined";
@@ -529,12 +530,14 @@ function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {
   }
 
   return messages.some((message) => {
-    if (
-      query.fromEmail &&
-      canonicalizeEmailAddress(message.headers.from) !==
-        canonicalizeEmailAddress(query.fromEmail)
-    ) {
-      return false;
+    if (query.fromEmail) {
+      const messageFrom = canonicalizeEmailAddress(message.headers.from);
+      const domain = getFromFilterDomain(query.fromEmail);
+      if (domain) {
+        if (!messageFrom.endsWith(`@${domain}`)) return false;
+      } else if (messageFrom !== canonicalizeEmailAddress(query.fromEmail)) {
+        return false;
+      }
     }
     const timestamp = getMessageTimestamp(message);
     if (query.after && timestamp <= query.after.getTime()) return false;

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -386,6 +386,7 @@ describe("OutlookProvider.getSentMessageIds", () => {
       apiPath: "/me/mailFolders/sentitems/messages",
       filter:
         "sentDateTime ge 2026-03-31T12:00:00.000Z and sentDateTime le 2026-04-30T17:00:00.000Z",
+      top: 50,
     });
     expect(result).toEqual({
       messages: [{ id: "message-1", threadId: "thread-1" }],
@@ -423,7 +424,53 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     expect(client.getRequestLog()[0]).toEqual({
       apiPath: "/me/mailFolders/inbox/messages",
       filter: `inferenceClassification eq '${inboxSection}'`,
+      top: 50,
     });
+  });
+
+  it("scopes domain FROM queries to the inbox via $search", async () => {
+    const client = createMockOutlookClient([
+      createMessage({
+        id: "domain-message",
+        conversationId: "domain-thread",
+        parentFolderId: "inbox-folder-id",
+      }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    await provider.getThreadsWithQuery({
+      query: { type: "inbox", fromEmail: "@getinboxzero.on.crisp.email" },
+      maxResults: 50,
+    });
+
+    expect(client.getRequestLog()[0]).toEqual({
+      apiPath: "/me/mailFolders/inbox/messages",
+      filter: undefined,
+      search: '"from:@getinboxzero.on.crisp.email"',
+      top: 25,
+    });
+  });
+
+  it("keeps exact FROM address queries on $filter with the inbox folder", async () => {
+    const client = createMockOutlookClient([
+      createMessage({
+        id: "exact-message",
+        conversationId: "exact-thread",
+        parentFolderId: "inbox-folder-id",
+      }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    await provider.getThreadsWithQuery({
+      query: { type: "inbox", fromEmail: "support@example.com" },
+    });
+
+    const request = client.getRequestLog()[0];
+    expect(request?.search).toBeUndefined();
+    expect(request?.filter).toContain(
+      "from/emailAddress/address eq 'support@example.com'",
+    );
+    expect(request?.filter).toContain("parentFolderId eq");
   });
 
   it("does not apply an inbox section filter to a custom folder", async () => {
@@ -439,6 +486,7 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     expect(client.getRequestLog()[0]).toEqual({
       apiPath: "/me/mailFolders/custom-folder/messages",
       filter: undefined,
+      top: 50,
     });
   });
 
@@ -961,6 +1009,7 @@ describe("OutlookProvider.searchThreads", () => {
       apiPath: "/me/messages",
       filter: undefined,
       search: '"quarterly invoice"',
+      top: 25,
     });
     expect(result.threads.map((thread) => thread.id)).toEqual(["thread-1"]);
   });
@@ -1078,6 +1127,7 @@ function createMockOutlookClient(
     apiPath: string;
     filter?: string;
     search?: string;
+    top?: number;
   }> = [];
   const selectLog: string[] = [];
 
@@ -1086,6 +1136,7 @@ function createMockOutlookClient(
       api: (apiPath: string) => {
         let filterValue: string | undefined;
         let searchValue: string | undefined;
+        let topValue: number | undefined;
         const request = {
           filter: (value: string) => {
             filterValue = value;
@@ -1100,13 +1151,17 @@ function createMockOutlookClient(
             return request;
           },
           expand: () => request,
-          top: () => request,
+          top: (value: number) => {
+            topValue = value;
+            return request;
+          },
           orderby: () => request,
           get: async () => {
             requestLog.push({
               apiPath,
               filter: filterValue,
               search: searchValue,
+              top: topValue,
             });
             const response = options?.responsesByApiPath?.[apiPath];
             if (typeof response === "function") {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -450,6 +450,53 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
       top: 25,
     });
   });
+  it("keeps paging domain FROM searches until enough threads match local filters", async () => {
+    const client = createMockOutlookClient([], {
+      responsesByApiPath: {
+        "/me/mailFolders/inbox/messages": {
+          value: [
+            createMessage({
+              id: "read-message",
+              conversationId: "read-thread",
+              parentFolderId: "inbox-folder-id",
+              isRead: true,
+            }),
+          ],
+          "@odata.nextLink":
+            "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$skiptoken=next",
+        },
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$skiptoken=next":
+          {
+            value: [
+              createMessage({
+                id: "unread-message",
+                conversationId: "unread-thread",
+                parentFolderId: "inbox-folder-id",
+                isRead: false,
+              }),
+            ],
+          },
+      },
+    });
+    const provider = new OutlookProvider(client);
+
+    const result = await provider.getThreadsWithQuery({
+      query: {
+        type: "inbox",
+        fromEmail: "@example.com",
+        isUnread: true,
+      },
+      maxResults: 1,
+    });
+
+    expect(result.threads.map((thread) => thread.id)).toEqual([
+      "unread-thread",
+    ]);
+    expect(client.getRequestLog().map((request) => request.apiPath)).toEqual([
+      "/me/mailFolders/inbox/messages",
+      "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages?$skiptoken=next",
+    ]);
+  });
 
   it("keeps exact FROM address queries on $filter with the inbox folder", async () => {
     const client = createMockOutlookClient([

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -84,6 +84,7 @@ import type { SendEmailBody } from "@/utils/types/mail";
 import { getOutlookCategoryPreset } from "@/utils/outlook/category-colors";
 import { unwatchOutlook, watchOutlook } from "@/utils/outlook/watch";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
+import { getFromFilterDomain } from "@/utils/mail/from-split";
 import {
   extractEmailAddress,
   getSearchTermForSender,
@@ -1699,8 +1700,16 @@ export class OutlookProvider implements EmailProvider {
       }
 
       if (fromEmail) {
-        const escapedEmail = escapeODataString(fromEmail);
-        filters.push(`from/emailAddress/address eq '${escapedEmail}'`);
+        const domain = getFromFilterDomain(fromEmail);
+        if (domain) {
+          // Domain filters can't use eq; endsWith needs the advanced query headers below.
+          filters.push(
+            `endswith(from/emailAddress/address,'@${escapeODataString(domain)}')`,
+          );
+        } else {
+          const escapedEmail = escapeODataString(fromEmail);
+          filters.push(`from/emailAddress/address eq '${escapedEmail}'`);
+        }
       }
 
       if (after) {
@@ -1729,6 +1738,14 @@ export class OutlookProvider implements EmailProvider {
             : MESSAGE_SELECT_FIELDS,
         )
         .top(maxResults);
+
+      const domainFromFilter =
+        fromEmail != null ? getFromFilterDomain(fromEmail) : null;
+
+      if (domainFromFilter) {
+        // endsWith is an advanced query; Graph requires these headers.
+        request = request.header("ConsistencyLevel", "eventual").count(true);
+      }
 
       if (filter) {
         request = request.filter(filter);

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1839,7 +1839,15 @@ export class OutlookProvider implements EmailProvider {
       collectedMessages.push(...response.value);
       nextPageToken = response["@odata.nextLink"];
 
-      if (!requiresLocalLabelFiltering || !nextPageToken) break;
+      // Domain $search pages are capped at 25 and may be thinned by local
+      // after/before/unread/inboxSection filters — keep paging for those too.
+      const requiresDomainSearchPaging = Boolean(domainFromFilter);
+      if (
+        (!requiresLocalLabelFiltering && !requiresDomainSearchPaging) ||
+        !nextPageToken
+      ) {
+        break;
+      }
 
       const matchedThreads = buildOutlookThreadsFromMessages({
         messages: collectedMessages,

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1663,10 +1663,31 @@ export class OutlookProvider implements EmailProvider {
     );
     const maxResults = options.maxResults || 50;
 
+    const domainFromFilter =
+      fromEmail != null ? getFromFilterDomain(fromEmail) : null;
+    const domainSearchConstraints = domainFromFilter
+      ? {
+          after: after ?? undefined,
+          before: before ?? undefined,
+          isUnread: isUnread ?? undefined,
+          inboxSection: folderId ? undefined : inboxSection,
+        }
+      : null;
+
     const fetchThreadPage = async (pageToken?: string) => {
       const nextLink = resolveMicrosoftGraphNextLink(pageToken);
       if (nextLink) {
-        return await client.api(nextLink).get();
+        const response = await client.api(nextLink).get();
+        if (!domainSearchConstraints) {
+          return response;
+        }
+        return {
+          ...response,
+          value: filterMessagesForDomainSearchConstraints(
+            response.value ?? [],
+            domainSearchConstraints,
+          ),
+        };
       }
 
       // Determine endpoint and build filters based on query type
@@ -1724,9 +1745,6 @@ export class OutlookProvider implements EmailProvider {
         filters.push(`inferenceClassification eq '${inboxSection}'`);
       }
 
-      const domainFromFilter =
-        fromEmail != null ? getFromFilterDomain(fromEmail) : null;
-
       // Graph forbids combining $search with $filter/$orderby. Scope domain
       // sender searches via a folder endpoint so inbox (etc.) still applies.
       if (
@@ -1746,13 +1764,19 @@ export class OutlookProvider implements EmailProvider {
       const filter = filters.length > 0 ? filters.join(" and ") : undefined;
       const pageSize = domainFromFilter ? Math.min(maxResults, 25) : maxResults;
 
+      const selectFields =
+        options.messageFormat === "metadata"
+          ? MESSAGE_LIST_SELECT_FIELDS
+          : MESSAGE_SELECT_FIELDS;
+      // Domain+$search cannot $filter inboxSection; select it for local filtering.
+      const domainSelectFields =
+        domainFromFilter && inboxSection && !folderId
+          ? `${selectFields},inferenceClassification`
+          : selectFields;
+
       let request = client
         .api(endpoint)
-        .select(
-          options.messageFormat === "metadata"
-            ? MESSAGE_LIST_SELECT_FIELDS
-            : MESSAGE_SELECT_FIELDS,
-        )
+        .select(domainSelectFields)
         .top(pageSize);
 
       // Exact addresses keep using $filter; domain matching uses $search.
@@ -1773,18 +1797,16 @@ export class OutlookProvider implements EmailProvider {
 
       // Folder scope is preserved via endpoint; remaining constraints that
       // would have been $filter must be applied locally for domain searches.
-      if (!domainFromFilter) {
+      if (!domainSearchConstraints) {
         return response;
       }
 
       return {
         ...response,
-        value: filterMessagesForDomainSearchConstraints(response.value ?? [], {
-          after: after ?? undefined,
-          before: before ?? undefined,
-          isUnread: isUnread ?? undefined,
-          inboxSection: folderId ? undefined : inboxSection,
-        }),
+        value: filterMessagesForDomainSearchConstraints(
+          response.value ?? [],
+          domainSearchConstraints,
+        ),
       };
     };
 
@@ -2468,11 +2490,8 @@ function filterMessagesForDomainSearchConstraints(
 
     if (isUnread && message.isRead !== false) return false;
 
-    if (
-      inboxSection &&
-      message.inferenceClassification &&
-      message.inferenceClassification !== inboxSection
-    ) {
+    if (inboxSection && message.inferenceClassification !== inboxSection) {
+      // Missing inferenceClassification fails closed once we select the field.
       return false;
     }
 

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1724,7 +1724,27 @@ export class OutlookProvider implements EmailProvider {
         filters.push(`inferenceClassification eq '${inboxSection}'`);
       }
 
+      const domainFromFilter =
+        fromEmail != null ? getFromFilterDomain(fromEmail) : null;
+
+      // Graph forbids combining $search with $filter/$orderby. Scope domain
+      // sender searches via a folder endpoint so inbox (etc.) still applies.
+      if (
+        domainFromFilter &&
+        endpoint === "/me/messages" &&
+        !hasExplicitLabelFilters
+      ) {
+        const scopedEndpoint = getOutlookDomainSearchFolderEndpoint({
+          type,
+          folderId,
+        });
+        if (scopedEndpoint) {
+          endpoint = scopedEndpoint;
+        }
+      }
+
       const filter = filters.length > 0 ? filters.join(" and ") : undefined;
+      const pageSize = domainFromFilter ? Math.min(maxResults, 25) : maxResults;
 
       let request = client
         .api(endpoint)
@@ -1733,13 +1753,9 @@ export class OutlookProvider implements EmailProvider {
             ? MESSAGE_LIST_SELECT_FIELDS
             : MESSAGE_SELECT_FIELDS,
         )
-        .top(maxResults);
+        .top(pageSize);
 
-      const domainFromFilter =
-        fromEmail != null ? getFromFilterDomain(fromEmail) : null;
-
-      // Graph forbids combining $search with $filter/$orderby. Domain sender
-      // matching has to go through $search; exact addresses keep using $filter.
+      // Exact addresses keep using $filter; domain matching uses $search.
       if (domainFromFilter) {
         const escapedDomain = domainFromFilter.replace(/"/g, "");
         request = request.search(`"from:@${escapedDomain}"`);
@@ -1753,7 +1769,23 @@ export class OutlookProvider implements EmailProvider {
         }
       }
 
-      return await request.get();
+      const response = await request.get();
+
+      // Folder scope is preserved via endpoint; remaining constraints that
+      // would have been $filter must be applied locally for domain searches.
+      if (!domainFromFilter) {
+        return response;
+      }
+
+      return {
+        ...response,
+        value: filterMessagesForDomainSearchConstraints(response.value ?? [], {
+          after,
+          before,
+          isUnread,
+          inboxSection: folderId ? undefined : inboxSection,
+        }),
+      };
     };
 
     const localPageState = parseOutlookThreadPageToken(options.pageToken);
@@ -2370,6 +2402,82 @@ function getRequiredOutlookThreadLabelIds({
     default:
       return [type];
   }
+}
+
+/** Folder endpoint for domain $search so inbox/sent scope is not lost. */
+function getOutlookDomainSearchFolderEndpoint({
+  type,
+  folderId,
+}: {
+  type?: string | null;
+  folderId?: string | null;
+}): string | null {
+  if (folderId) {
+    return `/me/mailFolders/${encodeURIComponent(folderId)}/messages`;
+  }
+
+  switch (type) {
+    case "sent":
+      return "/me/mailFolders/sentitems/messages";
+    case "archive":
+      return "/me/mailFolders/archive/messages";
+    case "draft":
+      return "/me/mailFolders/drafts/messages";
+    case "spam":
+      return "/me/mailFolders/junkemail/messages";
+    case "trash":
+      return "/me/mailFolders/deleteditems/messages";
+    case "all":
+      // Inbox + archive cannot be expressed as a single folder endpoint.
+      return null;
+    case "unread":
+    case "inbox":
+    case undefined:
+    case null:
+    case "undefined":
+    case "null":
+      return "/me/mailFolders/inbox/messages";
+    default:
+      return "/me/mailFolders/inbox/messages";
+  }
+}
+
+function filterMessagesForDomainSearchConstraints(
+  messages: Message[],
+  {
+    after,
+    before,
+    isUnread,
+    inboxSection,
+  }: {
+    after?: Date;
+    before?: Date;
+    isUnread?: boolean;
+    inboxSection?: string | null;
+  },
+): Message[] {
+  return messages.filter((message) => {
+    if (after || before) {
+      const receivedAt = message.receivedDateTime
+        ? new Date(message.receivedDateTime)
+        : null;
+      if (!receivedAt) return false;
+      if (after && receivedAt <= after) return false;
+      if (before && receivedAt >= before) return false;
+    }
+
+    if (isUnread && message.isRead !== false) return false;
+
+    if (
+      inboxSection &&
+      message.inferenceClassification &&
+      message.inferenceClassification !== inboxSection
+    ) {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 function getDefaultOutlookThreadFolderFilter({

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1780,9 +1780,9 @@ export class OutlookProvider implements EmailProvider {
       return {
         ...response,
         value: filterMessagesForDomainSearchConstraints(response.value ?? [], {
-          after,
-          before,
-          isUnread,
+          after: after ?? undefined,
+          before: before ?? undefined,
+          isUnread: isUnread ?? undefined,
           inboxSection: folderId ? undefined : inboxSection,
         }),
       };
@@ -2450,9 +2450,9 @@ function filterMessagesForDomainSearchConstraints(
     isUnread,
     inboxSection,
   }: {
-    after?: Date;
-    before?: Date;
-    isUnread?: boolean;
+    after?: Date | null;
+    before?: Date | null;
+    isUnread?: boolean | null;
     inboxSection?: string | null;
   },
 ): Message[] {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1701,15 +1701,11 @@ export class OutlookProvider implements EmailProvider {
 
       if (fromEmail) {
         const domain = getFromFilterDomain(fromEmail);
-        if (domain) {
-          // Domain filters can't use eq; endsWith needs the advanced query headers below.
-          filters.push(
-            `endswith(from/emailAddress/address,'@${escapeODataString(domain)}')`,
-          );
-        } else {
+        if (!domain) {
           const escapedEmail = escapeODataString(fromEmail);
           filters.push(`from/emailAddress/address eq '${escapedEmail}'`);
         }
+        // Domain filters use $search below — endswith is unsupported on message from/.
       }
 
       if (after) {
@@ -1742,17 +1738,19 @@ export class OutlookProvider implements EmailProvider {
       const domainFromFilter =
         fromEmail != null ? getFromFilterDomain(fromEmail) : null;
 
+      // Graph forbids combining $search with $filter/$orderby. Domain sender
+      // matching has to go through $search; exact addresses keep using $filter.
       if (domainFromFilter) {
-        // endsWith is an advanced query; Graph requires these headers.
-        request = request.header("ConsistencyLevel", "eventual").count(true);
-      }
+        const escapedDomain = domainFromFilter.replace(/"/g, "");
+        request = request.search(`"from:@${escapedDomain}"`);
+      } else {
+        if (filter) {
+          request = request.filter(filter);
+        }
 
-      if (filter) {
-        request = request.filter(filter);
-      }
-
-      if (!fromEmail) {
-        request = request.orderby("receivedDateTime DESC");
+        if (!fromEmail) {
+          request = request.orderby("receivedDateTime DESC");
+        }
       }
 
       return await request.get();

--- a/apps/web/utils/mail/from-split.test.ts
+++ b/apps/web/utils/mail/from-split.test.ts
@@ -49,6 +49,21 @@ describe("parseFromSplitInput", () => {
     expect(parseFromSplitInput("@a..b.com")).toBeNull();
     expect(parseFromSplitInput("unread")).toBeNull();
     expect(parseFromSplitInput("receipts label")).toBeNull();
+    expect(
+      parseFromSplitInput(
+        'all emails from "user@example.com..evil" that are in the inbox',
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps long filter names unique when truncated", () => {
+    const longLocal = `${"a".repeat(50)}@example.com`;
+    const longerLocal = `${"a".repeat(51)}@example.com`;
+    const first = parseFromSplitInput(longLocal);
+    const second = parseFromSplitInput(longerLocal);
+    expect(first?.name).not.toEqual(second?.name);
+    expect(first?.name.length).toBeLessThanOrEqual(60);
+    expect(second?.name.length).toBeLessThanOrEqual(60);
   });
 });
 

--- a/apps/web/utils/mail/from-split.test.ts
+++ b/apps/web/utils/mail/from-split.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFromFilterDomain,
+  isFromDomainFilter,
+  parseFromSplitInput,
+} from "@/utils/mail/from-split";
+
+describe("parseFromSplitInput", () => {
+  it("parses a bare domain into an inbox from-filter", () => {
+    expect(parseFromSplitInput("@getinboxzero.on.crisp.email")).toEqual({
+      value: "@getinboxzero.on.crisp.email",
+      name: "getinboxzero.on.crisp.email",
+    });
+  });
+
+  it("parses a bare email address", () => {
+    expect(parseFromSplitInput("Support@Example.com")).toEqual({
+      value: "support@example.com",
+      name: "support",
+    });
+  });
+
+  it("parses from: prefixes and inbox phrasing", () => {
+    expect(
+      parseFromSplitInput("from:@getinboxzero.on.crisp.email in inbox"),
+    ).toEqual({
+      value: "@getinboxzero.on.crisp.email",
+      name: "getinboxzero.on.crisp.email",
+    });
+    expect(
+      parseFromSplitInput(
+        'all emails from "@getinboxzero.on.crisp.email" that are in the inbox',
+      ),
+    ).toEqual({
+      value: "@getinboxzero.on.crisp.email",
+      name: "getinboxzero.on.crisp.email",
+    });
+  });
+
+  it("returns null for unrelated descriptions", () => {
+    expect(parseFromSplitInput("unread")).toBeNull();
+    expect(parseFromSplitInput("receipts label")).toBeNull();
+  });
+});
+
+describe("from domain helpers", () => {
+  it("detects domain filters", () => {
+    expect(isFromDomainFilter("@example.com")).toBe(true);
+    expect(isFromDomainFilter("user@example.com")).toBe(false);
+    expect(getFromFilterDomain("@Example.COM")).toBe("example.com");
+    expect(getFromFilterDomain("user@example.com")).toBeNull();
+  });
+});

--- a/apps/web/utils/mail/from-split.test.ts
+++ b/apps/web/utils/mail/from-split.test.ts
@@ -13,10 +13,10 @@ describe("parseFromSplitInput", () => {
     });
   });
 
-  it("parses a bare email address", () => {
+  it("uses the full address as the tab name", () => {
     expect(parseFromSplitInput("Support@Example.com")).toEqual({
       value: "support@example.com",
-      name: "support",
+      name: "support@example.com",
     });
   });
 
@@ -37,7 +37,16 @@ describe("parseFromSplitInput", () => {
     });
   });
 
-  it("returns null for unrelated descriptions", () => {
+  it("keeps addresses whose local part is from", () => {
+    expect(parseFromSplitInput("from@example.com")).toEqual({
+      value: "from@example.com",
+      name: "from@example.com",
+    });
+  });
+
+  it("rejects malformed addresses and domains", () => {
+    expect(parseFromSplitInput("a..b@example.com")).toBeNull();
+    expect(parseFromSplitInput("@a..b.com")).toBeNull();
     expect(parseFromSplitInput("unread")).toBeNull();
     expect(parseFromSplitInput("receipts label")).toBeNull();
   });

--- a/apps/web/utils/mail/from-split.test.ts
+++ b/apps/web/utils/mail/from-split.test.ts
@@ -47,6 +47,8 @@ describe("parseFromSplitInput", () => {
   it("rejects malformed addresses and domains", () => {
     expect(parseFromSplitInput("a..b@example.com")).toBeNull();
     expect(parseFromSplitInput("@a..b.com")).toBeNull();
+    expect(parseFromSplitInput("@a-.com")).toBeNull();
+    expect(parseFromSplitInput("user@x-.com")).toBeNull();
     expect(parseFromSplitInput("unread")).toBeNull();
     expect(parseFromSplitInput("receipts label")).toBeNull();
     expect(

--- a/apps/web/utils/mail/from-split.ts
+++ b/apps/web/utils/mail/from-split.ts
@@ -6,7 +6,7 @@ export type ParsedFromSplit = {
 };
 
 const LOCAL_PART = "[a-z0-9](?:[a-z0-9_%+-]|[.](?=[a-z0-9]))*";
-const DNS_DOMAIN = String.raw`[a-z0-9](?:[a-z0-9-]|[.](?=[a-z0-9]))*\.[a-z]{2,}`;
+const DNS_DOMAIN = String.raw`[a-z0-9](?:[a-z0-9]|[.-](?=[a-z0-9]))*\.[a-z]{2,}`;
 
 // Dot-atom local part and DNS labels; rejects consecutive dots.
 const EMAIL_RE = new RegExp(`${LOCAL_PART}@${DNS_DOMAIN}`, "i");

--- a/apps/web/utils/mail/from-split.ts
+++ b/apps/web/utils/mail/from-split.ts
@@ -1,0 +1,82 @@
+export type ParsedFromSplit = {
+  /** Full address (`user@domain.com`) or domain (`@domain.com`). */
+  value: string;
+  /** Short tab title derived from the address or domain. */
+  name: string;
+};
+
+const EMAIL_RE =
+  /[a-z0-9](?:[a-z0-9._%+-]*[a-z0-9])?@[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,}/i;
+const DOMAIN_RE = /@([a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})/i;
+
+/**
+ * Extract a sender or domain filter from a short split description.
+ * Supports bare addresses/domains and light phrasing like "from @domain in inbox".
+ */
+export function parseFromSplitInput(input: string): ParsedFromSplit | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const fromPrefixed = trimmed.match(
+    /^(?:from)\s*:?\s*(.+?)(?:\s+(?:in\s+)?(?:the\s+)?inbox)?$/i,
+  );
+  const candidate = (fromPrefixed?.[1] ?? trimmed)
+    .trim()
+    .replace(/^["']|["']$/g, "");
+
+  const emailMatch = candidate.match(EMAIL_RE);
+  if (emailMatch && isMostlyAddress(candidate, emailMatch[0])) {
+    const value = emailMatch[0].toLowerCase();
+    return { value, name: nameFromFromValue(value) };
+  }
+
+  const domainMatch = candidate.match(DOMAIN_RE);
+  if (domainMatch && isMostlyAddress(candidate, domainMatch[0])) {
+    const value = `@${domainMatch[1].toLowerCase()}`;
+    return { value, name: nameFromFromValue(value) };
+  }
+
+  // Phrases like "all emails from @domain that are in the inbox"
+  const phraseEmail = trimmed.match(
+    /\bfrom\s+(?:address\s+)?(?:"|')?([a-z0-9](?:[a-z0-9._%+-]*[a-z0-9])?@[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})(?:"|')?/i,
+  );
+  if (phraseEmail) {
+    const value = phraseEmail[1].toLowerCase();
+    return { value, name: nameFromFromValue(value) };
+  }
+
+  const phraseDomain = trimmed.match(
+    /\bfrom\s+(?:domain\s+)?(?:"|')?@([a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})(?:"|')?/i,
+  );
+  if (phraseDomain) {
+    const value = `@${phraseDomain[1].toLowerCase()}`;
+    return { value, name: nameFromFromValue(value) };
+  }
+
+  return null;
+}
+
+export function isFromDomainFilter(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("@") && !trimmed.slice(1).includes("@");
+}
+
+export function getFromFilterDomain(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (isFromDomainFilter(trimmed)) return trimmed.slice(1);
+  return null;
+}
+
+export function nameFromFromValue(value: string): string {
+  const trimmed = value.trim().toLowerCase();
+  if (isFromDomainFilter(trimmed)) {
+    return trimmed.slice(1).slice(0, 60);
+  }
+  const local = trimmed.split("@")[0]?.trim();
+  return (local || trimmed).slice(0, 60);
+}
+
+function isMostlyAddress(candidate: string, match: string): boolean {
+  const remainder = candidate.replace(match, "").replace(/[\s<>"']/g, "");
+  return remainder.length === 0;
+}

--- a/apps/web/utils/mail/from-split.ts
+++ b/apps/web/utils/mail/from-split.ts
@@ -5,9 +5,12 @@ export type ParsedFromSplit = {
   name: string;
 };
 
-const EMAIL_RE =
-  /[a-z0-9](?:[a-z0-9._%+-]*[a-z0-9])?@[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,}/i;
-const DOMAIN_RE = /@([a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})/i;
+const LOCAL_PART = "[a-z0-9](?:[a-z0-9_%+-]|[.](?=[a-z0-9]))*";
+const DNS_DOMAIN = String.raw`[a-z0-9](?:[a-z0-9-]|[.](?=[a-z0-9]))*\.[a-z]{2,}`;
+
+// Dot-atom local part and DNS labels; rejects consecutive dots.
+const EMAIL_RE = new RegExp(`${LOCAL_PART}@${DNS_DOMAIN}`, "i");
+const DOMAIN_RE = new RegExp(`@(${DNS_DOMAIN})`, "i");
 
 /**
  * Extract a sender or domain filter from a short split description.
@@ -17,8 +20,9 @@ export function parseFromSplitInput(input: string): ParsedFromSplit | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
+  // Require a separator after "from" so addresses like from@example.com stay intact.
   const fromPrefixed = trimmed.match(
-    /^(?:from)\s*:?\s*(.+?)(?:\s+(?:in\s+)?(?:the\s+)?inbox)?$/i,
+    /^(?:from)(?:\s*:\s*|\s+)(.+?)(?:\s+(?:in\s+)?(?:the\s+)?inbox)?$/i,
   );
   const candidate = (fromPrefixed?.[1] ?? trimmed)
     .trim()
@@ -38,7 +42,10 @@ export function parseFromSplitInput(input: string): ParsedFromSplit | null {
 
   // Phrases like "all emails from @domain that are in the inbox"
   const phraseEmail = trimmed.match(
-    /\bfrom\s+(?:address\s+)?(?:"|')?([a-z0-9](?:[a-z0-9._%+-]*[a-z0-9])?@[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})(?:"|')?/i,
+    new RegExp(
+      String.raw`\bfrom\s+(?:address\s+)?(?:"|')?(${EMAIL_RE.source})(?:"|')?`,
+      "i",
+    ),
   );
   if (phraseEmail) {
     const value = phraseEmail[1].toLowerCase();
@@ -46,7 +53,10 @@ export function parseFromSplitInput(input: string): ParsedFromSplit | null {
   }
 
   const phraseDomain = trimmed.match(
-    /\bfrom\s+(?:domain\s+)?(?:"|')?@([a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.[a-z]{2,})(?:"|')?/i,
+    new RegExp(
+      String.raw`\bfrom\s+(?:domain\s+)?(?:"|')?@(${DNS_DOMAIN})(?:"|')?`,
+      "i",
+    ),
   );
   if (phraseDomain) {
     const value = `@${phraseDomain[1].toLowerCase()}`;
@@ -67,13 +77,13 @@ export function getFromFilterDomain(value: string): string | null {
   return null;
 }
 
+/** Prefer the full address so distinct senders with the same local part don't collide. */
 export function nameFromFromValue(value: string): string {
   const trimmed = value.trim().toLowerCase();
   if (isFromDomainFilter(trimmed)) {
     return trimmed.slice(1).slice(0, 60);
   }
-  const local = trimmed.split("@")[0]?.trim();
-  return (local || trimmed).slice(0, 60);
+  return trimmed.slice(0, 60);
 }
 
 function isMostlyAddress(candidate: string, match: string): boolean {

--- a/apps/web/utils/mail/from-split.ts
+++ b/apps/web/utils/mail/from-split.ts
@@ -43,7 +43,7 @@ export function parseFromSplitInput(input: string): ParsedFromSplit | null {
   // Phrases like "all emails from @domain that are in the inbox"
   const phraseEmail = trimmed.match(
     new RegExp(
-      String.raw`\bfrom\s+(?:address\s+)?(?:"|')?(${EMAIL_RE.source})(?:"|')?`,
+      String.raw`\bfrom\s+(?:address\s+)?(?:"|')?(${EMAIL_RE.source})(?:"|')?(?=\s|$)`,
       "i",
     ),
   );
@@ -54,7 +54,7 @@ export function parseFromSplitInput(input: string): ParsedFromSplit | null {
 
   const phraseDomain = trimmed.match(
     new RegExp(
-      String.raw`\bfrom\s+(?:domain\s+)?(?:"|')?@(${DNS_DOMAIN})(?:"|')?`,
+      String.raw`\bfrom\s+(?:domain\s+)?(?:"|')?@(${DNS_DOMAIN})(?:"|')?(?=\s|$)`,
       "i",
     ),
   );
@@ -77,16 +77,28 @@ export function getFromFilterDomain(value: string): string | null {
   return null;
 }
 
-/** Prefer the full address so distinct senders with the same local part don't collide. */
+/**
+ * Prefer the full address so distinct senders with the same local part don't
+ * collide. Names are capped at 60 chars (DB limit); longer values get a short
+ * hash suffix so truncated names stay unique.
+ */
 export function nameFromFromValue(value: string): string {
   const trimmed = value.trim().toLowerCase();
-  if (isFromDomainFilter(trimmed)) {
-    return trimmed.slice(1).slice(0, 60);
-  }
-  return trimmed.slice(0, 60);
+  const base = isFromDomainFilter(trimmed) ? trimmed.slice(1) : trimmed;
+  if (base.length <= 60) return base;
+  const suffix = shortHash(base);
+  return `${base.slice(0, 60 - suffix.length - 1)}-${suffix}`;
 }
 
 function isMostlyAddress(candidate: string, match: string): boolean {
   const remainder = candidate.replace(match, "").replace(/[\s<>"']/g, "");
   return remainder.length === 0;
+}
+
+function shortHash(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(36).slice(0, 6);
 }

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -49,12 +49,24 @@ describe("mailSplitToThreadsQuery", () => {
     ).toEqual({ type: "inbox", inboxSection });
   });
 
+  it("limits from splits to matching inbox senders or domains", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split(MailSplitKind.FROM, "@getinboxzero.on.crisp.email"),
+      ),
+    ).toEqual({ type: "inbox", fromEmail: "@getinboxzero.on.crisp.email" });
+    expect(
+      mailSplitToThreadsQuery(split(MailSplitKind.FROM, "a@example.com")),
+    ).toEqual({ type: "inbox", fromEmail: "a@example.com" });
+  });
+
   it.each([
     MailSplitKind.LABEL,
     MailSplitKind.CATEGORY,
+    MailSplitKind.FROM,
   ])("throws rather than silently querying the whole inbox when %s has no value", (kind) => {
     expect(() => mailSplitToThreadsQuery(split(kind))).toThrow(
-      /has no (label|category)/,
+      /has no (label|category|sender)/,
     );
   });
 });

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -31,6 +31,9 @@ export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
         return mailTypeToThreadsQuery(split.value);
       }
       return { labelIds: [split.value, "INBOX"] };
+    case MailSplitKind.FROM:
+      if (!split.value) throw new Error(`Split "${split.name}" has no sender`);
+      return { type: "inbox", fromEmail: split.value };
   }
 }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260902-214207_pr-3492_7b070292da7b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds user-defined **FROM** split inboxes on `/mail`: saved views filtered by sender address or domain (e.g. `@getinboxzero.on.crisp.email`), always scoped to Inbox.

Extends the existing `MailSplit` system (`INBOX` / `UNREAD` / `LABEL` / `CATEGORY`) with a new `FROM` kind — no parallel saved-views stack.

## How filters are stored and queried
- **Storage:** Prisma `MailSplit` per email account. `kind = FROM`, `value` = full address (`user@domain.com`) or domain (`@domain.com`).
- **Query:** `mailSplitToThreadsQuery` → `{ type: "inbox", fromEmail: value }` → normal threads API / provider path (same list & pagination as other splits).
- **Gmail:** `from:` + Inbox `labelIds`.
- **Outlook:** exact address via `$filter eq`; domain via `$search "from:@domain"` on `/me/mailFolders/inbox/messages` (Graph forbids `$search` + `$filter`, so inbox scope is the folder endpoint; search pages capped at 25). Local constraints apply on first and continuation pages, and paging continues until `maxResults` when those filters thin a page. Synced mailbox cache matches `@domain` as a sender suffix.
- **Create UX:** typing a from-address/domain in the existing New Split popover creates a FROM split directly (no AI). Rename via double-click or F2; delete via the tab ×.

## Review follow-ups
- Inbox-scoped domain `$search`, `$top` ≤ 25, F2 focus restore, nullable bound typecheck.
- Domain-search constraints on `@odata.nextLink` pages; `inferenceClassification` selected for Focused/Other; hyphen-ended DNS labels rejected; F2 tooltip.
- Keep paging domain FROM results when local filters / 25-item pages underfill `maxResults`.

## Test plan
- [x] Unit: `from-split`, `split-query`, `mail-split` actions, Outlook domain FROM query + multi-page local filter paging + mailbox domain matching
- [ ] Manual `/mail` screenshot — not available here (no authenticated OAuth session in this environment)

## Notes
- Does not add a general rules engine or AI categorization.
- Existing Inbox / Done / category navigation unchanged.
- CLA check is pending contributor signature (cannot be completed by this agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf15ba40-284a-4677-8bcf-06b0e93a99b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf15ba40-284a-4677-8bcf-06b0e93a99b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create inbox splits by sender email address or domain using natural-language prompts or the direct “From” option.
  * Sender-based splits support matching messages from an entire domain or a specific address.
  * Rename mail split tabs inline by double-clicking or pressing F2, with validation and keyboard controls.
  * Rename errors appear as notifications, and settings refresh after successful updates.

* **Bug Fixes**
  * Added validation and clearer messages for incomplete or invalid sender filters.
  * Improved Microsoft mailbox searches for domain-based sender filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->