### PR TITLE
mail: Group attachment filing notifications

### DIFF
--- a/apps/web/__tests__/eval/filing-reply.test.ts
+++ b/apps/web/__tests__/eval/filing-reply.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
+
+// pnpm --filter inbox-zero-ai test-ai __tests__/eval/filing-reply.test.ts
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 60_000;
+
+const filings = [
+  { id: "filing-1", filename: "invoice.pdf", currentFolder: "Finance" },
+  {
+    id: "filing-2",
+    filename: "quarterly-summary.pdf",
+    currentFolder: "Reports",
+  },
+  { id: "filing-3", filename: "notes.txt", currentFolder: "Documents" },
+];
+
+describe.runIf(shouldRunEval)("filing reply eval", () => {
+  const evalReporter = createEvalReporter({ evalName: "filing-reply" });
+
+  describeEvalMatrix("filing reply", (model, emailAccount) => {
+    const testCases = [
+      {
+        name: "targets one named document",
+        reply: "Move quarterly-summary.pdf to Finance/Quarterly.",
+        expected: [
+          {
+            filingId: "filing-2",
+            action: "move",
+            folderPath: "Finance/Quarterly",
+          },
+        ],
+      },
+      {
+        name: "targets multiple named documents",
+        reply:
+          "Move invoice.pdf to Finance/Invoices and undo the filing for notes.txt.",
+        expected: [
+          {
+            filingId: "filing-1",
+            action: "move",
+            folderPath: "Finance/Invoices",
+          },
+          { filingId: "filing-3", action: "undo", folderPath: null },
+        ],
+      },
+      {
+        name: "applies a clear batch-wide reply to every document",
+        reply: "These all look good.",
+        expected: filings.map((filing) => ({
+          filingId: filing.id,
+          action: "approve",
+          folderPath: null,
+        })),
+      },
+    ] as const;
+
+    for (const testCase of testCases) {
+      test(
+        testCase.name,
+        async () => {
+          const result = await aiParseFilingReply({
+            messages: [{ role: "user", content: testCase.reply }],
+            filingContexts: filings,
+            emailAccount,
+          });
+          const actual = sortActions(result.actions);
+          const expected = sortActions([...testCase.expected]);
+          const pass = JSON.stringify(actual) === JSON.stringify(expected);
+
+          evalReporter.record({
+            testName: testCase.name,
+            model: model.label,
+            pass,
+            expected: JSON.stringify(expected),
+            actual: JSON.stringify(actual),
+          });
+
+          expect(actual).toEqual(expected);
+        },
+        TIMEOUT,
+      );
+    }
+
+    test(
+      "does not guess when a multi-document reply is ambiguous",
+      async () => {
+        const result = await aiParseFilingReply({
+          messages: [{ role: "user", content: "Move it to Archive." }],
+          filingContexts: filings,
+          emailAccount,
+        });
+        const pass = result.actions.length === 0 && result.reply.length > 0;
+
+        evalReporter.record({
+          testName: "does not guess when a multi-document reply is ambiguous",
+          model: model.label,
+          pass,
+          expected: "no actions and a clarification reply",
+          actual: JSON.stringify(result),
+        });
+
+        expect(result.actions).toEqual([]);
+        expect(result.reply.length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+function sortActions<T extends { filingId: string }>(actions: T[]): T[] {
+  return actions.toSorted((a, b) => a.filingId.localeCompare(b.filingId));
+}

--- a/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_batch/migration.sql
+++ b/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_batch/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "DocumentFiling"
+ADD COLUMN "notificationBatchId" TEXT;
+
+CREATE INDEX "DocumentFiling_emailAccountId_notificationBatchId_idx"
+ON "DocumentFiling"("emailAccountId", "notificationBatchId");

--- a/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_claim/migration.sql
+++ b/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_claim/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "DocumentFiling"
+ADD COLUMN "notificationClaimId" TEXT;

--- a/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_claim/migration.sql
+++ b/apps/web/prisma/migrations/20260903130000_add_document_filing_notification_claim/migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "DocumentFiling"
-ADD COLUMN "notificationClaimId" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1736,7 +1736,7 @@ model DocumentFiling {
 
   notificationMessageId String?   @unique
   notificationSentAt    DateTime?
-  notificationClaimId   String?
+  notificationBatchId   String?
 
   driveConnectionId String
   driveConnection   DriveConnection @relation(fields: [driveConnectionId], references: [id], onDelete: Cascade)
@@ -1745,6 +1745,7 @@ model DocumentFiling {
 
   @@unique([emailAccountId, messageId, attachmentId])
   @@index([emailAccountId, status])
+  @@index([emailAccountId, notificationBatchId])
   @@index([driveConnectionId])
   @@index([messageId])
 }

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1736,6 +1736,7 @@ model DocumentFiling {
 
   notificationMessageId String?   @unique
   notificationSentAt    DateTime?
+  notificationClaimId   String?
 
   driveConnectionId String
   driveConnection   DriveConnection @relation(fields: [driveConnectionId], references: [id], onDelete: Cascade)

--- a/apps/web/utils/ai/document-filing/parse-filing-reply.ts
+++ b/apps/web/utils/ai/document-filing/parse-filing-reply.ts
@@ -3,21 +3,32 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createGenerateObject } from "@/utils/llms";
 
-const system = `You are a document filing assistant. The user received a notification that we filed their document attachment to their Drive. They have replied to that email.
+const system = `You are a document filing assistant. The user received one notification about one or more document attachments. They have replied to that email.
 
-Determine their intent and always provide a reply to send back.
+Determine which documents they mean and always provide a reply to send back.
 
 Actions:
 - "approve": User is happy with the filing. We will mark it as approved in the database.
 - "move": User wants the document in a different folder. We will move the file to the path they specify.
 - "undo": User wants to reverse the filing. We will move the file to a "To Delete" folder for them to review.
-- "none": No action needed, just answering a question or continuing conversation.
+
+Return at most one action per filing. Use only filing IDs from the provided list. If the user names documents, act only on those documents. If their reply clearly applies to every document, return an action for each one. If it is ambiguous which document they mean, return no actions and ask them to identify it.
 
 Always write a helpful, concise reply.`;
 
 const schema = z.object({
-  action: z.enum(["approve", "move", "undo", "none"]),
-  folderPath: z.string().nullable(),
+  actions: z.array(
+    z.object({
+      filingId: z
+        .string()
+        .describe("The exact filing ID from the provided filing list"),
+      action: z.enum(["approve", "move", "undo"]),
+      folderPath: z
+        .string()
+        .nullable()
+        .describe("The destination path for move; null for other actions"),
+    }),
+  ),
   reply: z.string(),
 });
 
@@ -26,31 +37,38 @@ export type ParseFilingReplyResult = z.infer<typeof schema>;
 interface FilingContext {
   currentFolder: string;
   filename: string;
+  id: string;
 }
 
 type Message = { role: "user" | "assistant"; content: string };
 
 export async function aiParseFilingReply({
   messages,
-  filingContext,
+  filingContexts,
   emailAccount,
 }: {
   messages: Message[];
-  filingContext: FilingContext;
+  filingContexts: FilingContext[];
   emailAccount: EmailAccountWithAI;
 }): Promise<ParseFilingReplyResult> {
   if (!messages.length) {
-    return { action: "none", reply: "", folderPath: null };
+    return { actions: [], reply: "" };
   }
 
   const formattedMessages = messages
     .map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`)
     .join("\n\n");
 
-  const prompt = `<filing>
-Document: "${filingContext.filename}"
-Current folder: "${filingContext.currentFolder}"
-</filing>
+  const prompt = `<filings>
+${filingContexts
+  .map(
+    (filing) => `<filing id="${filing.id}">
+Document: ${JSON.stringify(filing.filename)}
+Current folder: ${JSON.stringify(filing.currentFolder)}
+</filing>`,
+  )
+  .join("\n")}
+</filings>
 
 <conversation>
 ${formattedMessages}

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -261,6 +261,40 @@ describe("filing-notifications", () => {
       });
     });
 
+    it("retries a transient failure when completing the claim", async () => {
+      prisma.documentFiling.findMany.mockResolvedValue([
+        createFiling({ id: "filing-1" }),
+      ]);
+      prisma.documentFiling.updateMany
+        .mockResolvedValueOnce({ count: 1 })
+        .mockRejectedValueOnce(new Error("temporary database failure"))
+        .mockResolvedValueOnce({ count: 1 });
+
+      await sendFilingNotifications({
+        emailProvider: createMockEmailProvider({
+          sendEmailWithHtml: vi
+            .fn()
+            .mockResolvedValue({ messageId: "", threadId: "thread-1" }),
+        }),
+        userEmail: "user@example.com",
+        filingIds: ["filing-1"],
+        sourceMessage,
+        logger,
+      });
+
+      expect(prisma.documentFiling.updateMany).toHaveBeenCalledTimes(3);
+      expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
+        where: {
+          id: { in: ["filing-1"] },
+          notificationClaimId: expect.any(String),
+        },
+        data: {
+          notificationClaimId: null,
+          notificationSentAt: expect.any(Date),
+        },
+      });
+    });
+
     it("keeps concurrent claims isolated when created at the same time", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -189,7 +189,9 @@ describe("filing-notifications", () => {
         createFiling({ id: "filing-1" }),
         createFiling({ id: "filing-2" }),
       ]);
-      prisma.documentFiling.updateMany.mockResolvedValue({ count: 0 });
+      prisma.documentFiling.updateMany
+        .mockResolvedValueOnce({ count: 1 })
+        .mockResolvedValueOnce({ count: 1 });
       const sendEmailWithHtml = vi.fn();
 
       await sendFilingNotifications({
@@ -201,6 +203,13 @@ describe("filing-notifications", () => {
       });
 
       expect(sendEmailWithHtml).not.toHaveBeenCalled();
+      expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
+        where: {
+          id: { in: ["filing-1", "filing-2"] },
+          notificationSentAt: expect.any(Date),
+        },
+        data: { notificationSentAt: null },
+      });
     });
 
     it("releases the claim when sending fails", async () => {

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createMockEmailProvider } from "@/__tests__/mocks/email-provider.mock";
 import { createTestLogger } from "@/__tests__/helpers";
+import type { DocumentFiling } from "@/generated/prisma/client";
+import { DocumentFilingStatus } from "@/generated/prisma/enums";
 import {
   sendAskNotification,
   sendFiledNotification,
@@ -23,13 +25,15 @@ describe("filing-notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    prisma.documentFiling.findUnique.mockResolvedValue({
-      id: filingId,
-      filename: "receipt.pdf",
-      folderPath: "Receipts",
-      reasoning: null,
-      driveConnection: { provider: "outlook" },
-    } as any);
+    prisma.documentFiling.findUnique.mockResolvedValue(
+      createFiling({
+        id: filingId,
+        filename: "receipt.pdf",
+        folderPath: "Receipts",
+        provider: "outlook",
+      }),
+    );
+    prisma.documentFiling.updateMany.mockResolvedValue({ count: 1 });
   });
 
   describe("sendFiledNotification", () => {
@@ -106,25 +110,20 @@ describe("filing-notifications", () => {
   describe("sendFilingNotifications", () => {
     it("sends one summary email for multiple filings", async () => {
       prisma.documentFiling.findMany.mockResolvedValue([
-        {
+        createFiling({
           id: "filing-1",
           filename: "first.pdf",
           folderPath: "Receipts",
-          reasoning: null,
-          status: "FILED",
-          wasAsked: false,
-          driveConnection: { provider: "google" },
-        },
-        {
+          provider: "google",
+        }),
+        createFiling({
           id: "filing-2",
           filename: "second.pdf",
           folderPath: "Invoices",
-          reasoning: null,
-          status: "FILED",
-          wasAsked: false,
-          driveConnection: { provider: "outlook" },
-        },
-      ] as any);
+          provider: "outlook",
+        }),
+      ]);
+      prisma.documentFiling.updateMany.mockResolvedValue({ count: 2 });
       const sendEmailWithHtml = vi
         .fn()
         .mockResolvedValue({ messageId: "sent-123", threadId: "thread-1" });
@@ -139,6 +138,9 @@ describe("filing-notifications", () => {
       });
 
       expect(sendEmailWithHtml).toHaveBeenCalledOnce();
+      expect(
+        prisma.documentFiling.updateMany.mock.invocationCallOrder[0],
+      ).toBeLessThan(sendEmailWithHtml.mock.invocationCallOrder[0]);
       expect(sendEmailWithHtml).toHaveBeenCalledWith(
         expect.objectContaining({
           subject: "✓ Filed 2 documents",
@@ -146,7 +148,10 @@ describe("filing-notifications", () => {
         }),
       );
       expect(prisma.documentFiling.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: ["filing-1", "filing-2"] } },
+        where: {
+          id: { in: ["filing-1", "filing-2"] },
+          notificationSentAt: null,
+        },
         data: { notificationSentAt: expect.any(Date) },
       });
       expect(prisma.documentFiling.update).toHaveBeenCalledWith({
@@ -178,5 +183,91 @@ describe("filing-notifications", () => {
       );
       expect(sendEmailWithHtml).not.toHaveBeenCalled();
     });
+
+    it("does not send when another process claims the filings first", async () => {
+      prisma.documentFiling.findMany.mockResolvedValue([
+        createFiling({ id: "filing-1" }),
+        createFiling({ id: "filing-2" }),
+      ]);
+      prisma.documentFiling.updateMany.mockResolvedValue({ count: 0 });
+      const sendEmailWithHtml = vi.fn();
+
+      await sendFilingNotifications({
+        emailProvider: createMockEmailProvider({ sendEmailWithHtml }),
+        userEmail: "user@example.com",
+        filingIds: ["filing-1", "filing-2"],
+        sourceMessage,
+        logger,
+      });
+
+      expect(sendEmailWithHtml).not.toHaveBeenCalled();
+    });
+
+    it("releases the claim when sending fails", async () => {
+      prisma.documentFiling.findMany.mockResolvedValue([
+        createFiling({ id: "filing-1" }),
+      ]);
+      const sendError = new Error("send failed");
+
+      await expect(
+        sendFilingNotifications({
+          emailProvider: createMockEmailProvider({
+            sendEmailWithHtml: vi.fn().mockRejectedValue(sendError),
+          }),
+          userEmail: "user@example.com",
+          filingIds: ["filing-1"],
+          sourceMessage,
+          logger,
+        }),
+      ).rejects.toThrow(sendError);
+
+      expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
+        where: {
+          id: { in: ["filing-1"] },
+          notificationSentAt: expect.any(Date),
+        },
+        data: { notificationSentAt: null },
+      });
+    });
   });
 });
+
+function createFiling({
+  id,
+  filename = "document.pdf",
+  folderPath = "Documents",
+  provider = "google",
+}: {
+  id: string;
+  filename?: string;
+  folderPath?: string;
+  provider?: string;
+}): DocumentFiling & { driveConnection: { provider: string } } {
+  const now = new Date();
+
+  return {
+    id,
+    createdAt: now,
+    updatedAt: now,
+    messageId: "message-1",
+    attachmentId: `${id}-attachment`,
+    filename,
+    folderId: "folder-1",
+    folderPath,
+    fileId: "file-1",
+    reasoning: null,
+    confidence: 1,
+    status: DocumentFilingStatus.FILED,
+    wasAsked: false,
+    wasCorrected: false,
+    originalPath: null,
+    correctedAt: null,
+    feedbackPositive: null,
+    feedbackAt: null,
+    notificationMessageId: null,
+    notificationSentAt: null,
+    driveConnectionId: "drive-1",
+    emailAccountId: "account-1",
+    driveConnection: { provider },
+  };
+}

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -5,6 +5,7 @@ import { createTestLogger } from "@/__tests__/helpers";
 import {
   sendAskNotification,
   sendFiledNotification,
+  sendFilingNotifications,
 } from "./filing-notifications";
 
 vi.mock("@/utils/prisma");
@@ -99,6 +100,83 @@ describe("filing-notifications", () => {
         | { data: { notificationMessageId?: string | null } }
         | undefined;
       expect(updateCall?.data.notificationMessageId ?? null).not.toBe("");
+    });
+  });
+
+  describe("sendFilingNotifications", () => {
+    it("sends one summary email for multiple filings", async () => {
+      prisma.documentFiling.findMany.mockResolvedValue([
+        {
+          id: "filing-1",
+          filename: "first.pdf",
+          folderPath: "Receipts",
+          reasoning: null,
+          status: "FILED",
+          wasAsked: false,
+          driveConnection: { provider: "google" },
+        },
+        {
+          id: "filing-2",
+          filename: "second.pdf",
+          folderPath: "Invoices",
+          reasoning: null,
+          status: "FILED",
+          wasAsked: false,
+          driveConnection: { provider: "outlook" },
+        },
+      ] as any);
+      const sendEmailWithHtml = vi
+        .fn()
+        .mockResolvedValue({ messageId: "sent-123", threadId: "thread-1" });
+      const emailProvider = createMockEmailProvider({ sendEmailWithHtml });
+
+      await sendFilingNotifications({
+        emailProvider,
+        userEmail: "user@example.com",
+        filingIds: ["filing-1", "filing-2"],
+        sourceMessage,
+        logger,
+      });
+
+      expect(sendEmailWithHtml).toHaveBeenCalledOnce();
+      expect(sendEmailWithHtml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: "✓ Filed 2 documents",
+          messageHtml: expect.stringMatching(/first\.pdf[\s\S]*second\.pdf/),
+        }),
+      );
+      expect(prisma.documentFiling.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ["filing-1", "filing-2"] } },
+        data: { notificationSentAt: expect.any(Date) },
+      });
+      expect(prisma.documentFiling.update).toHaveBeenCalledWith({
+        where: { id: "filing-1" },
+        data: { notificationMessageId: "sent-123" },
+      });
+    });
+
+    it("does not resend notifications for filings that were already notified", async () => {
+      prisma.documentFiling.findMany.mockResolvedValue([]);
+      const sendEmailWithHtml = vi.fn();
+      const emailProvider = createMockEmailProvider({ sendEmailWithHtml });
+
+      await sendFilingNotifications({
+        emailProvider,
+        userEmail: "user@example.com",
+        filingIds: ["filing-1", "filing-2"],
+        sourceMessage,
+        logger,
+      });
+
+      expect(prisma.documentFiling.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: { in: ["filing-1", "filing-2"] },
+            notificationSentAt: null,
+          },
+        }),
+      );
+      expect(sendEmailWithHtml).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -147,25 +147,24 @@ describe("filing-notifications", () => {
           messageHtml: expect.stringMatching(/first\.pdf[\s\S]*second\.pdf/),
         }),
       );
