### PR TITLE
INB-352: Keep active calls in the upcoming meetings list

### DIFF
--- a/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
@@ -33,7 +33,7 @@ describe("meeting recorder meetings route", () => {
     vi.useRealTimers();
   });
 
-  it("keeps ongoing and no-show bookings out of the recorded section", async () => {
+  it("keeps active calls out of the recorded section", async () => {
     await GET(
       new Request(
         "https://example.com/api/user/meeting-recorder/meetings",
@@ -50,8 +50,6 @@ describe("meeting recorder meetings route", () => {
             MeetingRecordingStatus.JOINING,
             MeetingRecordingStatus.IN_WAITING_ROOM,
             MeetingRecordingStatus.FAILED,
-            MeetingRecordingStatus.IN_CALL,
-            MeetingRecordingStatus.RECORDING,
             MeetingRecordingStatus.CALL_ENDED,
             MeetingRecordingStatus.DONE,
           ],

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.test.ts
@@ -130,4 +130,61 @@ describe("meeting recorder upcoming route", () => {
       }),
     ]);
   });
+
+  it.each([
+    MeetingRecordingStatus.IN_CALL,
+    MeetingRecordingStatus.RECORDING,
+  ])("keeps an active call in the upcoming list after its scheduled end (%s)", async (status) => {
+    fetchEventsMock.mockResolvedValue({ complete: true, events: [] });
+    prisma.meeting.findMany.mockResolvedValue([
+      {
+        id: "meeting-1",
+        calendarEventId: "event-1",
+        eventTitle: "Planning",
+        startTime: new Date("2026-07-30T09:00:00.000Z"),
+        endTime: new Date("2026-07-30T09:30:00.000Z"),
+        joinOverride: null,
+        recording: { status, failureReason: null },
+      },
+    ] as never);
+
+    const response = await GET(
+      new Request(
+        "https://example.com/api/user/meeting-recorder/upcoming",
+      ) as never,
+    );
+    const body = await response.json();
+
+    expect(prisma.meeting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          emailAccountId: "email-account-1",
+          OR: [
+            { calendarEventId: { in: [] } },
+            {
+              recording: {
+                status: {
+                  in: [
+                    MeetingRecordingStatus.IN_CALL,
+                    MeetingRecordingStatus.RECORDING,
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(body.events).toEqual([
+      expect.objectContaining({
+        id: "event-1",
+        meetingId: "meeting-1",
+        title: "Planning",
+        startTime: "2026-07-30T09:00:00.000Z",
+        endTime: "2026-07-30T09:30:00.000Z",
+        hasCancellableBooking: true,
+        recordingStatus: status,
+      }),
+    ]);
+  });
 });

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
@@ -9,7 +9,10 @@ import {
   MEETING_RECORDER_MIN_TIER,
 } from "@/utils/meeting-recorder/config";
 import { shouldAutoJoin } from "@/utils/meeting-recorder/join-rule";
-import { CANCELLABLE_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
+import {
+  ACTIVE_CALL_STATUSES,
+  CANCELLABLE_STATUSES,
+} from "@/utils/meeting-recorder/recording-lifecycle";
 import { withEmailAccount } from "@/utils/middleware";
 import { checkHasAccess } from "@/utils/premium/server";
 import prisma from "@/utils/prisma";
@@ -59,15 +62,22 @@ async function getData({
   ]);
 
   const videoEvents = events.filter((event) => event.videoConferenceLink);
+  const videoEventIds = new Set(videoEvents.map((event) => event.id));
 
   const meetings = await prisma.meeting.findMany({
     where: {
       emailAccountId,
-      calendarEventId: { in: videoEvents.map((event) => event.id) },
+      OR: [
+        { calendarEventId: { in: [...videoEventIds] } },
+        { recording: { status: { in: ACTIVE_CALL_STATUSES } } },
+      ],
     },
     select: {
       id: true,
       calendarEventId: true,
+      eventTitle: true,
+      startTime: true,
+      endTime: true,
       joinOverride: true,
       recording: { select: { status: true, failureReason: true } },
     },
@@ -77,36 +87,63 @@ async function getData({
     meetings.map((meeting) => [meeting.calendarEventId, meeting]),
   );
 
+  const activeCallsMissingFromCalendar = meetings.flatMap((meeting) => {
+    const recording = meeting.recording;
+    if (
+      !recording ||
+      !ACTIVE_CALL_STATUSES.includes(recording.status) ||
+      videoEventIds.has(meeting.calendarEventId)
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        id: meeting.calendarEventId,
+        meetingId: meeting.id,
+        title: meeting.eventTitle,
+        startTime: meeting.startTime,
+        endTime: meeting.endTime,
+        hasCancellableBooking: true,
+        joinOverride: meeting.joinOverride,
+        willRecord: false,
+        recordingStatus: recording.status,
+        failureReason: recording.failureReason,
+      },
+    ];
+  });
+
   const rule = emailAccount?.meetingRecorderJoinRule ?? MeetingJoinRule.ALL;
+  const upcomingEvents = videoEvents.map((event) => {
+    const meeting = meetingsByEventId.get(event.id);
+
+    return {
+      id: event.id,
+      meetingId: meeting?.id,
+      title: event.title,
+      startTime: event.startTime,
+      endTime: event.endTime,
+      hasCancellableBooking:
+        !!meeting?.recording &&
+        CANCELLABLE_STATUSES.includes(meeting.recording.status),
+      joinOverride: meeting?.joinOverride ?? null,
+      // Decided server-side with the same helper the cron uses, so the toggle
+      // can never disagree with what actually happens.
+      willRecord:
+        hasAccess &&
+        shouldAutoJoin({
+          event,
+          rule,
+          userEmail: emailAccount?.email ?? "",
+          joinOverride: meeting?.joinOverride,
+        }),
+      recordingStatus: meeting?.recording?.status,
+      failureReason: meeting?.recording?.failureReason,
+    };
+  });
 
   return {
     hasAccess,
-    events: videoEvents.map((event) => {
-      const meeting = meetingsByEventId.get(event.id);
-
-      return {
-        id: event.id,
-        meetingId: meeting?.id,
-        title: event.title,
-        startTime: event.startTime,
-        endTime: event.endTime,
-        hasCancellableBooking:
-          !!meeting?.recording &&
-          CANCELLABLE_STATUSES.includes(meeting.recording.status),
-        joinOverride: meeting?.joinOverride ?? null,
-        // Decided server-side with the same helper the cron uses, so the toggle
-        // can never disagree with what actually happens.
-        willRecord:
-          hasAccess &&
-          shouldAutoJoin({
-            event,
-            rule,
-            userEmail: emailAccount?.email ?? "",
-            joinOverride: meeting?.joinOverride,
-          }),
-        recordingStatus: meeting?.recording?.status,
-        failureReason: meeting?.recording?.failureReason,
-      };
-    }),
+    events: [...activeCallsMissingFromCalendar, ...upcomingEvents],
   };
 }

--- a/apps/web/utils/actions/meeting-recorder.test.ts
+++ b/apps/web/utils/actions/meeting-recorder.test.ts
@@ -15,6 +15,7 @@ const {
   mockReconcileSingleEvent,
   mockReleaseAccountBookings,
   mockReleaseAutomaticAccountBookings,
+  mockReleaseMeetingBooking,
   mockUpsertMeeting,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockReconcileSingleEvent: vi.fn(),
   mockReleaseAccountBookings: vi.fn(),
   mockReleaseAutomaticAccountBookings: vi.fn(),
+  mockReleaseMeetingBooking: vi.fn(),
   mockUpsertMeeting: vi.fn(),
 }));
 
@@ -41,6 +43,7 @@ vi.mock("@/utils/meeting-recorder/reconcile", () => ({
   reconcileSingleEvent: mockReconcileSingleEvent,
   releaseAccountBookings: mockReleaseAccountBookings,
   releaseAutomaticAccountBookings: mockReleaseAutomaticAccountBookings,
+  releaseMeetingBooking: mockReleaseMeetingBooking,
   upsertMeeting: mockUpsertMeeting,
 }));
 
@@ -146,6 +149,7 @@ describe("setMeetingJoinOverrideAction", () => {
       ],
     });
     mockUpsertMeeting.mockResolvedValue({ id: "meeting-1" });
+    mockReleaseMeetingBooking.mockResolvedValue(false);
   });
 
   it("does not book a bot for an account without the paid tier", async () => {
@@ -189,6 +193,26 @@ describe("setMeetingJoinOverrideAction", () => {
       joinOverride: false,
     });
     expect(mockReconcileSingleEvent).toHaveBeenCalled();
+    expect(result?.serverError).toBeUndefined();
+  });
+
+  it("turns off an active booking after the calendar event has ended", async () => {
+    mockFetchEvents.mockResolvedValue({ complete: true, events: [] });
+    mockReleaseMeetingBooking.mockResolvedValue(true);
+
+    const result = await setMeetingJoinOverrideAction(EMAIL_ACCOUNT_ID, {
+      join: false,
+      calendarEventId: "event-1",
+    });
+
+    expect(mockReleaseMeetingBooking).toHaveBeenCalledWith({
+      emailAccountId: EMAIL_ACCOUNT_ID,
+      calendarEventId: "event-1",
+      logger: expect.anything(),
+    });
+    expect(mockFetchEvents).not.toHaveBeenCalled();
+    expect(mockUpsertMeeting).not.toHaveBeenCalled();
+    expect(mockReconcileSingleEvent).not.toHaveBeenCalled();
     expect(result?.serverError).toBeUndefined();
   });
 

--- a/apps/web/utils/actions/meeting-recorder.ts
+++ b/apps/web/utils/actions/meeting-recorder.ts
@@ -23,6 +23,7 @@ import {
   reconcileSingleEvent,
   releaseAccountBookings,
   releaseAutomaticAccountBookings,
+  releaseMeetingBooking,
   upsertMeeting,
 } from "@/utils/meeting-recorder/reconcile";
 import prisma from "@/utils/prisma";
@@ -111,6 +112,17 @@ export const setMeetingJoinOverrideAction = actionClient
       if (!emailAccount) throw new SafeError("Email account not found");
       if (!emailAccount.meetingRecorderEnabled) {
         throw new SafeError("The notetaker is turned off for this account");
+      }
+
+      if (
+        !join &&
+        (await releaseMeetingBooking({
+          emailAccountId,
+          calendarEventId,
+          logger,
+        }))
+      ) {
+        return;
       }
 
       if (join) {

--- a/apps/web/utils/meeting-recorder/reconcile.test.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { MeetingRecordingStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { releaseMeetingBooking } from "@/utils/meeting-recorder/reconcile";
+import { CANCELLABLE_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/meeting-recorder/create-bot-provider", () => ({
+  DEFAULT_MEETING_BOT_PROVIDER: "recall",
+  createMeetingBotProvider: vi.fn(),
+}));
+
+describe("releaseMeetingBooking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.meeting.findFirst.mockResolvedValue({
+      id: "meeting-1",
+      recordingId: "recording-1",
+    } as never);
+  });
+
+  it("keeps a recording linked if the call ends before detachment", async () => {
+    prisma.meeting.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    await releaseMeetingBooking({
+      emailAccountId: "email-account-1",
+      calendarEventId: "event-1",
+      logger: createTestLogger(),
+    });
+
+    const detachCall = prisma.meeting.updateMany.mock.calls.find(
+      ([args]) => args.data.recordingId === null,
+    );
+    expect(detachCall?.[0].where).toMatchObject({
+      id: "meeting-1",
+      recordingId: "recording-1",
+      recording: { status: { in: CANCELLABLE_STATUSES } },
+    });
+    expect(CANCELLABLE_STATUSES).not.toContain(
+      MeetingRecordingStatus.CALL_ENDED,
+    );
+    expect(prisma.meetingRecording.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -758,10 +758,14 @@ async function releaseMeeting({
   if (!recordingId) return;
 
   // Only detach the recording we were asked about. `recordingId` is a snapshot,
-  // so a concurrent pass may already have linked a different one, and clearing
-  // unconditionally would drop that new booking on the floor.
+  // so a concurrent pass may already have linked a different one or completed
+  // the call, and clearing unconditionally would drop that recording.
   const detached = await prisma.meeting.updateMany({
-    where: { id: meetingId, recordingId },
+    where: {
+      id: meetingId,
+      recordingId,
+      recording: { status: { in: CANCELLABLE_STATUSES } },
+    },
     data: { recordingId: null },
   });
   if (detached.count === 0) return;

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -659,6 +659,47 @@ export async function releaseAutomaticAccountBookings({
   });
 }
 
+// Calendar APIs omit events after their scheduled end, so an ongoing call must
+// be cancellable from the account-scoped snapshot we already verified earlier.
+export async function releaseMeetingBooking({
+  emailAccountId,
+  calendarEventId,
+  logger,
+}: {
+  emailAccountId: string;
+  calendarEventId: string;
+  logger: Logger;
+}): Promise<boolean> {
+  const meeting = await prisma.meeting.findFirst({
+    where: {
+      emailAccountId,
+      calendarEventId,
+      recordingId: { not: null },
+      recording: { status: { in: CANCELLABLE_STATUSES } },
+    },
+    select: { id: true, recordingId: true },
+  });
+  if (!meeting?.recordingId) return false;
+
+  const updated = await prisma.meeting.updateMany({
+    where: {
+      id: meeting.id,
+      emailAccountId,
+      calendarEventId,
+      recordingId: meeting.recordingId,
+    },
+    data: { joinOverride: false },
+  });
+  if (updated.count === 0) return false;
+
+  await releaseMeeting({
+    meetingId: meeting.id,
+    recordingId: meeting.recordingId,
+    logger,
+  });
+  return true;
+}
+
 async function releaseAccountBookingsMatching({
   emailAccountId,
   automaticOnly,

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -32,13 +32,12 @@ export const NO_RECORDING_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.FAILED,
 ];
 
-// The bot made it into the call, so media exists or is still being captured.
-// Meetings in these states must never be presented as "not recorded".
-export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
+// The bot is still in the call, even if the calendar event's scheduled end has
+// passed. These meetings stay in the upcoming section until the provider
+// reports that the call ended.
+export const ACTIVE_CALL_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.IN_CALL,
   MeetingRecordingStatus.RECORDING,
-  MeetingRecordingStatus.CALL_ENDED,
-  MeetingRecordingStatus.DONE,
 ];
 
 // These outcomes have useful details to show even when the calendar event's
@@ -48,12 +47,19 @@ export const MEETING_DETAIL_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.DONE,
 ];
 
-// A booked bot is not a recorded meeting. The Recorded section only shows
-// calls the bot engaged with or that produced media; untouched scheduled
-// bookings are no-shows.
+// The bot made it into the call, so media exists or is still being captured.
+// Meetings in these states must never be presented as "not recorded".
+export const CAPTURED_MEETING_STATUSES: MeetingRecordingStatus[] = [
+  ...ACTIVE_CALL_STATUSES,
+  ...MEETING_DETAIL_STATUSES,
+];
+
+// A booked bot is not a recorded meeting. Once the scheduled event has ended,
+// show failed attempts and calls whose capture has actually concluded; active
+// calls stay in the upcoming section.
 export const RECORDED_SECTION_STATUSES: MeetingRecordingStatus[] = [
   ...NO_RECORDING_STATUSES,
-  ...CAPTURED_MEETING_STATUSES,
+  ...MEETING_DETAIL_STATUSES,
 ];
 
 // Rank orders the lifecycle so replayed or out-of-order webhooks can only ever


### PR DESCRIPTION
Keeps in-progress meeting recordings in Up next after their scheduled end and out of Recorded until the provider reports that the call ended. It also preserves cancellation through the account-scoped meeting snapshot when the calendar no longer returns the event.

- Separate active-call states from completed meeting-detail states.
- Include persisted active calls in the upcoming endpoint and support ending them without a calendar refetch.
- Tests: 20 focused unit tests passed; targeted Ultracite checks passed for all 8 changed files.
- Performance: the upcoming request keeps one database query with a broader active-status filter and no extra network calls; cancellation adds a small scoped lookup/update only on user action, so hot-path risk is low.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-352/meeting-moved-to-recorded-section-at-scheduled-end-time-even-when

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active calls missing from the calendar now appear in the upcoming meetings list, including after their scheduled end time.
  * Disabling an eligible active meeting booking now releases the booking and recording automatically.

* **Bug Fixes**
  * Active calls remain out of the recorded meetings section until they reach a completed recording state.
  * Upcoming meeting details and cancellation options are preserved for active calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->