### PR TITLE
feat: expanded snippet density mode on /mail

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -2,21 +2,27 @@
 
 import { useRef } from "react";
 import {
+  AlignJustifyIcon,
   ColumnsIcon,
   RowsIcon,
   SearchIcon,
   SparklesIcon,
+  TextIcon,
   XIcon,
 } from "lucide-react";
 import { Kbd } from "@/components/Kbd";
 import { Tooltip } from "@/components/Tooltip";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
+import type {
+  MailLayoutMode,
+  MailListDensityMode,
+} from "@/app/(app)/[emailAccountId]/mail/types";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
 
 export type ListToolbarProps = {
   layout: MailLayoutMode;
+  density: MailListDensityMode;
   showLayoutToggle?: boolean;
   /** Committed search query. Only meaningful when `onSearch` is provided. */
   searchQuery?: string;
@@ -24,21 +30,25 @@ export type ListToolbarProps = {
   onSearch?: (query: string) => void;
   onOpenSearch: () => void;
   onToggleLayout: () => void;
+  onToggleDensity: () => void;
   onToggleAssistant: () => void;
   showSidebarToggle?: boolean;
 };
 
 export function ListToolbar({
   layout,
+  density,
   showLayoutToggle = true,
   searchQuery = "",
   onSearch,
   onOpenSearch,
   onToggleLayout,
+  onToggleDensity,
   onToggleAssistant,
   showSidebarToggle = false,
 }: ListToolbarProps) {
   const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
+  const DensityIcon = density === "expanded" ? AlignJustifyIcon : TextIcon;
 
   return (
     <div
@@ -82,6 +92,20 @@ export function ListToolbar({
           </button>
         </Tooltip>
       ) : null}
+
+      <Tooltip
+        content={`Switch compact / expanded snippets (${getShortcutHint("toggleDensity")})`}
+      >
+        <button
+          type="button"
+          onClick={onToggleDensity}
+          aria-label="Switch compact or expanded snippets"
+          aria-pressed={density === "expanded"}
+          className={cn(toolbarButton, "w-8 justify-center px-0")}
+        >
+          <DensityIcon className="size-3.5" />
+        </button>
+      </Tooltip>
 
       <Tooltip content="Assistant">
         <button

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -24,6 +24,7 @@ export type ListToolbarProps = {
   layout: MailLayoutMode;
   density: MailListDensityMode;
   showLayoutToggle?: boolean;
+  showDensityToggle?: boolean;
   /** Committed search query. Only meaningful when `onSearch` is provided. */
   searchQuery?: string;
   /** When provided, the toolbar shows a real mail search input. */
@@ -39,6 +40,7 @@ export function ListToolbar({
   layout,
   density,
   showLayoutToggle = true,
+  showDensityToggle = true,
   searchQuery = "",
   onSearch,
   onOpenSearch,
@@ -93,19 +95,21 @@ export function ListToolbar({
         </Tooltip>
       ) : null}
 
-      <Tooltip
-        content={`Switch compact / expanded snippets (${getShortcutHint("toggleDensity")})`}
-      >
-        <button
-          type="button"
-          onClick={onToggleDensity}
-          aria-label="Switch compact or expanded snippets"
-          aria-pressed={density === "expanded"}
-          className={cn(toolbarButton, "w-8 justify-center px-0")}
+      {showDensityToggle ? (
+        <Tooltip
+          content={`Switch compact / expanded snippets (${getShortcutHint("toggleDensity")})`}
         >
-          <DensityIcon className="size-3.5" />
-        </button>
-      </Tooltip>
+          <button
+            type="button"
+            onClick={onToggleDensity}
+            aria-label="Switch compact or expanded snippets"
+            aria-pressed={density === "expanded"}
+            className={cn(toolbarButton, "w-8 justify-center px-0")}
+          >
+            <DensityIcon className="size-3.5" />
+          </button>
+        </Tooltip>
+      ) : null}
 
       <Tooltip content="Assistant">
         <button

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -175,6 +175,9 @@ export function MailShell() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
   const pendingReplyThreadKey = useRef<string | null>(null);
+  // Serializes density preference writes so overlapping toggles cannot
+  // finish out of order and overwrite EmailAccount.mailListDensity.
+  const densityWriteQueueRef = useRef(Promise.resolve());
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   const isAllAccounts = accountScope === "all";
@@ -206,8 +209,14 @@ export function MailShell() {
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
   const layout = isAllAccounts ? "list" : accountLayout;
-  const density: MailListDensityMode =
+  const accountDensity: MailListDensityMode =
     settings?.density === MailListDensity.EXPANDED ? "expanded" : "compact";
+  // All-accounts has no single EmailAccount preference owner (same reason the
+  // layout toggle is hidden), so keep rows compact rather than projecting the
+  // current account's density onto every mailbox.
+  const density: MailListDensityMode = isAllAccounts
+    ? "compact"
+    : accountDensity;
 
   // Written through the SWR cache rather than mirrored in local state, so the
   // preference has one source of truth and every reader sees the new value.
@@ -252,28 +261,37 @@ export function MailShell() {
         : MailListDensity.EXPANDED;
     const loadedSettings = settings;
 
+    // Optimistic UI immediately so rapid toggles still feel instant.
     mutateSettings(
-      async (current) => {
-        const result = await updateMailPreferencesAction(emailAccountId, {
-          density: next,
-        });
-        if (result?.serverError || result?.validationErrors)
-          throw new Error(getActionErrorMessage(result));
-        return { ...(current ?? loadedSettings), density: next };
-      },
+      (current) => ({ ...(current ?? loadedSettings), density: next }),
       {
         optimisticData: (current) => ({
           ...(current ?? loadedSettings),
           density: next,
         }),
         revalidate: false,
-        rollbackOnError: true,
+        populateCache: true,
       },
-    ).catch((error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Couldn't save that",
-      );
-    });
+    ).catch(() => undefined);
+
+    // Persist in order. Each click captures its own `next`, so a compact →
+    // expanded → compact burst writes the same sequence and cannot land with
+    // an older response overwriting the latest choice.
+    densityWriteQueueRef.current = densityWriteQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const result = await updateMailPreferencesAction(emailAccountId, {
+          density: next,
+        });
+        if (result?.serverError || result?.validationErrors)
+          throw new Error(getActionErrorMessage(result));
+      })
+      .catch((error) => {
+        toast.error(
+          error instanceof Error ? error.message : "Couldn't save that",
+        );
+        mutateSettings().catch(() => undefined);
+      });
   }, [density, emailAccountId, mutateSettings, settings]);
 
   // A sidebar selection scopes the whole list, which replaces the split tabs —
@@ -767,7 +785,7 @@ export function MailShell() {
         : undefined,
       undo: () => undo(),
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
-      toggleDensity,
+      toggleDensity: isAllAccounts ? undefined : toggleDensity,
       focusMode: openThreadId ? () => setIsFocusMode((on) => !on) : undefined,
       help: () => setIsHelpOpen(true),
     };
@@ -1110,6 +1128,7 @@ export function MailShell() {
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
               showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
+              showDensityToggle={!isAllAccounts}
             />
             {!isScoped && !searchQuery && (
               <SplitTabs

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -45,6 +45,7 @@ import {
   getListThreadSelection,
   getThreadSelectionKey,
   type MailLayoutMode,
+  type MailListDensityMode,
   type ThreadSelection,
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import type { ThreadMessage } from "@/components/email-list/types";
@@ -55,7 +56,11 @@ import { useThreadPrefetchCoordinator } from "@/app/(app)/[emailAccountId]/mail/
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
-import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import {
+  MailLayout,
+  MailListDensity,
+  MailSplitKind,
+} from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { Sidebar, useSidebar } from "@/components/ui/sidebar";
 import { useAtom, useSetAtom } from "jotai";
@@ -201,6 +206,8 @@ export function MailShell() {
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
   const layout = isAllAccounts ? "list" : accountLayout;
+  const density: MailListDensityMode =
+    settings?.density === MailListDensity.EXPANDED ? "expanded" : "compact";
 
   // Written through the SWR cache rather than mirrored in local state, so the
   // preference has one source of truth and every reader sees the new value.
@@ -235,6 +242,39 @@ export function MailShell() {
       );
     });
   }, [emailAccountId, layout, mutateSettings, settings]);
+
+  const toggleDensity = useCallback(() => {
+    if (!settings) return;
+
+    const next =
+      density === "expanded"
+        ? MailListDensity.COMPACT
+        : MailListDensity.EXPANDED;
+    const loadedSettings = settings;
+
+    mutateSettings(
+      async (current) => {
+        const result = await updateMailPreferencesAction(emailAccountId, {
+          density: next,
+        });
+        if (result?.serverError || result?.validationErrors)
+          throw new Error(getActionErrorMessage(result));
+        return { ...(current ?? loadedSettings), density: next };
+      },
+      {
+        optimisticData: (current) => ({
+          ...(current ?? loadedSettings),
+          density: next,
+        }),
+        revalidate: false,
+        rollbackOnError: true,
+      },
+    ).catch((error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Couldn't save that",
+      );
+    });
+  }, [density, emailAccountId, mutateSettings, settings]);
 
   // A sidebar selection scopes the whole list, which replaces the split tabs —
   // splits are a way of slicing the inbox, not of slicing an arbitrary view.
@@ -727,6 +767,7 @@ export function MailShell() {
         : undefined,
       undo: () => undo(),
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
+      toggleDensity,
       focusMode: openThreadId ? () => setIsFocusMode((on) => !on) : undefined,
       help: () => setIsHelpOpen(true),
     };
@@ -1060,10 +1101,12 @@ export function MailShell() {
           >
             <ListToolbar
               layout={layout}
+              density={density}
               searchQuery={searchQuery ?? ""}
               onSearch={isAllAccounts ? undefined : setSearch}
               onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
+              onToggleDensity={toggleDensity}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
               showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
@@ -1096,6 +1139,7 @@ export function MailShell() {
               <ThreadList
                 threads={threads}
                 layout={layout}
+                density={density}
                 userEmail={userEmail}
                 userLabels={isAllAccounts ? NO_LABELS : userLabels}
                 labelsByAccount={labelsByAccount}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -80,12 +80,13 @@ export function ThreadList({
 
   // Keep the J/K cursor on screen without centering every row. Layout phase so
   // a held arrow key never paints a selected row that's already off-screen.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: density changes row height without changing focusedIndex
   useLayoutEffect(() => {
     if (!scrollRoot || focusedIndex < 0 || !focusedThreadId) return;
     const row = focusedRowRef.current;
     if (!row) return;
     scrollElementIntoContainer(scrollRoot, row);
-  }, [focusedIndex, focusedThreadId, scrollRoot]);
+  }, [density, focusedIndex, focusedThreadId, scrollRoot]);
 
   useEffect(() => {
     if (prefetchListKey.current !== listKey) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -6,6 +6,7 @@ import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
 import type {
   ListThread,
   MailLayoutMode,
+  MailListDensityMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
 import {
@@ -21,6 +22,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 export type ThreadListProps = {
   threads: ListThread[];
   layout: MailLayoutMode;
+  density: MailListDensityMode;
   userEmail: string;
   userLabels: EmailLabels;
   labelsByAccount?: Record<string, EmailLabels>;
@@ -45,6 +47,7 @@ export type ThreadListProps = {
 export function ThreadList({
   threads,
   layout,
+  density,
   userEmail,
   userLabels,
   labelsByAccount,
@@ -154,6 +157,7 @@ export function ThreadList({
                   <ThreadRow
                     hasAnySelection={selectionEnabled && selectedCount > 0}
                     compact={isMobile}
+                    density={density}
                     index={index}
                     isFocused={index === focusedIndex}
                     isSelected={selectionEnabled && isSelected(threadKey)}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -7,7 +7,9 @@ import { getThreadParticipantNames } from "@/app/(app)/[emailAccountId]/mail/thr
 import type {
   ListThread,
   MailLayoutMode,
+  MailListDensityMode,
 } from "@/app/(app)/[emailAccountId]/mail/types";
+import { getMailListSnippetClassName } from "@/app/(app)/[emailAccountId]/mail/mail-list-density";
 import { EmailDate } from "@/components/email-list/EmailDate";
 import { getEmailThreadLabels } from "@/components/EmailMessageCellLabels";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
@@ -30,6 +32,7 @@ export type ThreadRowProps = {
   /** Position in the rendered list — selection and focus are index-addressed. */
   index: number;
   layout: MailLayoutMode;
+  density: MailListDensityMode;
   userEmail: string;
   userLabels: EmailLabels;
   isFocused: boolean;
@@ -48,6 +51,7 @@ export const ThreadRow = memo(function ThreadRow({
   thread,
   index,
   layout,
+  density,
   userEmail,
   userLabels,
   isFocused,
@@ -166,9 +170,11 @@ export const ThreadRow = memo(function ThreadRow({
       ref={rowRef}
       className={cn(
         "group relative flex cursor-pointer border-b border-border/60 outline-none",
-        isWide
+        isWide && density === "compact"
           ? "items-center gap-2.5 py-2.5 pr-5 pl-3"
-          : "items-start gap-2 px-3.5 py-2.5",
+          : isWide
+            ? "items-start gap-2.5 py-2.5 pr-5 pl-3"
+            : "items-start gap-2 px-3.5 py-2.5",
         rowBackground({ isSelected, isFocused }),
         isFocused &&
           // Inset so the marker reads as a marker rather than a border, and so
@@ -194,30 +200,66 @@ export const ThreadRow = memo(function ThreadRow({
           <div className="flex w-48 shrink-0 items-baseline gap-1 overflow-hidden whitespace-nowrap">
             {participantLine}
           </div>
-          <div className="flex min-w-0 flex-1 items-center gap-2.5">
-            {account ? <AccountAvatar account={account} /> : null}
-            {chips.map((label) => (
-              <MailLabelChip
-                color={label.color}
-                key={label.id}
-                name={label.name}
-              />
-            ))}
-            <span
-              className={cn(
-                "max-w-[46%] shrink-0 truncate whitespace-nowrap text-sm",
-                isUnread
-                  ? "font-semibold text-foreground"
-                  : "font-normal text-muted-foreground",
+          <div
+            className={cn(
+              "flex min-w-0 flex-1 gap-2.5",
+              density === "expanded"
+                ? "flex-col items-stretch"
+                : "items-center",
+            )}
+          >
+            <div className="flex min-w-0 items-center gap-2.5">
+              {account ? <AccountAvatar account={account} /> : null}
+              {chips.map((label) => (
+                <MailLabelChip
+                  color={label.color}
+                  key={label.id}
+                  name={label.name}
+                />
+              ))}
+              <span
+                className={cn(
+                  "truncate whitespace-nowrap text-sm",
+                  density === "expanded"
+                    ? "min-w-0 flex-1"
+                    : "max-w-[46%] shrink-0",
+                  isUnread
+                    ? "font-semibold text-foreground"
+                    : "font-normal text-muted-foreground",
+                )}
+              >
+                {subject}
+              </span>
+              {density === "expanded" ? null : (
+                <span
+                  className={getMailListSnippetClassName({
+                    density,
+                    variant: "wide",
+                  })}
+                >
+                  {snippet}
+                </span>
               )}
-            >
-              {subject}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-muted-foreground text-sm">
-              {snippet}
-            </span>
+            </div>
+            {density === "expanded" ? (
+              <div
+                className={getMailListSnippetClassName({
+                  density,
+                  variant: "wide",
+                })}
+              >
+                {snippet}
+              </div>
+            ) : null}
           </div>
-          <div className="w-16 shrink-0 text-right">{date}</div>
+          <div
+            className={cn(
+              "w-16 shrink-0 text-right",
+              density === "expanded" && "pt-0.5",
+            )}
+          >
+            {date}
+          </div>
         </>
       ) : (
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -235,7 +277,12 @@ export const ThreadRow = memo(function ThreadRow({
           >
             {subject}
           </div>
-          <div className="truncate text-muted-foreground text-xs">
+          <div
+            className={getMailListSnippetClassName({
+              density,
+              variant: "stacked",
+            })}
+          >
             {snippet}
           </div>
           {account ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-list-density.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-list-density.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getMailListSnippetClassName } from "@/app/(app)/[emailAccountId]/mail/mail-list-density";
+
+describe("getMailListSnippetClassName", () => {
+  it("keeps compact snippets on a single truncated line", () => {
+    expect(
+      getMailListSnippetClassName({ density: "compact", variant: "wide" }),
+    ).toContain("truncate");
+    expect(
+      getMailListSnippetClassName({ density: "compact", variant: "stacked" }),
+    ).toContain("truncate");
+  });
+
+  it("clamps expanded snippets to about five lines", () => {
+    expect(
+      getMailListSnippetClassName({ density: "expanded", variant: "wide" }),
+    ).toContain("line-clamp-5");
+    expect(
+      getMailListSnippetClassName({ density: "expanded", variant: "stacked" }),
+    ).toContain("line-clamp-5");
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-list-density.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-list-density.ts
@@ -1,0 +1,20 @@
+import type { MailListDensityMode } from "@/app/(app)/[emailAccountId]/mail/types";
+
+/** Snippet typography for list rows — compact is one line, expanded is ~5. */
+export function getMailListSnippetClassName({
+  density,
+  variant,
+}: {
+  density: MailListDensityMode;
+  variant: "wide" | "stacked";
+}): string {
+  if (density === "expanded") {
+    return variant === "wide"
+      ? "line-clamp-5 text-muted-foreground text-sm"
+      : "line-clamp-5 whitespace-normal text-muted-foreground text-xs";
+  }
+
+  return variant === "wide"
+    ? "min-w-0 flex-1 truncate text-muted-foreground text-sm"
+    : "truncate text-muted-foreground text-xs";
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/types.ts
@@ -10,6 +10,9 @@ export type ThreadPlan = NonNullable<ListThread["plans"]>[number];
 /** Split view is the two-column list + reader; list view gives the list the full width. */
 export type MailLayoutMode = "list" | "split";
 
+/** Compact shows a one-line snippet; expanded shows ~5 lines of the available snippet. */
+export type MailListDensityMode = "compact" | "expanded";
+
 export type ThreadSelection = {
   emailAccountId: string;
   threadId: string;

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -11,6 +11,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
       where: { id: emailAccountId },
       select: {
         mailLayout: true,
+        mailListDensity: true,
         mailSplits: {
           // createdAt breaks ties so tab order can't shuffle between requests
           orderBy: [{ order: "asc" }, { createdAt: "asc" }],
@@ -29,6 +30,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
 
   return {
     layout: emailAccount?.mailLayout ?? null,
+    density: emailAccount?.mailListDensity ?? null,
     splits: emailAccount?.mailSplits ?? [],
     defaultSplits,
   };

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -211,6 +211,13 @@ const SHORTCUT_DEFINITIONS = [
     label: "List view / split view",
   },
   {
+    id: "toggleDensity",
+    keys: ["d"],
+    scope: "mail",
+    group: "View",
+    label: "Compact / expanded snippets",
+  },
+  {
     id: "focusMode",
     keys: ["f"],
     scope: "mail",

--- a/apps/web/prisma/migrations/20260902220000_add_mail_list_density/migration.sql
+++ b/apps/web/prisma/migrations/20260902220000_add_mail_list_density/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "MailListDensity" AS ENUM ('COMPACT', 'EXPANDED');
+
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN "mailListDensity" "MailListDensity" NOT NULL DEFAULT 'COMPACT';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -157,7 +157,8 @@ model EmailAccount {
   allowHiddenAiDraftLinks   Boolean              @default(false)
   rulesRevision             Int                  @default(0)
 
-  mailLayout MailLayout @default(LIST)
+  mailLayout      MailLayout      @default(LIST)
+  mailListDensity MailListDensity @default(COMPACT)
 
   includeInAllAccounts Boolean @default(true)
 
@@ -1958,6 +1959,11 @@ enum Frequency {
 enum MailLayout {
   LIST
   SPLIT
+}
+
+enum MailListDensity {
+  COMPACT
+  EXPANDED
 }
 
 enum MailSplitKind {

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@/generated/prisma/client";
 import {
   ActionType,
   MailLayout,
+  MailListDensity,
   MailSplitKind,
   SystemType,
 } from "@/generated/prisma/enums";
@@ -224,6 +225,17 @@ describe("mail split actions", () => {
     expect(prisma.emailAccount.update).toHaveBeenCalledWith({
       where: { id: EMAIL_ACCOUNT_ID },
       data: { mailLayout: MailLayout.SPLIT },
+    });
+  });
+
+  it("persists the selected mail list density", async () => {
+    await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
+      density: MailListDensity.EXPANDED,
+    });
+
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: EMAIL_ACCOUNT_ID },
+      data: { mailListDensity: MailListDensity.EXPANDED },
     });
   });
 });

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -117,12 +117,17 @@ export const setDefaultMailSplitsAction = actionClient
 export const updateMailPreferencesAction = actionClient
   .metadata({ name: "updateMailPreferences" })
   .inputSchema(updateMailPreferencesBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { layout } }) => {
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { mailLayout: layout },
-    });
-  });
+  .action(
+    async ({ ctx: { emailAccountId }, parsedInput: { layout, density } }) => {
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: {
+          ...(layout !== undefined ? { mailLayout: layout } : {}),
+          ...(density !== undefined ? { mailListDensity: density } : {}),
+        },
+      });
+    },
+  );
 
 async function createMailSplitOrThrow(
   data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">,

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import {
+  MailLayout,
+  MailListDensity,
+  MailSplitKind,
+} from "@/generated/prisma/enums";
 
 // LABEL splits carry a provider label id; CATEGORY splits carry a provider category
 // (e.g. CATEGORY_PERSONAL). INBOX and UNREAD need no value.
@@ -53,9 +57,14 @@ export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
 export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
-export const updateMailPreferencesBody = z.object({
-  layout: z.nativeEnum(MailLayout),
-});
+export const updateMailPreferencesBody = z
+  .object({
+    layout: z.nativeEnum(MailLayout).optional(),
+    density: z.nativeEnum(MailListDensity).optional(),
+  })
+  .refine((data) => data.layout !== undefined || data.density !== undefined, {
+    message: "At least one preference is required",
+  });
 export type UpdateMailPreferencesBody = z.infer<
   typeof updateMailPreferencesBody
 >;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260902-221311_pr-3493_64c7eb611a1b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds a compact/expanded snippet toggle next to the existing list/split (V) control so thread rows can show ~5 lines of the provider snippet. Works in both Gmail list and Outlook split-pane layouts. Shortcut is D (V is unchanged). Preference is persisted as EmailAccount.mailListDensity. Snippet text only — no full body fetch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compact and expanded density modes for mail lists.
  - Added a toolbar control and keyboard shortcut to switch between modes.
  - Mail list preferences are saved and restored automatically.
  - Expanded mode shows more snippet text, while compact mode keeps rows concise.
  - Density settings adapt to wide and narrow layouts.
  - All-accounts views consistently use compact density.

- **Bug Fixes**
  - Improved snippet formatting and truncation consistency across layouts.

- **Tests**
  - Added coverage for compact and expanded snippet behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->