### PR TITLE
mail: Show Outlook drafts in the thread view (INB-349)

### DIFF
--- a/apps/web/components/email-list/EmailThread.test.tsx
+++ b/apps/web/components/email-list/EmailThread.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadMessage } from "@/components/email-list/types";
+import { organizeThreadMessages } from "@/components/email-list/EmailThread";
+
+describe("organizeThreadMessages", () => {
+  it("attaches a draft to the message its headers reply to", () => {
+    const first = createMessage({ id: "first", messageId: "<first@mail>" });
+    const second = createMessage({ id: "second", messageId: "<second@mail>" });
+    const draft = createDraft({ id: "draft", inReplyTo: "<first@mail>" });
+
+    const organized = organizeThreadMessages([first, second, draft]);
+
+    expect(organized.map(({ message }) => message.id)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(organized[0]?.draftMessage?.id).toBe("draft");
+    expect(organized[1]?.draftMessage).toBeUndefined();
+  });
+
+  it("prefers the last entry of the references header", () => {
+    const first = createMessage({ id: "first", messageId: "<first@mail>" });
+    const second = createMessage({ id: "second", messageId: "<second@mail>" });
+    const draft = createDraft({
+      id: "draft",
+      references: "<first@mail> <second@mail>",
+    });
+
+    const organized = organizeThreadMessages([first, second, draft]);
+
+    expect(organized[1]?.draftMessage?.id).toBe("draft");
+  });
+
+  // Outlook thread messages carry no References header and expose In-Reply-To
+  // only when full internet headers are fetched, so its drafts arrive with no
+  // parent to match. They were previously dropped from the thread entirely.
+  it("shows a draft that has no threading headers on the last message", () => {
+    const first = createMessage({ id: "first", messageId: "<first@mail>" });
+    const second = createMessage({ id: "second", messageId: "<second@mail>" });
+    const draft = createDraft({ id: "outlook-draft" });
+
+    const organized = organizeThreadMessages([first, second, draft]);
+
+    expect(organized).toHaveLength(2);
+    expect(organized[0]?.draftMessage).toBeUndefined();
+    expect(organized[1]?.draftMessage?.id).toBe("outlook-draft");
+  });
+
+  it("shows a draft whose parent is not part of the thread", () => {
+    const only = createMessage({ id: "only", messageId: "<only@mail>" });
+    const draft = createDraft({ id: "draft", inReplyTo: "<elsewhere@mail>" });
+
+    const organized = organizeThreadMessages([only, draft]);
+
+    expect(organized[0]?.draftMessage?.id).toBe("draft");
+  });
+
+  it("does not attach a draft to messages that lack a message id", () => {
+    const first = createMessage({ id: "first", messageId: undefined });
+    const second = createMessage({ id: "second", messageId: undefined });
+    const draft = createDraft({ id: "draft", inReplyTo: "<missing@mail>" });
+
+    const organized = organizeThreadMessages([first, second, draft]);
+
+    expect(organized[0]?.draftMessage).toBeUndefined();
+    expect(organized[1]?.draftMessage?.id).toBe("draft");
+  });
+
+  it("returns nothing for a thread that holds only a draft", () => {
+    expect(organizeThreadMessages([createDraft({ id: "draft" })])).toEqual([]);
+  });
+
+  it("handles a missing message list", () => {
+    expect(organizeThreadMessages(undefined)).toEqual([]);
+  });
+});
+
+function createMessage({
+  id,
+  messageId,
+}: {
+  id: string;
+  messageId?: string;
+}): ThreadMessage {
+  return {
+    id,
+    threadId: "thread",
+    labelIds: ["INBOX"],
+    headers: { "message-id": messageId },
+  } as unknown as ThreadMessage;
+}
+
+function createDraft({
+  id,
+  inReplyTo,
+  references,
+}: {
+  id: string;
+  inReplyTo?: string;
+  references?: string;
+}): ThreadMessage {
+  return {
+    id,
+    threadId: "thread",
+    labelIds: ["DRAFT"],
+    headers: { "in-reply-to": inReplyTo, references },
+  } as unknown as ThreadMessage;
+}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -22,30 +22,10 @@ export function EmailThread({
   onOpenSenderContext?: (message: ThreadMessage) => void;
   withHeader?: boolean;
 }) {
-  // Place draft messages as replies to their parent message
-  const organizedMessages = useMemo(() => {
-    const drafts = new Map<string, ThreadMessage>();
-    const regularMessages: ThreadMessage[] = [];
-
-    messages?.forEach((message) => {
-      if (message.labelIds?.includes("DRAFT")) {
-        // Get the parent message ID from the references or in-reply-to header
-        const parentId =
-          message.headers.references?.split(" ").pop() ||
-          message.headers["in-reply-to"];
-        if (parentId) {
-          drafts.set(parentId, message);
-        }
-      } else {
-        regularMessages.push(message);
-      }
-    });
-
-    return regularMessages.map((message) => ({
-      message,
-      draftMessage: drafts.get(message.headers["message-id"] || ""),
-    }));
-  }, [messages]);
+  const organizedMessages = useMemo(
+    () => organizeThreadMessages(messages),
+    [messages],
+  );
 
   const lastMessageId = organizedMessages.at(-1)?.message.id;
 
@@ -137,4 +117,39 @@ export function EmailThread({
       </ul>
     </div>
   );
+}
+
+// Drafts render inline under the message they reply to, so each one has to be
+// matched to a parent. Outlook thread messages never carry a References header
+// and only expose In-Reply-To when full internet headers are fetched, which the
+// thread query does not select, so its drafts arrive with nothing to match on.
+// A draft still belongs to this thread, so anything unmatched falls back to the
+// message a reply would target: the most recent one.
+export function organizeThreadMessages(messages: ThreadMessage[] | undefined) {
+  const drafts: ThreadMessage[] = [];
+  const regularMessages: ThreadMessage[] = [];
+
+  for (const message of messages ?? []) {
+    if (message.labelIds?.includes("DRAFT")) drafts.push(message);
+    else regularMessages.push(message);
+  }
+
+  const draftsByMessageId = new Map<string, ThreadMessage>();
+  for (const draft of drafts) {
+    const parentId =
+      draft.headers.references?.split(" ").pop() ||
+      draft.headers["in-reply-to"];
+    const parent = parentId
+      ? regularMessages.find(
+          (message) => message.headers["message-id"] === parentId,
+        )
+      : undefined;
+    const target = parent ?? regularMessages.at(-1);
+    if (target) draftsByMessageId.set(target.id, draft);
+  }
+
+  return regularMessages.map((message) => ({
+    message,
+    draftMessage: draftsByMessageId.get(message.id),
+  }));
 }


### PR DESCRIPTION
## Root cause is in the client, not the sync

The two previous PRs both worked on fetching. #3472 made `getThread` include drafts for Outlook, and #3485 moved the `includeDrafts` decision into the provider. Both were correct, and the draft does now reach the browser — `/mail` requests `includeDrafts: true` from `thread-prefetch.ts` and `MailShell.tsx`.

The draft is then discarded by the thread view. `EmailThread` matches each draft to a parent message using RFC 5322 threading headers:

```ts
const parentId =
  message.headers.references?.split(" ").pop() ||
  message.headers["in-reply-to"];
if (parentId) drafts.set(parentId, message);
```

A draft with no `parentId` is never stored, and it is never pushed into `regularMessages` either, so it vanishes from the rendered thread.

Outlook messages never have either header at this point:

- `convertMessage` in `utils/outlook/message.ts` sets no `references` at all.
- It sets `in-reply-to` from `getInternetHeader`, which reads `message.internetMessageHeaders` — a field selected only by `createMessageRequest` (single message). The thread query uses `createMessagesRequest`, whose `MESSAGE_SELECT_FIELDS` does not include it.

So every Outlook draft arrives with `references: undefined` and `in-reply-to: undefined` and is dropped. Gmail supplies both headers, which is exactly why Gmail drafts render and Outlook drafts do not.

## Fix

A draft returned with a thread belongs to that thread, so it should never be silently dropped for want of a header.

- When a draft has no usable headers, or names a parent that is not in the thread, attach it to the most recent message — the one a reply targets, and where the composer already opens.
- Key drafts by internal message id instead of the `Message-ID` header, so messages missing that header cannot collide on an empty-string key.
- Extract `organizeThreadMessages` so the pairing logic is directly testable without rendering the message tree.

Fetching is left alone. Adding `internetMessageHeaders` to the thread query would fix the header gap too, but that field is large and would be pulled for every message in every thread; the client-side fallback costs nothing and also covers Gmail drafts that lack headers.

## Validation

- 7 new tests in `EmailThread.test.tsx` cover header-based matching, `references` taking the last entry, a draft with no headers, a parent outside the thread, messages with no `Message-ID`, a draft-only thread, and an empty list. The no-headers case fails on `main`.
- `components/email-list`: 4 files, 19 tests pass.
- Full `apps/web` suite run before and after. Five tests differ between runs (`chat`, `archive-sender-queue`, `auth-login-providers`, `emulated-suite-selection`) — all pass in isolation both with and without this change, and none import `EmailThread`. They are load-ordering flakes surfaced by adding a test file, not regressions.

## Note for reviewers

This should be verified against a real Outlook account with an auto-generated draft, since the previous two attempts each looked correct in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email thread organization so drafts are displayed with the correct parent message when reply or reference details are available.
  - Drafts without threading information are now placed with the most recent message, including Outlook-style drafts.
  - Drafts with missing or unmatched parent messages are handled more reliably, preventing incorrect thread placement or empty thread displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->