### PR TITLE
ai: Fall back after wrapped provider failures

### DIFF
--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { APICallError, NoObjectGeneratedError } from "ai";
+import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
 import { createScopedLogger } from "@/utils/logger";
 
 const { mockSentryCaptureException, mockSetUser } = vi.hoisted(() => ({
@@ -24,6 +24,7 @@ import {
   isInsufficientCreditsError,
   isContentFilterRefusal,
   isHandledUserKeyError,
+  isAiQuotaExceededError,
   isKnownApiError,
   isInvalidAIModelError,
   isKnownOutlookError,
@@ -32,6 +33,20 @@ import {
   isOutlookThrottlingError,
   markAsHandledUserKeyError,
 } from "./error";
+
+describe("isAiQuotaExceededError", () => {
+  it("detects quota errors wrapped by the AI SDK retry error", () => {
+    const error = new RetryError({
+      message: "Failed after multiple attempts",
+      reason: "maxRetriesExceeded",
+      errors: [
+        createAPICallError({ message: "Quota exceeded", statusCode: 429 }),
+      ],
+    });
+
+    expect(isAiQuotaExceededError(error)).toBe(true);
+  });
+});
 
 describe("assertActionSucceeded", () => {
   it("does not throw for a successful action result", () => {

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -277,7 +277,10 @@ export function isHandledUserKeyError(error: unknown): boolean {
 
 // Handling AI quota/retry errors. This can be related to the user's own API quota or the system's quota.
 export function isAiQuotaExceededError(error: RetryError): boolean {
-  const message = error.message.toLowerCase();
+  const message = [error.message, getErrorMessage(error.lastError)]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
   const quotaErrorMessages = [
     "exceeded your current quota",
     "quota exceeded",

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { APICallError } from "ai";
+import { APICallError, RetryError } from "ai";
 import { createGenerateText } from "./index";
 import type { SelectModel } from "./model";
 
@@ -139,6 +139,58 @@ describe("createGenerateText fallback chain", () => {
         model: "fallback",
       }),
     );
+  });
+
+  it("falls back when an SDK retry error wraps a retryable provider failure", async () => {
+    const { extractLLMErrorInfo } =
+      await vi.importActual<typeof import("./retry")>("./retry");
+    mockExtractLLMErrorInfo.mockImplementationOnce(extractLLMErrorInfo);
+
+    const primaryModel = createModel("primary-model");
+    const fallbackModel = createModel("fallback-model");
+    const modelOptions = createModelOptions({
+      provider: "bedrock",
+      modelName: "primary",
+      model: primaryModel,
+      fallbackModels: [
+        createResolvedModel({
+          provider: "google",
+          modelName: "fallback",
+          model: fallbackModel,
+        }),
+      ],
+    });
+    const retryError = new RetryError({
+      message: "Failed after multiple attempts",
+      reason: "maxRetriesExceeded",
+      errors: [
+        new APICallError({
+          message: "Provider temporarily unavailable",
+          url: "https://example.com",
+          requestBodyValues: {},
+          statusCode: 503,
+          responseHeaders: {},
+          responseBody: "",
+        }),
+      ],
+    });
+    mockGenerateText
+      .mockRejectedValueOnce(retryError)
+      .mockResolvedValueOnce(createTextResult({ text: "fallback success" }));
+
+    const generateText = createGenerateTextForTest({
+      label: "Wrapped provider fallback",
+      modelOptions,
+    });
+
+    const result = await generateText({
+      prompt: "hello",
+      model: primaryModel,
+    });
+
+    expect(result.text).toBe("fallback success");
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(mockGenerateText.mock.calls[1][0].model).toBe(fallbackModel);
   });
 
   it("falls back when the primary model is no longer available", async () => {

--- a/apps/web/utils/llms/retry.test.ts
+++ b/apps/web/utils/llms/retry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RetryError } from "ai";
 import { extractLLMErrorInfo, withLLMRetry } from "./retry";
 
 vi.mock("@/utils/sleep", () => ({
@@ -222,6 +223,25 @@ describe("withLLMRetry", () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce("success after retry");
+
+    const result = await withLLMRetry(fn, { label: "test" });
+
+    expect(result).toBe("success after retry");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries when an SDK retry error wraps a server error", async () => {
+    const retryError = new RetryError({
+      message: "Failed after multiple attempts",
+      reason: "maxRetriesExceeded",
+      errors: [
+        createError("Provider temporarily unavailable", { status: 503 }),
+      ],
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(retryError)
       .mockResolvedValueOnce("success after retry");
 
     const result = await withLLMRetry(fn, { label: "test" });

--- a/apps/web/utils/llms/retry.ts
+++ b/apps/web/utils/llms/retry.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { RetryError } from "ai";
 import pRetry from "p-retry";
 import { createScopedLogger } from "@/utils/logger";
 import { sleep } from "@/utils/sleep";
@@ -157,7 +158,10 @@ interface LLMErrorInfo {
 export function extractLLMErrorInfo(error: unknown): LLMErrorInfo {
   // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
   const err = error as any;
-  const original = err?.error ?? err;
+  const wrappedError = err?.error ?? err;
+  const original = RetryError.isInstance(wrappedError)
+    ? wrappedError.lastError
+    : wrappedError;
   const cause = original?.cause ?? original;
 
   const status: number | undefined =


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260903-215059_pr-3499_23eec83c5d72/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Ensure provider failures remain retryable after the AI SDK exhausts its internal retries.

- classify `RetryError.lastError` for server-error retry and fallback selection
- recognize quota messages carried by the inner provider error
- add regression coverage for app retry, cross-provider fallback, and quota classification
- validate the full unit suite: 6,063 passed (884 integration/eval tests skipped by the unit command)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested AI service errors, including quota, rate-limit, and temporary server failures.
  * Retry logic now correctly recognizes wrapped failures and can retry or switch to a fallback model when appropriate.

* **Tests**
  * Added coverage for quota detection, retry behavior, and fallback handling with wrapped provider errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->