### PR TITLE
mail: Reset embedded message sizing

### DIFF
--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -1,7 +1,13 @@
 /** @vitest-environment jsdom */
 
 import React from "react";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next-themes", () => ({
@@ -147,6 +153,7 @@ describe("HtmlEmail", () => {
   });
 
   it("expands when an image increases the iframe document height after loading", async () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByTitle } = render(
       <HtmlEmail
         html='<img src="https://cdn.example.com/tall-image.png" />'
@@ -179,6 +186,52 @@ describe("HtmlEmail", () => {
         640,
       ),
     );
+  });
+
+  it("remeasures from a minimal height when quoted content is toggled", async () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    const { getByRole, getByTitle } = render(
+      <HtmlEmail
+        html={
+          '<div>Current reply</div><div class="gmail_quote"><div>Earlier message</div></div>'
+        }
+        messageId="message-with-quote"
+      />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    let contentHeight = 40;
+
+    Object.defineProperty(
+      iframe.contentDocument!.documentElement,
+      "scrollHeight",
+      {
+        configurable: true,
+        get: () => contentHeight,
+      },
+    );
+    Object.defineProperty(iframe.contentDocument!.body, "scrollHeight", {
+      configurable: true,
+      get: () => contentHeight,
+    });
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+
+    await waitFor(() => expect(iframe.style.height).toBe("43px"));
+
+    fireEvent.click(getByRole("button", { name: "Show quoted content" }));
+
+    expect(iframe.style.height).toBe("");
+    expect(iframe.getAttribute("height")).toBe("1");
+
+    contentHeight = 640;
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(iframe.style.height).toBe("643px"));
+
+    fireEvent.click(getByRole("button", { name: "Hide quoted content" }));
+
+    expect(iframe.style.height).toBe("");
+    expect(iframe.getAttribute("height")).toBe("1");
   });
 
   it("keeps watching until the email document replaces the placeholder", async () => {
@@ -307,5 +360,10 @@ function addEmailDocumentMarker(
     .parseFromString(iframe.srcdoc, "text/html")
     .querySelector('meta[name="inbox-zero-email-document"]');
   if (!marker) throw new Error("Expected an email document marker");
+  for (const existingMarker of targetDocument.querySelectorAll(
+    'meta[name="inbox-zero-email-document"]',
+  )) {
+    existingMarker.remove();
+  }
   targetDocument.head.append(marker.cloneNode());
 }

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -232,6 +232,11 @@ describe("HtmlEmail", () => {
 
     expect(iframe.style.height).toBe("");
     expect(iframe.getAttribute("height")).toBe("1");
+
+    contentHeight = 40;
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(iframe.style.height).toBe("43px"));
   });
 
   it("keeps watching until the email document replaces the placeholder", async () => {

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -125,6 +125,7 @@ export function HtmlEmail({
         ref={iframeRef}
         srcDoc={srcDoc}
         className="min-h-0 w-full"
+        height={1}
         style={iframeHeight ? { height: `${iframeHeight + 3}px` } : undefined}
         title="Email content preview"
         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
@@ -410,7 +411,10 @@ function useIframeHeight(
   srcDoc: string,
   documentKey: string,
 ) {
-  const [height, setHeight] = useState(0);
+  const [measurement, setMeasurement] = useState<{
+    documentKey: string;
+    height: number;
+  }>();
 
   useEffect(() => {
     const iframe = iframeRef.current;
@@ -428,7 +432,7 @@ function useIframeHeight(
         documentElement.scrollHeight,
         body.scrollHeight,
       );
-      if (newHeight) setHeight(newHeight);
+      if (newHeight) setMeasurement({ documentKey, height: newHeight });
     };
 
     const resizeObserver = new ResizeObserver(updateHeight);
@@ -487,7 +491,7 @@ function useIframeHeight(
     };
   }, [iframeRef, srcDoc, documentKey]);
 
-  return height;
+  return measurement?.documentKey === documentKey ? measurement.height : 0;
 }
 
 function getIframeDocumentKey(html: string, isDarkMode: boolean) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260903-111952_pr-3495_ec1d7ea57deb/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Prevent embedded message previews from retaining stale heights when their rendered content changes. This keeps quoted-content controls close to the visible message while preserving dynamic resizing.

- reset measurements for each embedded document
- cover quoted-content toggling with a regression test
- verify the focused mail reader browser flow

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email iframe sizing when quoted content is shown or hidden.
  * Prevented stale sizing measurements from being applied after the iframe document changes.
  * Ensured newly loaded email content starts at a minimal height before being measured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->