### PR TITLE
mail: Order cached thread messages chronologically (INB-343)

### DIFF
--- a/apps/web/utils/email-cache/threads.test.ts
+++ b/apps/web/utils/email-cache/threads.test.ts
@@ -216,7 +216,113 @@ describe("cached thread details", () => {
       ).content,
     ).toBeUndefined();
   });
+
+  // A record outlives the server behaviour that wrote it, so a thread stored
+  // while Outlook still returned newest-first has to be reordered on read
+  // rather than replayed in the order it was persisted.
+  it("orders a legacy record that was stored newest-first", async () => {
+    await seedLegacyThreadDetailRecord({
+      byteSize: 0,
+      data: getThreadResponseWithMessages([
+        { id: "newest", internalDate: "2026-08-27T10:00:00.000Z" },
+        { id: "middle", internalDate: "2026-08-26T10:00:00.000Z" },
+        { id: "oldest", internalDate: "2026-08-25T10:00:00.000Z" },
+      ]),
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    const cached = await readCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(cached?.data.thread.messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+    ]);
+  });
+
+  it("orders messages when writing a thread to the cache", async () => {
+    await writeCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+      data: getThreadResponseWithMessages([
+        { id: "newest", internalDate: "2026-08-27T10:00:00.000Z" },
+        { id: "oldest", internalDate: "2026-08-25T10:00:00.000Z" },
+      ]),
+    });
+
+    const cached = await readCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(cached?.data.thread.messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "newest",
+    ]);
+  });
+
+  // Gmail reports epoch milliseconds where Outlook reports an ISO string.
+  it("orders messages across both internalDate formats", async () => {
+    await seedLegacyThreadDetailRecord({
+      byteSize: 0,
+      data: getThreadResponseWithMessages([
+        { id: "newest", internalDate: "1788000000000" },
+        { id: "oldest", internalDate: "2026-08-25T10:00:00.000Z" },
+      ]),
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    const cached = await readCachedThreadDetail({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    });
+
+    expect(cached?.data.thread.messages.map((message) => message.id)).toEqual([
+      "oldest",
+      "newest",
+    ]);
+  });
 });
+
+function getThreadResponseWithMessages(
+  messages: Array<{ id: string; internalDate: string }>,
+): ThreadResponse {
+  return {
+    thread: {
+      historyId: "history-1",
+      id: "thread-1",
+      messages: messages.map(({ id, internalDate }) => ({
+        date: internalDate,
+        headers: {
+          date: internalDate,
+          from: "sender@example.com",
+          subject: "Subject",
+          to: "me@example.com",
+        },
+        historyId: "history-1",
+        id,
+        inline: [],
+        internalDate,
+        snippet: id,
+        subject: "Subject",
+        textPlain: id,
+        threadId: "thread-1",
+      })),
+      snippet: messages.at(-1)?.id ?? "",
+    },
+  };
+}
 
 function getThreadResponse({
   textPlain,

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -4,6 +4,7 @@ import type {
   ParsedMessage,
   ParsedMessageHeaders,
 } from "@/utils/types";
+import { sortByInternalDate } from "@/utils/date";
 import { scheduleEmailCacheCleanup } from "./cleanup";
 import {
   captureEmailCacheEpoch,
@@ -109,7 +110,13 @@ function sanitizeThreadResponse(data: ThreadResponse): ThreadResponse {
     thread: {
       historyId: data.thread.historyId,
       id: data.thread.id,
-      messages: data.thread.messages.map(sanitizeMessage),
+      // Records survive for as long as EMAIL_CACHE_MAX_AGE_MS and carry no
+      // schema version, so a payload written by an older client is replayed
+      // exactly as it was stored. Ordering is the reader's contract, not the
+      // stored payload's, so re-establish it rather than trusting the record.
+      messages: data.thread.messages
+        .map(sanitizeMessage)
+        .sort(sortByInternalDate()),
       snippet: data.thread.snippet,
     },
   };


### PR DESCRIPTION
## Why #3456 didn't fix it

#3456 was correct: every server-side thread sort for Outlook now returns oldest-first, and I verified there is no descending sort left on the reader's path.

The reader does not always reach the server. `useThread` resolves a thread from IndexedDB and **returns it without fetching** when a record exists:

```ts
const cached = await readCachedThreadDetail({ emailAccountId, threadId, variant });
if (cached) return cached.data;
```

`readCachedThreadDetail` replays the stored payload verbatim — the only gate is age, and `EMAIL_CACHE_MAX_AGE_MS` is 30 days. There is no schema or ordering version, so a thread opened while the server still returned newest-first keeps rendering in that order for up to a month after the fix shipped. `useThread` also sets `revalidateOnMount: !hasMatchingMemoryData` with focus and reconnect revalidation off, so nothing naturally displaces it.

That is exactly the reported symptom: the server is fixed, the thread still renders newest-first, and the newest message sits at the top while the reader expands the last entry — the oldest.

## Fix

Re-establish chronological order in `sanitizeThreadResponse`, which is already the normalisation point for the cache and runs on both read and write. A cached payload's ordering is not a contract the reader should trust; it is the reader's contract to enforce.

Sorting uses the existing `sortByInternalDate`, which reads Gmail's epoch milliseconds and Outlook's ISO strings alike, so it is provider-agnostic. Messages without an `internalDate` compare equal and keep their relative order, so existing behaviour is untouched.

## Validation

- 3 tests added to `threads.test.ts`: a legacy record stored newest-first, ordering applied on write, and ordering across both `internalDate` formats.
- Verified red/green — with the sort removed, all three fail; the 6 pre-existing tests in that file still pass.
- `utils/email-cache`, `hooks`, `components/email-list`: 26 files, 151 tests pass.

## Follow-up worth considering

The underlying hazard is broader than ordering: the thread cache has no schema version, so **any** change to the shape or semantics of a thread payload is silently replayed from records written by an older client for up to 30 days. INB-349 has the same exposure — a thread cached before drafts were included stays draft-less. A version stamped into the cache key, bumped when the payload contract changes, would close the whole class. I left that out of this PR since it is a broader change than the bug at hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email thread messages appearing in the wrong order.
  * Thread messages are now consistently displayed from oldest to newest, including messages from older cached records and mixed date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->