### PR TITLE
meetings: Open the related draft from Go to Drafts (INB-328)

### DIFF
--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
@@ -42,12 +42,15 @@ describe("meeting follow-up draft route", () => {
     getEmailAccountMock.mockResolvedValue("user@gmail.com");
   });
 
-  it("opens the related Gmail draft using its embedded message ID", async () => {
+  it("opens the related Gmail draft's conversation in Drafts", async () => {
     prisma.meeting.findFirst.mockResolvedValue({
       followUpDraftId: "draft-resource-123",
       emailAccount: { account: { provider: "google" } },
     } as never);
-    emailProvider.getDraft.mockResolvedValue({ id: "draft-message-123" });
+    emailProvider.getDraft.mockResolvedValue({
+      id: "draft-message-123",
+      threadId: "thread-123",
+    });
 
     const response = await GET(new NextRequest(requestUrl), routeContext);
 
@@ -58,7 +61,29 @@ describe("meeting follow-up draft route", () => {
     );
     expect(emailProvider.getDraft).toHaveBeenCalledWith("draft-resource-123");
     expect(response.headers.get("location")).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/thread-123",
+    );
+  });
+
+  // The Graph webLink resolves the item without translating a REST id into the
+  // EWS id the compose deeplink expects.
+  it("opens the related Outlook draft through the link Graph supplied", async () => {
+    getEmailAccountMock.mockResolvedValue("user@contoso.com");
+    prisma.meeting.findFirst.mockResolvedValue({
+      followUpDraftId: "draft-resource-123",
+      emailAccount: { account: { provider: "microsoft" } },
+    } as never);
+    emailProvider.getDraft.mockResolvedValue({
+      id: "draft-message-123",
+      threadId: "thread-123",
+      externalUrl:
+        "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+    });
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(response.headers.get("location")).toBe(
+      "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
     );
   });
 

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
@@ -50,7 +50,7 @@ export const GET = withAuth(
 
     if (!draft) return draftNotFound();
 
-    return NextResponse.redirect(getEmailDraftUrl(draft.id, email, provider));
+    return NextResponse.redirect(getEmailDraftUrl(draft, email, provider));
   },
 );
 

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -167,40 +167,79 @@ describe("getEmailUrl", () => {
 });
 
 describe("getEmailDraftUrl", () => {
+  // Graph resolves its own webLink without any id translation, so it wins over
+  // anything assembled from a Graph REST id.
+  it("uses the Outlook link the provider supplied", () => {
+    expect(
+      getEmailDraftUrl(
+        {
+          id: "draft-123",
+          externalUrl:
+            "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+        },
+        "user@contoso.com",
+        "microsoft",
+      ),
+    ).toBe(
+      "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+    );
+  });
+
   it.each([
     {
-      name: "Google account",
-      draftMessageId: "draft-message-123",
-      emailAddress: "user@gmail.com",
-      provider: "google",
-      expected:
-        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+      name: "an unexpected host",
+      externalUrl: "https://evil.example.com/mail",
     },
+    { name: "a non-https scheme", externalUrl: "http://outlook.office.com/x" },
+    { name: "an unparseable value", externalUrl: "not-a-url" },
+  ])("ignores a draft link with $name", ({ externalUrl }) => {
+    expect(
+      getEmailDraftUrl(
+        { id: "draft-123", externalUrl },
+        "user@outlook.com",
+        "microsoft",
+      ),
+    ).toBe("https://outlook.live.com/mail/0/drafts/id/draft-123");
+  });
+
+  it.each([
     {
       name: "personal Microsoft account",
-      draftMessageId: "draft-123",
+      draft: { id: "draft-123" },
       emailAddress: "user@outlook.com",
       provider: "microsoft",
-      expected:
-        "https://outlook.live.com/mail/0/deeplink/compose?itemid=draft-123&exvsurl=1",
+      expected: "https://outlook.live.com/mail/0/drafts/id/draft-123",
     },
     {
       name: "business Microsoft account",
-      draftMessageId: "draft+123/abc",
+      draft: { id: "draft+123/abc" },
       emailAddress: "user@contoso.com",
       provider: "microsoft",
+      expected: "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
+    },
+    {
+      name: "Google account",
+      draft: { id: "draft-message-123", threadId: "thread-123" },
+      emailAddress: "user@gmail.com",
+      provider: "google",
       expected:
-        "https://outlook.office.com/mail/deeplink/compose?itemid=draft%2B123%2Fabc&exvsurl=1",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/thread-123",
+    },
+    {
+      name: "Google account without a thread",
+      draft: { id: "draft-message-123" },
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-message-123",
     },
   ])("opens the draft for a $name", ({
-    draftMessageId,
+    draft,
     emailAddress,
     provider,
     expected,
   }) => {
-    expect(getEmailDraftUrl(draftMessageId, emailAddress, provider)).toBe(
-      expected,
-    );
+    expect(getEmailDraftUrl(draft, emailAddress, provider)).toBe(expected);
   });
 });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -44,11 +44,39 @@ function getOutlookBaseUrl(emailAddress?: string | null) {
     : "https://outlook.office.com/mail";
 }
 
+// Only the fields a draft deeplink can be built from. `externalUrl` is the
+// provider's own link to the item, which beats anything assembled here.
+type DraftLinkTarget = {
+  id: string;
+  threadId?: string | null;
+  externalUrl?: string | null;
+};
+
+const MICROSOFT_MAIL_HOSTS = [
+  "outlook.live.com",
+  "outlook.office.com",
+  "outlook.office365.com",
+];
+
+// The link is redirected to, so treat it as untrusted until the host proves it
+// belongs to Outlook rather than forwarding wherever the payload points.
+function getTrustedMicrosoftLink(externalUrl?: string | null) {
+  if (!externalUrl) return null;
+
+  try {
+    const url = new URL(externalUrl);
+    if (url.protocol !== "https:") return null;
+    return MICROSOFT_MAIL_HOSTS.includes(url.hostname) ? externalUrl : null;
+  } catch {
+    return null;
+  }
+}
+
 type ProviderUrlConfig = {
   requiresMessageId: boolean;
   buildUrl: (messageOrThreadId: string, emailAddress?: string | null) => string;
   buildDraftUrl: (
-    draftMessageId: string,
+    draft: DraftLinkTarget,
     emailAddress?: string | null,
   ) => string;
   selectId: (messageId: string, threadId: string) => string;
@@ -59,9 +87,12 @@ const GOOGLE_CONFIG: ProviderUrlConfig = {
   requiresMessageId: false,
   buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
     getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
-  buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
+  // Gmail's compose deeplink takes an internal id that cannot be derived from
+  // an API id, so the draft itself cannot be opened. Its conversation can, and
+  // Drafts is the one label that holds it.
+  buildDraftUrl: (draft: DraftLinkTarget, emailAddress?: string | null) =>
     getGmailUrlForFragment(
-      `inbox?compose=${encodeURIComponent(draftMessageId)}`,
+      `drafts/${encodeURIComponent(draft.threadId || draft.id)}`,
       emailAddress,
     ),
   selectId: (messageId: string, _threadId: string) => messageId,
@@ -79,8 +110,12 @@ const PROVIDER_CONFIG: Record<string, ProviderUrlConfig> = {
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
-    buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
-      `${getOutlookBaseUrl(emailAddress)}/deeplink/compose?itemid=${encodeURIComponent(draftMessageId)}&exvsurl=1`,
+    // Graph hands back a webLink that resolves the item without any id
+    // translation. The deeplink built here needs an EWS id, which a Graph REST
+    // id is not, so it only stands in when the provider gave us no link.
+    buildDraftUrl: (draft: DraftLinkTarget, emailAddress?: string | null) =>
+      getTrustedMicrosoftLink(draft.externalUrl) ??
+      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draft.id)}`,
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
@@ -111,17 +146,21 @@ export function getEmailUrl(
 }
 
 /**
- * Takes the draft's underlying *message* id, not the draft resource id — on
- * Gmail those differ (and the message id changes on every draft edit), so
- * resolve it via `EmailProvider.getDraft` at link time.
+ * Takes the draft message itself rather than an id, because the fields that
+ * produce a working link differ by provider: Outlook resolves its own webLink,
+ * while Gmail needs the thread. Resolve the draft via `EmailProvider.getDraft`
+ * at link time — its message id changes on every edit.
+ *
+ * Outlook lands on the draft. Gmail lands on the draft's conversation in
+ * Drafts; opening its composer needs an internal id the API does not expose.
  */
 export function getEmailDraftUrl(
-  draftMessageId: string,
+  draft: DraftLinkTarget,
   emailAddress?: string | null,
   provider?: string,
 ): string {
   const config = getProviderConfig(provider);
-  return config.buildDraftUrl(draftMessageId, emailAddress);
+  return config.buildDraftUrl(draft, emailAddress);
 }
 
 /**


### PR DESCRIPTION
## Why the previous attempts didn't work

Both #3328 and #3346 assembled a deeplink by hand from an id the target interface does not accept, which is why the button lands on a folder rather than the draft.

**Outlook.** The `deeplink/compose?itemid=` form expects an **EWS item id**, and we hold a **Graph REST id**. Those are different id spaces, so OWA cannot resolve the item and falls back to the mailbox. Graph already returns a [`webLink`](https://learn.microsoft.com/en-us/answers/questions/4619414/open-a-draft-message-created-with-ms-graph-api-for) that resolves the item with no translation at all, and `getDraftMessage` issues no `$select`, so the full default payload — `webLink` included — is already on every draft we fetch. We were building a link while holding the provider's own.

**Gmail.** This one cannot be fully fixed. The `compose=` parameter takes an internal id that is not derivable from an API id — [Google's own community thread](https://support.google.com/mail/thread/86596268/the-url-https-mail-google-com-mail-u-0-drafts-compose-draftmailid-doesn-t-work-anymore?hl=en) confirms the old `#drafts?compose=<messageId>` form stopped working, and a [follow-up discussion](https://community.latenode.com/t/navigating-to-draft-messages-in-gmails-updated-interface-using-api-generated-ids/11481) concludes the new URLs "use an internal encoding system that's not publicly accessible." So `#inbox?compose=` (#3328) could never have opened the composer, and neither could `#drafts/<messageId>` (#3346) — that one also passed a *message* id where Gmail conversation URLs take a *thread* id.

## Changes

- Pass the draft message to `getEmailDraftUrl` instead of an id, because the fields that yield a working link differ by provider.
- Outlook: use the Graph `webLink`, keeping the constructed URL as a fallback. Since this value is redirected to, it is only trusted once its host is confirmed to be an Outlook host over https — otherwise the endpoint would forward wherever the payload pointed.
- Gmail: link to the draft's conversation under Drafts, addressed by **thread** id, falling back to the message id when no thread is present.

## Result

Outlook opens the draft itself. Gmail opens the draft's conversation in Drafts, which is as close as its interface allows — the composer is not reachable from an API id.

## Validation

- 6 new tests: the provider link taking precedence, three rejected-link cases (wrong host, non-https, unparseable), and Gmail thread-vs-message id selection.
- Route tests cover both providers end to end.
- Full `apps/web` suite run before and after; the failure set is **identical** (8 files, 19 tests, all pre-existing), with 6 net-new passing tests.

## Note for reviewers

The Gmail half is the honest best available rather than a fix, and it is worth confirming on a real account which provider the reporter was using — if it was Outlook, this closes the ticket; if Gmail, the button's promise may need rewording instead, since the composer cannot be deeplinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved meeting follow-up draft redirects for Gmail and Outlook.
  - Gmail drafts now open directly in the relevant conversation within the Drafts folder.
  - Outlook drafts now use the provider’s supplied web link when trusted, with a fallback link when needed.
  - Updated draft-link handling to provide more reliable navigation across supported email providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->