-      const notificationClaimId =
+      const notificationBatchId =
         prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
-          .notificationClaimId;
-      expect(notificationClaimId).toEqual(expect.any(String));
+          .notificationBatchId;
+      expect(notificationBatchId).toEqual(expect.any(String));
       expect(prisma.documentFiling.updateMany).toHaveBeenNthCalledWith(1, {
         where: {
           id: { in: ["filing-1", "filing-2"] },
-          notificationClaimId: null,
+          notificationBatchId: null,
           notificationSentAt: null,
         },
-        data: { notificationClaimId },
+        data: { notificationBatchId },
       });
       expect(prisma.documentFiling.updateMany).toHaveBeenNthCalledWith(2, {
         where: {
           id: { in: ["filing-1", "filing-2"] },
-          notificationClaimId,
+          notificationBatchId,
         },
         data: {
-          notificationClaimId: null,
           notificationSentAt: expect.any(Date),
         },
       });
@@ -192,7 +191,7 @@ describe("filing-notifications", () => {
         expect.objectContaining({
           where: {
             id: { in: ["filing-1", "filing-2"] },
-            notificationClaimId: null,
+            notificationBatchId: null,
             notificationSentAt: null,
           },
         }),
@@ -219,15 +218,15 @@ describe("filing-notifications", () => {
       });
 
       expect(sendEmailWithHtml).not.toHaveBeenCalled();
-      const notificationClaimId =
+      const notificationBatchId =
         prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
-          .notificationClaimId;
+          .notificationBatchId;
       expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
         where: {
           id: { in: ["filing-1", "filing-2"] },
-          notificationClaimId,
+          notificationBatchId,
         },
-        data: { notificationClaimId: null },
+        data: { notificationBatchId: null },
       });
     });
 
