### PR TITLE
test: validate meeting bot request constraints

### DIFF
--- a/apps/web/__tests__/emulators/recall.ts
+++ b/apps/web/__tests__/emulators/recall.ts
@@ -54,6 +54,18 @@ interface RecallEmulatorRequest {
   path: string;
 }
 
+interface RecallBotCreatePayload {
+  automatic_leave?: {
+    bot_detection?: {
+      using_participant_events?: unknown;
+      using_participant_names?: unknown;
+    };
+  };
+  bot_name?: string;
+  join_at?: string;
+  meeting_url?: string;
+}
+
 export interface RecallEmulator {
   /** Push the bot to the next lifecycle code, as Recall would during a call. */
   advance(botId: string, code: string, subCode?: string): void;
@@ -243,9 +255,7 @@ export async function createRecallEmulator({
   }
 
   function createBot(body: unknown): { status: number; body?: unknown } {
-    const payload = body as
-      | { meeting_url?: string; bot_name?: string; join_at?: string }
-      | undefined;
+    const payload = body as RecallBotCreatePayload | undefined;
 
     if (!payload?.meeting_url) {
       return {
@@ -268,6 +278,14 @@ export async function createRecallEmulator({
           body: { join_at: ["The datetime must be in the future."] },
         };
       }
+    }
+
+    const automaticLeaveError = validateAutomaticLeave(payload.automatic_leave);
+    if (automaticLeaveError) {
+      return {
+        status: 400,
+        body: { automatic_leave: automaticLeaveError },
+      };
     }
 
     const bot: RecallEmulatorBot = {
@@ -474,6 +492,89 @@ function safeJsonParse(raw: string): unknown {
   } catch {
     return raw;
   }
+}
+
+function validateAutomaticLeave(
+  automaticLeave: RecallBotCreatePayload["automatic_leave"],
+): unknown | null {
+  const botDetection = automaticLeave?.bot_detection;
+  if (!botDetection) return null;
+
+  const participantNames = botDetection.using_participant_names;
+  if (participantNames !== undefined) {
+    if (!isRecord(participantNames)) {
+      return {
+        bot_detection: {
+          using_participant_names: ["Expected an object."],
+        },
+      };
+    }
+
+    const errors = validateBotDetectionTiming(participantNames, true);
+    if (
+      !Array.isArray(participantNames.matches) ||
+      participantNames.matches.some(
+        (match) => typeof match !== "string" || match.length === 0,
+      )
+    ) {
+      errors.matches = ["Expected a list of non-empty strings."];
+    }
+    if (Object.keys(errors).length > 0) {
+      return {
+        bot_detection: { using_participant_names: errors },
+      };
+    }
+  }
+
+  const participantEvents = botDetection.using_participant_events;
+  if (participantEvents !== undefined) {
+    if (!isRecord(participantEvents)) {
+      return {
+        bot_detection: {
+          using_participant_events: ["Expected an object."],
+        },
+      };
+    }
+
+    const errors = validateBotDetectionTiming(participantEvents, false);
+    if (Object.keys(errors).length > 0) {
+      return {
+        bot_detection: { using_participant_events: errors },
+      };
+    }
+  }
+
+  return null;
+}
+
+function validateBotDetectionTiming(
+  config: Record<string, unknown>,
+  required: boolean,
+): Record<string, string[]> {
+  const errors: Record<string, string[]> = {};
+  if (
+    (required || config.activate_after !== undefined) &&
+    !isIntegerAtLeast(config.activate_after, 1)
+  ) {
+    errors.activate_after = [
+      "Ensure this value is greater than or equal to 1.",
+    ];
+  }
+  if (
+    (required || config.timeout !== undefined) &&
+    !isIntegerAtLeast(config.timeout, 10)
+  ) {
+    errors.timeout = ["Ensure this value is greater than or equal to 10."];
+  }
+  return errors;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIntegerAtLeast(value: unknown, minimum: number): boolean {
+  return Number.isInteger(value) && (value as number) >= minimum;
 }
 
 /** Convenience for building the webhook bodies Recall sends. */

--- a/apps/web/__tests__/emulators/recall.ts
+++ b/apps/web/__tests__/emulators/recall.ts
@@ -54,18 +54,6 @@ interface RecallEmulatorRequest {
   path: string;
 }
 
-interface RecallBotCreatePayload {
-  automatic_leave?: {
-    bot_detection?: {
-      using_participant_events?: unknown;
-      using_participant_names?: unknown;
-    };
-  };
-  bot_name?: string;
-  join_at?: string;
-  meeting_url?: string;
-}
-
 export interface RecallEmulator {
   /** Push the bot to the next lifecycle code, as Recall would during a call. */
   advance(botId: string, code: string, subCode?: string): void;
@@ -255,23 +243,24 @@ export async function createRecallEmulator({
   }
 
   function createBot(body: unknown): { status: number; body?: unknown } {
-    const payload = body as RecallBotCreatePayload | undefined;
-
-    if (!payload?.meeting_url) {
+    if (!isRecord(body) || typeof body.meeting_url !== "string") {
       return {
         status: 400,
         body: { meeting_url: ["This field is required."] },
       };
     }
     // Recall rejects links it cannot join, and it does so permanently.
-    if (!/^https?:\/\//.test(payload.meeting_url)) {
+    if (!/^https?:\/\//.test(body.meeting_url)) {
       return {
         status: 400,
         body: { meeting_url: ["Not a valid meeting URL."] },
       };
     }
-    if (payload.join_at !== undefined) {
-      const joinAt = new Date(payload.join_at).getTime();
+    if (body.join_at !== undefined) {
+      const joinAt =
+        typeof body.join_at === "string"
+          ? new Date(body.join_at).getTime()
+          : Number.NaN;
       if (Number.isNaN(joinAt) || joinAt <= Date.now()) {
         return {
           status: 400,
@@ -280,7 +269,7 @@ export async function createRecallEmulator({
       }
     }
 
-    const automaticLeaveError = validateAutomaticLeave(payload.automatic_leave);
+    const automaticLeaveError = validateAutomaticLeave(body.automatic_leave);
     if (automaticLeaveError) {
       return {
         status: 400,
@@ -290,9 +279,9 @@ export async function createRecallEmulator({
 
     const bot: RecallEmulatorBot = {
       id: `bot_${nextId++}`,
-      meeting_url: payload.meeting_url,
-      bot_name: payload.bot_name ?? "",
-      join_at: payload.join_at ?? null,
+      meeting_url: body.meeting_url,
+      bot_name: typeof body.bot_name === "string" ? body.bot_name : "",
+      join_at: typeof body.join_at === "string" ? body.join_at : null,
       status_changes: [{ code: "ready", sub_code: null }],
       media_deleted: false,
       recording_id: `rec_${nextId++}`,
@@ -494,11 +483,15 @@ function safeJsonParse(raw: string): unknown {
   }
 }
 
-function validateAutomaticLeave(
-  automaticLeave: RecallBotCreatePayload["automatic_leave"],
-): unknown | null {
-  const botDetection = automaticLeave?.bot_detection;
-  if (!botDetection) return null;
+function validateAutomaticLeave(automaticLeave: unknown): unknown | null {
+  if (automaticLeave === undefined || automaticLeave === null) return null;
+  if (!isRecord(automaticLeave)) return ["Expected an object."];
+
+  const botDetection = automaticLeave.bot_detection;
+  if (botDetection === undefined) return null;
+  if (!isRecord(botDetection)) {
+    return { bot_detection: ["Expected an object."] };
+  }
 
   const participantNames = botDetection.using_participant_names;
   if (participantNames !== undefined) {

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -120,6 +120,60 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       });
     });
 
+    test.each([
+      {
+        field: "activate_after",
+        heuristic: "using_participant_names",
+        config: { matches: ["notetaker"], activate_after: 0, timeout: 10 },
+      },
+      {
+        field: "timeout",
+        heuristic: "using_participant_names",
+        config: { matches: ["notetaker"], activate_after: 1, timeout: 9 },
+      },
+      {
+        field: "activate_after",
+        heuristic: "using_participant_events",
+        config: { activate_after: 0, timeout: 10 },
+      },
+      {
+        field: "timeout",
+        heuristic: "using_participant_events",
+        config: { activate_after: 1, timeout: 9 },
+      },
+    ])("rejects $heuristic $field below Recall's minimum", async ({
+      field,
+      heuristic,
+      config,
+    }) => {
+      const response = await fetch(`${emulator.apiBase}/bot/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${emulator.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          meeting_url: "https://meet.google.com/abc-defg-hij",
+          automatic_leave: {
+            bot_detection: {
+              [heuristic]: config,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        automatic_leave: {
+          bot_detection: {
+            [heuristic]: {
+              [field]: expect.any(Array),
+            },
+          },
+        },
+      });
+    });
+
     test("joins an ongoing meeting without scheduling it in the past", async () => {
       const { externalBotId } = await provider.scheduleBot({
         meetingUrl: "https://meet.google.com/abc-defg-hij",

--- a/apps/web/__tests__/integration/recall-bot-provider.test.ts
+++ b/apps/web/__tests__/integration/recall-bot-provider.test.ts
@@ -174,6 +174,33 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       });
     });
 
+    test.each([
+      { label: "false", value: false },
+      { label: "zero", value: 0 },
+      { label: "an empty string", value: "" },
+      { label: "null", value: null },
+      { label: "an array", value: [] },
+    ])("rejects $label as bot_detection", async ({ value }) => {
+      const response = await fetch(`${emulator.apiBase}/bot/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${emulator.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          meeting_url: "https://meet.google.com/abc-defg-hij",
+          automatic_leave: { bot_detection: value },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        automatic_leave: {
+          bot_detection: expect.any(Array),
+        },
+      });
+    });
+
     test("joins an ongoing meeting without scheduling it in the past", async () => {
       const { externalBotId } = await provider.scheduleBot({
         meetingUrl: "https://meet.google.com/abc-defg-hij",


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260904-105344_pr-3505_73c2a8f28554/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Improve provider-emulator fidelity so invalid meeting bot requests fail during integration testing.

- validate documented bot-detection timing boundaries
- cover rejected request variants with focused integration tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for automatic meeting-leave settings.
  * Invalid participant detection configurations—including unsupported primitive and array values—are now rejected with clear validation errors.
  * Timing values below the supported minimum now return field-specific errors instead of being accepted.

* **Tests**
  * Added coverage for invalid configurations and timing values across participant-name and participant-event detection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->