### PR TITLE
meeting recorder: use valid provider timeouts

### DIFF
--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -65,7 +65,12 @@ describe("RecallBotProvider", () => {
     const botDetection = JSON.parse(request?.body as string).automatic_leave
       ?.bot_detection;
     expect(botDetection.using_participant_names.matches).toContain("notetaker");
-    expect(botDetection.using_participant_names.activate_after).toBe(0);
+    expect(
+      botDetection.using_participant_names.activate_after,
+    ).toBeGreaterThanOrEqual(1);
+    expect(botDetection.using_participant_names.timeout).toBeGreaterThanOrEqual(
+      10,
+    );
     expect(
       botDetection.using_participant_events.activate_after,
     ).toBeGreaterThan(0);

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -109,8 +109,8 @@ export class RecallBotProvider implements MeetingBotProvider {
           bot_detection: {
             using_participant_names: {
               matches: MEETING_BOT_NAME_MATCHES,
-              activate_after: 0,
-              timeout: 5,
+              activate_after: 1,
+              timeout: 10,
             },
             using_participant_events: {
               // Give real attendees time to speak or share before using


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260904-101107_pr-3504_12bd2f1b8ddf/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Correct meeting bot scheduling parameters to comply with the provider API contract.

- use accepted automatic-leave timeout boundaries
- add regression coverage for request validation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting bot departure detection by adding a brief activation delay and extending the inactivity timeout, helping prevent premature departures when other bots are still present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->