@@ -249,15 +248,15 @@ describe("filing-notifications", () => {
         }),
       ).rejects.toThrow(sendError);
 
-      const notificationClaimId =
+      const notificationBatchId =
         prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
-          .notificationClaimId;
+          .notificationBatchId;
       expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
         where: {
           id: { in: ["filing-1"] },
-          notificationClaimId,
+          notificationBatchId,
         },
-        data: { notificationClaimId: null },
+        data: { notificationBatchId: null },
       });
     });
 
@@ -286,10 +285,9 @@ describe("filing-notifications", () => {
       expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
         where: {
           id: { in: ["filing-1"] },
-          notificationClaimId: expect.any(String),
+          notificationBatchId: expect.any(String),
         },
         data: {
-          notificationClaimId: null,
           notificationSentAt: expect.any(Date),
         },
       });
@@ -308,15 +306,15 @@ describe("filing-notifications", () => {
         let activeClaimId: string | null = null;
         prisma.documentFiling.updateMany.mockImplementation(
           async ({ data, where }) => {
-            if (typeof data.notificationClaimId === "string") {
-              attemptedClaimIds.push(data.notificationClaimId);
+            if (typeof data.notificationBatchId === "string") {
+              attemptedClaimIds.push(data.notificationBatchId);
               if (activeClaimId) return { count: 0 };
 
-              activeClaimId = data.notificationClaimId;
+              activeClaimId = data.notificationBatchId;
               return { count: 2 };
             }
 
-            if (where.notificationClaimId !== activeClaimId) {
+            if (where.notificationBatchId !== activeClaimId) {
               return { count: 0 };
             }
 
@@ -395,7 +393,7 @@ function createFiling({
     feedbackAt: null,
     notificationMessageId: null,
     notificationSentAt: null,
-    notificationClaimId: null,
+    notificationBatchId: null,
     driveConnectionId: "drive-1",
     emailAccountId: "account-1",
     driveConnection: { provider },

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -147,12 +147,27 @@ describe("filing-notifications", () => {
           messageHtml: expect.stringMatching(/first\.pdf[\s\S]*second\.pdf/),
         }),
       );
-      expect(prisma.documentFiling.updateMany).toHaveBeenCalledWith({
+      const notificationClaimId =
+        prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
+          .notificationClaimId;
+      expect(notificationClaimId).toEqual(expect.any(String));
+      expect(prisma.documentFiling.updateMany).toHaveBeenNthCalledWith(1, {
         where: {
           id: { in: ["filing-1", "filing-2"] },
+          notificationClaimId: null,
           notificationSentAt: null,
         },
-        data: { notificationSentAt: expect.any(Date) },
+        data: { notificationClaimId },
+      });
+      expect(prisma.documentFiling.updateMany).toHaveBeenNthCalledWith(2, {
+        where: {
+          id: { in: ["filing-1", "filing-2"] },
+          notificationClaimId,
+        },
+        data: {
+          notificationClaimId: null,
+          notificationSentAt: expect.any(Date),
+        },
       });
       expect(prisma.documentFiling.update).toHaveBeenCalledWith({
         where: { id: "filing-1" },
@@ -177,6 +192,7 @@ describe("filing-notifications", () => {
         expect.objectContaining({
           where: {
             id: { in: ["filing-1", "filing-2"] },
+            notificationClaimId: null,
             notificationSentAt: null,
           },
         }),
@@ -203,12 +219,15 @@ describe("filing-notifications", () => {
       });
 
       expect(sendEmailWithHtml).not.toHaveBeenCalled();
+      const notificationClaimId =
+        prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
+          .notificationClaimId;
       expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
         where: {
           id: { in: ["filing-1", "filing-2"] },
-          notificationSentAt: expect.any(Date),
+          notificationClaimId,
         },
-        data: { notificationSentAt: null },
+        data: { notificationClaimId: null },
       });
     });
 
@@ -230,13 +249,80 @@ describe("filing-notifications", () => {
         }),
       ).rejects.toThrow(sendError);
 
+      const notificationClaimId =
+        prisma.documentFiling.updateMany.mock.calls[0]?.[0].data
+          .notificationClaimId;
       expect(prisma.documentFiling.updateMany).toHaveBeenLastCalledWith({
         where: {
           id: { in: ["filing-1"] },
-          notificationSentAt: expect.any(Date),
+          notificationClaimId,
         },
-        data: { notificationSentAt: null },
+        data: { notificationClaimId: null },
       });
+    });
+
+    it("keeps concurrent claims isolated when created at the same time", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      try {
+        prisma.documentFiling.findMany.mockResolvedValue([
+          createFiling({ id: "filing-1" }),
+          createFiling({ id: "filing-2" }),
+        ]);
+        const attemptedClaimIds: string[] = [];
+        let activeClaimId: string | null = null;
+        prisma.documentFiling.updateMany.mockImplementation(
+          async ({ data, where }) => {
+            if (typeof data.notificationClaimId === "string") {
+              attemptedClaimIds.push(data.notificationClaimId);
+              if (activeClaimId) return { count: 0 };
+
+              activeClaimId = data.notificationClaimId;
+              return { count: 2 };
+            }
+
+            if (where.notificationClaimId !== activeClaimId) {
+              return { count: 0 };
+            }
+
+            activeClaimId = null;
+            return { count: 2 };
+          },
+        );
+
+        const sendStarted = createDeferred<void>();
+        const pendingSend = createDeferred<{
+          messageId: string;
+          threadId: string;
+        }>();
+        const sendEmailWithHtml = vi.fn(() => {
+          sendStarted.resolve();
+          return pendingSend.promise;
+        });
+        const params = {
+          emailProvider: createMockEmailProvider({ sendEmailWithHtml }),
+          userEmail: "user@example.com",
+          filingIds: ["filing-1", "filing-2"],
+          sourceMessage,
+          logger,
+        };
+
+        const firstSend = sendFilingNotifications(params);
+        await sendStarted.promise;
+        await sendFilingNotifications(params);
+
+        expect(sendEmailWithHtml).toHaveBeenCalledOnce();
+        expect(new Set(attemptedClaimIds).size).toBe(2);
+        expect(activeClaimId).toBe(attemptedClaimIds[0]);
+
+        pendingSend.resolve({ messageId: "sent-123", threadId: "thread-1" });
+        await firstSend;
+
+        expect(activeClaimId).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });
@@ -275,8 +361,21 @@ function createFiling({
     feedbackAt: null,
     notificationMessageId: null,
     notificationSentAt: null,
+    notificationClaimId: null,
     driveConnectionId: "drive-1",
     emailAccountId: "account-1",
     driveConnection: { provider },
   };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve = (_value: T) => {};
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
 }

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -29,6 +29,19 @@ interface FilingNotificationParams {
   userEmail: string;
 }
 
+interface FilingNotificationsParams
+  extends Omit<FilingNotificationParams, "filingId"> {
+  filingIds: string[];
+}
+
+type FilingNotification = {
+  driveConnection: { provider: string };
+  filename: string;
+  folderPath: string;
+  reasoning: string | null;
+  wasAsked: boolean;
+};
+
 // ============================================================================
 // Main Functions
 // ============================================================================
@@ -69,29 +82,17 @@ export async function sendFiledNotification({
     driveProvider: filing.driveConnection.provider,
   });
 
-  try {
-    const result = await emailProvider.sendEmailWithHtml({
-      replyToEmail: sourceMessage,
-      to: userEmail,
-      from: fromAddress,
-      replyTo: replyToAddress,
-      subject,
-      messageHtml,
-    });
-
-    await prisma.documentFiling.update({
-      where: { id: filingId },
-      data: {
-        notificationMessageId: result.messageId || null,
-        notificationSentAt: new Date(),
-      },
-    });
-
-    log.info("Filed notification sent", { messageId: result.messageId });
-  } catch (error) {
-    log.error("Failed to send filed notification", { error });
-    throw error;
-  }
+  await sendNotificationEmail({
+    emailProvider,
+    filingIds: [filingId],
+    fromAddress,
+    logger: log,
+    messageHtml,
+    replyToAddress,
+    sourceMessage,
+    subject,
+    userEmail,
+  });
 }
 
 /**
@@ -126,29 +127,71 @@ export async function sendAskNotification({
     reasoning: filing.reasoning,
   });
 
-  try {
-    const result = await emailProvider.sendEmailWithHtml({
-      replyToEmail: sourceMessage,
-      to: userEmail,
-      from: fromAddress,
-      replyTo: replyToAddress,
-      subject,
-      messageHtml,
-    });
+  await sendNotificationEmail({
+    emailProvider,
+    filingIds: [filingId],
+    fromAddress,
+    logger: log,
+    messageHtml,
+    replyToAddress,
+    sourceMessage,
+    subject,
+    userEmail,
+  });
+}
 
-    await prisma.documentFiling.update({
-      where: { id: filingId },
-      data: {
-        notificationMessageId: result.messageId || null,
-        notificationSentAt: new Date(),
-      },
-    });
+/**
+ * Send one notification for all newly processed attachments in a source email.
+ */
+export async function sendFilingNotifications({
+  emailProvider,
+  userEmail,
+  filingIds,
+  sourceMessage,
+  logger,
+}: FilingNotificationsParams): Promise<void> {
+  const log = logger.with({
+    action: "sendFilingNotifications",
+    filingCount: filingIds.length,
+  });
 
-    log.info("Ask notification sent", { messageId: result.messageId });
-  } catch (error) {
-    log.error("Failed to send ask notification", { error });
-    throw error;
+  const filings = await prisma.documentFiling.findMany({
+    where: {
+      id: { in: filingIds },
+      notificationSentAt: null,
+    },
+    include: {
+      driveConnection: { select: { provider: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (filings.length === 0) {
+    log.info("No filing notifications to send");
+    return;
   }
+
+  const replyToAddress = getFilebotReplyTo({ userEmail });
+  const fromAddress = getFilebotFrom({ userEmail });
+  const askedFilings = filings.filter((filing) => filing.wasAsked);
+  const subject = getFilingNotificationSubject({
+    filingCount: filings.length,
+    askedCount: askedFilings.length,
+    firstFilename: filings[0].filename,
+  });
+  const messageHtml = getFilingNotificationHtml(filings);
+
+  await sendNotificationEmail({
+    emailProvider,
+    filingIds: filings.map((filing) => filing.id),
+    fromAddress,
+    logger: log,
+    messageHtml,
+    replyToAddress,
+    sourceMessage,
+    subject,
+    userEmail,
+  });
 }
 
 /**
@@ -214,23 +257,10 @@ function buildFiledEmailHtml({
   folderPath: string;
   driveProvider: string;
 }): string {
-  const driveName = driveProvider === "google" ? "Google Drive" : "OneDrive";
-
   return `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 500px;">
       <p>Filed your document:</p>
-      
-      <div style="background: #f5f5f5; padding: 16px; border-radius: 8px; margin: 16px 0;">
-        <p style="margin: 0 0 8px 0;">
-          <strong>📄 ${escapeHtml(filename)}</strong>
-        </p>
-        <p style="margin: 0; color: #666;">
-          📁 → ${escapeHtml(folderPath)}
-        </p>
-        <p style="margin: 8px 0 0 0; font-size: 12px; color: #888;">
-          ${driveName}
-        </p>
-      </div>
+      ${buildFiledItemHtml({ filename, folderPath, driveName: getDriveName(driveProvider) })}
       
       <p style="color: #666; font-size: 14px;">
         Wrong folder? Just reply with where it should go.
@@ -249,13 +279,7 @@ function buildAskEmailHtml({
   return `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 500px;">
       <p>Got a document I'm not sure about:</p>
-      
-      <div style="background: #f5f5f5; padding: 16px; border-radius: 8px; margin: 16px 0;">
-        <p style="margin: 0;">
-          <strong>📄 ${escapeHtml(filename)}</strong>
-        </p>
-        ${reasoning ? `<p style="margin: 8px 0 0 0; color: #666; font-size: 14px;">${escapeHtml(reasoning)}</p>` : ""}
-      </div>
+      ${buildAskItemHtml({ filename, reasoning })}
       
       <p><strong>Where should I put it?</strong></p>
       
@@ -267,6 +291,185 @@ function buildAskEmailHtml({
       </p>
     </div>
   `;
+}
+
+function buildFilingSummaryEmailHtml(filings: FilingNotification[]): string {
+  const filedItems = filings.filter((filing) => !filing.wasAsked);
+  const askedItems = filings.filter((filing) => filing.wasAsked);
+
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 500px;">
+      ${
+        filedItems.length > 0
+          ? `<p>Filed your documents:</p>
+             ${filedItems
+               .map((filing) =>
+                 buildFiledItemHtml({
+                   filename: filing.filename,
+                   folderPath: filing.folderPath,
+                   driveName: getDriveName(filing.driveConnection.provider),
+                 }),
+               )
+               .join("")}`
+          : ""
+      }
+      ${
+        askedItems.length > 0
+          ? `<p>Got some documents I'm not sure about:</p>
+             ${askedItems.map(buildAskItemHtml).join("")}`
+          : ""
+      }
+
+      <p style="color: #666; font-size: 14px;">
+        ${
+          askedItems.length > 0
+            ? "Reply with the document name and folder path for anything that needs your input."
+            : "Wrong folder? Reply with the document name and where it should go."
+        }
+      </p>
+    </div>
+  `;
+}
+
+function getFilingNotificationHtml(filings: FilingNotification[]): string {
+  if (filings.length > 1) return buildFilingSummaryEmailHtml(filings);
+
+  const filing = filings[0];
+  if (filing.wasAsked) {
+    return buildAskEmailHtml({
+      filename: filing.filename,
+      reasoning: filing.reasoning,
+    });
+  }
+
+  return buildFiledEmailHtml({
+    filename: filing.filename,
+    folderPath: filing.folderPath,
+    driveProvider: filing.driveConnection.provider,
+  });
+}
+
+function buildFiledItemHtml({
+  filename,
+  folderPath,
+  driveName,
+}: {
+  filename: string;
+  folderPath: string;
+  driveName: string;
+}): string {
+  return `
+    <div style="background: #f5f5f5; padding: 16px; border-radius: 8px; margin: 12px 0;">
+      <p style="margin: 0 0 8px 0;"><strong>📄 ${escapeHtml(filename)}</strong></p>
+      <p style="margin: 0; color: #666;">📁 → ${escapeHtml(folderPath)}</p>
+      <p style="margin: 8px 0 0 0; font-size: 12px; color: #888;">${driveName}</p>
+    </div>
+  `;
+}
+
+function buildAskItemHtml({
+  filename,
+  reasoning,
+}: {
+  filename: string;
+  reasoning: string | null;
+}): string {
+  return `
+    <div style="background: #f5f5f5; padding: 16px; border-radius: 8px; margin: 12px 0;">
+      <p style="margin: 0;"><strong>📄 ${escapeHtml(filename)}</strong></p>
+      ${reasoning ? `<p style="margin: 8px 0 0 0; color: #666; font-size: 14px;">${escapeHtml(reasoning)}</p>` : ""}
+    </div>
+  `;
+}
+
+function getFilingNotificationSubject({
+  filingCount,
+  askedCount,
+  firstFilename,
+}: {
+  filingCount: number;
+  askedCount: number;
+  firstFilename: string;
+}): string {
+  if (filingCount === 1) {
+    return askedCount === 1
+      ? `📄 Where should I file ${firstFilename}?`
+      : `✓ Filed ${firstFilename}`;
+  }
+
+  if (askedCount === 0) return `✓ Filed ${filingCount} documents`;
+  if (askedCount === filingCount) {
+    return `📄 Where should I file ${filingCount} documents?`;
+  }
+  return `📄 Filing update for ${filingCount} documents`;
+}
+
+function getDriveName(provider: string): string {
+  return provider === "google" ? "Google Drive" : "OneDrive";
+}
+
+async function sendNotificationEmail({
+  emailProvider,
+  filingIds,
+  fromAddress,
+  logger,
+  messageHtml,
+  replyToAddress,
+  sourceMessage,
+  subject,
+  userEmail,
+}: {
+  emailProvider: EmailProvider;
+  filingIds: string[];
+  fromAddress: string;
+  logger: Logger;
+  messageHtml: string;
+  replyToAddress: string;
+  sourceMessage: SourceMessageInfo;
+  subject: string;
+  userEmail: string;
+}): Promise<void> {
+  try {
+    const result = await emailProvider.sendEmailWithHtml({
+      replyToEmail: sourceMessage,
+      to: userEmail,
+      from: fromAddress,
+      replyTo: replyToAddress,
+      subject,
+      messageHtml,
+    });
+    const notificationSentAt = new Date();
+
+    if (filingIds.length === 1) {
+      await prisma.documentFiling.update({
+        where: { id: filingIds[0] },
+        data: {
+          notificationMessageId: result.messageId || null,
+          notificationSentAt,
+        },
+      });
+    } else {
+      await prisma.documentFiling.updateMany({
+        where: { id: { in: filingIds } },
+        data: { notificationSentAt },
+      });
+
+      if (result.messageId) {
+        await prisma.documentFiling.update({
+          where: { id: filingIds[0] },
+          data: { notificationMessageId: result.messageId },
+        });
+      }
+    }
+
+    logger.info("Filing notification sent", {
+      messageId: result.messageId,
+      filingCount: filingIds.length,
+    });
+  } catch (error) {
+    logger.error("Failed to send filing notification", { error });
+    throw error;
+  }
 }
 
 function buildCorrectionConfirmationHtml({

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import prisma from "@/utils/prisma";
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
@@ -158,6 +159,7 @@ export async function sendFilingNotifications({
   const filings = await prisma.documentFiling.findMany({
     where: {
       id: { in: filingIds },
+      notificationClaimId: null,
       notificationSentAt: null,
     },
     include: {
@@ -429,20 +431,21 @@ async function sendNotificationEmail({
   subject: string;
   userEmail: string;
 }): Promise<void> {
-  const notificationSentAt = new Date();
+  const notificationClaimId = randomUUID();
   const claim = await prisma.documentFiling.updateMany({
     where: {
       id: { in: filingIds },
+      notificationClaimId: null,
       notificationSentAt: null,
     },
-    data: { notificationSentAt },
+    data: { notificationClaimId },
   });
 
   if (claim.count !== filingIds.length) {
     await releaseNotificationClaim({
       filingIds,
       logger,
-      notificationSentAt,
+      notificationClaimId,
     });
     logger.info("Filing notification already claimed", {
       filingCount: filingIds.length,
@@ -465,11 +468,27 @@ async function sendNotificationEmail({
     await releaseNotificationClaim({
       filingIds,
       logger,
-      notificationSentAt,
+      notificationClaimId,
     });
 
     logger.error("Failed to send filing notification", { error });
     throw error;
+  }
+
+  try {
+    await prisma.documentFiling.updateMany({
+      where: {
+        id: { in: filingIds },
+        notificationClaimId,
+      },
+      data: {
+        notificationClaimId: null,
+        notificationSentAt: new Date(),
+      },
+    });
+  } catch (error) {
+    logger.error("Failed to complete filing notification claim", { error });
+    return;
   }
 
   if (result.messageId) {
@@ -492,19 +511,19 @@ async function sendNotificationEmail({
 async function releaseNotificationClaim({
   filingIds,
   logger,
-  notificationSentAt,
+  notificationClaimId,
 }: {
   filingIds: string[];
   logger: Logger;
-  notificationSentAt: Date;
+  notificationClaimId: string;
 }): Promise<void> {
   try {
     await prisma.documentFiling.updateMany({
       where: {
         id: { in: filingIds },
-        notificationSentAt,
+        notificationClaimId,
       },
-      data: { notificationSentAt: null },
+      data: { notificationClaimId: null },
     });
   } catch (error) {
     logger.error("Failed to release filing notification claim", { error });

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -159,7 +159,7 @@ export async function sendFilingNotifications({
   const filings = await prisma.documentFiling.findMany({
     where: {
       id: { in: filingIds },
-      notificationClaimId: null,
+      notificationBatchId: null,
       notificationSentAt: null,
     },
     include: {
@@ -431,21 +431,21 @@ async function sendNotificationEmail({
   subject: string;
   userEmail: string;
 }): Promise<void> {
-  const notificationClaimId = randomUUID();
+  const notificationBatchId = randomUUID();
   const claim = await prisma.documentFiling.updateMany({
     where: {
       id: { in: filingIds },
-      notificationClaimId: null,
+      notificationBatchId: null,
       notificationSentAt: null,
     },
-    data: { notificationClaimId },
+    data: { notificationBatchId },
   });
 
   if (claim.count !== filingIds.length) {
-    await releaseNotificationClaim({
+    await releaseNotificationBatch({
       filingIds,
       logger,
-      notificationClaimId,
+      notificationBatchId,
     });
     logger.info("Filing notification already claimed", {
       filingCount: filingIds.length,
@@ -465,22 +465,22 @@ async function sendNotificationEmail({
       messageHtml,
     });
   } catch (error) {
-    await releaseNotificationClaim({
+    await releaseNotificationBatch({
       filingIds,
       logger,
-      notificationClaimId,
+      notificationBatchId,
     });
 
     logger.error("Failed to send filing notification", { error });
     throw error;
   }
 
-  const claimCompleted = await completeNotificationClaim({
+  const batchCompleted = await completeNotificationBatch({
     filingIds,
     logger,
-    notificationClaimId,
+    notificationBatchId,
   });
-  if (!claimCompleted) return;
+  if (!batchCompleted) return;
 
   if (result.messageId) {
     try {
@@ -499,14 +499,14 @@ async function sendNotificationEmail({
   });
 }
 
-async function completeNotificationClaim({
+async function completeNotificationBatch({
   filingIds,
   logger,
-  notificationClaimId,
+  notificationBatchId,
 }: {
   filingIds: string[];
   logger: Logger;
-  notificationClaimId: string;
+  notificationBatchId: string;
 }): Promise<boolean> {
   const notificationSentAt = new Date();
   let lastError: unknown;
@@ -516,10 +516,9 @@ async function completeNotificationClaim({
       const result = await prisma.documentFiling.updateMany({
         where: {
           id: { in: filingIds },
-          notificationClaimId,
+          notificationBatchId,
         },
         data: {
-          notificationClaimId: null,
           notificationSentAt,
         },
       });
@@ -542,22 +541,22 @@ async function completeNotificationClaim({
   return false;
 }
 
-async function releaseNotificationClaim({
+async function releaseNotificationBatch({
   filingIds,
   logger,
-  notificationClaimId,
+  notificationBatchId,
 }: {
   filingIds: string[];
   logger: Logger;
-  notificationClaimId: string;
+  notificationBatchId: string;
 }): Promise<void> {
   try {
     await prisma.documentFiling.updateMany({
       where: {
         id: { in: filingIds },
-        notificationClaimId,
+        notificationBatchId,
       },
-      data: { notificationClaimId: null },
+      data: { notificationBatchId: null },
     });
   } catch (error) {
     logger.error("Failed to release filing notification claim", { error });

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -475,21 +475,12 @@ async function sendNotificationEmail({
     throw error;
   }
 
-  try {
-    await prisma.documentFiling.updateMany({
-      where: {
-        id: { in: filingIds },
-        notificationClaimId,
-      },
-      data: {
-        notificationClaimId: null,
-        notificationSentAt: new Date(),
-      },
-    });
-  } catch (error) {
-    logger.error("Failed to complete filing notification claim", { error });
-    return;
-  }
+  const claimCompleted = await completeNotificationClaim({
+    filingIds,
+    logger,
+    notificationClaimId,
+  });
+  if (!claimCompleted) return;
 
   if (result.messageId) {
     try {
@@ -506,6 +497,49 @@ async function sendNotificationEmail({
     messageId: result.messageId,
     filingCount: filingIds.length,
   });
+}
+
+async function completeNotificationClaim({
+  filingIds,
+  logger,
+  notificationClaimId,
+}: {
+  filingIds: string[];
+  logger: Logger;
+  notificationClaimId: string;
+}): Promise<boolean> {
+  const notificationSentAt = new Date();
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const result = await prisma.documentFiling.updateMany({
+        where: {
+          id: { in: filingIds },
+          notificationClaimId,
+        },
+        data: {
+          notificationClaimId: null,
+          notificationSentAt,
+        },
+      });
+
+      if (result.count === filingIds.length) return true;
+
+      logger.error("Failed to complete every filing notification claim", {
+        completedCount: result.count,
+        filingCount: filingIds.length,
+      });
+      return false;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  logger.error("Failed to complete filing notification claim", {
+    error: lastError,
+  });
+  return false;
 }
 
 async function releaseNotificationClaim({

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -439,6 +439,11 @@ async function sendNotificationEmail({
   });
 
   if (claim.count !== filingIds.length) {
+    await releaseNotificationClaim({
+      filingIds,
+      logger,
+      notificationSentAt,
+    });
     logger.info("Filing notification already claimed", {
       filingCount: filingIds.length,
     });
@@ -457,19 +462,11 @@ async function sendNotificationEmail({
       messageHtml,
     });
   } catch (error) {
-    try {
-      await prisma.documentFiling.updateMany({
-        where: {
-          id: { in: filingIds },
-          notificationSentAt,
-        },
-        data: { notificationSentAt: null },
-      });
-    } catch (releaseError) {
-      logger.error("Failed to release filing notification claim", {
-        error: releaseError,
-      });
-    }
+    await releaseNotificationClaim({
+      filingIds,
+      logger,
+      notificationSentAt,
+    });
 
     logger.error("Failed to send filing notification", { error });
     throw error;
@@ -490,6 +487,28 @@ async function sendNotificationEmail({
     messageId: result.messageId,
     filingCount: filingIds.length,
   });
+}
+
+async function releaseNotificationClaim({
+  filingIds,
+  logger,
+  notificationSentAt,
+}: {
+  filingIds: string[];
+  logger: Logger;
+  notificationSentAt: Date;
+}): Promise<void> {
+  try {
+    await prisma.documentFiling.updateMany({
+      where: {
+        id: { in: filingIds },
+        notificationSentAt,
+      },
+      data: { notificationSentAt: null },
+    });
+  } catch (error) {
+    logger.error("Failed to release filing notification claim", { error });
+  }
 }
 
 function buildCorrectionConfirmationHtml({

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -429,8 +429,26 @@ async function sendNotificationEmail({
   subject: string;
   userEmail: string;
 }): Promise<void> {
+  const notificationSentAt = new Date();
+  const claim = await prisma.documentFiling.updateMany({
+    where: {
+      id: { in: filingIds },
+      notificationSentAt: null,
+    },
+    data: { notificationSentAt },
+  });
+
+  if (claim.count !== filingIds.length) {
+    logger.info("Filing notification already claimed", {
+      filingCount: filingIds.length,
+    });
+    return;
+  }
+
+  let result: Awaited<ReturnType<EmailProvider["sendEmailWithHtml"]>>;
+
   try {
-    const result = await emailProvider.sendEmailWithHtml({
+    result = await emailProvider.sendEmailWithHtml({
       replyToEmail: sourceMessage,
       to: userEmail,
       from: fromAddress,
@@ -438,38 +456,40 @@ async function sendNotificationEmail({
       subject,
       messageHtml,
     });
-    const notificationSentAt = new Date();
-
-    if (filingIds.length === 1) {
-      await prisma.documentFiling.update({
-        where: { id: filingIds[0] },
-        data: {
-          notificationMessageId: result.messageId || null,
+  } catch (error) {
+    try {
+      await prisma.documentFiling.updateMany({
+        where: {
+          id: { in: filingIds },
           notificationSentAt,
         },
+        data: { notificationSentAt: null },
       });
-    } else {
-      await prisma.documentFiling.updateMany({
-        where: { id: { in: filingIds } },
-        data: { notificationSentAt },
+    } catch (releaseError) {
+      logger.error("Failed to release filing notification claim", {
+        error: releaseError,
       });
-
-      if (result.messageId) {
-        await prisma.documentFiling.update({
-          where: { id: filingIds[0] },
-          data: { notificationMessageId: result.messageId },
-        });
-      }
     }
 
-    logger.info("Filing notification sent", {
-      messageId: result.messageId,
-      filingCount: filingIds.length,
-    });
-  } catch (error) {
     logger.error("Failed to send filing notification", { error });
     throw error;
   }
+
+  if (result.messageId) {
+    try {
+      await prisma.documentFiling.update({
+        where: { id: filingIds[0] },
+        data: { notificationMessageId: result.messageId },
+      });
+    } catch (error) {
+      logger.error("Failed to save filing notification message ID", { error });
+    }
+  }
+
+  logger.info("Filing notification sent", {
+    messageId: result.messageId,
+    filingCount: filingIds.length,
+  });
 }
 
 function buildCorrectionConfirmationHtml({

--- a/apps/web/utils/drive/handle-filing-reply.test.ts
+++ b/apps/web/utils/drive/handle-filing-reply.test.ts
@@ -126,6 +126,36 @@ describe("processFilingReply", () => {
     expect(prisma.documentFiling.update).not.toHaveBeenCalled();
   });
 
+  it("continues processing the batch when one filing action fails", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst.mockResolvedValue(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+    prisma.documentFiling.update
+      .mockRejectedValueOnce(new Error("Database unavailable"))
+      .mockResolvedValueOnce(filings[1]);
+    vi.mocked(aiParseFilingReply).mockResolvedValue({
+      actions: [
+        { filingId: "filing-1", action: "approve", folderPath: null },
+        { filingId: "filing-2", action: "approve", folderPath: null },
+      ],
+      reply: "Done",
+    });
+    const params = getReplyParams();
+
+    await processFilingReply(params);
+
+    expect(prisma.documentFiling.update).toHaveBeenCalledTimes(2);
+    expect(prisma.documentFiling.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: { id: "filing-2" } }),
+    );
+    expect(params.emailProvider.replyToEmail).toHaveBeenCalledWith(
+      params.message,
+      "Done",
+      expect.any(Object),
+    );
+  });
+
   it("limits legacy notifications without a batch ID to their anchor filing", async () => {
     const legacyFiling = {
       ...getFilingBatch()[0],

--- a/apps/web/utils/drive/handle-filing-reply.test.ts
+++ b/apps/web/utils/drive/handle-filing-reply.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { getEmailAccount } from "@/__tests__/helpers";
+import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import {
   createMockEmailProvider,
   getMockParsedMessage,
 } from "@/__tests__/mocks/email-provider.mock";
-import { createTestLogger } from "@/__tests__/helpers";
+import type {
+  DocumentFiling,
+  DriveConnection,
+} from "@/generated/prisma/client";
+import { DocumentFilingStatus } from "@/generated/prisma/enums";
+import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
 import { processFilingReply } from "./handle-filing-reply";
 
 vi.mock("@/utils/prisma");
@@ -13,13 +18,10 @@ vi.mock("@/utils/ai/document-filing/parse-filing-reply", () => ({
   aiParseFilingReply: vi.fn(),
 }));
 vi.mock("@/utils/ai/content-sanitizer", () => ({
-  emailToContentForAI: vi.fn().mockReturnValue("approve"),
+  emailToContentForAI: vi.fn().mockReturnValue("Update the second document"),
 }));
 
-import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
-
 const logger = createTestLogger();
-
 const emailAccountId = "email-account-id";
 const userEmail = "user@example.com";
 
@@ -27,59 +29,257 @@ describe("processFilingReply", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(aiParseFilingReply).mockResolvedValue({
-      action: "approve",
-      reply: null,
-      folderPath: null,
-    } as any);
+      actions: [],
+      reply: "",
+    });
   });
 
-  it("finds filing by source messageId when notificationMessageId is null", async () => {
-    const filingRow = {
-      id: "filing-1",
-      filename: "receipt.pdf",
-      folderPath: "Receipts",
-      fileId: "file-1",
-      status: "FILED",
-      wasCorrected: false,
-      originalPath: null,
-      messageId: "source-123",
-      notificationMessageId: null,
-      emailAccountId,
-      driveConnection: { id: "conn-1", provider: "outlook" } as any,
-    };
-
-    prisma.documentFiling.findFirst.mockImplementation(async (args: any) => {
-      const messageIdIn: string[] = args?.where?.messageId?.in ?? [];
-      return messageIdIn.includes(filingRow.messageId)
-        ? (filingRow as any)
-        : null;
+  it("applies a named action to the correct filing in a batch", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst.mockResolvedValue(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+    vi.mocked(aiParseFilingReply).mockResolvedValue({
+      actions: [{ filingId: "filing-2", action: "approve", folderPath: null }],
+      reply: "",
     });
 
-    const emailProvider = createMockEmailProvider({
-      getThreadMessages: vi
-        .fn()
-        .mockResolvedValue([{ id: "source-123" }, { id: "reply-456" }]),
-      isSentMessage: vi.fn().mockReturnValue(true),
-    });
+    await processFilingReply(getReplyParams());
 
-    await processFilingReply({
-      emailAccountId,
-      userEmail,
-      message: getMockParsedMessage({
-        id: "reply-456",
-        threadId: "thread-1",
-        headers: { from: userEmail, to: userEmail, subject: "Re: Filed" },
-      }),
-      emailProvider,
-      emailAccount: getEmailAccount({ id: emailAccountId }),
-      logger,
-    });
-
-    expect(prisma.documentFiling.update).toHaveBeenCalledWith(
+    expect(prisma.documentFiling.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "filing-1" },
-        data: expect.objectContaining({ feedbackPositive: true }),
+        where: {
+          emailAccountId,
+          notificationMessageId: "notification-1",
+        },
+      }),
+    );
+    expect(prisma.documentFiling.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { emailAccountId, notificationBatchId: "batch-1" },
+      }),
+    );
+    expect(aiParseFilingReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filingContexts: [
+          {
+            id: "filing-1",
+            filename: "first.pdf",
+            currentFolder: "Receipts",
+          },
+          {
+            id: "filing-2",
+            filename: "second.pdf",
+            currentFolder: "Invoices",
+          },
+        ],
+      }),
+    );
+    expect(prisma.documentFiling.update).toHaveBeenCalledOnce();
+    expect(prisma.documentFiling.update).toHaveBeenCalledWith({
+      where: { id: "filing-2" },
+      data: {
+        feedbackPositive: true,
+        feedbackAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("applies multiple actions to their matching filings", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst.mockResolvedValue(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+    vi.mocked(aiParseFilingReply).mockResolvedValue({
+      actions: [
+        { filingId: "filing-1", action: "approve", folderPath: null },
+        { filingId: "filing-2", action: "approve", folderPath: null },
+        { filingId: "filing-1", action: "undo", folderPath: null },
+      ],
+      reply: "",
+    });
+
+    await processFilingReply(getReplyParams());
+
+    expect(prisma.documentFiling.update).toHaveBeenCalledTimes(2);
+    expect(prisma.documentFiling.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: { id: "filing-1" } }),
+    );
+    expect(prisma.documentFiling.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: { id: "filing-2" } }),
+    );
+  });
+
+  it("ignores actions for filings outside the notification batch", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst.mockResolvedValue(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+    vi.mocked(aiParseFilingReply).mockResolvedValue({
+      actions: [
+        { filingId: "unrelated-filing", action: "approve", folderPath: null },
+      ],
+      reply: "",
+    });
+
+    await processFilingReply(getReplyParams());
+
+    expect(prisma.documentFiling.update).not.toHaveBeenCalled();
+  });
+
+  it("limits legacy notifications without a batch ID to their anchor filing", async () => {
+    const legacyFiling = {
+      ...getFilingBatch()[0],
+      notificationBatchId: null,
+    };
+    prisma.documentFiling.findFirst.mockResolvedValue(legacyFiling);
+    prisma.documentFiling.findMany.mockResolvedValue([legacyFiling]);
+
+    await processFilingReply(getReplyParams());
+
+    expect(prisma.documentFiling.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "filing-1" } }),
+    );
+    expect(aiParseFilingReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filingContexts: [expect.objectContaining({ id: "filing-1" })],
+      }),
+    );
+  });
+
+  it("falls back to the source message when the provider message ID changed", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+
+    await processFilingReply(getReplyParams());
+
+    expect(prisma.documentFiling.findFirst).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          emailAccountId,
+          messageId: "source-1",
+        },
+      }),
+    );
+    expect(aiParseFilingReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filingContexts: expect.arrayContaining([
+          expect.objectContaining({ id: "filing-1" }),
+          expect.objectContaining({ id: "filing-2" }),
+        ]),
       }),
     );
   });
 });
+
+function getReplyParams() {
+  const sourceMessage = getMockParsedMessage({
+    id: "source-1",
+    threadId: "thread-1",
+    headers: { "message-id": "<source-1@example.com>" },
+  });
+  const notificationMessage = getMockParsedMessage({
+    id: "notification-1",
+    threadId: "thread-1",
+    headers: {
+      "in-reply-to": "<source-1@example.com>",
+      "message-id": "<notification-1@example.com>",
+    },
+  });
+  const message = getMockParsedMessage({
+    id: "reply-1",
+    threadId: "thread-1",
+    headers: {
+      from: userEmail,
+      "in-reply-to": "<notification-1@example.com>",
+    },
+  });
+  const emailProvider = createMockEmailProvider({
+    getThreadMessages: vi
+      .fn()
+      .mockResolvedValue([sourceMessage, notificationMessage, message]),
+    isSentMessage: vi.fn().mockReturnValue(true),
+  });
+
+  return {
+    emailAccountId,
+    userEmail,
+    message,
+    emailProvider,
+    emailAccount: getEmailAccount({ id: emailAccountId }),
+    logger,
+  };
+}
+
+function getFilingBatch(): Array<
+  DocumentFiling & { driveConnection: DriveConnection }
+> {
+  return [
+    getFiling({
+      id: "filing-1",
+      filename: "first.pdf",
+      folderPath: "Receipts",
+      notificationMessageId: "notification-1",
+    }),
+    getFiling({
+      id: "filing-2",
+      filename: "second.pdf",
+      folderPath: "Invoices",
+    }),
+  ];
+}
+
+function getFiling({
+  id,
+  filename,
+  folderPath,
+  notificationMessageId = null,
+}: {
+  id: string;
+  filename: string;
+  folderPath: string;
+  notificationMessageId?: string | null;
+}): DocumentFiling & { driveConnection: DriveConnection } {
+  const now = new Date();
+
+  return {
+    id,
+    createdAt: now,
+    updatedAt: now,
+    messageId: "source-1",
+    attachmentId: `${id}-attachment`,
+    filename,
+    folderId: "folder-1",
+    folderPath,
+    fileId: `${id}-file`,
+    reasoning: null,
+    confidence: 1,
+    status: DocumentFilingStatus.FILED,
+    wasAsked: false,
+    wasCorrected: false,
+    originalPath: null,
+    correctedAt: null,
+    feedbackPositive: null,
+    feedbackAt: null,
+    notificationMessageId,
+    notificationSentAt: now,
+    notificationBatchId: "batch-1",
+    driveConnectionId: "drive-1",
+    emailAccountId,
+    driveConnection: {
+      id: "drive-1",
+      createdAt: now,
+      updatedAt: now,
+      provider: "google",
+      email: userEmail,
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+      isConnected: true,
+      emailAccountId,
+    },
+  };
+}

--- a/apps/web/utils/drive/handle-filing-reply.test.ts
+++ b/apps/web/utils/drive/handle-filing-reply.test.ts
@@ -151,7 +151,32 @@ describe("processFilingReply", () => {
     );
     expect(params.emailProvider.replyToEmail).toHaveBeenCalledWith(
       params.message,
+      expect.stringContaining("couldn't complete"),
+      expect.any(Object),
+    );
+    expect(params.emailProvider.replyToEmail).not.toHaveBeenCalledWith(
+      params.message,
       "Done",
+      expect.any(Object),
+    );
+  });
+
+  it("replaces confirmation when a requested move is incomplete", async () => {
+    const filings = getFilingBatch();
+    prisma.documentFiling.findFirst.mockResolvedValue(filings[0]);
+    prisma.documentFiling.findMany.mockResolvedValue(filings);
+    vi.mocked(aiParseFilingReply).mockResolvedValue({
+      actions: [{ filingId: "filing-1", action: "move", folderPath: null }],
+      reply: "Done",
+    });
+    const params = getReplyParams();
+
+    await processFilingReply(params);
+
+    expect(prisma.documentFiling.update).not.toHaveBeenCalled();
+    expect(params.emailProvider.replyToEmail).toHaveBeenCalledWith(
+      params.message,
+      expect.stringContaining("couldn't complete"),
       expect.any(Object),
     );
   });

--- a/apps/web/utils/drive/handle-filing-reply.ts
+++ b/apps/web/utils/drive/handle-filing-reply.ts
@@ -99,12 +99,18 @@ export async function processFilingReply({
     }
 
     processedFilingIds.add(filing.id);
-    await applyFilingReplyAction({
-      action,
-      emailAccountId,
-      filing,
-      logger: logger.with({ filingId: filing.id }),
-    });
+    const filingLogger = logger.with({ filingId: filing.id });
+
+    try {
+      await applyFilingReplyAction({
+        action,
+        emailAccountId,
+        filing,
+        logger: filingLogger,
+      });
+    } catch (error) {
+      filingLogger.error("Failed to apply filing reply action", { error });
+    }
   }
 
   if (parseResult.reply) {

--- a/apps/web/utils/drive/handle-filing-reply.ts
+++ b/apps/web/utils/drive/handle-filing-reply.ts
@@ -7,7 +7,10 @@ import type { DriveConnection } from "@/generated/prisma/client";
 import { extractEmailAddress } from "@/utils/email";
 import { createDriveProviderWithRefresh } from "@/utils/drive/provider";
 import { createAndSaveFilingFolder } from "@/utils/drive/folder-utils";
-import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
+import {
+  aiParseFilingReply,
+  type ParseFilingReplyResult,
+} from "@/utils/ai/document-filing/parse-filing-reply";
 import {
   getFilebotFrom,
   getFilebotReplyTo,
@@ -48,25 +51,18 @@ export async function processFilingReply({
     return;
   }
 
-  const filing = await findFilingFromThread({
+  const filings = await findFilingsFromThread({
     message,
     emailProvider,
     emailAccountId,
   });
 
-  if (!filing) {
-    logger.error("Filing not found for thread", {
+  if (filings.length === 0) {
+    logger.error("Filings not found for thread", {
       threadId: message.threadId,
     });
     return;
   }
-
-  if (filing.emailAccountId !== emailAccountId) {
-    logger.error("Filing does not belong to this email account");
-    return;
-  }
-
-  logger = logger.with({ filingId: filing.id });
 
   const replyContent = emailToContentForAI(message, {
     extractReply: true,
@@ -82,12 +78,34 @@ export async function processFilingReply({
 
   const parseResult = await aiParseFilingReply({
     messages,
-    filingContext: {
+    filingContexts: filings.map((filing) => ({
+      id: filing.id,
       filename: filing.filename,
       currentFolder: filing.folderPath || "root",
-    },
+    })),
     emailAccount,
   });
+
+  const filingsById = new Map(filings.map((filing) => [filing.id, filing]));
+  const processedFilingIds = new Set<string>();
+
+  for (const action of parseResult.actions) {
+    const filing = filingsById.get(action.filingId);
+    if (!filing || processedFilingIds.has(filing.id)) {
+      logger.warn("Ignoring invalid filing reply action", {
+        filingId: action.filingId,
+      });
+      continue;
+    }
+
+    processedFilingIds.add(filing.id);
+    await applyFilingReplyAction({
+      action,
+      emailAccountId,
+      filing,
+      logger: logger.with({ filingId: filing.id }),
+    });
+  }
 
   if (parseResult.reply) {
     const filebotReplyTo = getFilebotReplyTo({ userEmail });
@@ -96,36 +114,6 @@ export async function processFilingReply({
       replyTo: filebotReplyTo,
       from: filebotFrom,
     });
-  }
-
-  switch (parseResult.action) {
-    case "approve":
-      await handleApprove(filing.id);
-      break;
-    case "undo":
-      await handleUndo({
-        filingId: filing.id,
-        fileId: filing.fileId,
-        driveConnection: filing.driveConnection,
-        logger,
-      });
-      break;
-    case "move":
-      await handleMove({
-        filingId: filing.id,
-        fileId: filing.fileId,
-        filingStatus: filing.status,
-        filingFolderPath: filing.folderPath,
-        filingWasCorrected: filing.wasCorrected,
-        filingOriginalPath: filing.originalPath,
-        driveConnection: filing.driveConnection,
-        folderPath: parseResult.folderPath,
-        emailAccountId,
-        logger,
-      });
-      break;
-    case "none":
-      break;
   }
 }
 
@@ -270,12 +258,7 @@ async function handleMove({
   }
 }
 
-/**
- * Find the filing by matching the source email's message ID against the
- * reply thread. The notification is sent as a reply to the source email, so
- * both live in the same thread as any subsequent reply from the user.
- */
-async function findFilingFromThread({
+async function findFilingsFromThread({
   message,
   emailProvider,
   emailAccountId,
@@ -287,15 +270,117 @@ async function findFilingFromThread({
   const threadMessages = await emailProvider.getThreadMessages(
     message.threadId,
   );
-  if (!threadMessages?.length) return null;
+  if (!threadMessages?.length) return [];
 
-  const messageIds = threadMessages.map((m) => m.id);
+  const anchor = await findNotificationAnchor({
+    emailAccountId,
+    message,
+    threadMessages,
+  });
+  if (!anchor) return [];
+
+  return prisma.documentFiling.findMany({
+    where: {
+      ...(anchor.notificationBatchId
+        ? { emailAccountId, notificationBatchId: anchor.notificationBatchId }
+        : { id: anchor.id }),
+    },
+    include: { driveConnection: true },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+async function findNotificationAnchor({
+  emailAccountId,
+  message,
+  threadMessages,
+}: {
+  emailAccountId: string;
+  message: ParsedMessage;
+  threadMessages: ParsedMessage[];
+}) {
+  const repliedToMessage = threadMessages.find(
+    (threadMessage) =>
+      threadMessage.headers["message-id"]?.trim() ===
+      message.headers["in-reply-to"]?.trim(),
+  );
+
+  let anchor = repliedToMessage
+    ? await prisma.documentFiling.findFirst({
+        where: {
+          emailAccountId,
+          notificationMessageId: repliedToMessage.id,
+        },
+      })
+    : null;
+
+  if (!anchor && repliedToMessage?.headers["in-reply-to"]) {
+    const sourceMessage = threadMessages.find(
+      (threadMessage) =>
+        threadMessage.headers["message-id"]?.trim() ===
+        repliedToMessage.headers["in-reply-to"]?.trim(),
+    );
+
+    if (sourceMessage) {
+      anchor = await prisma.documentFiling.findFirst({
+        where: {
+          emailAccountId,
+          messageId: sourceMessage.id,
+        },
+        orderBy: { createdAt: "desc" },
+      });
+    }
+  }
+
+  if (anchor) return anchor;
 
   return prisma.documentFiling.findFirst({
     where: {
       emailAccountId,
-      messageId: { in: messageIds },
+      messageId: {
+        in: threadMessages.map((threadMessage) => threadMessage.id),
+      },
     },
-    include: { driveConnection: true },
+    orderBy: { createdAt: "desc" },
   });
+}
+
+async function applyFilingReplyAction({
+  action,
+  emailAccountId,
+  filing,
+  logger,
+}: {
+  action: ParseFilingReplyResult["actions"][number];
+  emailAccountId: string;
+  filing: Awaited<ReturnType<typeof findFilingsFromThread>>[number];
+  logger: Logger;
+}): Promise<void> {
+  switch (action.action) {
+    case "approve":
+      await handleApprove(filing.id);
+      break;
+    case "undo":
+      await handleUndo({
+        filingId: filing.id,
+        fileId: filing.fileId,
+        driveConnection: filing.driveConnection,
+        logger,
+      });
+      break;
+    case "move":
+      await handleMove({
+        filingId: filing.id,
+        fileId: filing.fileId,
+        filingStatus: filing.status,
+        filingFolderPath: filing.folderPath,
+        filingWasCorrected: filing.wasCorrected,
+        filingOriginalPath: filing.originalPath,
+        driveConnection: filing.driveConnection,
+        folderPath: action.folderPath,
+        emailAccountId,
+        logger,
+      });
+      break;
+  }
 }

--- a/apps/web/utils/drive/handle-filing-reply.ts
+++ b/apps/web/utils/drive/handle-filing-reply.ts
@@ -26,6 +26,9 @@ interface ProcessFilingReplyArgs {
   userEmail: string;
 }
 
+const FILING_ACTION_FAILURE_REPLY =
+  "I couldn't complete one or more requested filing changes. Please try again.";
+
 /**
  * Process a reply to a filebot notification email.
  * Uses the In-Reply-To header to find which notification was replied to,
@@ -88,11 +91,20 @@ export async function processFilingReply({
 
   const filingsById = new Map(filings.map((filing) => [filing.id, filing]));
   const processedFilingIds = new Set<string>();
+  let hadActionFailure = false;
 
   for (const action of parseResult.actions) {
     const filing = filingsById.get(action.filingId);
-    if (!filing || processedFilingIds.has(filing.id)) {
+    if (!filing) {
       logger.warn("Ignoring invalid filing reply action", {
+        filingId: action.filingId,
+      });
+      hadActionFailure = true;
+      continue;
+    }
+
+    if (processedFilingIds.has(filing.id)) {
+      logger.warn("Ignoring duplicate filing reply action", {
         filingId: action.filingId,
       });
       continue;
@@ -102,21 +114,26 @@ export async function processFilingReply({
     const filingLogger = logger.with({ filingId: filing.id });
 
     try {
-      await applyFilingReplyAction({
+      const actionSucceeded = await applyFilingReplyAction({
         action,
         emailAccountId,
         filing,
         logger: filingLogger,
       });
+      hadActionFailure ||= !actionSucceeded;
     } catch (error) {
       filingLogger.error("Failed to apply filing reply action", { error });
+      hadActionFailure = true;
     }
   }
 
-  if (parseResult.reply) {
+  const reply = hadActionFailure
+    ? FILING_ACTION_FAILURE_REPLY
+    : parseResult.reply;
+  if (reply) {
     const filebotReplyTo = getFilebotReplyTo({ userEmail });
     const filebotFrom = getFilebotFrom({ userEmail });
-    await emailProvider.replyToEmail(message, parseResult.reply, {
+    await emailProvider.replyToEmail(message, reply, {
       replyTo: filebotReplyTo,
       from: filebotFrom,
     });
@@ -164,7 +181,9 @@ async function handleUndo({
   fileId: string | null;
   driveConnection: DriveConnection;
   logger: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
+  let fileMoved = true;
+
   // Move file to "To Delete" folder so user can easily find and delete
   if (fileId) {
     try {
@@ -184,6 +203,7 @@ async function handleUndo({
       await driveProvider.moveFile(fileId, toDeleteFolder.id);
     } catch (error) {
       logger.error("Failed to move file to To Delete folder", { error });
+      fileMoved = false;
     }
   }
 
@@ -191,6 +211,8 @@ async function handleUndo({
     where: { id: filingId },
     data: { status: "REJECTED" },
   });
+
+  return fileMoved;
 }
 
 async function handleMove({
@@ -215,15 +237,15 @@ async function handleMove({
   folderPath: string | null;
   emailAccountId: string;
   logger: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   if (!folderPath) {
     logger.warn("Move action but no folder path provided");
-    return;
+    return false;
   }
 
   if (!fileId) {
     logger.warn("Move action but no file ID available");
-    return;
+    return false;
   }
 
   try {
@@ -255,12 +277,14 @@ async function handleMove({
         correctedAt: new Date(),
       },
     });
+    return true;
   } catch (error) {
     logger.error("Error moving file", { error });
     await prisma.documentFiling.update({
       where: { id: filingId },
       data: { status: "ERROR" },
     });
+    return false;
   }
 }
 
@@ -361,21 +385,20 @@ async function applyFilingReplyAction({
   emailAccountId: string;
   filing: Awaited<ReturnType<typeof findFilingsFromThread>>[number];
   logger: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   switch (action.action) {
     case "approve":
       await handleApprove(filing.id);
-      break;
+      return true;
     case "undo":
-      await handleUndo({
+      return handleUndo({
         filingId: filing.id,
         fileId: filing.fileId,
         driveConnection: filing.driveConnection,
         logger,
       });
-      break;
     case "move":
-      await handleMove({
+      return handleMove({
         filingId: filing.id,
         fileId: filing.fileId,
         filingStatus: filing.status,
@@ -387,6 +410,5 @@ async function applyFilingReplyAction({
         emailAccountId,
         logger,
       });
-      break;
   }
 }

--- a/apps/web/utils/drive/process-filing-attachments.test.ts
+++ b/apps/web/utils/drive/process-filing-attachments.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
+import {
+  createMockEmailProvider,
+  getMockParsedMessage,
+} from "@/__tests__/mocks/email-provider.mock";
+import { processAttachment } from "@/utils/drive/filing-engine";
+import { sendFilingNotifications } from "@/utils/drive/filing-notifications";
+import { processAttachmentsForFiling } from "./process-filing-attachments";
+
+vi.mock("@/utils/drive/filing-engine", () => ({
+  processAttachment: vi.fn(),
+}));
+vi.mock("@/utils/drive/filing-notifications", () => ({
+  sendFilingNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+
+const logger = createTestLogger();
+
+describe("processAttachmentsForFiling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends one notification after filing multiple attachments", async () => {
+    const attachments = [
+      {
+        attachmentId: "attachment-1",
+        filename: "first.pdf",
+        mimeType: "application/pdf",
+        size: 123,
+      },
+      {
+        attachmentId: "attachment-2",
+        filename: "second.pdf",
+        mimeType: "application/pdf",
+        size: 456,
+      },
+    ];
+    const message = getMockParsedMessage({ attachments });
+    const emailProvider = createMockEmailProvider();
+    const emailAccount = {
+      ...getEmailAccount(),
+      filingEnabled: true,
+      filingPrompt: "File documents",
+      filingConfirmationSendEmail: true,
+    };
+    vi.mocked(processAttachment)
+      .mockResolvedValueOnce({
+        success: true,
+        filing: {
+          id: "filing-1",
+          filename: "first.pdf",
+          folderPath: "Receipts",
+          fileId: "file-1",
+          wasAsked: false,
+          confidence: 0.95,
+          provider: "google",
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        filing: {
+          id: "filing-2",
+          filename: "second.pdf",
+          folderPath: "Invoices",
+          fileId: "file-2",
+          wasAsked: false,
+          confidence: 0.95,
+          provider: "google",
+        },
+      });
+
+    await processAttachmentsForFiling({
+      attachments,
+      emailAccount,
+      emailProvider,
+      logger,
+      message,
+    });
+
+    expect(processAttachment).toHaveBeenCalledTimes(2);
+    expect(processAttachment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        attachment: attachments[0],
+        sendNotification: false,
+      }),
+    );
+    expect(processAttachment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        attachment: attachments[1],
+        sendNotification: false,
+      }),
+    );
+    expect(sendFilingNotifications).toHaveBeenCalledOnce();
+    expect(sendFilingNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filingIds: ["filing-1", "filing-2"],
+        emailProvider,
+        userEmail: emailAccount.email,
+      }),
+    );
+  });
+});

--- a/apps/web/utils/drive/process-filing-attachments.ts
+++ b/apps/web/utils/drive/process-filing-attachments.ts
@@ -1,0 +1,59 @@
+import type { ProcessAttachmentOptions } from "@/utils/drive/filing-engine";
+import { processAttachment } from "@/utils/drive/filing-engine";
+import { sendFilingNotifications } from "@/utils/drive/filing-notifications";
+import type { Attachment } from "@/utils/types";
+
+export async function processAttachmentsForFiling({
+  attachments,
+  emailAccount,
+  emailProvider,
+  logger,
+  message,
+}: Omit<ProcessAttachmentOptions, "attachment" | "sendNotification"> & {
+  attachments: Attachment[];
+}): Promise<void> {
+  const filingIds: string[] = [];
+
+  for (const attachment of attachments) {
+    const result = await processAttachment({
+      attachment,
+      emailAccount,
+      emailProvider,
+      logger,
+      message,
+      sendNotification: false,
+    }).catch((error) => {
+      logger.error("Failed to process attachment", {
+        filename: attachment.filename,
+        error,
+      });
+      return null;
+    });
+
+    if (
+      result?.filing &&
+      (result.filing.wasAsked || emailAccount.filingConfirmationSendEmail)
+    ) {
+      filingIds.push(result.filing.id);
+    }
+  }
+
+  if (filingIds.length === 0) return;
+
+  try {
+    await sendFilingNotifications({
+      emailProvider,
+      userEmail: emailAccount.email,
+      filingIds,
+      sourceMessage: {
+        threadId: message.threadId,
+        headerMessageId: message.headers["message-id"] || "",
+        references: message.headers.references,
+        messageId: message.id,
+      },
+      logger,
+    });
+  } catch (error) {
+    logger.error("Failed to send filing notifications", { error });
+  }
+}

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/__tests__/mocks/email-provider.mock";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
-import { processAttachment } from "@/utils/drive/filing-engine";
+import { processAttachmentsForFiling } from "@/utils/drive/process-filing-attachments";
 import {
   DraftReplyConfidence,
   NewsletterStatus,
@@ -46,7 +46,9 @@ vi.mock("@/utils/reply-tracker/handle-outbound", () => ({
 }));
 vi.mock("@/utils/drive/filing-engine", () => ({
   getFilableAttachments: vi.fn((message) => message.attachments ?? []),
-  processAttachment: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock("@/utils/drive/process-filing-attachments", () => ({
+  processAttachmentsForFiling: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/utils/otp-push", () => ({
   sendOtpPushNotification: vi.fn().mockResolvedValue(undefined),
@@ -571,9 +573,9 @@ describe("Provider Edge Cases", () => {
         },
       );
 
-      expect(processAttachment).toHaveBeenCalledWith(
+      expect(processAttachmentsForFiling).toHaveBeenCalledWith(
         expect.objectContaining({
-          attachment,
+          attachments: [attachment],
           emailProvider: provider,
           message,
         }),

--- a/apps/web/utils/webhook/process-history-item.ts
+++ b/apps/web/utils/webhook/process-history-item.ts
@@ -7,10 +7,8 @@ import {
   isFilebotNotificationMessage,
 } from "@/utils/filebot/is-filebot-email";
 import { processFilingReply } from "@/utils/drive/handle-filing-reply";
-import {
-  processAttachment,
-  getFilableAttachments,
-} from "@/utils/drive/filing-engine";
+import { getFilableAttachments } from "@/utils/drive/filing-engine";
+import { processAttachmentsForFiling } from "@/utils/drive/process-filing-attachments";
 import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
 import { cleanupThreadAIDrafts } from "@/utils/reply-tracker/draft-tracking";
 import { clearFollowUpLabel } from "@/utils/follow-up/labels";
@@ -242,28 +240,20 @@ export async function processHistoryItem(
                 count: extractableAttachments.length,
               });
 
-              // Process each attachment (don't await all - let them run in background)
-              for (const attachment of extractableAttachments) {
-                await processAttachment({
-                  emailAccount: {
-                    ...emailAccount,
-                    filingEnabled: emailAccount.filingEnabled,
-                    filingPrompt: emailAccount.filingPrompt,
-                    filingConfirmationSendEmail:
-                      emailAccount.filingConfirmationSendEmail,
-                    email: emailAccount.email,
-                  },
-                  message: parsedMessage,
-                  attachment,
-                  emailProvider: provider,
-                  logger,
-                }).catch((error) => {
-                  logger.error("Failed to process attachment", {
-                    filename: attachment.filename,
-                    error,
-                  });
-                });
-              }
+              await processAttachmentsForFiling({
+                attachments: extractableAttachments,
+                emailAccount: {
+                  ...emailAccount,
+                  filingEnabled: emailAccount.filingEnabled,
+                  filingPrompt: emailAccount.filingPrompt,
+                  filingConfirmationSendEmail:
+                    emailAccount.filingConfirmationSendEmail,
+                  email: emailAccount.email,
+                },
+                message: parsedMessage,
+                emailProvider: provider,
+                logger,
+              });
             }
           },
           extra: { operation: "process-attachments" },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260903-131656_pr-3496_5b2f069445d5/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Groups attachment filing results from one source message into a single notification while preserving single-record behavior.

- Adds durable batch delivery tracking and an indexed batch lookup to prevent duplicate notifications without adding work proportional to filing history.
- Updates reply parsing to return validated per-record actions, including safe handling for ambiguous, duplicate, and out-of-batch responses.
- Adds focused unit coverage and AI behavior evals; the supported-runtime unit suite and repository checks pass.