### PR TITLE
mail: Refine thread navigation, drafts, and reply delivery

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,7 +72,11 @@ concurrency:
 
 jobs:
   playwright:
-    name: Web E2E
+    name: E2E shard ${{ matrix.shard }}/4
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     runs-on: ubuntu-latest
     timeout-minutes: 75
     services:
@@ -106,6 +110,7 @@ jobs:
           - 8079:80
 
     env:
+      PLAYWRIGHT_SHARD: ${{ matrix.shard }}/4
       NODE_ENV: development
       NODE_OPTIONS: --max_old_space_size=6144
       NEXT_PUBLIC_BASE_URL: http://localhost:3000
@@ -190,9 +195,53 @@ jobs:
         run: pnpm -F inbox-zero-ai test:playwright:emulated
 
       - name: Upload Playwright artifacts
-        if: >-
-          always() &&
-          (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-shard-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}
+          path: |
+            apps/web/.tmp/playwright/blob-report
+            apps/web/test-results
+          include-hidden-files: true
+          compression-level: 1
+          retention-days: 7
+          if-no-files-found: warn
+
+  report:
+    name: Web E2E
+    needs: playwright
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+      - name: Install dependencies
+        run: bash scripts/pnpm-install-without-desktop.sh --frozen-lockfile
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+      - name: Download shard reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-shard-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: apps/web
+          merge-multiple: true
+      - name: Merge browser reports
+        shell: bash
+        run: |
+          if compgen -G 'apps/web/.tmp/playwright/blob-report/*.zip' > /dev/null; then
+            pnpm -F inbox-zero-ai exec playwright merge-reports --reporter=html .tmp/playwright/blob-report
+          else
+            echo "No browser targets were selected."
+          fi
+        env:
+          PLAYWRIGHT_HTML_OPEN: never
+      - name: Upload Playwright artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
@@ -202,3 +251,8 @@ jobs:
           compression-level: 1
           retention-days: 7
           if-no-files-found: warn
+      - name: Require every shard to pass
+        if: always()
+        env:
+          SHARD_RESULT: ${{ needs.playwright.result }}
+        run: test "$SHARD_RESULT" = success

--- a/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
@@ -3,6 +3,57 @@ import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
 import { markAutomationOnboardingViewed } from "./automation-tabs-test-helpers";
 
+for (const custom of [false, true]) {
+  test(`can test ${custom ? "custom content" : "an email"} after browser translation replaces button text`, async ({
+    page,
+  }) => {
+    const emailAccountId = await getEmailAccountId(page);
+    await markAutomationOnboardingViewed(page);
+    await page.goto(`/${emailAccountId}/automation?tab=test&custom=${custom}`);
+    if (custom) {
+      await page
+        .locator("textarea[name=content]")
+        .fill("A routine project update.");
+    }
+    const scope = custom
+      ? page.locator("form").filter({ has: page.locator("textarea") })
+      : page.getByRole("row").filter({ hasText: "Playwright Test Message" });
+    const button = scope.getByRole("button", { name: "Test", exact: true });
+    await expect(button).toBeVisible();
+
+    await button.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const textNodes: Node[] = [];
+      while (walker.nextNode()) textNodes.push(walker.currentNode);
+      for (const node of textNodes) {
+        if (!node.textContent?.trim()) continue;
+        // Translation replaces React's text nodes with its own elements.
+        const translated = document.createElement("font");
+        translated.textContent = node.textContent;
+        node.parentNode?.replaceChild(translated, node);
+      }
+    });
+
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        !!response.request().headers()["next-action"],
+    );
+    await button.click();
+    await actionResponse;
+    await expect(scope).toBeVisible();
+    if (custom) {
+      await expect(
+        page.getByText("Test result", { exact: true }),
+      ).toBeVisible();
+    } else {
+      await expect(
+        scope.getByRole("button", { name: "Retest", exact: true }),
+      ).toBeEnabled();
+    }
+  });
+}
+
 test("preserves search, custom email, and Apply workspace state", async ({
   page,
 }) => {

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -372,7 +372,7 @@ test("opens and sends a reply from the reader with Enter", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "protected-quoted-reply");
   await sendButton.click();
 
-  await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
+  await expect(replyEditor).toHaveCount(0);
   await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
   await capturePlaywrightCheckpoint(page, testInfo, "reply-sent-in-thread");
 });

--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -3,7 +3,7 @@ import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
-test("switches between list, split, and focused reading layouts", async ({
+test("switches between list and split reading layouts", async ({
   page,
 }, testInfo) => {
   const { conversations } = await openMail(page);
@@ -37,15 +37,9 @@ test("switches between list, split, and focused reading layouts", async ({
     "mail-selected-conversation-layout",
   );
 
-  await page.getByRole("button", { name: /^Focus mode/ }).click();
-  await expect(conversations).toBeHidden();
-  await expect(
-    page.getByRole("button", { name: /^Exit focus mode/ }),
-  ).toBeVisible();
-  await capturePlaywrightCheckpoint(page, testInfo, "mail-focus-layout");
-
-  await page.getByRole("button", { name: /^Exit focus mode/ }).click();
-  await expect(conversations).toBeVisible();
+  await expect(page.getByRole("button", { name: /Focus mode/i })).toHaveCount(
+    0,
+  );
   await page.getByRole("button", { name: "Switch list or split view" }).click();
   await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -174,7 +174,7 @@ async function deleteDefaultSplitRule(client: Client, emailAccountId: string) {
   );
 }
 
-async function withClient<T>(callback: (client: Client) => Promise<T>) {
+export async function withClient<T>(callback: (client: Client) => Promise<T>) {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   await client.connect();
   try {

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -8,7 +8,9 @@ const DEFAULT_SPLIT_LABEL_ID = "Label_project";
 
 export async function openMail(page: Page) {
   const emailAccountId = await getEmailAccountId(page);
-  await page.goto(`/${emailAccountId}/mail`);
+  await page.goto(`/${emailAccountId}/mail`, {
+    waitUntil: "domcontentloaded",
+  });
 
   const conversations = page.getByRole("listbox", { name: "Conversations" });
   await expect(conversations).toBeVisible({ timeout: 60_000 });

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -112,8 +112,8 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
 
   try {
     await page
-      .getByRole("group", { name: "Thread actions" })
       .getByRole("button", { name: "Reply", exact: true })
+      .last()
       .click();
     const editor = page.locator("[contenteditable='true']");
     await editor.pressSequentially(replyBody);

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -117,7 +117,7 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
       .click();
     const editor = page.locator("[contenteditable='true']");
     await editor.pressSequentially(replyBody);
-    await page.getByRole("button", { name: /^Send/ }).click();
+    await page.getByRole("button", { name: "Send", exact: true }).click();
 
     await expect(
       page.getByText("Email queued. It will send when you're back online.", {

--- a/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-outbox.spec.ts
@@ -96,8 +96,16 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
   await stubMailboxSync(page);
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=${REPLY_THREAD_ID}`);
+  const replyMessage = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  const collapsedReply = replyMessage.locator(
+    '[role="button"][aria-expanded="false"]',
+  );
+  await expect(replyMessage).toBeVisible();
+  if (await collapsedReply.count()) await collapsedReply.click();
   await expect(
-    page.getByText("Please reply to this seeded conversation."),
+    replyMessage.getByText("Please reply to this seeded conversation."),
   ).toBeVisible({ timeout: 60_000 });
   const sentByMe = page.getByText("Me", { exact: true });
   const initialSentByMeCount = await sentByMe.count();
@@ -111,18 +119,17 @@ test("keeps a reply queued across reload and sends it after reconnect", async ({
   await setNavigatorOnline(page, false);
 
   try {
-    await page
+    await replyMessage
       .getByRole("button", { name: "Reply", exact: true })
-      .last()
       .click();
     const editor = page.locator("[contenteditable='true']");
     await editor.pressSequentially(replyBody);
     await page.getByRole("button", { name: "Send", exact: true }).click();
 
     await expect(
-      page.getByText("Email queued. It will send when you're back online.", {
-        exact: true,
-      }),
+      page
+        .getByRole("region", { name: "Reply delivery status" })
+        .getByText("Waiting for connection", { exact: true }),
     ).toBeVisible();
     await expect
       .poll(() =>

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -80,7 +80,7 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
   await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-rich-message");
 
   await page.getByRole("button", { name: "Show details", exact: true }).click();
-  await expect(page.getByText("From:", { exact: true })).toBeVisible();
+  await expect(page.getByText("From", { exact: true })).toBeVisible();
   await capturePlaywrightCheckpoint(
     page,
     testInfo,

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -1,0 +1,204 @@
+import { expect, type Page } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail, withClient } from "./mail-test-helpers";
+
+const THREAD_ID = "thr_playwright_reply";
+
+test("schedules a reply with a reminder, persists it and cancels both", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await openReply(page);
+  const delivery = page.getByRole("region", { name: "Reply delivery status" });
+  try {
+    await page.getByRole("button", { name: "Send later", exact: true }).click();
+    const sendDialog = page.getByRole("dialog", { name: "Send later" });
+    await expect(sendDialog).toBeVisible();
+    await capturePlaywrightCheckpoint(page, testInfo, "16-send-later-menu");
+    await sendDialog.getByRole("button", { name: /Tomorrow morning/ }).click();
+    await page.getByRole("button", { name: "Remind me", exact: true }).click();
+    const reminderDialog = page.getByRole("dialog", { name: "Remind me" });
+    await expect(reminderDialog).toContainText("if no one replies");
+    await capturePlaywrightCheckpoint(page, testInfo, "17-reminder-menu");
+    await reminderDialog
+      .getByRole("button", { name: /2 days after sending/ })
+      .click();
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect(delivery.getByText(/^Scheduled for/)).toBeVisible();
+    await expect(delivery.getByText(/Remind me .* if no reply/)).toBeVisible();
+    await page.reload();
+    await expect(delivery.getByText(/^Scheduled for/)).toBeVisible();
+    await expect(delivery.getByText(/Remind me .* if no reply/)).toBeVisible();
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "18-scheduled-after-reload",
+    );
+    await delivery.getByRole("button", { name: "Cancel reminder" }).click();
+    await expect(
+      delivery.getByRole("button", { name: "Cancel reminder" }),
+    ).toHaveCount(0);
+    await expect(delivery.getByText(/^Scheduled for/)).toBeVisible();
+    await delivery.getByRole("button", { name: "Cancel send" }).click();
+    await expect(delivery.getByText(/^Scheduled for/)).toHaveCount(0);
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Reply Workflow Message" }),
+    ).toBeVisible();
+    await expect(delivery.getByText(/^Scheduled for/)).toHaveCount(0);
+    await capturePlaywrightCheckpoint(page, testInfo, "19-scheduled-cancelled");
+  } finally {
+    await withClient((client) =>
+      client.query(
+        'DELETE FROM "ScheduledEmail" WHERE "emailAccountId" = $1 AND "threadId" = $2',
+        [emailAccountId, THREAD_ID],
+      ),
+    );
+  }
+});
+
+test("offers recovery for a failed scheduled reply and guards uncertain delivery", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await openReply(page);
+  const delivery = page.getByRole("region", { name: "Reply delivery status" });
+  try {
+    await page.getByRole("button", { name: "Send later", exact: true }).click();
+    await page
+      .getByRole("dialog", { name: "Send later" })
+      .getByRole("button", { name: /Tomorrow morning/ })
+      .click();
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect(delivery.getByText(/^Scheduled for/)).toBeVisible();
+    await setScheduledStatus(
+      emailAccountId,
+      "FAILED",
+      "The email provider rejected this reply before delivery.",
+    );
+    await page.reload();
+    await expect(
+      delivery.getByText("Reply needs attention", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      delivery.getByRole("button", { name: "Retry send" }),
+    ).toBeVisible();
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "20-failed-reply-recovery",
+    );
+    await delivery.getByRole("button", { name: "Retry send" }).click();
+    await expect(delivery.getByText(/^Scheduled for/)).toBeVisible();
+    await setScheduledStatus(
+      emailAccountId,
+      "UNCERTAIN",
+      "The connection ended before delivery could be confirmed.",
+    );
+    await page.reload();
+    await expect(
+      delivery.getByText("Delivery uncertain", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      delivery.getByRole("link", { name: "Check Sent" }),
+    ).toHaveAttribute("href", `/${emailAccountId}/mail?type=sent`);
+    await expect(
+      delivery.getByRole("button", { name: "Retry send" }),
+    ).toHaveCount(0);
+    await expect(
+      delivery.getByRole("button", { name: "Cancel send" }),
+    ).toHaveCount(0);
+    await capturePlaywrightCheckpoint(page, testInfo, "21-uncertain-delivery");
+  } finally {
+    await withClient((client) =>
+      client.query(
+        'DELETE FROM "ScheduledEmail" WHERE "emailAccountId" = $1 AND "threadId" = $2',
+        [emailAccountId, THREAD_ID],
+      ),
+    );
+  }
+});
+
+async function openReply(page: Page) {
+  page.setDefaultTimeout(20_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=${THREAD_ID}`);
+  await expect(
+    page.getByText("Please reply to this seeded conversation."),
+  ).toBeVisible();
+  await page
+    .getByRole("group", { name: "Thread actions" })
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
+  await page
+    .getByRole("textbox", { name: "Email message" })
+    .fill("Thanks Leslie, Thursday works. I will bring the updated proposal.");
+  return emailAccountId;
+}
+
+function setScheduledStatus(
+  emailAccountId: string,
+  status: "FAILED" | "UNCERTAIN",
+  error: string,
+) {
+  return withClient((client) =>
+    client.query(
+      'UPDATE "ScheduledEmail" SET status = $1, error = $2 WHERE "emailAccountId" = $3 AND "threadId" = $4 AND status != \'CANCELLED\'',
+      [status, error, emailAccountId, THREAD_ID],
+    ),
+  );
+}
+
+test("sends a reply with a reminder through the local email provider", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await openReply(page);
+  const message = "Confirmed for Thursday. Please bring the updated proposal.";
+  await page.getByRole("textbox", { name: "Email message" }).fill(message);
+  try {
+    await page.getByRole("button", { name: "Remind me", exact: true }).click();
+    await page
+      .getByRole("dialog", { name: "Remind me" })
+      .getByRole("button", { name: /Tomorrow morning/ })
+      .click();
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    const delivery = page.getByRole("region", {
+      name: "Reply delivery status",
+    });
+    await expect(delivery.getByText("Reply sent", { exact: true })).toBeVisible(
+      { timeout: 60_000 },
+    );
+    await expect(
+      delivery.getByRole("button", { name: "Cancel reminder" }),
+    ).toBeVisible();
+    const scheduled = await withClient((client) =>
+      client.query(
+        'SELECT status, "reminderStatus" FROM "ScheduledEmail" WHERE "emailAccountId" = $1 AND "threadId" = $2',
+        [emailAccountId, THREAD_ID],
+      ),
+    );
+    expect(scheduled.rows).toEqual([
+      { status: "SENT", reminderStatus: "PENDING" },
+    ]);
+    const response = await page.request.get(
+      `/api/threads/${THREAD_ID}?includeDrafts=true`,
+      { headers: { "X-Email-Account-ID": emailAccountId } },
+    );
+    expect(response.ok()).toBe(true);
+    const body = await response.json();
+    expect(
+      body.thread.messages.some(
+        (item: { textPlain?: string; textHtml?: string }) =>
+          `${item.textPlain ?? ""}${item.textHtml ?? ""}`.includes(message),
+      ),
+    ).toBe(true);
+    await capturePlaywrightCheckpoint(page, testInfo, "23-sent-with-reminder");
+  } finally {
+    await withClient((client) =>
+      client.query(
+        'DELETE FROM "ScheduledEmail" WHERE "emailAccountId" = $1 AND "threadId" = $2',
+        [emailAccountId, THREAD_ID],
+      ),
+    );
+  }
+});

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -16,10 +16,20 @@ test("schedules a reply with a reminder, persists it and cancels both", async ({
     const sendDialog = page.getByRole("dialog", { name: "Send later" });
     await expect(sendDialog).toBeVisible();
     await capturePlaywrightCheckpoint(page, testInfo, "16-send-later-menu");
+    await sendDialog
+      .getByRole("button", { name: "Choose date and time" })
+      .click();
+    await expect(
+      sendDialog.getByLabel("Send later date and time"),
+    ).toBeVisible();
+    await sendDialog.getByRole("button", { name: "Back", exact: true }).click();
+    await expect(sendDialog.getByLabel("Send later date and time")).toHaveCount(
+      0,
+    );
     await sendDialog.getByRole("button", { name: /Tomorrow morning/ }).click();
     await page.getByRole("button", { name: "Remind me", exact: true }).click();
     const reminderDialog = page.getByRole("dialog", { name: "Remind me" });
-    await expect(reminderDialog).toContainText("if no one replies");
+    await expect(reminderDialog).toContainText("if no reply");
     await capturePlaywrightCheckpoint(page, testInfo, "17-reminder-menu");
     await reminderDialog
       .getByRole("button", { name: /2 days after sending/ })

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -201,10 +201,7 @@ async function openReply(page: Page) {
   await expect(
     page.getByRole("heading", { name: /Reply Workflow Message/ }),
   ).toBeVisible();
-  await page
-    .getByRole("group", { name: "Thread actions" })
-    .getByRole("button", { name: "Reply", exact: true })
-    .click();
+  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
   await page
     .getByRole("textbox", { name: "Email message" })
     .fill("Thanks Leslie, Thursday works. I will bring the updated proposal.");

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { openMail, withClient } from "./mail-test-helpers";
@@ -118,42 +119,20 @@ test("offers recovery for a failed scheduled reply and guards uncertain delivery
   }
 });
 
-async function openReply(page: Page) {
-  page.setDefaultTimeout(20_000);
-  await page.setViewportSize({ width: 1440, height: 1000 });
-  const { emailAccountId } = await openMail(page);
-  await page.goto(`/${emailAccountId}/mail?thread-id=${THREAD_ID}`);
-  await expect(
-    page.getByText("Please reply to this seeded conversation."),
-  ).toBeVisible();
-  await page
-    .getByRole("group", { name: "Thread actions" })
-    .getByRole("button", { name: "Reply", exact: true })
-    .click();
-  await page
-    .getByRole("textbox", { name: "Email message" })
-    .fill("Thanks Leslie, Thursday works. I will bring the updated proposal.");
-  return emailAccountId;
-}
-
-function setScheduledStatus(
-  emailAccountId: string,
-  status: "FAILED" | "UNCERTAIN",
-  error: string,
-) {
-  return withClient((client) =>
-    client.query(
-      'UPDATE "ScheduledEmail" SET status = $1, error = $2 WHERE "emailAccountId" = $3 AND "threadId" = $4 AND status != \'CANCELLED\'',
-      [status, error, emailAccountId, THREAD_ID],
-    ),
-  );
-}
-
 test("sends a reply with a reminder through the local email provider", async ({
   page,
 }, testInfo) => {
   const emailAccountId = await openReply(page);
-  const message = "Confirmed for Thursday. Please bring the updated proposal.";
+  const initialResponse = await page.request.get(
+    `/api/threads/${THREAD_ID}?includeDrafts=true`,
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(initialResponse.ok()).toBe(true);
+  const initialThread: ThreadResponse = await initialResponse.json();
+  const initialSentIds = initialThread.thread.messages
+    .filter((message) => message.labelIds?.includes("SENT"))
+    .map((message) => message.id);
+  const message = `Confirmed for Thursday. Please bring the updated proposal. Attempt ${testInfo.retry}.`;
   await page.getByRole("textbox", { name: "Email message" }).fill(message);
   try {
     await page.getByRole("button", { name: "Remind me", exact: true }).click();
@@ -185,13 +164,24 @@ test("sends a reply with a reminder through the local email provider", async ({
       { headers: { "X-Email-Account-ID": emailAccountId } },
     );
     expect(response.ok()).toBe(true);
-    const body = await response.json();
+    const body: ThreadResponse = await response.json();
+    const sentMessages = body.thread.messages.filter((item) =>
+      item.labelIds?.includes("SENT"),
+    );
+    expect(sentMessages).toHaveLength(initialSentIds.length + 1);
+    const appended = sentMessages.filter(
+      (item) => !initialSentIds.includes(item.id),
+    );
+    expect(appended).toHaveLength(1);
     expect(
-      body.thread.messages.some(
-        (item: { textPlain?: string; textHtml?: string }) =>
-          `${item.textPlain ?? ""}${item.textHtml ?? ""}`.includes(message),
-      ),
-    ).toBe(true);
+      `${appended[0].textPlain ?? ""}${appended[0].textHtml ?? ""}`,
+    ).toContain(message);
+    await expect(
+      page
+        .frameLocator('iframe[title="Email content preview"]')
+        .last()
+        .getByText(message, { exact: true }),
+    ).toBeVisible();
     await capturePlaywrightCheckpoint(page, testInfo, "23-sent-with-reminder");
   } finally {
     await withClient((client) =>
@@ -202,3 +192,34 @@ test("sends a reply with a reminder through the local email provider", async ({
     );
   }
 });
+
+async function openReply(page: Page) {
+  page.setDefaultTimeout(20_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=${THREAD_ID}`);
+  await expect(
+    page.getByRole("heading", { name: /Reply Workflow Message/ }),
+  ).toBeVisible();
+  await page
+    .getByRole("group", { name: "Thread actions" })
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
+  await page
+    .getByRole("textbox", { name: "Email message" })
+    .fill("Thanks Leslie, Thursday works. I will bring the updated proposal.");
+  return emailAccountId;
+}
+
+function setScheduledStatus(
+  emailAccountId: string,
+  status: "FAILED" | "UNCERTAIN",
+  error: string,
+) {
+  return withClient((client) =>
+    client.query(
+      'UPDATE "ScheduledEmail" SET status = $1, error = $2 WHERE "emailAccountId" = $3 AND "threadId" = $4 AND status != \'CANCELLED\'',
+      [status, error, emailAccountId, THREAD_ID],
+    ),
+  );
+}

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -205,6 +205,7 @@ test("sends a reply with a reminder through the local email provider", async ({
 
 async function openReply(page: Page) {
   page.setDefaultTimeout(20_000);
+  page.setDefaultNavigationTimeout(30_000);
   await page.setViewportSize({ width: 1440, height: 1000 });
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=${THREAD_ID}`);

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -212,7 +212,10 @@ async function openReply(page: Page) {
   await expect(
     page.getByRole("heading", { name: /Reply Workflow Message/ }),
   ).toBeVisible();
-  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
+  await page
+    .locator('li[data-thread-message-id="msg_playwright_reply"]')
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
   await page
     .getByRole("textbox", { name: "Email message" })
     .fill("Thanks Leslie, Thursday works. I will bring the updated proposal.");

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail } from "./mail-test-helpers";
+
+test("keeps arrow navigation inside the thread and expands from its toolbar", async ({
+  page,
+}, testInfo) => {
+  page.setDefaultTimeout(15_000);
+  page.setDefaultNavigationTimeout(30_000);
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(
+    page.getByText(
+      "A second message proves the complete conversation is rendered.",
+    ),
+  ).toBeVisible();
+  const threadUrl = page.url();
+  const messages = page.locator("li[data-thread-message-id]");
+  const selected = page.locator('li[aria-current="true"]');
+  await expect(messages).toHaveCount(2);
+  await expect(selected).toHaveCount(1);
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await page.keyboard.press("ArrowUp");
+  await expect(messages.first()).toHaveAttribute("aria-current", "true");
+  await page.keyboard.press("ArrowUp");
+  await expect(messages.first()).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(threadUrl);
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "navigation-selected-message",
+  );
+  await page.keyboard.press("ArrowDown");
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await page.keyboard.press("ArrowDown");
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(threadUrl);
+  const toolbar = page.getByRole("group", { name: "Thread actions" });
+  const expand = toolbar.getByRole("button", {
+    name: "Expand all messages",
+    exact: true,
+  });
+  await expect(
+    page.getByRole("button", { name: "Expand all messages", exact: true }),
+  ).toHaveCount(1);
+  await expand.click();
+  await expect(
+    page.getByText("First message in the reader conversation."),
+  ).toBeVisible();
+  await toolbar
+    .getByRole("button", { name: "Collapse all messages", exact: true })
+    .click();
+  await expect(
+    messages.first().locator('[role="button"][aria-expanded]'),
+  ).toHaveAttribute("aria-expanded", "false");
+  await expect(expand).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "navigation-mobile-toolbar",
+  );
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
+  const editor = page.getByRole("textbox", { name: "Email message" });
+  await editor.fill(
+    "A reply on the first line.\nAnother line for cursor navigation.",
+  );
+  await page.keyboard.press("ArrowUp");
+  await expect(editor).toBeFocused();
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await page.keyboard.press("ArrowDown");
+  await expect(editor).toBeFocused();
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(threadUrl);
+});
+
+test("navigates messages from inside a rich email body", async ({ page }) => {
+  page.setDefaultTimeout(15_000);
+  page.setDefaultNavigationTimeout(30_000);
+  await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
+    const response = await route.fetch();
+    const body: ThreadResponse = await response.json();
+    const last = body.thread.messages.at(-1);
+    expect(last).toBeDefined();
+    if (!last) throw new Error("Reader fixture has no messages");
+    last.textHtml = "<p>A rich email body for keyboard navigation.</p>";
+    await route.fulfill({ response, json: body });
+  });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
+    waitUntil: "domcontentloaded",
+  });
+  const emailBody = page
+    .frameLocator('iframe[title="Email content preview"]')
+    .last()
+    .getByText("A rich email body for keyboard navigation.");
+  await expect(emailBody).toBeVisible();
+  const threadUrl = page.url();
+  const messages = page.locator("li[data-thread-message-id]");
+  await emailBody.click();
+  await page.keyboard.press("ArrowUp");
+  await expect(messages.first()).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(threadUrl);
+  await page.keyboard.press("ArrowDown");
+  await expect(messages.last()).toHaveAttribute("aria-current", "true");
+  await expect(page).toHaveURL(threadUrl);
+});

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -65,8 +65,12 @@ test("keeps arrow navigation inside the thread and expands from its toolbar", as
     "navigation-mobile-toolbar",
   );
   await page.setViewportSize({ width: 1440, height: 1000 });
-  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
+  await page.locator("body").press("Enter");
+  await expect(
+    page.getByText("Generating reply...", { exact: true }),
+  ).toHaveCount(0);
   const editor = page.getByRole("textbox", { name: "Email message" });
+  await expect(editor).toBeFocused();
   await editor.fill(
     "A reply on the first line.\nAnother line for cursor navigation.",
   );

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -67,11 +67,10 @@ test("keeps arrow navigation inside the thread and expands from its toolbar", as
   await page.setViewportSize({ width: 1440, height: 1000 });
   await messages.last().focus();
   await page.keyboard.press("Enter");
-  await expect(
-    page.getByText("Generating reply...", { exact: true }),
-  ).toHaveCount(0);
+
   const editor = page.getByRole("textbox", { name: "Email message" });
   await expect(editor).toBeFocused();
+  await expect(editor.locator("p")).toHaveText("");
   await page.getByLabel("Show quoted message").click();
   await expect(
     page.getByRole("toolbar", { name: "Selection formatting" }),

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -65,7 +65,8 @@ test("keeps arrow navigation inside the thread and expands from its toolbar", as
     "navigation-mobile-toolbar",
   );
   await page.setViewportSize({ width: 1440, height: 1000 });
-  await page.locator("body").press("Enter");
+  await messages.last().focus();
+  await page.keyboard.press("Enter");
   await expect(
     page.getByText("Generating reply...", { exact: true }),
   ).toHaveCount(0);
@@ -121,4 +122,9 @@ test("navigates messages from inside a rich email body", async ({ page }) => {
   await page.keyboard.press("ArrowDown");
   await expect(messages.last()).toHaveAttribute("aria-current", "true");
   await expect(page).toHaveURL(threadUrl);
+  await emailBody.click();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("textbox", { name: "Email message" }),
+  ).toBeVisible();
 });

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -71,6 +71,14 @@ test("keeps arrow navigation inside the thread and expands from its toolbar", as
   ).toHaveCount(0);
   const editor = page.getByRole("textbox", { name: "Email message" });
   await expect(editor).toBeFocused();
+  await page.getByLabel("Show quoted message").click();
+  await expect(
+    page.getByRole("toolbar", { name: "Selection formatting" }),
+  ).toBeHidden();
+  await page.getByLabel("Hide quoted message").click();
+  await expect(
+    page.getByRole("toolbar", { name: "Selection formatting" }),
+  ).toBeHidden();
   await editor.fill(
     "A reply on the first line.\nAnother line for cursor navigation.",
   );

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { openMail, readLatestMailMutation } from "./mail-test-helpers";
@@ -62,11 +63,6 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
     "Thanks Leslie, Thursday at 2 pm works for me.",
   );
   await capturePlaywrightCheckpoint(page, testInfo, "08-draft-after-reload");
-  if (!(await editor.count()))
-    await page
-      .getByRole("group", { name: "Thread actions" })
-      .getByRole("button", { name: "Reply", exact: true })
-      .click();
   await editor.fill("A reply that should survive navigation.");
   await expect(
     page.getByText("Saved on this device", { exact: true }),
@@ -82,11 +78,6 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
     testInfo,
     "12-draft-after-navigation",
   );
-  if (!(await editor.count()))
-    await page
-      .getByRole("group", { name: "Thread actions" })
-      .getByRole("button", { name: "Reply", exact: true })
-      .click();
   await editor.fill("Mobile reply: the proposed time works well.");
   await page.setViewportSize({ width: 390, height: 844 });
   await capturePlaywrightCheckpoint(page, testInfo, "13-mobile-reply");
@@ -100,6 +91,16 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   await expect(
     page.getByRole("heading", { name: "Reply Workflow Message" }),
   ).toBeVisible();
+  const initialResponse = await page.request.get(
+    "/api/threads/thr_playwright_reply?includeDrafts=true",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(initialResponse.ok()).toBe(true);
+  const initialThread: ThreadResponse = await initialResponse.json();
+  const initialSentIds = initialThread.thread.messages
+    .filter((message) => message.labelIds?.includes("SENT"))
+    .map((message) => message.id);
+  const replyBody = `Confirmed, see you Thursday. This reply is sent only inside the local emulator. Attempt ${testInfo.retry}.`;
   const editor = page.locator("[contenteditable='true']");
   if (!(await editor.count()))
     await page
@@ -107,9 +108,7 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
       .getByRole("button", { name: "Reply", exact: true })
       .click();
   await expect(editor).toBeVisible();
-  await editor.fill(
-    "Confirmed, see you Thursday. This reply is sent only inside the local emulator.",
-  );
+  await editor.fill(replyBody);
   await page.evaluate(() =>
     Object.defineProperty(navigator, "onLine", {
       configurable: true,
@@ -126,8 +125,12 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
       }),
     )
     .toMatchObject({ status: "pending" });
+  const queuedToast = page.locator("[data-sonner-toast]").filter({
+    hasText: "Email queued. It will send when you're back online.",
+  });
+  await expect(queuedToast).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "09-queued-reply");
-  await page.waitForTimeout(5500);
+  await expect(queuedToast).toHaveCount(0);
   await capturePlaywrightCheckpoint(page, testInfo, "10-queued-after-toast");
   const queuedReply = await readLatestMailMutation(page, {
     emailAccountId,
@@ -182,10 +185,26 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   await expect(
     page
       .frameLocator('iframe[title="Email content preview"]')
-      .getByText(
-        "Confirmed, see you Thursday. This reply is sent only inside the local emulator.",
-      ),
+      .last()
+      .getByText(replyBody, { exact: true }),
   ).toBeVisible({ timeout: 60_000 });
+  const response = await page.request.get(
+    "/api/threads/thr_playwright_reply?includeDrafts=true",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(response.ok()).toBe(true);
+  const body: ThreadResponse = await response.json();
+  const sentMessages = body.thread.messages.filter((message) =>
+    message.labelIds?.includes("SENT"),
+  );
+  expect(sentMessages).toHaveLength(initialSentIds.length + 1);
+  const appended = sentMessages.filter(
+    (message) => !initialSentIds.includes(message.id),
+  );
+  expect(appended).toHaveLength(1);
+  expect(
+    `${appended[0].textPlain ?? ""}${appended[0].textHtml ?? ""}`,
+  ).toContain(replyBody);
   await capturePlaywrightCheckpoint(page, testInfo, "11-sent-reply");
 });
 

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -1,0 +1,297 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail, readLatestMailMutation } from "./mail-test-helpers";
+
+test("captures thread reading and reply states", async ({ page }, testInfo) => {
+  page.setDefaultTimeout(15_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`);
+  await expect(
+    page.getByText(
+      "A second message proves the complete conversation is rendered.",
+    ),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "01-collapsed-history");
+  const collapsed = page
+    .locator('[role="button"][aria-expanded="false"]')
+    .filter({ hasText: "Dana Example" });
+  if (await collapsed.count()) await collapsed.click();
+  await expect(
+    page.getByText("First message in the reader conversation."),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "02-expanded-history");
+  await page
+    .getByRole("button", { name: "Show details", exact: true })
+    .last()
+    .click();
+  await expect(page.getByText("From:", { exact: true })).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "03-header-details");
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  await expect(
+    page.getByText("Please reply to this seeded conversation."),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "04-single-message");
+  await page
+    .getByRole("group", { name: "Thread actions" })
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
+  const editor = page.locator("[contenteditable='true']");
+  await expect(editor).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "05-empty-reply");
+  await editor.pressSequentially(
+    "Thanks Leslie, Thursday at 2 pm works for me. I will bring the updated proposal.",
+  );
+  await capturePlaywrightCheckpoint(page, testInfo, "06-populated-reply");
+  await page.getByRole("button", { name: /^To Leslie/ }).click();
+  await page.getByRole("button", { name: "Cc/Bcc", exact: true }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Cc", exact: true }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "07-reply-recipients");
+  await page.getByRole("button", { name: "Hide Cc/Bcc", exact: true }).click();
+  await expect(
+    page.getByText("Saved on this device", { exact: true }),
+  ).toBeVisible();
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Reply Workflow Message" }),
+  ).toBeVisible();
+  await expect(editor).toContainText(
+    "Thanks Leslie, Thursday at 2 pm works for me.",
+  );
+  await capturePlaywrightCheckpoint(page, testInfo, "08-draft-after-reload");
+  if (!(await editor.count()))
+    await page
+      .getByRole("group", { name: "Thread actions" })
+      .getByRole("button", { name: "Reply", exact: true })
+      .click();
+  await editor.fill("A reply that should survive navigation.");
+  await expect(
+    page.getByText("Saved on this device", { exact: true }),
+  ).toBeVisible();
+  await page.goto(`/${emailAccountId}/mail`);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  await expect(
+    page.getByRole("heading", { name: "Reply Workflow Message" }),
+  ).toBeVisible();
+  await expect(editor).toContainText("A reply that should survive navigation.");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "12-draft-after-navigation",
+  );
+  if (!(await editor.count()))
+    await page
+      .getByRole("group", { name: "Thread actions" })
+      .getByRole("button", { name: "Reply", exact: true })
+      .click();
+  await editor.fill("Mobile reply: the proposed time works well.");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await capturePlaywrightCheckpoint(page, testInfo, "13-mobile-reply");
+});
+
+test("captures queued reply and reconnect", async ({ page }, testInfo) => {
+  page.setDefaultTimeout(15_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  await expect(
+    page.getByRole("heading", { name: "Reply Workflow Message" }),
+  ).toBeVisible();
+  const editor = page.locator("[contenteditable='true']");
+  if (!(await editor.count()))
+    await page
+      .getByRole("group", { name: "Thread actions" })
+      .getByRole("button", { name: "Reply", exact: true })
+      .click();
+  await expect(editor).toBeVisible();
+  await editor.fill(
+    "Confirmed, see you Thursday. This reply is sent only inside the local emulator.",
+  );
+  await page.evaluate(() =>
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    }),
+  );
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "reply",
+        threadId: "thr_playwright_reply",
+      }),
+    )
+    .toMatchObject({ status: "pending" });
+  await capturePlaywrightCheckpoint(page, testInfo, "09-queued-reply");
+  await page.waitForTimeout(5500);
+  await capturePlaywrightCheckpoint(page, testInfo, "10-queued-after-toast");
+  const releaseSend = Promise.withResolvers<void>();
+  let sendRequestStarted = false;
+  await page.route("**/api/messages/send", async (route) => {
+    sendRequestStarted = true;
+    await releaseSend.promise;
+    await route.continue();
+  });
+  try {
+    await page.evaluate(() => {
+      Object.defineProperty(navigator, "onLine", {
+        configurable: true,
+        get: () => true,
+      });
+      window.dispatchEvent(new Event("online"));
+    });
+    await expect.poll(() => sendRequestStarted, { timeout: 60_000 }).toBe(true);
+    await expect(
+      page
+        .getByRole("region", { name: "Reply delivery status" })
+        .getByText("Sending…", { exact: true }),
+    ).toBeVisible();
+    await capturePlaywrightCheckpoint(page, testInfo, "24-sending-reply");
+  } finally {
+    releaseSend.resolve();
+  }
+  await expect
+    .poll(
+      () =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "reply",
+          threadId: "thr_playwright_reply",
+        }),
+      { timeout: 60_000 },
+    )
+    .toMatchObject({ status: "succeeded" });
+  await expect(
+    page
+      .frameLocator('iframe[title="Email content preview"]')
+      .getByText(
+        "Confirmed, see you Thursday. This reply is sent only inside the local emulator.",
+      ),
+  ).toBeVisible({ timeout: 60_000 });
+  await capturePlaywrightCheckpoint(page, testInfo, "11-sent-reply");
+});
+
+test("captures a longer thread and draft collapse", async ({
+  page,
+}, testInfo) => {
+  page.setDefaultTimeout(15_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    const first = body.thread.messages[0];
+    body.thread.messages = [
+      ...Array.from({ length: 6 }, (_, index) => ({
+        ...first,
+        id: `gallery-history-${index}`,
+        labelIds: ["INBOX"],
+        headers: {
+          ...first.headers,
+          date: new Date(Date.UTC(2025, 0, 1, 9, index)).toISOString(),
+          from:
+            index % 2
+              ? "Morgan Example <morgan@example.com>"
+              : "Dana Example <dana@example.com>",
+        },
+        internalDate: String(Date.UTC(2025, 0, 1, 9, index)),
+        textPlain: `Planning update ${index + 1}: the proposal is ready for our review.`,
+        snippet: `Planning update ${index + 1}: the proposal is ready for our review.`,
+      })),
+      ...body.thread.messages,
+    ];
+    await route.fulfill({ response, json: body });
+  });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`);
+  await expect(
+    page.getByText(
+      "A second message proves the complete conversation is rendered.",
+    ),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "14-long-thread");
+  await page
+    .getByRole("group", { name: "Thread actions" })
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
+  const editor = page.locator("[contenteditable='true']");
+  await editor.fill("This reply should survive collapsing its parent message.");
+  const header = page
+    .locator('[role="button"][aria-expanded="true"]')
+    .filter({ hasText: "Me" })
+    .last();
+  await header.click();
+  await page
+    .locator('[role="button"][aria-expanded="false"]')
+    .filter({ hasText: "Me" })
+    .last()
+    .click();
+  await expect(editor).toBeVisible();
+  await expect(editor).toContainText(
+    "This reply should survive collapsing its parent message.",
+  );
+  await capturePlaywrightCheckpoint(page, testInfo, "15-draft-after-collapse");
+});
+
+test("restores a queued reply for editing without sending a duplicate", async ({
+  page,
+}, testInfo) => {
+  page.setDefaultTimeout(20_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  await expect(
+    page.getByRole("heading", { name: "Reply Workflow Message" }),
+  ).toBeVisible();
+  await page
+    .getByRole("group", { name: "Thread actions" })
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
+  const editor = page.getByRole("textbox", { name: "Email message" });
+  const text = "I can review the updated proposal on Thursday.";
+  await editor.fill(text);
+  await page.evaluate(() =>
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    }),
+  );
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const delivery = page.getByRole("region", { name: "Reply delivery status" });
+  await expect(
+    delivery.getByText("Reply queued", { exact: true }),
+  ).toBeVisible();
+  await delivery.getByRole("button", { name: "Edit reply" }).click();
+  await expect(editor).toContainText(text);
+  await expect(delivery.getByText("Reply queued", { exact: true })).toHaveCount(
+    0,
+  );
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "reply",
+        threadId: "thr_playwright_reply",
+      }),
+    )
+    .toBeUndefined();
+  await editor.fill(`${text} Let's meet at 3 pm.`);
+  await expect(
+    page.getByText("Saved on this device", { exact: true }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "22-edit-queued-reply");
+  await page.reload();
+  await expect(editor).toContainText("Let's meet at 3 pm.");
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "reply",
+        threadId: "thr_playwright_reply",
+      }),
+    )
+    .toBeUndefined();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -7,6 +7,7 @@ import { openMail, readLatestMailMutation } from "./mail-test-helpers";
 
 test("captures thread reading and reply states", async ({ page }, testInfo) => {
   page.setDefaultTimeout(15_000);
+  page.setDefaultNavigationTimeout(30_000);
   await page.setViewportSize({ width: 1440, height: 1000 });
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`);
@@ -52,7 +53,7 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
     "Thanks Leslie, Thursday at 2 pm works for me. I will bring the updated proposal.",
   );
   await capturePlaywrightCheckpoint(page, testInfo, "06-populated-reply");
-  await page.getByRole("button", { name: /^To Leslie/ }).click();
+  await page.getByRole("button", { name: /^Reply to Leslie/ }).click();
   await page.getByRole("button", { name: "Cc/Bcc", exact: true }).click();
   await expect(
     page.getByRole("textbox", { name: "Cc", exact: true }),
@@ -96,6 +97,7 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
 
 test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   page.setDefaultTimeout(15_000);
+  page.setDefaultNavigationTimeout(30_000);
   await page.setViewportSize({ width: 1440, height: 1000 });
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
@@ -228,6 +230,7 @@ test("captures a longer thread and draft collapse", async ({
   page,
 }, testInfo) => {
   page.setDefaultTimeout(15_000);
+  page.setDefaultNavigationTimeout(30_000);
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
     const response = await route.fetch();
@@ -286,6 +289,7 @@ test("restores a queued reply for editing without sending a duplicate", async ({
   page,
 }, testInfo) => {
   page.setDefaultTimeout(20_000);
+  page.setDefaultNavigationTimeout(30_000);
   await page.setViewportSize({ width: 1440, height: 1000 });
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -129,9 +129,23 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   await capturePlaywrightCheckpoint(page, testInfo, "09-queued-reply");
   await page.waitForTimeout(5500);
   await capturePlaywrightCheckpoint(page, testInfo, "10-queued-after-toast");
+  const queuedReply = await readLatestMailMutation(page, {
+    emailAccountId,
+    kind: "reply",
+    threadId: "thr_playwright_reply",
+  });
+  expect(queuedReply?.id).toEqual(expect.any(String));
   const releaseSend = Promise.withResolvers<void>();
   let sendRequestStarted = false;
-  await page.route("**/api/messages/send", async (route) => {
+  // Web sends use a Next server action on the current page URL.
+  await page.route(page.url(), async (route) => {
+    if (
+      route.request().method() !== "POST" ||
+      !route.request().postData()?.includes(`"mutationId":"${queuedReply?.id}"`)
+    ) {
+      await route.continue();
+      return;
+    }
     sendRequestStarted = true;
     await releaseSend.promise;
     await route.continue();

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -1,4 +1,5 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
+import type { StoredReplyDraft } from "@/utils/email-cache/database";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
@@ -58,9 +59,11 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   ).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "07-reply-recipients");
   await page.getByRole("button", { name: "Hide Cc/Bcc", exact: true }).click();
-  await expect(
-    page.getByText("Saved on this device", { exact: true }),
-  ).toBeVisible();
+  await expectStoredReply(
+    page,
+    emailAccountId,
+    "Thanks Leslie, Thursday at 2 pm works for me.",
+  );
   await page.reload();
   await expect(
     page.getByRole("heading", { name: "Reply Workflow Message" }),
@@ -70,9 +73,11 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   );
   await capturePlaywrightCheckpoint(page, testInfo, "08-draft-after-reload");
   await editor.fill("A reply that should survive navigation.");
-  await expect(
-    page.getByText("Saved on this device", { exact: true }),
-  ).toBeVisible();
+  await expectStoredReply(
+    page,
+    emailAccountId,
+    "A reply that should survive navigation.",
+  );
   await page.goto(`/${emailAccountId}/mail`);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
   await expect(
@@ -134,7 +139,12 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   const queuedToast = page.locator("[data-sonner-toast]").filter({
     hasText: "Email queued. It will send when you're back online.",
   });
-  await expect(queuedToast).toBeVisible();
+  await expect(
+    page
+      .getByRole("region", { name: "Reply delivery status" })
+      .getByText("Waiting for connection", { exact: true }),
+  ).toBeVisible();
+  await expect(queuedToast).toHaveCount(0);
   await capturePlaywrightCheckpoint(page, testInfo, "09-queued-reply");
   await expect(queuedToast).toHaveCount(0);
   await capturePlaywrightCheckpoint(page, testInfo, "10-queued-after-toast");
@@ -295,13 +305,13 @@ test("restores a queued reply for editing without sending a duplicate", async ({
   await page.getByRole("button", { name: "Send", exact: true }).click();
   const delivery = page.getByRole("region", { name: "Reply delivery status" });
   await expect(
-    delivery.getByText("Reply queued", { exact: true }),
+    delivery.getByText("Waiting for connection", { exact: true }),
   ).toBeVisible();
   await delivery.getByRole("button", { name: "Edit reply" }).click();
   await expect(editor).toContainText(text);
-  await expect(delivery.getByText("Reply queued", { exact: true })).toHaveCount(
-    0,
-  );
+  await expect(
+    delivery.getByText("Waiting for connection", { exact: true }),
+  ).toHaveCount(0);
   await expect
     .poll(() =>
       readLatestMailMutation(page, {
@@ -312,9 +322,7 @@ test("restores a queued reply for editing without sending a duplicate", async ({
     )
     .toBeUndefined();
   await editor.fill(`${text} Let's meet at 3 pm.`);
-  await expect(
-    page.getByText("Saved on this device", { exact: true }),
-  ).toBeVisible();
+  await expectStoredReply(page, emailAccountId, "Let's meet at 3 pm.");
   await capturePlaywrightCheckpoint(page, testInfo, "22-edit-queued-reply");
   await page.reload();
   await expect(editor).toContainText("Let's meet at 3 pm.");
@@ -328,3 +336,45 @@ test("restores a queued reply for editing without sending a duplicate", async ({
     )
     .toBeUndefined();
 });
+
+async function expectStoredReply(
+  page: Page,
+  emailAccountId: string,
+  text: string,
+) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        async (accountId) =>
+          await new Promise<string[]>((resolve, reject) => {
+            const request = indexedDB.open("inbox-zero-email-cache");
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => {
+              const database = request.result;
+              const transaction = database.transaction(
+                "replyDrafts",
+                "readonly",
+              );
+              const drafts = transaction
+                .objectStore("replyDrafts")
+                .index("byAccountThread")
+                .getAll([accountId, "thr_playwright_reply"]);
+              transaction.oncomplete = () => {
+                database.close();
+                resolve(
+                  (drafts.result as StoredReplyDraft[]).map(
+                    (row) => row.content?.draft.editableHtml ?? "",
+                  ),
+                );
+              };
+              transaction.onerror = () => {
+                database.close();
+                reject(transaction.error);
+              };
+            };
+          }),
+        emailAccountId,
+      ),
+    )
+    .toEqual(expect.arrayContaining([expect.stringContaining(text)]));
+}

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -33,11 +33,17 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   await expect(
     page.getByText("Please reply to this seeded conversation."),
   ).toBeVisible();
+  const toolbar = page.getByRole("group", { name: "Thread actions" });
+  await expect(
+    toolbar.getByRole("button", { name: "Reply", exact: true }),
+  ).toHaveCount(0);
+  await expect(toolbar.getByRole("button", { name: /^Delete/ })).toHaveCount(0);
   await capturePlaywrightCheckpoint(page, testInfo, "04-single-message");
-  await page
-    .getByRole("group", { name: "Thread actions" })
-    .getByRole("button", { name: "Reply", exact: true })
-    .click();
+  await toolbar.getByRole("button", { name: /^More actions/ }).click();
+  await expect(page.getByRole("menuitem", { name: /^Delete/ })).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "25-thread-actions-menu");
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
   const editor = page.locator("[contenteditable='true']");
   await expect(editor).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "05-empty-reply");
@@ -104,8 +110,8 @@ test("captures queued reply and reconnect", async ({ page }, testInfo) => {
   const editor = page.locator("[contenteditable='true']");
   if (!(await editor.count()))
     await page
-      .getByRole("group", { name: "Thread actions" })
       .getByRole("button", { name: "Reply", exact: true })
+      .last()
       .click();
   await expect(editor).toBeVisible();
   await editor.fill(replyBody);
@@ -246,10 +252,7 @@ test("captures a longer thread and draft collapse", async ({
     ),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "14-long-thread");
-  await page
-    .getByRole("group", { name: "Thread actions" })
-    .getByRole("button", { name: "Reply", exact: true })
-    .click();
+  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
   const editor = page.locator("[contenteditable='true']");
   await editor.fill("This reply should survive collapsing its parent message.");
   const header = page
@@ -279,10 +282,7 @@ test("restores a queued reply for editing without sending a duplicate", async ({
   await expect(
     page.getByRole("heading", { name: "Reply Workflow Message" }),
   ).toBeVisible();
-  await page
-    .getByRole("group", { name: "Thread actions" })
-    .getByRole("button", { name: "Reply", exact: true })
-    .click();
+  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
   const editor = page.getByRole("textbox", { name: "Email message" });
   const text = "I can review the updated proposal on Thursday.";
   await editor.fill(text);

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -29,7 +29,7 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
     .getByRole("button", { name: "Show details", exact: true })
     .last()
     .click();
-  await expect(page.getByText("From:", { exact: true })).toBeVisible();
+  await expect(page.getByText("From", { exact: true })).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "03-header-details");
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
   await expect(

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -54,12 +54,13 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   );
   await capturePlaywrightCheckpoint(page, testInfo, "06-populated-reply");
   await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
-  await page.getByRole("button", { name: "Cc/Bcc", exact: true }).click();
   await expect(
     page.getByRole("textbox", { name: "Cc", exact: true }),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "07-reply-recipients");
-  await page.getByRole("button", { name: "Hide Cc/Bcc", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Hide recipients", exact: true })
+    .click();
   await expectStoredReply(
     page,
     emailAccountId,

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -53,7 +53,7 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
     "Thanks Leslie, Thursday at 2 pm works for me. I will bring the updated proposal.",
   );
   await capturePlaywrightCheckpoint(page, testInfo, "06-populated-reply");
-  await page.getByRole("button", { name: /^Reply to Leslie/ }).click();
+  await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
   await page.getByRole("button", { name: "Cc/Bcc", exact: true }).click();
   await expect(
     page.getByRole("textbox", { name: "Cc", exact: true }),

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -32,8 +32,16 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   await expect(page.getByText("From", { exact: true })).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "03-header-details");
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  const replyMessage = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  const collapsedReply = replyMessage.locator(
+    '[role="button"][aria-expanded="false"]',
+  );
+  await expect(replyMessage).toBeVisible();
+  if (await collapsedReply.count()) await collapsedReply.click();
   await expect(
-    page.getByText("Please reply to this seeded conversation."),
+    replyMessage.getByText("Please reply to this seeded conversation."),
   ).toBeVisible();
   const toolbar = page.getByRole("group", { name: "Thread actions" });
   await expect(
@@ -45,7 +53,9 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   await expect(page.getByRole("menuitem", { name: /^Delete/ })).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "25-thread-actions-menu");
   await page.keyboard.press("Escape");
-  await page.getByRole("button", { name: "Reply", exact: true }).last().click();
+  await replyMessage
+    .getByRole("button", { name: "Reply", exact: true })
+    .click();
   const editor = page.locator("[contenteditable='true']");
   await expect(editor).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "05-empty-reply");

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -47,7 +47,8 @@ test("deletes an open conversation and returns to the list", async ({
     page.getByRole("heading", { name: "Delete Action Message" }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: /^Delete \(/ }).click();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await page.getByRole("menuitem", { name: /^Delete/ }).click();
 
   await expect(conversations).toBeVisible();
   await expect(deletedConversation).toHaveCount(0);

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -12,6 +12,7 @@ import {
   fullSuites,
   selectChangedPlaywrightTargets,
 } from "../../utils/playwright/emulated-suite-selection.mjs";
+import { shardPlaywrightTargets } from "../../utils/playwright/emulated-suite-sharding.mjs";
 const requestedTargets = getRequestedPlaywrightTargets(process.argv.slice(2));
 const changedSelection = requestedTargets.length
   ? undefined
@@ -20,11 +21,16 @@ const changedSelection = requestedTargets.length
       process.cwd(),
     );
 const changedTargetFiles = changedSelection?.targetFiles ?? [];
-const targets = requestedTargets.length
+const selectedTargets = requestedTargets.length
   ? requestedTargets
   : changedSelection?.runFullSuite
     ? getFullSuiteTargets()
     : getChangedPlaywrightTargets(changedTargetFiles);
+const targets = shardPlaywrightTargets(
+  selectedTargets,
+  process.env.PLAYWRIGHT_SHARD,
+);
+const shardSuffix = process.env.PLAYWRIGHT_SHARD?.replace("/", "-of-");
 const dryRun = process.env.PLAYWRIGHT_DRY_RUN === "1";
 const playwrightRunRootDir = path.resolve(".tmp/playwright");
 const blobReportDir = path.join(playwrightRunRootDir, "blob-report");
@@ -40,6 +46,7 @@ if (!dryRun) {
 }
 
 let failed = false;
+const timings = [];
 
 if (requestedTargets.length) {
   console.log(`Running ${targets.length} requested Playwright target(s).`);
@@ -50,8 +57,11 @@ if (requestedTargets.length) {
 
 if (!dryRun && !targets.length) {
   writeFileSync(
-    path.join(testResultsDir, "selection.json"),
-    `${JSON.stringify({ reason: changedSelection.reason }, null, 2)}\n`,
+    path.join(
+      testResultsDir,
+      shardSuffix ? `selection-${shardSuffix}.json` : "selection.json",
+    ),
+    `${JSON.stringify({ reason: changedSelection?.reason ?? "No targets assigned to this shard." }, null, 2)}\n`,
   );
 }
 
@@ -62,6 +72,7 @@ for (const target of targets) {
     : `${process.pid}-${target.name}-${Date.now()}`;
   const targetRunDir = path.join(playwrightRunRootDir, targetRunId);
   let result;
+  const startedAt = Date.now();
 
   try {
     result = runPlaywright(
@@ -98,10 +109,24 @@ for (const target of targets) {
     if (!dryRun) rmSync(targetRunDir, { force: true, recursive: true });
   }
 
+  const seconds = Math.round((Date.now() - startedAt) / 1000);
+  timings.push({ target: target.name, seconds, status: result.status });
+  console.log(
+    `Finished ${target.name} in ${seconds}s (exit ${result.status}).`,
+  );
+  if (!dryRun) {
+    writeFileSync(
+      path.join(
+        testResultsDir,
+        shardSuffix ? `timings-${shardSuffix}.json` : "timings.json",
+      ),
+      JSON.stringify(timings, null, 2),
+    );
+  }
   if (result.status !== 0) failed = true;
 }
 
-if (!dryRun && targets.length) {
+if (!dryRun && targets.length && !process.env.PLAYWRIGHT_SHARD) {
   const mergeResult = runPlaywright(
     ["merge-reports", "--reporter=html", blobReportDir],
     { PLAYWRIGHT_HTML_OPEN: "never" },

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -23,6 +23,7 @@ import {
 } from "@headlessui/react";
 import {
   CheckCircleIcon,
+  ChevronDownIcon,
   ImageIcon,
   PaperclipIcon,
   TrashIcon,
@@ -942,25 +943,39 @@ function ComposeEmailFormContent({
           <button
             type="button"
             className={cn(
-              "flex gap-1 text-left",
+              "flex items-center gap-1 text-left",
+              isInlineReply &&
+                "gap-1.5 text-xs leading-5 text-muted-foreground hover:text-foreground",
               isComposeWindow && "min-h-11 items-center border-b",
             )}
             onClick={() => setEditReply(true)}
           >
-            <span className="text-muted-foreground text-sm">To</span>{" "}
-            <span className="max-w-md break-words text-foreground">
-              {extractNameFromEmail(watch("to") || replyingToEmail.to)}
-            </span>
+            {isInlineReply ? (
+              <>
+                <span>
+                  Reply to{" "}
+                  {extractNameFromEmail(watch("to") || replyingToEmail.to)}
+                </span>
+                <ChevronDownIcon className="size-3" />
+              </>
+            ) : (
+              <>
+                <span className="text-muted-foreground text-sm">To</span>
+                <span className="max-w-md break-words text-foreground">
+                  {extractNameFromEmail(watch("to") || replyingToEmail.to)}
+                </span>
+              </>
+            )}
           </button>
         ) : isInlineReply ? (
-          <div className="space-y-1 [&_input]:bg-transparent">
+          <div className="space-y-0.5 [&_input]:bg-transparent">
             {(
               ["to", ...(showCcBcc ? (["cc", "bcc"] as const) : [])] as const
             ).map((field) => (
-              <div key={field} className="flex min-h-8 items-center gap-2">
+              <div key={field} className="flex min-h-7 items-center gap-2">
                 <label
                   htmlFor={field}
-                  className="w-6 shrink-0 text-xs text-muted-foreground"
+                  className="w-8 shrink-0 text-xs leading-5 text-muted-foreground"
                 >
                   {RECIPIENT_LABELS[field]}
                 </label>
@@ -981,7 +996,7 @@ function ComposeEmailFormContent({
                         required: field === "to",
                       })}
                       error={errors[field]}
-                      className="h-8 rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus:border-transparent focus:ring-0"
+                      className="h-7 rounded-none border-0 bg-transparent p-0 text-xs leading-5 shadow-none focus:border-transparent focus:ring-0 sm:text-xs"
                     />
                   )}
                 </div>
@@ -1019,10 +1034,11 @@ function ComposeEmailFormContent({
             ) : (
               <button
                 type="button"
+                aria-label="Edit subject"
                 onClick={() => setEditSubject(true)}
-                className="py-1 text-xs text-muted-foreground hover:text-foreground"
+                className="pt-2 pb-1 text-left text-xs leading-5 text-muted-foreground hover:text-foreground"
               >
-                Edit subject
+                {watch("subject")}
               </button>
             )}
           </div>
@@ -1151,7 +1167,7 @@ function ComposeEmailFormContent({
       </div>
 
       <EmailEditor
-        placeholder={isInlineReply ? "Reply…" : undefined}
+        placeholder={isInlineReply ? "" : undefined}
         appearance={isComposeWindow || isInlineReply ? "seamless" : "contained"}
         autofocus={!focusRecipientField}
         ref={editorRef}

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -211,9 +211,8 @@ function ComposeEmailFormContent({
     () => storedDraft?.content?.requestId ?? randomUuid(),
   );
   const deliveryPath = useRef(storedDraft?.content?.deliveryPath);
-  const [saveStatus, setSaveStatus] = useState(
-    draftLoadError?.message ??
-      (storedDraft?.content ? "Saved on this device" : ""),
+  const [draftSaveError, setDraftSaveError] = useState(
+    draftLoadError?.message ?? "",
   );
   const [submissionError, setSubmissionError] = useState(() => {
     const times = parseDeliveryTimes(sendAt, remindAt);
@@ -309,6 +308,7 @@ function ComposeEmailFormContent({
     useState(false);
   const [isReconnectingContacts, setIsReconnectingContacts] = useState(false);
   const [editReply, setEditReply] = useState(false);
+  const [editSubject, setEditSubject] = useState(false);
   const [showCcBcc, setShowCcBcc] = useState(
     Boolean(
       storedDraft?.content?.values.cc ||
@@ -350,10 +350,7 @@ function ComposeEmailFormContent({
     const content = latestDraft.current;
     if (!content || !draftWriter || draftStopped.current) return;
     const snapshot = latestDraftSnapshot.current;
-    if (snapshot === lastSavedSnapshot.current) {
-      if (isMountedRef.current) setSaveStatus("Saved on this device");
-      return;
-    }
+    if (snapshot === lastSavedSnapshot.current) return;
     draftWriter.save(content).then(
       () => {
         lastSavedSnapshot.current = snapshot;
@@ -362,11 +359,11 @@ function ComposeEmailFormContent({
           !draftStopped.current &&
           latestDraftSnapshot.current === snapshot
         )
-          setSaveStatus("Saved on this device");
+          setDraftSaveError("");
       },
       (error) => {
         if (isMountedRef.current)
-          setSaveStatus(
+          setDraftSaveError(
             error instanceof Error
               ? error.message
               : "Could not save draft on this device.",
@@ -405,7 +402,6 @@ function ComposeEmailFormContent({
     if (snapshot === latestDraftSnapshot.current) return;
     latestDraftSnapshot.current = snapshot;
     latestDraft.current = content;
-    setSaveStatus("Saving…");
     clearTimeout(draftTimer.current);
     draftTimer.current = setTimeout(persistDraft, 300);
   };
@@ -751,13 +747,14 @@ function ComposeEmailFormContent({
             return;
           }
           if (outcome.status === "sent") {
-            toastSuccess({ description: "Email sent!" });
+            if (!isInlineReply) toastSuccess({ description: "Email sent!" });
             onSuccess?.(outcome.messageId, outcome.threadId);
             refetch?.();
           } else if (outcome.status === "queued") {
-            toastSuccess({
-              description: getQueuedEmailDescription(outcome.reason),
-            });
+            if (!isInlineReply)
+              toastSuccess({
+                description: getQueuedEmailDescription(outcome.reason),
+              });
             onClose?.();
           } else if (outcome.status === "uncertain") {
             if (outcome.ownsNotification) {
@@ -886,12 +883,13 @@ function ComposeEmailFormContent({
 
   return (
     <form
+      data-inline-reply={isInlineReply || undefined}
       ref={formRef}
       style={
         isInlineReply
           ? ({
-              "--email-editor-content-min-height": "100px",
-              "--email-editor-content-padding": "0.5rem 0",
+              "--email-editor-content-min-height": "56px",
+              "--email-editor-content-padding": "0.25rem 0",
             } as CSSProperties)
           : undefined
       }
@@ -901,8 +899,7 @@ function ComposeEmailFormContent({
         isComposeWindow
           ? "flex h-full min-h-0 flex-col overflow-hidden [&_[data-email-editor-root]]:min-h-0 [&_[data-email-editor-root]]:flex-1"
           : "space-y-2",
-        isInlineReply &&
-          "space-y-3 [&_[data-email-editor-root]]:min-h-[120px] [&_[contenteditable]]:min-h-[100px]",
+        isInlineReply && "space-y-2",
       )}
     >
       <div className={cn(isComposeWindow ? "shrink-0 px-4" : "contents")}>
@@ -955,6 +952,80 @@ function ComposeEmailFormContent({
               {extractNameFromEmail(watch("to") || replyingToEmail.to)}
             </span>
           </button>
+        ) : isInlineReply ? (
+          <div className="space-y-1 [&_input]:bg-transparent">
+            {(
+              ["to", ...(showCcBcc ? (["cc", "bcc"] as const) : [])] as const
+            ).map((field) => (
+              <div key={field} className="flex min-h-8 items-center gap-2">
+                <label
+                  htmlFor={field}
+                  className="w-6 shrink-0 text-xs text-muted-foreground"
+                >
+                  {RECIPIENT_LABELS[field]}
+                </label>
+                <div className="min-w-0 flex-1">
+                  {env.NEXT_PUBLIC_CONTACTS_ENABLED ? (
+                    <ComposeContactRecipientField
+                      {...recipientFieldProps}
+                      active={activeRecipientField === field}
+                      className="min-h-8"
+                      name={field}
+                      selectedRecipients={watch(field) ?? ""}
+                    />
+                  ) : (
+                    <Input
+                      type="text"
+                      name={field}
+                      registerProps={register(field, {
+                        required: field === "to",
+                      })}
+                      error={errors[field]}
+                      className="h-8 rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus:border-transparent focus:ring-0"
+                    />
+                  )}
+                </div>
+                {field === "to" && (
+                  <button
+                    type="button"
+                    aria-label={showCcBcc ? "Hide Cc/Bcc" : "Cc/Bcc"}
+                    onClick={() => setShowCcBcc(!showCcBcc)}
+                    className="shrink-0 py-2 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    Cc/Bcc
+                  </button>
+                )}
+              </div>
+            ))}
+            {editSubject ? (
+              <div className="flex min-h-8 items-center gap-2">
+                <label
+                  htmlFor="subject"
+                  className="text-xs text-muted-foreground"
+                >
+                  Subject
+                </label>
+                <div className="min-w-0 flex-1">
+                  <Input
+                    type="text"
+                    name="subject"
+                    registerProps={register("subject", { required: true })}
+                    error={errors.subject}
+                    placeholder="Subject"
+                    className="h-8 rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus:border-transparent focus:ring-0"
+                  />
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditSubject(true)}
+                className="py-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                Edit subject
+              </button>
+            )}
+          </div>
         ) : (
           <>
             <div
@@ -1080,6 +1151,7 @@ function ComposeEmailFormContent({
       </div>
 
       <EmailEditor
+        placeholder={isInlineReply ? "Reply…" : undefined}
         appearance={isComposeWindow || isInlineReply ? "seamless" : "contained"}
         autofocus={!focusRecipientField}
         ref={editorRef}
@@ -1238,7 +1310,7 @@ function ComposeEmailFormContent({
                   onDiscard();
                 } catch (error) {
                   draftStopped.current = false;
-                  setSaveStatus(
+                  setDraftSaveError(
                     error instanceof Error
                       ? error.message
                       : "Could not discard this draft.",
@@ -1255,9 +1327,9 @@ function ComposeEmailFormContent({
           )}
         </div>
       </div>
-      {isInlineReply && saveStatus && (
-        <p role="status" className="text-xs text-muted-foreground">
-          {saveStatus}
+      {isInlineReply && draftSaveError && (
+        <p role="alert" className="text-xs text-destructive">
+          {draftSaveError}
         </p>
       )}
     </form>

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -95,6 +95,7 @@ import type { StoredReplyDraft } from "@/utils/email-cache/database";
 import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import { DeliveryOptions } from "./DeliveryOptions";
 import { useSWRConfig } from "swr";
+import { getReminderAfterSendTimeChange } from "./delivery-times";
 import { queueReaderEmail } from "./queued-reply";
 
 export type ReplyingToEmail = {
@@ -167,6 +168,7 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
         <ComposeEmailFormContent
           {...props}
           storedDraft={localDraft.draft}
+          draftLoadError={localDraft.error}
           accountProvider={selectedAccountProvider}
           accountSignatureHtml={emailAccount.signature ?? ""}
           key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftKeyMessageId ?? ""}`}
@@ -182,6 +184,7 @@ function ComposeEmailFormContent({
   layout = "default",
   draftKeyMessageId,
   storedDraft,
+  draftLoadError,
   replyingToEmail,
   fromAccounts,
   accountProvider,
@@ -194,6 +197,7 @@ function ComposeEmailFormContent({
   onDiscard,
 }: ComposeEmailFormProps & {
   storedDraft?: StoredReplyDraft;
+  draftLoadError?: Error;
   accountProvider: string;
   accountSignatureHtml: string;
   selectedEmailAccountId: string;
@@ -211,7 +215,8 @@ function ComposeEmailFormContent({
   );
   const deliveryPath = useRef(storedDraft?.content?.deliveryPath);
   const [saveStatus, setSaveStatus] = useState(
-    storedDraft?.content ? "Saved on this device" : "",
+    draftLoadError?.message ??
+      (storedDraft?.content ? "Saved on this device" : ""),
   );
   const [submissionError, setSubmissionError] = useState("");
   const [draftWriter] = useState(() =>
@@ -259,11 +264,11 @@ function ComposeEmailFormContent({
   const [initialComposer] = useState(() => {
     if (storedDraft?.content) {
       const { draft, preservedBlocks } = storedDraft.content;
-      const document = new DOMParser().parseFromString(
+      const parsedDraft = new DOMParser().parseFromString(
         draft.editableHtml,
         "text/html",
       );
-      for (const image of document.querySelectorAll(
+      for (const image of parsedDraft.querySelectorAll(
         'img[data-content-id], img[src^="cid:"]',
       )) {
         const contentId =
@@ -278,7 +283,7 @@ function ComposeEmailFormContent({
         }
       }
       return {
-        draft: { ...draft, editableHtml: document.body.innerHTML },
+        draft: { ...draft, editableHtml: parsedDraft.body.innerHTML },
         preservedBlocks,
       };
     }
@@ -703,7 +708,9 @@ function ComposeEmailFormContent({
           return;
         }
         const readerThreadId = replyingToEmail?.threadId?.trim();
-        const readerMessageId = replyingToEmail?.messageId;
+        const readerMessageId = isInlineReply
+          ? draftKeyMessageId
+          : replyingToEmail?.messageId;
         if (readerThreadId) {
           let outcome: Awaited<ReturnType<typeof queueReaderEmail>>;
           try {
@@ -1154,8 +1161,13 @@ function ComposeEmailFormContent({
               remindAt={remindAt}
               disabled={isSubmitting}
               onSendAtChange={(value) => {
+                const nextRemindAt = getReminderAfterSendTimeChange(
+                  value,
+                  remindAt,
+                );
                 setSendAt(value);
-                saveDraftRef.current({ sendAt: value });
+                setRemindAt(nextRemindAt);
+                saveDraftRef.current({ sendAt: value, remindAt: nextRemindAt });
               }}
               onRemindAtChange={(value) => {
                 setRemindAt(value);

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -13,7 +13,6 @@ import {
 import {
   EmailEditor,
   type EmailEditorHandle,
-  type EmailEditorPreservedBlock,
   type EmailEditorState,
 } from "@inboxzero/email-editor/web";
 import {
@@ -31,6 +30,7 @@ import {
 } from "lucide-react";
 import {
   type ChangeEvent,
+  type CSSProperties,
   useCallback,
   useEffect,
   useRef,
@@ -70,6 +70,7 @@ import {
   isValidEmail,
   splitRecipientList,
 } from "@/utils/email";
+import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { getActionErrorMessage } from "@/utils/error";
 import { redirectToSafeUrl } from "@/utils/redirect";
@@ -85,6 +86,15 @@ import {
   resolveComposeRecipients,
   resolveRecipientSelection,
 } from "./compose-recipients";
+import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
+import {
+  createReplyDraftWriter,
+  type ReplyDraftContent,
+} from "@/utils/email-cache/reply-drafts";
+import type { StoredReplyDraft } from "@/utils/email-cache/database";
+import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
+import { DeliveryOptions } from "./DeliveryOptions";
+import { useSWRConfig } from "swr";
 import { queueReaderEmail } from "./queued-reply";
 
 export type ReplyingToEmail = {
@@ -105,6 +115,7 @@ export type ReplyingToEmail = {
 type ComposeEmailFormProps = {
   fromAccounts?: GetEmailAccountsResponse["emailAccounts"];
   layout?: "default" | "window";
+  draftKeyMessageId?: string;
   replyingToEmail?: ReplyingToEmail;
   refetch?: () => void;
   onSuccess?: (messageId: string, threadId: string) => void;
@@ -135,14 +146,27 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
     props.fromAccounts?.find((account) => account.id === selectedEmailAccountId)
       ?.account.provider ?? provider;
 
+  const localDraft = useLocalReplyDraft(
+    props.draftKeyMessageId && props.replyingToEmail?.threadId
+      ? {
+          emailAccountId: selectedEmailAccountId,
+          threadId: props.replyingToEmail.threadId,
+          messageId: props.draftKeyMessageId,
+        }
+      : undefined,
+  );
   return (
-    <LoadingContent error={error} loading={isLoading}>
+    <LoadingContent
+      error={error || localDraft.error}
+      loading={isLoading || localDraft.isLoading}
+    >
       {emailAccount && (
         <ComposeEmailFormContent
           {...props}
+          storedDraft={localDraft.draft}
           accountProvider={selectedAccountProvider}
           accountSignatureHtml={emailAccount.signature ?? ""}
-          key={selectedEmailAccountId}
+          key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftKeyMessageId ?? ""}`}
           onSelectEmailAccount={setSelectedEmailAccountId}
           selectedEmailAccountId={selectedEmailAccountId}
         />
@@ -153,6 +177,8 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
 
 function ComposeEmailFormContent({
   layout = "default",
+  draftKeyMessageId,
+  storedDraft,
   replyingToEmail,
   fromAccounts,
   accountProvider,
@@ -164,41 +190,103 @@ function ComposeEmailFormContent({
   onClose,
   onDiscard,
 }: ComposeEmailFormProps & {
+  storedDraft?: StoredReplyDraft;
   accountProvider: string;
   accountSignatureHtml: string;
   selectedEmailAccountId: string;
   onSelectEmailAccount: (emailAccountId: string) => void;
 }) {
   const isComposeWindow = layout === "window";
+  const isInlineReply = Boolean(draftKeyMessageId && replyingToEmail?.threadId);
+  const { mutate } = useSWRConfig();
+  const [sendAt, setSendAt] = useState(storedDraft?.content?.sendAt ?? "");
+  const [remindAt, setRemindAt] = useState(
+    storedDraft?.content?.remindAt ?? "",
+  );
+  const [requestId] = useState(
+    () => storedDraft?.content?.requestId ?? randomUuid(),
+  );
+  const deliveryPath = useRef(storedDraft?.content?.deliveryPath);
+  const [saveStatus, setSaveStatus] = useState(
+    storedDraft?.content ? "Saved on this device" : "",
+  );
+  const [submissionError, setSubmissionError] = useState("");
+  const [draftWriter] = useState(() =>
+    isInlineReply
+      ? createReplyDraftWriter(
+          {
+            emailAccountId: selectedEmailAccountId,
+            threadId: replyingToEmail!.threadId!,
+            messageId: draftKeyMessageId!,
+          },
+          storedDraft?.revision,
+        )
+      : undefined,
+  );
+  const draftStopped = useRef(false);
+  const draftTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const latestDraft = useRef<ReplyDraftContent | undefined>(undefined);
+  const saveDraftRef = useRef<
+    (options?: { sendAt?: string; remindAt?: string }) => void
+  >(() => {});
+  const editorInitialized = useRef(false);
+  const lastSavedSnapshot = useRef<string | undefined>(undefined);
+  const latestDraftSnapshot = useRef<string | undefined>(undefined);
+
+  const [restoredAttachments] = useState<ComposeAttachment[]>(() =>
+    (storedDraft?.content?.attachments ?? []).map((attachment) => ({
+      ...attachment,
+      previewUrl:
+        attachment.disposition === "inline"
+          ? URL.createObjectURL(
+              new Blob(
+                [
+                  Uint8Array.from(atob(attachment.contentBase64), (character) =>
+                    character.charCodeAt(0),
+                  ),
+                ],
+                { type: attachment.mimeType },
+              ),
+            )
+          : undefined,
+    })),
+  );
   const [initialComposer] = useState(() => {
+    if (storedDraft?.content) {
+      const { draft, preservedBlocks } = storedDraft.content;
+      const document = new DOMParser().parseFromString(
+        draft.editableHtml,
+        "text/html",
+      );
+      for (const image of document.querySelectorAll(
+        'img[data-content-id], img[src^="cid:"]',
+      )) {
+        const contentId =
+          image.getAttribute("data-content-id") ??
+          image.getAttribute("src")?.slice(4);
+        const attachment = restoredAttachments.find(
+          (item) => item.contentId === contentId,
+        );
+        if (attachment?.previewUrl && contentId) {
+          image.setAttribute("src", attachment.previewUrl);
+          image.setAttribute("data-content-id", contentId);
+        }
+      }
+      return {
+        draft: { ...draft, editableHtml: document.body.innerHTML },
+        preservedBlocks,
+      };
+    }
+
     const draft = prepareEmailDraft({
       html: replyingToEmail?.draftHtml ?? "",
       quotedHtml: replyingToEmail?.quotedContentHtml,
       signatureHtml:
         replyingToEmail?.signatureHtml ?? accountSignatureHtml ?? undefined,
     });
-    const preservedBlocks: EmailEditorPreservedBlock[] = [
-      ...(draft.signatureHtml
-        ? [
-            {
-              id: "signature",
-              kind: "signature" as const,
-              html: draft.signatureHtml,
-              collapsed: false,
-            },
-          ]
-        : []),
-      ...(draft.quotedHtml
-        ? [
-            {
-              id: "quote",
-              kind: "quote" as const,
-              html: draft.quotedHtml,
-              collapsed: true,
-            },
-          ]
-        : []),
-    ];
+    const preservedBlocks = createPreservedEmailBlocks(draft);
     return { draft, preservedBlocks };
   });
   const { draft: initialDraft, preservedBlocks } = initialComposer;
@@ -214,11 +302,17 @@ function ComposeEmailFormContent({
   const [isReconnectingContacts, setIsReconnectingContacts] = useState(false);
   const [editReply, setEditReply] = useState(false);
   const [showCcBcc, setShowCcBcc] = useState(
-    Boolean(replyingToEmail?.cc || replyingToEmail?.bcc),
+    Boolean(
+      storedDraft?.content?.values.cc ||
+        storedDraft?.content?.values.bcc ||
+        replyingToEmail?.cc ||
+        replyingToEmail?.bcc,
+    ),
   );
   const focusRecipientField = !replyingToEmail;
-  const [attachments, setAttachments] = useState<ComposeAttachment[]>([]);
-  const attachmentsRef = useRef<ComposeAttachment[]>([]);
+  const [attachments, setAttachments] =
+    useState<ComposeAttachment[]>(restoredAttachments);
+  const attachmentsRef = useRef<ComposeAttachment[]>(restoredAttachments);
   const isMountedRef = useRef(true);
   const editorRef = useRef<EmailEditorHandle>(null);
   const formRef = useRef<HTMLFormElement>(null);
@@ -228,12 +322,13 @@ function ComposeEmailFormContent({
   const { symbol } = useModifierKey();
   const {
     register,
+    getValues,
     handleSubmit,
     formState: { errors, isSubmitting },
     watch,
     setValue,
   } = useForm<ComposeFormValues>({
-    defaultValues: {
+    defaultValues: storedDraft?.content?.values ?? {
       replyToEmail: getReplyToEmailPayload(replyingToEmail),
       subject: replyingToEmail?.subject,
       to: replyingToEmail?.to,
@@ -242,9 +337,101 @@ function ComposeEmailFormContent({
     },
   });
 
+  const persistDraft = useCallback(() => {
+    clearTimeout(draftTimer.current);
+    const content = latestDraft.current;
+    if (!content || !draftWriter || draftStopped.current) return;
+    const snapshot = latestDraftSnapshot.current;
+    if (snapshot === lastSavedSnapshot.current) {
+      if (isMountedRef.current) setSaveStatus("Saved on this device");
+      return;
+    }
+    draftWriter.save(content).then(
+      () => {
+        lastSavedSnapshot.current = snapshot;
+        if (
+          isMountedRef.current &&
+          !draftStopped.current &&
+          latestDraftSnapshot.current === snapshot
+        )
+          setSaveStatus("Saved on this device");
+      },
+      (error) => {
+        if (isMountedRef.current)
+          setSaveStatus(
+            error instanceof Error
+              ? error.message
+              : "Could not save draft on this device.",
+          );
+      },
+    );
+  }, [draftWriter]);
+  saveDraftRef.current = (options) => {
+    if (!draftWriter || draftStopped.current || !editorRef.current) return;
+    const value = editorRef.current.getValue();
+    const values = { ...getValues() };
+    for (const field of ["to", "cc", "bcc"] as const) {
+      const pending = pendingRecipientsRef.current[field].trim();
+      if (pending)
+        values[field] = [values[field], pending].filter(Boolean).join(", ");
+    }
+    const content: ReplyDraftContent = {
+      requestId,
+      deliveryPath: deliveryPath.current,
+      values,
+      draft: {
+        ...initialDraft,
+        editableHtml: value.editableHtml,
+        mode: value.mode,
+      },
+      preservedBlocks: preservedBlocks.filter((block) =>
+        value.preservedBlockIds.includes(block.id),
+      ),
+      attachments: attachmentsRef.current.map(
+        ({ previewUrl: _previewUrl, ...attachment }) => attachment,
+      ),
+      sendAt: options?.sendAt ?? sendAt,
+      remindAt: options?.remindAt ?? remindAt,
+    };
+    const snapshot = getReplyDraftSnapshot(content);
+    if (snapshot === latestDraftSnapshot.current) return;
+    latestDraftSnapshot.current = snapshot;
+    latestDraft.current = content;
+    setSaveStatus("Saving…");
+    clearTimeout(draftTimer.current);
+    draftTimer.current = setTimeout(persistDraft, 300);
+  };
+  useEffect(() => {
+    const subscription = watch(() => saveDraftRef.current());
+    return () => subscription.unsubscribe();
+  }, [watch]);
+  useEffect(
+    () => () => {
+      persistDraft();
+    },
+    [persistDraft],
+  );
+  useEffect(() => {
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") persistDraft();
+    };
+    window.addEventListener("pagehide", persistDraft);
+    document.addEventListener("visibilitychange", flushWhenHidden);
+    return () => {
+      window.removeEventListener("pagehide", persistDraft);
+      document.removeEventListener("visibilitychange", flushWhenHidden);
+    };
+  }, [persistDraft]);
+  const clearLocalDraft = useCallback(async () => {
+    draftStopped.current = true;
+    clearTimeout(draftTimer.current);
+    await draftWriter?.clear();
+  }, [draftWriter]);
+
   const updateAttachments = useCallback((next: ComposeAttachment[]) => {
     attachmentsRef.current = next;
     setAttachments(next);
+    saveDraftRef.current();
   }, []);
 
   const removeUnusedInlineAttachments = useCallback(
@@ -271,6 +458,13 @@ function ComposeEmailFormContent({
   const handleEditorStateChange = useCallback(
     (state: EmailEditorState) => {
       removeUnusedInlineAttachments(state.inlineContentIds);
+      if (!editorInitialized.current) {
+        queueMicrotask(() => {
+          editorInitialized.current = true;
+        });
+        return;
+      }
+      saveDraftRef.current();
     },
     [removeUnusedInlineAttachments],
   );
@@ -378,9 +572,11 @@ function ComposeEmailFormContent({
 
     return () => {
       isMountedRef.current = false;
-      for (const attachment of attachmentsRef.current) {
-        revokePreview(attachment);
-      }
+      const previews = [...attachmentsRef.current];
+      setTimeout(() => {
+        if (!isMountedRef.current)
+          for (const attachment of previews) revokePreview(attachment);
+      }, 0);
     };
   }, []);
 
@@ -454,7 +650,55 @@ function ComposeEmailFormContent({
         return;
       }
 
+      setSubmissionError("");
       try {
+        if (isInlineReply) {
+          if (deliveryPath.current === "outbox" && (sendAt || remindAt)) {
+            setSubmissionError(
+              "This reply was already submitted to the outbox. Check its delivery status before scheduling a new reply.",
+            );
+            return;
+          }
+          deliveryPath.current ??= sendAt || remindAt ? "scheduled" : "outbox";
+        }
+        if (draftWriter) {
+          saveDraftRef.current();
+          clearTimeout(draftTimer.current);
+          if (latestDraft.current) await draftWriter.save(latestDraft.current);
+        }
+        if (isInlineReply && deliveryPath.current === "scheduled") {
+          const result = await scheduleEmailAction(selectedEmailAccountId, {
+            clientMutationId: requestId,
+            threadId: replyingToEmail!.threadId!,
+            messageIds: [draftKeyMessageId!],
+            email: enrichedData,
+            sendAt: sendAt ? new Date(sendAt).toISOString() : null,
+            remindAt: remindAt ? new Date(remindAt).toISOString() : null,
+          });
+          if (!result?.data) {
+            setSubmissionError(
+              getActionErrorMessage(result ?? {}, {
+                prefix: "Could not schedule this reply",
+              }),
+            );
+            return;
+          }
+          try {
+            await clearLocalDraft();
+          } catch {
+            toastError({
+              description:
+                "Reply scheduled, but its local draft copy could not be cleared.",
+            });
+          }
+          await mutate([
+            `/api/user/scheduled-emails?threadId=${encodeURIComponent(replyingToEmail!.threadId!)}`,
+            selectedEmailAccountId,
+          ]);
+          onClose?.();
+          refetch?.();
+          return;
+        }
         const readerThreadId = replyingToEmail?.threadId?.trim();
         const readerMessageId = replyingToEmail?.messageId;
         if (readerThreadId) {
@@ -462,16 +706,33 @@ function ComposeEmailFormContent({
           try {
             outcome = await queueReaderEmail({
               email: enrichedData,
+              mutationId: isInlineReply ? requestId : undefined,
               emailAccountId: selectedEmailAccountId,
               messageIds: readerMessageId ? [readerMessageId] : [],
               online: navigator.onLine,
               threadId: readerThreadId,
+              onQueued: isInlineReply
+                ? async () => {
+                    try {
+                      await clearLocalDraft();
+                    } catch {
+                      toastError({
+                        description:
+                          "Reply queued, but its local draft copy could not be cleared.",
+                      });
+                    }
+                    onClose?.();
+                  }
+                : undefined,
             });
           } catch (error) {
             console.error(error);
-            toastError({
-              description: "Couldn't queue this email. It hasn't been sent.",
-            });
+            const description =
+              error instanceof Error
+                ? error.message
+                : "Could not confirm this reply was queued. Check the thread delivery status before retrying.";
+            setSubmissionError(description);
+            toastError({ description });
             return;
           }
           if (outcome.status === "sent") {
@@ -513,6 +774,9 @@ function ComposeEmailFormContent({
         }
       } catch (error) {
         console.error(error);
+        setSubmissionError(
+          "Could not confirm delivery. Check the thread status before trying again.",
+        );
         toastError({ description: "There was an error sending the email :(" });
       }
 
@@ -520,6 +784,14 @@ function ComposeEmailFormContent({
     },
     [
       initialDraft,
+      isInlineReply,
+      sendAt,
+      remindAt,
+      requestId,
+      draftKeyMessageId,
+      draftWriter,
+      clearLocalDraft,
+      mutate,
       onClose,
       onSuccess,
       preservedBlocks,
@@ -564,6 +836,9 @@ function ComposeEmailFormContent({
   const updatePendingRecipient = useCallback(
     (field: ComposeRecipientField, query: string) => {
       pendingRecipientsRef.current[field] = query;
+      queueMicrotask(() => {
+        if (isMountedRef.current) saveDraftRef.current();
+      });
     },
     [],
   );
@@ -597,11 +872,22 @@ function ComposeEmailFormContent({
   return (
     <form
       ref={formRef}
+      style={
+        isInlineReply
+          ? ({
+              "--email-editor-content-min-height": "100px",
+              "--email-editor-content-padding": "0.5rem 0",
+            } as CSSProperties)
+          : undefined
+      }
+      onInput={() => saveDraftRef.current()}
       onSubmit={handleSubmit(onSubmit)}
       className={cn(
         isComposeWindow
           ? "flex h-full min-h-0 flex-col overflow-hidden [&_[data-email-editor-root]]:min-h-0 [&_[data-email-editor-root]]:flex-1"
           : "space-y-2",
+        isInlineReply &&
+          "space-y-3 [&_[data-email-editor-root]]:min-h-[120px] [&_[contenteditable]]:min-h-[100px]",
       )}
     >
       <div className={cn(isComposeWindow ? "shrink-0 px-4" : "contents")}>
@@ -649,9 +935,9 @@ function ComposeEmailFormContent({
             )}
             onClick={() => setEditReply(true)}
           >
-            <span className="text-green-500">Draft</span>{" "}
+            <span className="text-muted-foreground text-sm">To</span>{" "}
             <span className="max-w-md break-words text-foreground">
-              to {extractNameFromEmail(replyingToEmail.to)}
+              {extractNameFromEmail(watch("to") || replyingToEmail.to)}
             </span>
           </button>
         ) : (
@@ -779,7 +1065,7 @@ function ComposeEmailFormContent({
       </div>
 
       <EmailEditor
-        appearance={isComposeWindow ? "seamless" : "contained"}
+        appearance={isComposeWindow || isInlineReply ? "seamless" : "contained"}
         autofocus={!focusRecipientField}
         ref={editorRef}
         initialHtml={initialDraft.editableHtml}
@@ -794,6 +1080,11 @@ function ComposeEmailFormContent({
         unsupported={initialDraft.unsupported}
       />
 
+      {submissionError && (
+        <p role="alert" className="text-destructive text-sm">
+          {submissionError}
+        </p>
+      )}
       {!!attachments.length && (
         <ul
           aria-label="Attachments"
@@ -831,11 +1122,11 @@ function ComposeEmailFormContent({
 
       <div
         className={cn(
-          "flex items-center justify-between",
+          "flex flex-wrap items-center justify-between gap-2",
           isComposeWindow && "shrink-0 border-t px-4 py-2",
         )}
       >
-        <div className="flex items-center">
+        <div className="flex flex-wrap items-center gap-1">
           {isComposeWindow ? (
             <Button
               className="h-9 px-0 font-semibold text-foreground hover:bg-transparent hover:text-foreground"
@@ -853,6 +1144,21 @@ function ComposeEmailFormContent({
                 Send
               </Button>
             </Tooltip>
+          )}
+          {isInlineReply && (
+            <DeliveryOptions
+              sendAt={sendAt}
+              remindAt={remindAt}
+              disabled={isSubmitting}
+              onSendAtChange={(value) => {
+                setSendAt(value);
+                saveDraftRef.current({ sendAt: value });
+              }}
+              onRemindAtChange={(value) => {
+                setRemindAt(value);
+                saveDraftRef.current({ remindAt: value });
+              }}
+            />
           )}
         </div>
 
@@ -906,7 +1212,19 @@ function ComposeEmailFormContent({
                   "text-muted-foreground hover:text-foreground",
               )}
               disabled={isSubmitting}
-              onClick={onDiscard}
+              onClick={async () => {
+                try {
+                  await clearLocalDraft();
+                  onDiscard();
+                } catch (error) {
+                  draftStopped.current = false;
+                  setSaveStatus(
+                    error instanceof Error
+                      ? error.message
+                      : "Could not discard this draft.",
+                  );
+                }
+              }}
               size={isComposeWindow ? "iconSm" : "icon"}
               title="Discard draft"
               type="button"
@@ -917,6 +1235,11 @@ function ComposeEmailFormContent({
           )}
         </div>
       </div>
+      {isInlineReply && saveStatus && (
+        <p role="status" className="text-xs text-muted-foreground">
+          {saveStatus}
+        </p>
+      )}
     </form>
   );
 }
@@ -1232,4 +1555,13 @@ function getQueuedEmailDescription(
     return "Email queued. Reconnect this account to send it.";
   }
   return "Email queued and will keep sending in the background.";
+}
+
+function getReplyDraftSnapshot(content: ReplyDraftContent) {
+  return JSON.stringify({
+    ...content,
+    attachments: content.attachments.map(
+      ({ contentBase64: _content, ...metadata }) => metadata,
+    ),
+  });
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -95,7 +95,10 @@ import type { StoredReplyDraft } from "@/utils/email-cache/database";
 import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import { DeliveryOptions } from "./DeliveryOptions";
 import { useSWRConfig } from "swr";
-import { getReminderAfterSendTimeChange } from "./delivery-times";
+import {
+  getReminderAfterSendTimeChange,
+  parseDeliveryTimes,
+} from "./delivery-times";
 import { queueReaderEmail } from "./queued-reply";
 
 export type ReplyingToEmail = {
@@ -157,13 +160,7 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
       : undefined,
   );
   return (
-    <LoadingContent
-      error={
-        error ||
-        (localDraft.error ? { error: localDraft.error.message } : undefined)
-      }
-      loading={isLoading || localDraft.isLoading}
-    >
+    <LoadingContent error={error} loading={isLoading || localDraft.isLoading}>
       {emailAccount && (
         <ComposeEmailFormContent
           {...props}
@@ -218,7 +215,10 @@ function ComposeEmailFormContent({
     draftLoadError?.message ??
       (storedDraft?.content ? "Saved on this device" : ""),
   );
-  const [submissionError, setSubmissionError] = useState("");
+  const [submissionError, setSubmissionError] = useState(() => {
+    const times = parseDeliveryTimes(sendAt, remindAt);
+    return times.valid ? "" : times.error;
+  });
   const [draftWriter] = useState(() =>
     isInlineReply
       ? createReplyDraftWriter(
@@ -658,6 +658,11 @@ function ComposeEmailFormContent({
         return;
       }
 
+      const deliveryTimes = parseDeliveryTimes(sendAt, remindAt);
+      if (!deliveryTimes.valid) {
+        setSubmissionError(deliveryTimes.error);
+        return;
+      }
       setSubmissionError("");
       try {
         if (isInlineReply) {
@@ -680,8 +685,8 @@ function ComposeEmailFormContent({
             threadId: replyingToEmail!.threadId!,
             messageIds: [draftKeyMessageId!],
             email: enrichedData,
-            sendAt: sendAt ? new Date(sendAt).toISOString() : null,
-            remindAt: remindAt ? new Date(remindAt).toISOString() : null,
+            sendAt: deliveryTimes.sendAt,
+            remindAt: deliveryTimes.remindAt,
           });
           if (!result?.data) {
             setSubmissionError(

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -157,7 +157,10 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
   );
   return (
     <LoadingContent
-      error={error || localDraft.error}
+      error={
+        error ||
+        (localDraft.error ? { error: localDraft.error.message } : undefined)
+      }
       loading={isLoading || localDraft.isLoading}
     >
       {emailAccount && (

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -309,7 +309,6 @@ function ComposeEmailFormContent({
     useState(false);
   const [isReconnectingContacts, setIsReconnectingContacts] = useState(false);
   const [editReply, setEditReply] = useState(false);
-  const [editSubject, setEditSubject] = useState(false);
   const [showCcBcc, setShowCcBcc] = useState(
     Boolean(
       storedDraft?.content?.values.cc ||
@@ -939,12 +938,12 @@ function ComposeEmailFormContent({
             </Select>
           </div>
         )}
-        {isInlineReply && (
+        {isInlineReply && !editReply && (
           <button
             type="button"
-            aria-expanded={editReply}
-            onClick={() => setEditReply(!editReply)}
-            className="flex items-center gap-1.5 text-left text-sm font-medium leading-5 text-foreground"
+            aria-expanded={false}
+            onClick={() => setEditReply(true)}
+            className="flex items-center gap-1.5 rounded-sm text-left text-sm font-medium leading-5 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <span className="text-emerald-600 dark:text-emerald-400">
               Draft
@@ -954,12 +953,7 @@ function ComposeEmailFormContent({
               {extractNameFromEmail(watch("to") || replyingToEmail?.to || "") ||
                 "recipients"}
             </span>
-            <ChevronDownIcon
-              className={cn(
-                "size-3 shrink-0 text-muted-foreground",
-                editReply && "rotate-180",
-              )}
-            />
+            <ChevronDownIcon className="size-3 shrink-0 text-muted-foreground" />
           </button>
         )}
         {replyingToEmail?.to && !editReply ? (
@@ -979,14 +973,12 @@ function ComposeEmailFormContent({
             </button>
           )
         ) : isInlineReply ? (
-          <div className="space-y-0.5 [&_input]:bg-transparent">
-            {(
-              ["to", ...(showCcBcc ? (["cc", "bcc"] as const) : [])] as const
-            ).map((field) => (
+          <div className="space-y-1 [&_input]:bg-transparent">
+            {(["to", "cc", "bcc"] as const).map((field) => (
               <div key={field} className="flex min-h-7 items-center gap-2">
                 <label
                   htmlFor={field}
-                  className="w-12 shrink-0 text-xs leading-5 text-muted-foreground"
+                  className="w-12 shrink-0 text-sm font-medium leading-5 text-foreground"
                 >
                   {RECIPIENT_LABELS[field]}
                 </label>
@@ -1007,51 +999,33 @@ function ComposeEmailFormContent({
                         required: field === "to",
                       })}
                       error={errors[field]}
-                      className="h-7 rounded-none border-0 bg-transparent p-0 text-xs leading-5 shadow-none focus:border-transparent focus:ring-0 sm:text-xs"
+                      className="h-7 rounded-none border-0 bg-transparent p-0 text-sm leading-5 shadow-none focus:border-transparent focus:ring-0 sm:text-sm"
                     />
                   )}
                 </div>
                 {field === "to" && (
                   <button
                     type="button"
-                    aria-label={showCcBcc ? "Hide Cc/Bcc" : "Cc/Bcc"}
-                    onClick={() => setShowCcBcc(!showCcBcc)}
-                    className="shrink-0 py-2 text-xs text-muted-foreground hover:text-foreground"
+                    aria-label="Hide recipients"
+                    onClick={() => setEditReply(false)}
+                    className="rounded-sm text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    Cc/Bcc
+                    <ChevronDownIcon className="size-3 rotate-180" />
                   </button>
                 )}
               </div>
             ))}
-            {editSubject ? (
-              <div className="flex min-h-8 items-center gap-2">
-                <label
-                  htmlFor="subject"
-                  className="w-12 shrink-0 text-xs text-muted-foreground"
-                >
-                  Subject
-                </label>
-                <div className="min-w-0 flex-1">
-                  <Input
-                    type="text"
-                    name="subject"
-                    registerProps={register("subject", { required: true })}
-                    error={errors.subject}
-                    placeholder="Subject"
-                    className="h-8 rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus:border-transparent focus:ring-0"
-                  />
-                </div>
-              </div>
-            ) : (
-              <button
-                type="button"
-                aria-label="Edit subject"
-                onClick={() => setEditSubject(true)}
-                className="pt-2 pb-1 text-left text-xs leading-5 text-muted-foreground hover:text-foreground"
-              >
-                Edit subject
-              </button>
-            )}
+            <div className="pt-3">
+              <Input
+                type="text"
+                name="subject"
+                registerProps={register("subject", { required: true })}
+                error={errors.subject}
+                placeholder="Subject"
+                aria-label="Subject"
+                className="h-8 rounded-none border-0 bg-transparent p-0 text-sm font-medium text-foreground shadow-none focus:border-transparent focus:ring-0 sm:text-sm"
+              />
+            </div>
           </div>
         ) : (
           <>

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -939,34 +939,45 @@ function ComposeEmailFormContent({
             </Select>
           </div>
         )}
-        {replyingToEmail?.to && !editReply ? (
+        {isInlineReply && (
           <button
             type="button"
-            className={cn(
-              "flex items-center gap-1 text-left",
-              isInlineReply &&
-                "gap-1.5 text-xs leading-5 text-muted-foreground hover:text-foreground",
-              isComposeWindow && "min-h-11 items-center border-b",
-            )}
-            onClick={() => setEditReply(true)}
+            aria-expanded={editReply}
+            onClick={() => setEditReply(!editReply)}
+            className="flex items-center gap-1.5 text-left text-sm font-medium leading-5 text-foreground"
           >
-            {isInlineReply ? (
-              <>
-                <span>
-                  Reply to{" "}
-                  {extractNameFromEmail(watch("to") || replyingToEmail.to)}
-                </span>
-                <ChevronDownIcon className="size-3" />
-              </>
-            ) : (
-              <>
-                <span className="text-muted-foreground text-sm">To</span>
-                <span className="max-w-md break-words text-foreground">
-                  {extractNameFromEmail(watch("to") || replyingToEmail.to)}
-                </span>
-              </>
-            )}
+            <span className="text-emerald-600 dark:text-emerald-400">
+              Draft
+            </span>
+            <span className="min-w-0 truncate">
+              to{" "}
+              {extractNameFromEmail(watch("to") || replyingToEmail?.to || "") ||
+                "recipients"}
+            </span>
+            <ChevronDownIcon
+              className={cn(
+                "size-3 shrink-0 text-muted-foreground",
+                editReply && "rotate-180",
+              )}
+            />
           </button>
+        )}
+        {replyingToEmail?.to && !editReply ? (
+          !isInlineReply && (
+            <button
+              type="button"
+              className={cn(
+                "flex items-center gap-1 text-left",
+                isComposeWindow && "min-h-11 items-center border-b",
+              )}
+              onClick={() => setEditReply(true)}
+            >
+              <span className="text-muted-foreground text-sm">To</span>
+              <span className="max-w-md break-words text-foreground">
+                {extractNameFromEmail(watch("to") || replyingToEmail.to)}
+              </span>
+            </button>
+          )
         ) : isInlineReply ? (
           <div className="space-y-0.5 [&_input]:bg-transparent">
             {(
@@ -975,7 +986,7 @@ function ComposeEmailFormContent({
               <div key={field} className="flex min-h-7 items-center gap-2">
                 <label
                   htmlFor={field}
-                  className="w-8 shrink-0 text-xs leading-5 text-muted-foreground"
+                  className="w-12 shrink-0 text-xs leading-5 text-muted-foreground"
                 >
                   {RECIPIENT_LABELS[field]}
                 </label>
@@ -1016,7 +1027,7 @@ function ComposeEmailFormContent({
               <div className="flex min-h-8 items-center gap-2">
                 <label
                   htmlFor="subject"
-                  className="text-xs text-muted-foreground"
+                  className="w-12 shrink-0 text-xs text-muted-foreground"
                 >
                   Subject
                 </label>
@@ -1038,7 +1049,7 @@ function ComposeEmailFormContent({
                 onClick={() => setEditSubject(true)}
                 className="pt-2 pb-1 text-left text-xs leading-5 text-muted-foreground hover:text-foreground"
               >
-                {watch("subject")}
+                Edit subject
               </button>
             )}
           </div>

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -1266,9 +1266,7 @@ function ComposeEmailFormContent({
           />
           <Button
             aria-label="Attach files"
-            className={cn(
-              isComposeWindow && "text-muted-foreground hover:text-foreground",
-            )}
+            className="text-muted-foreground hover:text-foreground"
             onClick={() => attachmentInputRef.current?.click()}
             size={isComposeWindow ? "iconSm" : "icon"}
             type="button"
@@ -1287,9 +1285,7 @@ function ComposeEmailFormContent({
           />
           <Button
             aria-label="Insert inline images"
-            className={cn(
-              isComposeWindow && "text-muted-foreground hover:text-foreground",
-            )}
+            className="text-muted-foreground hover:text-foreground"
             onClick={() => inlineImageInputRef.current?.click()}
             size={isComposeWindow ? "iconSm" : "icon"}
             type="button"
@@ -1300,10 +1296,7 @@ function ComposeEmailFormContent({
           {onDiscard && (
             <Button
               aria-label="Discard draft"
-              className={cn(
-                isComposeWindow &&
-                  "text-muted-foreground hover:text-foreground",
-              )}
+              className="text-muted-foreground hover:text-foreground"
               disabled={isSubmitting}
               onClick={async () => {
                 try {

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -1266,7 +1266,7 @@ function ComposeEmailFormContent({
           />
           <Button
             aria-label="Attach files"
-            className="text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:bg-transparent hover:text-foreground"
             onClick={() => attachmentInputRef.current?.click()}
             size={isComposeWindow ? "iconSm" : "icon"}
             type="button"
@@ -1285,7 +1285,7 @@ function ComposeEmailFormContent({
           />
           <Button
             aria-label="Insert inline images"
-            className="text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:bg-transparent hover:text-foreground"
             onClick={() => inlineImageInputRef.current?.click()}
             size={isComposeWindow ? "iconSm" : "icon"}
             type="button"
@@ -1296,7 +1296,7 @@ function ComposeEmailFormContent({
           {onDiscard && (
             <Button
               aria-label="Discard draft"
-              className="text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:bg-transparent hover:text-foreground"
               disabled={isSubmitting}
               onClick={async () => {
                 try {

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -39,7 +39,7 @@ import {
 } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { useHotkeys } from "react-hotkeys-hook";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import type {
   ContactsErrorResponse,
   ContactsResponse,
@@ -62,15 +62,22 @@ import {
 } from "@/components/ui/select";
 import { env } from "@/env";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
+import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
 import { useModifierKey } from "@/hooks/useModifierKey";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { sendEmailAction } from "@/utils/actions/mail";
+import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import {
   extractNameFromEmail,
   isValidEmail,
   splitRecipientList,
 } from "@/utils/email";
+import type { StoredReplyDraft } from "@/utils/email-cache/database";
+import {
+  createReplyDraftWriter,
+  type ReplyDraftContent,
+} from "@/utils/email-cache/reply-drafts";
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { getActionErrorMessage } from "@/utils/error";
@@ -87,15 +94,7 @@ import {
   resolveComposeRecipients,
   resolveRecipientSelection,
 } from "./compose-recipients";
-import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
-import {
-  createReplyDraftWriter,
-  type ReplyDraftContent,
-} from "@/utils/email-cache/reply-drafts";
-import type { StoredReplyDraft } from "@/utils/email-cache/database";
-import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import { DeliveryOptions } from "./DeliveryOptions";
-import { useSWRConfig } from "swr";
 import {
   getReminderAfterSendTimeChange,
   parseDeliveryTimes,
@@ -324,6 +323,8 @@ function ComposeEmailFormContent({
   const isMountedRef = useRef(true);
   const editorRef = useRef<EmailEditorHandle>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const inlineReplySummaryButtonRef = useRef<HTMLButtonElement>(null);
+  const collapseInlineReplyFieldsButtonRef = useRef<HTMLButtonElement>(null);
   const hideCcBccButtonRef = useRef<HTMLButtonElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const inlineImageInputRef = useRef<HTMLInputElement>(null);
@@ -880,6 +881,31 @@ function ComposeEmailFormContent({
         );
       }
     };
+  const canCollapseInlineReplyFields =
+    isInlineReply && Boolean(replyingToEmail?.to);
+  const showInlineReplySummary = canCollapseInlineReplyFields && !editReply;
+  const openInlineReplyFields = () => {
+    setEditReply(true);
+    requestAnimationFrame(() =>
+      collapseInlineReplyFieldsButtonRef.current?.focus(),
+    );
+  };
+  const closeInlineReplyFields = () => {
+    setEditReply(false);
+    requestAnimationFrame(() => inlineReplySummaryButtonRef.current?.focus());
+  };
+  const handleSendAtChange = (value: string) => {
+    const nextRemindAt = getReminderAfterSendTimeChange(value, remindAt);
+    setSubmissionError("");
+    setSendAt(value);
+    setRemindAt(nextRemindAt);
+    saveDraftRef.current({ sendAt: value, remindAt: nextRemindAt });
+  };
+  const handleRemindAtChange = (value: string) => {
+    setSubmissionError("");
+    setRemindAt(value);
+    saveDraftRef.current({ remindAt: value });
+  };
 
   return (
     <form
@@ -938,11 +964,12 @@ function ComposeEmailFormContent({
             </Select>
           </div>
         )}
-        {isInlineReply && !editReply && (
+        {showInlineReplySummary && (
           <button
             type="button"
             aria-expanded={false}
-            onClick={() => setEditReply(true)}
+            ref={inlineReplySummaryButtonRef}
+            onClick={openInlineReplyFields}
             className="flex items-center gap-1.5 rounded-sm text-left text-sm font-medium leading-5 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <span className="text-emerald-600 dark:text-emerald-400">
@@ -1003,11 +1030,12 @@ function ComposeEmailFormContent({
                     />
                   )}
                 </div>
-                {field === "to" && (
+                {field === "to" && canCollapseInlineReplyFields && (
                   <button
                     type="button"
                     aria-label="Hide recipients"
-                    onClick={() => setEditReply(false)}
+                    ref={collapseInlineReplyFieldsButtonRef}
+                    onClick={closeInlineReplyFields}
                     className="rounded-sm text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <ChevronDownIcon className="size-3 rotate-180" />
@@ -1238,19 +1266,8 @@ function ComposeEmailFormContent({
               sendAt={sendAt}
               remindAt={remindAt}
               disabled={isSubmitting}
-              onSendAtChange={(value) => {
-                const nextRemindAt = getReminderAfterSendTimeChange(
-                  value,
-                  remindAt,
-                );
-                setSendAt(value);
-                setRemindAt(nextRemindAt);
-                saveDraftRef.current({ sendAt: value, remindAt: nextRemindAt });
-              }}
-              onRemindAtChange={(value) => {
-                setRemindAt(value);
-                saveDraftRef.current({ remindAt: value });
-              }}
+              onSendAtChange={handleSendAtChange}
+              onRemindAtChange={handleRemindAtChange}
             />
           )}
         </div>

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { BellIcon, ClockIcon, XIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -55,7 +55,7 @@ function DeliveryTimePicker({
   value: string;
   onChange: (value: string) => void;
   disabled: boolean;
-  icon: React.ReactNode;
+  icon: ReactNode;
   after?: string;
 }) {
   const [open, setOpen] = useState(false);

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { BellIcon, ClockIcon, XIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export function DeliveryOptions({
+  sendAt,
+  remindAt,
+  disabled,
+  onSendAtChange,
+  onRemindAtChange,
+}: {
+  sendAt: string;
+  remindAt: string;
+  disabled: boolean;
+  onSendAtChange: (value: string) => void;
+  onRemindAtChange: (value: string) => void;
+}) {
+  return (
+    <>
+      <DeliveryTimePicker
+        label="Send later"
+        value={sendAt}
+        onChange={onSendAtChange}
+        disabled={disabled}
+        icon={<ClockIcon className="size-3.5" />}
+      />
+      <DeliveryTimePicker
+        label="Remind me"
+        value={remindAt}
+        onChange={onRemindAtChange}
+        disabled={disabled}
+        icon={<BellIcon className="size-3.5" />}
+        after={sendAt}
+      />
+    </>
+  );
+}
+
+function DeliveryTimePicker({
+  label,
+  value,
+  onChange,
+  disabled,
+  icon,
+  after,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+  icon: React.ReactNode;
+  after?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [custom, setCustom] = useState("");
+  const isReminder = label === "Remind me";
+  const earliest = Math.max(Date.now(), after ? new Date(after).getTime() : 0);
+  const choose = (date: Date) => {
+    onChange(date.toISOString());
+    setOpen(false);
+  };
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          className="gap-1.5 px-2 text-xs"
+          aria-label={label}
+        >
+          {icon}
+          {value
+            ? new Date(value).toLocaleString(undefined, {
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              })
+            : label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-72 space-y-3"
+        align="start"
+        role="dialog"
+        aria-label={label}
+      >
+        <div>
+          <p className="font-medium text-sm">{label}</p>
+          <p className="mt-1 text-muted-foreground text-xs">
+            {isReminder
+              ? "Return this thread to your inbox if no one replies."
+              : "Sends even when the app is closed. Times are local."}
+          </p>
+        </div>
+        {[1, 2, 7].map((days) => {
+          const date = new Date(earliest);
+          date.setDate(date.getDate() + days);
+          date.setHours(9, 0, 0, 0);
+          return (
+            <Button
+              key={days}
+              type="button"
+              variant="ghost"
+              className="flex h-auto w-full justify-between px-2 py-2 text-sm"
+              onClick={() => choose(date)}
+            >
+              <span>
+                {after
+                  ? `${days} ${days === 1 ? "day" : "days"} after sending`
+                  : days === 1
+                    ? "Tomorrow morning"
+                    : `In ${days} days`}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {date.toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}{" "}
+                · 9:00
+              </span>
+            </Button>
+          );
+        })}
+        <label className="block text-xs">
+          Choose a date and time
+          <input
+            aria-label={`${label} date and time`}
+            type="datetime-local"
+            value={custom}
+            onChange={(event) => setCustom(event.target.value)}
+            className="mt-2 w-full rounded-md border border-input bg-background p-2 text-sm"
+          />
+        </label>
+        <Button
+          type="button"
+          size="sm"
+          className="w-full"
+          disabled={!custom || new Date(custom).getTime() <= earliest}
+          onClick={() => choose(new Date(custom))}
+        >
+          Set time
+        </Button>
+        {value && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              onChange("");
+              setOpen(false);
+            }}
+          >
+            <XIcon className="mr-1 size-3.5" />
+            Clear time
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { type ReactNode, useState } from "react";
-import { BellIcon, ClockIcon, XIcon } from "lucide-react";
+import {
+  BellIcon,
+  CalendarDaysIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ClockIcon,
+  XIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -60,14 +67,22 @@ function DeliveryTimePicker({
 }) {
   const [open, setOpen] = useState(false);
   const [custom, setCustom] = useState("");
+  const [showCustom, setShowCustom] = useState(false);
   const isReminder = label === "Remind me";
   const earliest = Math.max(Date.now(), after ? new Date(after).getTime() : 0);
   const choose = (date: Date) => {
     onChange(date.toISOString());
+    setShowCustom(false);
     setOpen(false);
   };
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setShowCustom(false);
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -89,80 +104,103 @@ function DeliveryTimePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-72 space-y-3"
+        className="w-72 p-1"
         align="start"
         role="dialog"
         aria-label={label}
       >
-        <div>
-          <p className="font-medium text-sm">{label}</p>
-          <p className="mt-1 text-muted-foreground text-xs">
-            {isReminder
-              ? "Return this thread to your inbox if no one replies."
-              : "Sends even when the app is closed. Times are local."}
-          </p>
-        </div>
-        {[1, 2, 7].map((days) => {
-          const date = new Date(earliest);
-          date.setDate(date.getDate() + days);
-          date.setHours(9, 0, 0, 0);
-          return (
+        {showCustom ? (
+          <div className="space-y-3 p-2">
             <Button
-              key={days}
               type="button"
               variant="ghost"
-              className="flex h-auto w-full justify-between px-2 py-2 text-sm"
-              onClick={() => choose(date)}
+              size="sm"
+              className="-ml-1 h-7 gap-1 px-1 text-xs"
+              onClick={() => setShowCustom(false)}
             >
-              <span>
-                {after
-                  ? `${days} ${days === 1 ? "day" : "days"} after sending`
-                  : days === 1
-                    ? "Tomorrow morning"
-                    : `In ${days} days`}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {date.toLocaleDateString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                })}{" "}
-                · 9:00
-              </span>
+              <ChevronLeftIcon className="size-3.5" />
+              Back
             </Button>
-          );
-        })}
-        <label className="block text-xs">
-          Choose a date and time
-          <input
-            aria-label={`${label} date and time`}
-            type="datetime-local"
-            value={custom}
-            onChange={(event) => setCustom(event.target.value)}
-            className="mt-2 w-full rounded-md border border-input bg-background p-2 text-sm"
-          />
-        </label>
-        <Button
-          type="button"
-          size="sm"
-          className="w-full"
-          disabled={!custom || new Date(custom).getTime() <= earliest}
-          onClick={() => choose(new Date(custom))}
-        >
-          Set time
-        </Button>
-        {value && (
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            onClick={() => {
-              onChange("");
-              setOpen(false);
-            }}
-          >
-            <XIcon className="mr-1 size-3.5" />
-            Clear time
-          </Button>
+            <label className="block text-xs text-muted-foreground">
+              Choose a date and time
+              <input
+                aria-label={`${label} date and time`}
+                type="datetime-local"
+                value={custom}
+                onChange={(event) => setCustom(event.target.value)}
+                className="mt-2 w-full rounded-md border border-input bg-background p-2 text-sm text-foreground"
+              />
+            </label>
+            <Button
+              type="button"
+              size="sm"
+              className="w-full"
+              disabled={!custom || new Date(custom).getTime() <= earliest}
+              onClick={() => choose(new Date(custom))}
+            >
+              Set time
+            </Button>
+          </div>
+        ) : (
+          <>
+            <p className="px-2 py-2 text-xs font-medium text-muted-foreground">
+              {isReminder ? "Remind me if no reply" : label}
+            </p>
+            {[1, 2, 7].map((days) => {
+              const date = new Date(earliest);
+              date.setDate(date.getDate() + days);
+              date.setHours(9, 0, 0, 0);
+              return (
+                <Button
+                  key={days}
+                  type="button"
+                  variant="ghost"
+                  className="flex h-9 w-full justify-between gap-3 px-2 text-xs font-normal"
+                  onClick={() => choose(date)}
+                >
+                  <span>
+                    {after
+                      ? `${days} ${days === 1 ? "day" : "days"} after sending`
+                      : days === 1
+                        ? "Tomorrow morning"
+                        : `In ${days} days`}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground">
+                    {date.toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}{" "}
+                    · 9:00
+                  </span>
+                </Button>
+              );
+            })}
+            <div className="my-1 border-t" />
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 w-full justify-start gap-2 px-2 text-xs font-normal"
+              onClick={() => setShowCustom(true)}
+            >
+              <CalendarDaysIcon className="size-3.5 text-muted-foreground" />
+              Choose date and time
+              <ChevronRightIcon className="ml-auto size-3.5 text-muted-foreground" />
+            </Button>
+            {value && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-9 w-full justify-start gap-2 px-2 text-xs font-normal text-muted-foreground"
+                onClick={() => {
+                  onChange("");
+                  setOpen(false);
+                }}
+              >
+                <XIcon className="size-3.5" />
+                Clear time
+              </Button>
+            )}
+          </>
         )}
       </PopoverContent>
     </Popover>

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -83,7 +83,7 @@ function DeliveryTimePicker({
           variant="ghost"
           size="sm"
           disabled={disabled}
-          className="px-2 text-xs text-muted-foreground hover:text-foreground"
+          className="px-2 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
           aria-label={label}
         >
           {value

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import {
-  BellIcon,
   CalendarDaysIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
-  ClockIcon,
   XIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,14 +34,12 @@ export function DeliveryOptions({
         value={sendAt}
         onChange={onSendAtChange}
         disabled={disabled}
-        icon={<ClockIcon className="size-3.5" />}
       />
       <DeliveryTimePicker
         label="Remind me"
         value={remindAt}
         onChange={onRemindAtChange}
         disabled={disabled}
-        icon={<BellIcon className="size-3.5" />}
         after={sendAt}
       />
     </>
@@ -55,14 +51,12 @@ function DeliveryTimePicker({
   value,
   onChange,
   disabled,
-  icon,
   after,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   disabled: boolean;
-  icon: ReactNode;
   after?: string;
 }) {
   const [open, setOpen] = useState(false);
@@ -89,10 +83,9 @@ function DeliveryTimePicker({
           variant="ghost"
           size="sm"
           disabled={disabled}
-          className="gap-1.5 px-2 text-xs"
+          className="px-2 text-xs text-muted-foreground hover:text-foreground"
           aria-label={label}
         >
-          {icon}
           {value
             ? new Date(value).toLocaleString(undefined, {
                 month: "short",

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getReminderAfterSendTimeChange } from "./delivery-times";
+
+describe("changing a scheduled send time", () => {
+  it.each([
+    "2026-09-07T10:00:00Z",
+    "2026-09-08T10:00:00Z",
+  ])("clears a reminder when the new send time %s reaches or passes it", (sendAt) => {
+    expect(getReminderAfterSendTimeChange(sendAt, "2026-09-07T10:00:00Z")).toBe(
+      "",
+    );
+  });
+
+  it("keeps a reminder after the new send time", () => {
+    expect(
+      getReminderAfterSendTimeChange(
+        "2026-09-06T10:00:00Z",
+        "2026-09-07T10:00:00Z",
+      ),
+    ).toBe("2026-09-07T10:00:00Z");
+  });
+
+  it("keeps the reminder when switching back to send now", () => {
+    expect(getReminderAfterSendTimeChange("", "2026-09-07T10:00:00Z")).toBe(
+      "2026-09-07T10:00:00Z",
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getReminderAfterSendTimeChange } from "./delivery-times";
+import {
+  getReminderAfterSendTimeChange,
+  parseDeliveryTimes,
+} from "./delivery-times";
 
 describe("changing a scheduled send time", () => {
   it.each([
@@ -24,5 +27,42 @@ describe("changing a scheduled send time", () => {
     expect(getReminderAfterSendTimeChange("", "2026-09-07T10:00:00Z")).toBe(
       "2026-09-07T10:00:00Z",
     );
+  });
+});
+
+describe("persisted delivery times", () => {
+  it.each([
+    "not-a-date",
+    "2026-99-99T10:00:00Z",
+    " ",
+  ])("rejects invalid send time %s instead of converting it to send now", (sendAt) => {
+    expect(parseDeliveryTimes(sendAt, "")).toMatchObject({ valid: false });
+  });
+
+  it("rejects an invalid reminder without throwing or removing the schedule", () => {
+    expect(parseDeliveryTimes("2026-09-07T10:00:00Z", "broken")).toMatchObject({
+      valid: false,
+    });
+  });
+
+  it("preserves explicitly unset times as null", () => {
+    expect(parseDeliveryTimes("", "")).toEqual({
+      valid: true,
+      sendAt: null,
+      remindAt: null,
+    });
+  });
+
+  it("normalizes valid persisted dates for the server contract", () => {
+    expect(
+      parseDeliveryTimes(
+        "2026-09-07T12:00:00+02:00",
+        "2026-09-08T12:00:00+02:00",
+      ),
+    ).toEqual({
+      valid: true,
+      sendAt: "2026-09-07T10:00:00.000Z",
+      remindAt: "2026-09-08T10:00:00.000Z",
+    });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.test.ts
@@ -33,6 +33,8 @@ describe("changing a scheduled send time", () => {
 describe("persisted delivery times", () => {
   it.each([
     "not-a-date",
+    "2026-02-30T10:00:00Z",
+    "2025-02-29T10:00:00+02:00",
     "2026-99-99T10:00:00Z",
     " ",
   ])("rejects invalid send time %s instead of converting it to send now", (sendAt) => {

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
@@ -11,3 +11,38 @@ export function getReminderAfterSendTimeChange(
   }
   return remindAt;
 }
+
+export function parseDeliveryTimes(
+  sendAt: string,
+  remindAt: string,
+):
+  | { valid: false; error: string }
+  | { valid: true; sendAt: string | null; remindAt: string | null } {
+  const sendDate =
+    typeof sendAt === "string" && sendAt ? new Date(sendAt) : null;
+  const reminderDate =
+    typeof remindAt === "string" && remindAt ? new Date(remindAt) : null;
+  if (
+    typeof sendAt !== "string" ||
+    (sendDate && !Number.isFinite(sendDate.getTime()))
+  ) {
+    return {
+      valid: false,
+      error: "Choose a valid send time, or clear Send later to send now.",
+    };
+  }
+  if (
+    typeof remindAt !== "string" ||
+    (reminderDate && !Number.isFinite(reminderDate.getTime()))
+  ) {
+    return {
+      valid: false,
+      error: "Choose a valid reminder time, or clear the reminder.",
+    };
+  }
+  return {
+    valid: true,
+    sendAt: sendDate?.toISOString() ?? null,
+    remindAt: reminderDate?.toISOString() ?? null,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
@@ -1,0 +1,13 @@
+export function getReminderAfterSendTimeChange(
+  sendAt: string,
+  remindAt: string,
+) {
+  if (
+    sendAt &&
+    remindAt &&
+    new Date(sendAt).getTime() >= new Date(remindAt).getTime()
+  ) {
+    return "";
+  }
+  return remindAt;
+}

--- a/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/delivery-times.ts
@@ -1,3 +1,7 @@
+import { z } from "zod";
+
+const deliveryTimeSchema = z.string().datetime({ offset: true });
+
 export function getReminderAfterSendTimeChange(
   sendAt: string,
   remindAt: string,
@@ -24,7 +28,7 @@ export function parseDeliveryTimes(
     typeof remindAt === "string" && remindAt ? new Date(remindAt) : null;
   if (
     typeof sendAt !== "string" ||
-    (sendDate && !Number.isFinite(sendDate.getTime()))
+    (sendAt && !deliveryTimeSchema.safeParse(sendAt).success)
   ) {
     return {
       valid: false,
@@ -33,7 +37,7 @@ export function parseDeliveryTimes(
   }
   if (
     typeof remindAt !== "string" ||
-    (reminderDate && !Number.isFinite(reminderDate.getTime()))
+    (remindAt && !deliveryTimeSchema.safeParse(remindAt).success)
   ) {
     return {
       valid: false,

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
@@ -24,7 +24,10 @@ describe("queueReaderEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     outbox.listener = undefined;
-    outbox.enqueue.mockResolvedValue(createMutation("pending"));
+    outbox.enqueue.mockImplementation(async (input) => ({
+      ...createMutation("pending"),
+      ...input,
+    }));
     outbox.get.mockResolvedValue(createMutation("pending"));
     outbox.claimNotification.mockResolvedValue(undefined);
   });
@@ -51,6 +54,32 @@ describe("queueReaderEmail", () => {
       threadId: "thread",
     });
     expect(outbox.get).not.toHaveBeenCalled();
+  });
+
+  it("reuses a persisted reply identity without enqueueing a duplicate", async () => {
+    await queueReaderEmail({
+      email: createEmail(),
+      emailAccountId: "account",
+      messageIds: ["message"],
+      online: false,
+      threadId: "thread",
+      mutationId: "mutation",
+    });
+    expect(outbox.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("refuses changed content under an existing reply identity", async () => {
+    await expect(
+      queueReaderEmail({
+        email: { ...createEmail(), messageHtml: "Changed" },
+        emailAccountId: "account",
+        messageIds: ["message"],
+        online: false,
+        threadId: "thread",
+        mutationId: "mutation",
+      }),
+    ).rejects.toThrow("different content");
+    expect(outbox.enqueue).not.toHaveBeenCalled();
   });
 
   it("observes the persisted provider result while online", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
@@ -23,6 +23,8 @@ export async function queueReaderEmail({
   emailAccountId,
   messageIds,
   online,
+  onQueued,
+  mutationId,
   settlementTimeoutMs = DEFAULT_SETTLEMENT_TIMEOUT_MS,
   threadId,
 }: {
@@ -30,16 +32,38 @@ export async function queueReaderEmail({
   emailAccountId: string;
   messageIds: string[];
   online: boolean;
+  onQueued?: () => Promise<void>;
+  mutationId?: string;
   settlementTimeoutMs?: number;
   threadId: string;
 }): Promise<ReaderEmailOutcome> {
-  const mutation = await enqueueMailMutation({
-    email,
-    emailAccountId,
-    kind: "reply",
-    messageIds,
-    threadId,
-  });
+  let mutation = mutationId ? await getMailMutation(mutationId) : undefined;
+  if (!mutation) {
+    try {
+      mutation = await enqueueMailMutation({
+        ...(mutationId ? { id: mutationId } : {}),
+        email,
+        emailAccountId,
+        kind: "reply",
+        messageIds,
+        threadId,
+      });
+    } catch (error) {
+      mutation = mutationId ? await getMailMutation(mutationId) : undefined;
+      if (!mutation) throw error;
+    }
+  }
+  if (
+    mutation.kind !== "reply" ||
+    mutation.emailAccountId !== emailAccountId ||
+    mutation.threadId !== threadId ||
+    JSON.stringify(mutation.email) !== JSON.stringify(email)
+  ) {
+    throw new Error(
+      "This reply is already queued with different content. Check the thread delivery status.",
+    );
+  }
+  await onQueued?.();
   if (!online) return { status: "queued", reason: "offline", threadId };
 
   return waitForSettlement({

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1141,8 +1141,6 @@ export function MailShell() {
               onRemoveLabel={onRemoveLabel}
               onBackToInbox={closeReader}
               onArchive={archiveTargets}
-              onDelete={trashTargets}
-              onReply={requestReaderReply}
               onToggleFocusMode={() => setIsFocusMode((on) => !on)}
               showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}
@@ -1154,6 +1152,7 @@ export function MailShell() {
                   setChatInput={setChatInput}
                   isUnread={isOpenThreadUnread}
                   onMarkSpam={markSpamTargets}
+                  onDelete={trashTargets}
                   onToggleRead={() => {
                     if (!openThreadKey) return;
                     setReadState([openThreadKey], isOpenThreadUnread);

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1178,11 +1178,11 @@ export function MailShell() {
 
         {showReader && openThreadSelection && !readerEmailAccount ? (
           <div
-            aria-label="Loading account"
+            aria-label="Loading"
             className="flex min-h-0 min-w-0 flex-1 items-center justify-center text-muted-foreground text-sm"
             role="status"
           >
-            Loading account…
+            Loading…
           </div>
         ) : null}
       </div>

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -691,8 +691,14 @@ export function MailShell() {
   const handlers: ShortcutHandlers = (() => {
     if (sidePanelThreadId) return {};
     return {
-      next: () => move(1),
-      previous: () => move(-1),
+      next: (event) => {
+        if (openThreadId && event?.key === "ArrowDown") return;
+        move(1);
+      },
+      previous: (event) => {
+        if (openThreadId && event?.key === "ArrowUp") return;
+        move(-1);
+      },
       open: openThreadId ? requestReaderReply : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
@@ -1124,6 +1130,7 @@ export function MailShell() {
         {showReader && (!openThreadSelection || readerEmailAccount) ? (
           <EmailAccountScopeProvider emailAccount={readerEmailAccount}>
             <ThreadReader
+              enableMessageNavigation={!sidePanelThreadId}
               key={openReaderThreadKey ?? "empty"}
               thread={openThread ?? null}
               threadId={openThreadId}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -165,7 +165,6 @@ export function MailShell() {
   const [searchParam, setSearchParam] = useQueryState("q");
 
   const [focusedIndex, setFocusedIndex] = useState(0);
-  const [isFocusMode, setIsFocusMode] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
@@ -682,7 +681,6 @@ export function MailShell() {
     isHelpOpen || isPaletteOpen || (isMenuOpen && Boolean(openThreadId));
 
   const closeReader = () => {
-    setIsFocusMode(false);
     setOpenThread(null);
   };
 
@@ -703,8 +701,7 @@ export function MailShell() {
       backToList: isMailOverlayOpen
         ? undefined
         : () => {
-            if (isFocusMode) setIsFocusMode(false);
-            else if (selection.hasSelection) selection.clear();
+            if (selection.hasSelection) selection.clear();
             else if (layout === "list") closeReader();
           },
       nextSplit: () => {
@@ -733,7 +730,6 @@ export function MailShell() {
         : undefined,
       undo: () => undo(),
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
-      focusMode: openThreadId ? () => setIsFocusMode((on) => !on) : undefined,
       help: () => setIsHelpOpen(true),
     };
   })();
@@ -969,7 +965,7 @@ export function MailShell() {
     [openThreadSelection, refetchOpenThread],
   );
 
-  const showList = !isFocusMode && (layout === "split" || !openThreadSelection);
+  const showList = layout === "split" || !openThreadSelection;
   const showReader = layout === "split" || Boolean(openThreadSelection);
   const readerEmailAccount = openThreadSelection
     ? openThreadSelection.emailAccountId === emailAccountId
@@ -1014,7 +1010,7 @@ export function MailShell() {
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
         <div className="hidden [--sidebar-width:236px] lg:contents">
-          <Sidebar name="left-sidebar" forceCollapsed={isFocusMode}>
+          <Sidebar name="left-sidebar">
             <MailSidebar
               className="h-full w-full border-r-0"
               activeType={
@@ -1143,12 +1139,10 @@ export function MailShell() {
               messages={openMessages}
               userLabels={readerUserLabels}
               layout={layout}
-              isFocusMode={isFocusMode}
               labelHref={labelHref}
               onRemoveLabel={onRemoveLabel}
               onBackToInbox={closeReader}
               onArchive={archiveTargets}
-              onToggleFocusMode={() => setIsFocusMode((on) => !on)}
               showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}
               autoOpenReplyForMessageId={replyToMessageId}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -6,8 +6,6 @@ import {
   ArrowLeftIcon,
   MaximizeIcon,
   MinimizeIcon,
-  ReplyIcon,
-  Trash2Icon,
 } from "lucide-react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
@@ -27,8 +25,6 @@ type ReaderToolbarProps = {
   isFocusMode: boolean;
   onBackToInbox: () => void;
   onArchive: () => void;
-  onReply: () => void;
-  onDelete: () => void;
   onToggleFocusMode: () => void;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
@@ -45,8 +41,6 @@ export function ReaderToolbar({
   isFocusMode,
   onBackToInbox,
   onArchive,
-  onReply,
-  onDelete,
   onToggleFocusMode,
   menu,
 }: ReaderToolbarProps) {
@@ -92,20 +86,6 @@ export function ReaderToolbar({
         <Button onClick={onArchive} size="xs-2" variant="outline">
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
-        </Button>
-        <Button onClick={onReply} size="xs-2" variant="outline">
-          <ReplyIcon className="mr-1.5 size-3.5" />
-          Reply
-        </Button>
-        <Button
-          aria-label={`Delete (${getShortcutHint("delete")})`}
-          className="h-7 w-7 hover:border-destructive/30 hover:bg-destructive/5 hover:text-destructive"
-          onClick={onDelete}
-          size="icon"
-          title={`Delete (${getShortcutHint("delete")})`}
-          variant="outline"
-        >
-          <Trash2Icon className="size-3.5" />
         </Button>
         <Button
           aria-label={`${isFocusMode ? "Exit focus mode" : "Focus mode"} (${getShortcutHint("focusMode")})`}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -3,6 +3,8 @@
 import type { ReactNode } from "react";
 import {
   ArchiveIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
   ArrowLeftIcon,
   MaximizeIcon,
   MinimizeIcon,
@@ -28,6 +30,11 @@ type ReaderToolbarProps = {
   onToggleFocusMode: () => void;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
+  messageExpansion?: {
+    allExpanded: boolean;
+    canExpand: boolean;
+    onToggleAll: () => void;
+  };
 };
 
 /**
@@ -43,6 +50,7 @@ export function ReaderToolbar({
   onArchive,
   onToggleFocusMode,
   menu,
+  messageExpansion,
 }: ReaderToolbarProps) {
   const FocusIcon = isFocusMode ? MinimizeIcon : MaximizeIcon;
 
@@ -83,6 +91,30 @@ export function ReaderToolbar({
         className="ml-auto flex flex-wrap items-center gap-1.5"
         role="group"
       >
+        {messageExpansion?.canExpand && (
+          <Button
+            aria-label={
+              messageExpansion.allExpanded
+                ? "Collapse all messages"
+                : "Expand all messages"
+            }
+            title={
+              messageExpansion.allExpanded
+                ? "Collapse all messages"
+                : "Expand all messages"
+            }
+            className="h-7 w-7"
+            size="icon"
+            variant="ghost"
+            onClick={messageExpansion.onToggleAll}
+          >
+            {messageExpansion.allExpanded ? (
+              <ChevronsDownUpIcon className="size-3.5" />
+            ) : (
+              <ChevronsUpDownIcon className="size-3.5" />
+            )}
+          </Button>
+        )}
         <Button onClick={onArchive} size="xs-2" variant="outline">
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -55,7 +55,7 @@ export function ReaderToolbar({
   const FocusIcon = isFocusMode ? MinimizeIcon : MaximizeIcon;
 
   return (
-    <div className="flex flex-wrap items-start gap-x-4 gap-y-3 pb-6">
+    <div className="flex flex-wrap items-start gap-x-4 gap-y-3 pb-3">
       <Button
         aria-label="Back to inbox"
         className="h-7 w-7"

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -6,13 +6,10 @@ import {
   ChevronsDownUpIcon,
   ChevronsUpDownIcon,
   ArrowLeftIcon,
-  MaximizeIcon,
-  MinimizeIcon,
 } from "lucide-react";
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
-import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 type ReaderToolbarProps = {
   subject: string;
@@ -24,10 +21,8 @@ type ReaderToolbarProps = {
    */
   labelHref: (labelId: string) => string;
   onRemoveLabel?: (labelId: string) => void;
-  isFocusMode: boolean;
   onBackToInbox: () => void;
   onArchive: () => void;
-  onToggleFocusMode: () => void;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
   messageExpansion?: {
@@ -45,15 +40,11 @@ export function ReaderToolbar({
   labels,
   labelHref,
   onRemoveLabel,
-  isFocusMode,
   onBackToInbox,
   onArchive,
-  onToggleFocusMode,
   menu,
   messageExpansion,
 }: ReaderToolbarProps) {
-  const FocusIcon = isFocusMode ? MinimizeIcon : MaximizeIcon;
-
   return (
     <div className="flex flex-wrap items-start gap-x-4 gap-y-3 pb-3">
       <Button
@@ -118,17 +109,6 @@ export function ReaderToolbar({
         <Button onClick={onArchive} size="xs-2" variant="outline">
           <ArchiveIcon className="mr-1.5 size-3.5" />
           Archive
-        </Button>
-        <Button
-          aria-label={`${isFocusMode ? "Exit focus mode" : "Focus mode"} (${getShortcutHint("focusMode")})`}
-          aria-pressed={isFocusMode}
-          className="h-7 w-7"
-          onClick={onToggleFocusMode}
-          size="icon"
-          title={`${isFocusMode ? "Exit focus mode" : "Focus mode"} (${getShortcutHint("focusMode")})`}
-          variant="outline"
-        >
-          <FocusIcon className="size-3.5" />
         </Button>
         {menu}
       </div>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -10,6 +10,7 @@ import {
   MoreHorizontalIcon,
   ShieldAlertIcon,
   SparklesIcon,
+  Trash2Icon,
 } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
@@ -24,6 +25,7 @@ import {
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -54,6 +56,7 @@ export type ThreadActionsMenuProps = {
   setChatInput: (input: string) => void;
   isUnread: boolean;
   onMarkSpam: () => void;
+  onDelete: () => void;
   onToggleRead: () => void;
   /** Chat remains scoped to the route account, so cross-account rows hide it. */
   showFixWithChat?: boolean;
@@ -71,6 +74,7 @@ export function ThreadActionsMenu({
   setChatInput,
   isUnread,
   onMarkSpam,
+  onDelete,
   onToggleRead,
   showFixWithChat = true,
   open,
@@ -143,6 +147,14 @@ export function ThreadActionsMenu({
           <DropdownMenuItem onSelect={onToggleRead}>
             <ReadIcon className="mr-2 size-4" />
             {isUnread ? "Mark as read" : "Mark as unread"}
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onSelect={onDelete}>
+            <Trash2Icon className="mr-2 size-4" />
+            Delete
+            <DropdownMenuShortcut>
+              {getShortcutHint("delete")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
 
           <DropdownMenuItem onSelect={onMarkSpam}>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -150,7 +150,7 @@ export function ThreadActionsMenu({
           </DropdownMenuItem>
 
           <DropdownMenuItem onSelect={onDelete}>
-            <Trash2Icon className="mr-2 size-4" />
+            <Trash2Icon aria-hidden className="mr-2 size-4" />
             Delete
             <DropdownMenuShortcut>
               {getShortcutHint("delete")}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -199,7 +199,7 @@ function readerMeasure({
 }) {
   // Keep the reading measure consistent between full-width and focus views.
   if (isFocusMode)
-    return "mx-auto w-full max-w-[48rem] px-4 py-6 sm:px-10 sm:py-10";
-  if (layout === "split") return "px-4 pt-6 pb-5 sm:px-6 sm:pt-8";
-  return "mx-auto w-full max-w-[48rem] px-4 pt-6 pb-5 sm:px-6 sm:pt-8";
+    return "mx-auto w-full max-w-[48rem] px-2 py-6 sm:px-10 sm:py-10";
+  if (layout === "split") return "px-2 pt-6 pb-5 sm:px-6 sm:pt-8";
+  return "mx-auto w-full max-w-[48rem] px-2 pt-6 pb-5 sm:px-6 sm:pt-8";
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -203,8 +203,9 @@ function readerMeasure({
   layout: MailLayoutMode;
   isFocusMode: boolean;
 }) {
-  // ~860px: the mock's measure, and about as wide as an email body stays legible.
-  if (isFocusMode) return "mx-auto w-full max-w-[54rem] px-10 py-10";
-  if (layout === "split") return "px-6 pt-8 pb-5";
-  return "mx-auto w-full max-w-[54rem] px-6 pt-8 pb-5";
+  // Keep the reading measure consistent between full-width and focus views.
+  if (isFocusMode)
+    return "mx-auto w-full max-w-[48rem] px-4 py-6 sm:px-10 sm:py-10";
+  if (layout === "split") return "px-4 pt-6 pb-5 sm:px-6 sm:pt-8";
+  return "mx-auto w-full max-w-[48rem] px-4 pt-6 pb-5 sm:px-6 sm:pt-8";
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -45,8 +45,6 @@ export type ThreadReaderProps = {
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
-  onReply: () => void;
-  onDelete: () => void;
   onToggleFocusMode: () => void;
   showSidebarToggle?: boolean;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
@@ -74,8 +72,6 @@ export function ThreadReader({
   onRemoveLabel,
   onBackToInbox,
   onArchive,
-  onReply,
-  onDelete,
   onToggleFocusMode,
   showSidebarToggle = false,
   refetch,
@@ -149,9 +145,7 @@ export function ThreadReader({
             menu={menu}
             onArchive={onArchive}
             onBackToInbox={onBackToInbox}
-            onDelete={onDelete}
             onRemoveLabel={onRemoveLabel}
-            onReply={onReply}
             onToggleFocusMode={onToggleFocusMode}
             subject={headerMessage.headers.subject}
           />

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -41,12 +41,10 @@ export type ThreadReaderProps = {
   messages: ThreadMessage[];
   userLabels: EmailLabels;
   layout: MailLayoutMode;
-  isFocusMode: boolean;
   labelHref: (labelId: string) => string;
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
-  onToggleFocusMode: () => void;
   showSidebarToggle?: boolean;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
   refetch: () => void;
@@ -69,12 +67,10 @@ export function ThreadReader({
   messages,
   userLabels,
   layout,
-  isFocusMode,
   labelHref,
   onRemoveLabel,
   onBackToInbox,
   onArchive,
-  onToggleFocusMode,
   showSidebarToggle = false,
   refetch,
   autoOpenReplyForMessageId,
@@ -126,14 +122,12 @@ export function ThreadReader({
   ) => (
     <ReaderToolbar
       messageExpansion={messageExpansion}
-      isFocusMode={isFocusMode}
       labelHref={labelHref}
       labels={labels}
       menu={menu}
       onArchive={onArchive}
       onBackToInbox={onBackToInbox}
       onRemoveLabel={onRemoveLabel}
-      onToggleFocusMode={onToggleFocusMode}
       subject={headerMessage.headers.subject}
     />
   );
@@ -147,7 +141,7 @@ export function ThreadReader({
         data-detail-selection-settled={detailSelectionSettled}
         data-testid="thread-reader"
       >
-        {layout === "list" && !isFocusMode && showSidebarToggle ? (
+        {layout === "list" && showSidebarToggle ? (
           <div
             className="hidden px-3 py-3 lg:flex"
             data-desktop-mac-titlebar-spacer
@@ -156,7 +150,7 @@ export function ThreadReader({
           </div>
         ) : null}
 
-        <div className={readerMeasure({ layout, isFocusMode })}>
+        <div className={readerMeasure({ layout })}>
           {messages.length > 0 ? (
             <EmailThread
               renderToolbar={renderToolbar}
@@ -201,16 +195,7 @@ export function ThreadReader({
 }
 
 /** A readable measure, centred whenever the reader owns the full width. */
-function readerMeasure({
-  layout,
-  isFocusMode,
-}: {
-  layout: MailLayoutMode;
-  isFocusMode: boolean;
-}) {
-  // Keep the reading measure consistent between full-width and focus views.
-  if (isFocusMode)
-    return "mx-auto w-full max-w-[48rem] px-2 pt-4 pb-6 sm:px-10 sm:pt-5 sm:pb-10";
+function readerMeasure({ layout }: { layout: MailLayoutMode }) {
   if (layout === "split") return "px-2 pt-4 pb-5 sm:px-6 sm:pt-5";
   return "mx-auto w-full max-w-[48rem] px-2 pt-4 pb-5 sm:px-6 sm:pt-5";
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -25,6 +25,7 @@ const SenderContextSheet = dynamic(
 );
 
 export type ThreadReaderProps = {
+  enableMessageNavigation: boolean;
   /** The row that is open. It may lag behind the selected thread while loading. */
   thread: ListThread | null;
   /** The selected thread, including while its row and messages are loading. */
@@ -59,6 +60,7 @@ export type ThreadReaderProps = {
 };
 
 export function ThreadReader({
+  enableMessageNavigation,
   thread,
   threadId,
   detailSelectionSettled,
@@ -119,6 +121,23 @@ export function ThreadReader({
       userLabels,
     }) ?? [];
 
+  const renderToolbar = (
+    messageExpansion?: ComponentProps<typeof ReaderToolbar>["messageExpansion"],
+  ) => (
+    <ReaderToolbar
+      messageExpansion={messageExpansion}
+      isFocusMode={isFocusMode}
+      labelHref={labelHref}
+      labels={labels}
+      menu={menu}
+      onArchive={onArchive}
+      onBackToInbox={onBackToInbox}
+      onRemoveLabel={onRemoveLabel}
+      onToggleFocusMode={onToggleFocusMode}
+      subject={headerMessage.headers.subject}
+    />
+  );
+
   return (
     <>
       {/* White, unlike the list: the reader is its own surface, and it has to
@@ -138,20 +157,10 @@ export function ThreadReader({
         ) : null}
 
         <div className={readerMeasure({ layout, isFocusMode })}>
-          <ReaderToolbar
-            isFocusMode={isFocusMode}
-            labelHref={labelHref}
-            labels={labels}
-            menu={menu}
-            onArchive={onArchive}
-            onBackToInbox={onBackToInbox}
-            onRemoveLabel={onRemoveLabel}
-            onToggleFocusMode={onToggleFocusMode}
-            subject={headerMessage.headers.subject}
-          />
-
           {messages.length > 0 ? (
             <EmailThread
+              renderToolbar={renderToolbar}
+              enableMessageNavigation={enableMessageNavigation}
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
               key={threadId}
               messages={messages}
@@ -168,7 +177,9 @@ export function ThreadReader({
               refetch={refetch}
               showReplyButton
             />
-          ) : null}
+          ) : (
+            renderToolbar()
+          )}
         </div>
       </div>
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -210,7 +210,7 @@ function readerMeasure({
 }) {
   // Keep the reading measure consistent between full-width and focus views.
   if (isFocusMode)
-    return "mx-auto w-full max-w-[48rem] px-2 py-6 sm:px-10 sm:py-10";
-  if (layout === "split") return "px-2 pt-6 pb-5 sm:px-6 sm:pt-8";
-  return "mx-auto w-full max-w-[48rem] px-2 pt-6 pb-5 sm:px-6 sm:pt-8";
+    return "mx-auto w-full max-w-[48rem] px-2 pt-4 pb-6 sm:px-10 sm:pt-5 sm:pb-10";
+  if (layout === "split") return "px-2 pt-4 pb-5 sm:px-6 sm:pt-5";
+  return "mx-auto w-full max-w-[48rem] px-2 pt-4 pb-5 sm:px-6 sm:pt-5";
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -208,7 +208,7 @@ export const ThreadRow = memo(function ThreadRow({
                 "max-w-[46%] shrink-0 truncate whitespace-nowrap text-sm",
                 isUnread
                   ? "font-semibold text-foreground"
-                  : "font-normal text-muted-foreground",
+                  : "font-normal text-foreground",
               )}
             >
               {subject}
@@ -230,7 +230,7 @@ export const ThreadRow = memo(function ThreadRow({
               "truncate text-sm",
               isUnread
                 ? "font-semibold text-foreground"
-                : "font-normal text-muted-foreground",
+                : "font-normal text-foreground",
             )}
           >
             {subject}

--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -1,3 +1,4 @@
+import { processDueScheduledEmails } from "@/utils/scheduled-email/service";
 import { NextResponse } from "next/server";
 import { withError } from "@/utils/middleware";
 import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
@@ -144,16 +145,23 @@ async function processScheduledActions(logger: Logger) {
 
 async function processScheduledMail(logger: Logger) {
   if (!env.QSTASH_TOKEN) {
-    const [scheduledActions, snoozedThreads] = await Promise.all([
-      processScheduledActions(logger),
-      processDueSnoozedThreads(logger),
-    ]);
-    return { scheduledActions, snoozedThreads };
+    const [scheduledActions, snoozedThreads, scheduledEmails] =
+      await Promise.all([
+        processScheduledActions(logger),
+        processDueSnoozedThreads(logger),
+        processDueScheduledEmails(logger),
+      ]);
+    return { scheduledActions, snoozedThreads, scheduledEmails };
   }
 
   logger.info("QStash configured; checking snoozed thread fallback");
+  const [snoozedThreads, scheduledEmails] = await Promise.all([
+    processDueSnoozedThreads(logger),
+    processDueScheduledEmails(logger),
+  ]);
   return {
+    scheduledEmails,
     scheduledActions: { skipped: true, reason: "qstash-configured" },
-    snoozedThreads: await processDueSnoozedThreads(logger),
+    snoozedThreads,
   };
 }

--- a/apps/web/app/api/user/scheduled-emails/route.ts
+++ b/apps/web/app/api/user/scheduled-emails/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+
+export type ScheduledEmailsResponse = Awaited<ReturnType<typeof getData>>;
+export const GET = withEmailAccount(async (request) => {
+  const threadId = request.nextUrl.searchParams.get("threadId");
+  if (!threadId)
+    return NextResponse.json(
+      { error: "Thread ID is required" },
+      { status: 400 },
+    );
+  return NextResponse.json(
+    await getData(request.auth.emailAccountId, threadId),
+  );
+});
+
+async function getData(emailAccountId: string, threadId: string) {
+  const scheduledEmails = await prisma.scheduledEmail.findMany({
+    where: {
+      emailAccountId,
+      threadId,
+      status: { not: "CANCELLED" },
+      OR: [
+        { status: { not: "SENT" } },
+        { reminderStatus: { in: ["PENDING", "PROCESSING"] } },
+        { sentAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) } },
+      ],
+    },
+    select: {
+      id: true,
+      status: true,
+      sendAt: true,
+      remindAt: true,
+      reminderStatus: true,
+      sentAt: true,
+      error: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  return { scheduledEmails };
+}

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -153,6 +153,7 @@ describe("HtmlEmail", () => {
   });
 
   it("does not grow when the document reports the iframe viewport height", async () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByTitle } = render(
       <HtmlEmail html="<p>Short reply</p>" messageId="short-reply" />,
     );

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -152,6 +152,29 @@ describe("HtmlEmail", () => {
     });
   });
 
+  it("does not grow when the document reports the iframe viewport height", async () => {
+    const { getByTitle } = render(
+      <HtmlEmail html="<p>Short reply</p>" messageId="short-reply" />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    Object.defineProperty(
+      iframe.contentDocument!.documentElement,
+      "scrollHeight",
+      {
+        configurable: true,
+        get: () => Math.max(40, Number.parseFloat(iframe.style.height) || 0),
+      },
+    );
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+    await waitFor(() =>
+      expect(Number.parseFloat(iframe.style.height)).toBeGreaterThanOrEqual(40),
+    );
+    const initialHeight = iframe.style.height;
+    act(() => triggerResize?.());
+    expect(iframe.style.height).toBe(initialHeight);
+  });
+
   it("expands when an image increases the iframe document height after loading", async () => {
     vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByTitle } = render(
@@ -216,7 +239,7 @@ describe("HtmlEmail", () => {
     addEmailDocumentMarker(iframe, iframe.contentDocument);
     iframe.dispatchEvent(new Event("load"));
 
-    await waitFor(() => expect(iframe.style.height).toBe("43px"));
+    await waitFor(() => expect(iframe.style.height).toBe("40px"));
 
     fireEvent.click(getByRole("button", { name: "Show quoted content" }));
 
@@ -226,7 +249,7 @@ describe("HtmlEmail", () => {
     contentHeight = 640;
     addEmailDocumentMarker(iframe, iframe.contentDocument);
     iframe.dispatchEvent(new Event("load"));
-    await waitFor(() => expect(iframe.style.height).toBe("643px"));
+    await waitFor(() => expect(iframe.style.height).toBe("640px"));
 
     fireEvent.click(getByRole("button", { name: "Hide quoted content" }));
 
@@ -236,7 +259,7 @@ describe("HtmlEmail", () => {
     contentHeight = 40;
     addEmailDocumentMarker(iframe, iframe.contentDocument);
     iframe.dispatchEvent(new Event("load"));
-    await waitFor(() => expect(iframe.style.height).toBe("43px"));
+    await waitFor(() => expect(iframe.style.height).toBe("40px"));
   });
 
   it("keeps watching until the email document replaces the placeholder", async () => {

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -36,6 +36,7 @@ export function HtmlEmail({
   messageId,
   emailAccountId,
   inlineAttachments = NO_INLINE_ATTACHMENTS,
+  onReplyMessage,
   onNavigateMessage,
   onFocusMessage,
 }: {
@@ -43,6 +44,7 @@ export function HtmlEmail({
   messageId: string;
   emailAccountId?: string;
   inlineAttachments?: ParsedMessage["inline"];
+  onReplyMessage?: () => void;
   onNavigateMessage?: (direction: -1 | 1) => void;
   onFocusMessage?: () => void;
 }) {
@@ -123,6 +125,7 @@ export function HtmlEmail({
 
   const iframeHeight = useEmailIframe(iframeRef, srcDoc, documentKey, {
     onNavigateMessage,
+    onReplyMessage,
     onFocusMessage,
   });
 
@@ -418,6 +421,7 @@ function useEmailIframe(
   srcDoc: string,
   documentKey: string,
   callbacks: {
+    onReplyMessage?: () => void;
     onNavigateMessage?: (direction: -1 | 1) => void;
     onFocusMessage?: () => void;
   },
@@ -439,9 +443,10 @@ function useEmailIframe(
     const selectMessage = () => callbacksRef.current.onFocusMessage?.();
     const navigateMessage = (event: KeyboardEvent) => {
       const navigate = callbacksRef.current.onNavigateMessage;
+      const reply = callbacksRef.current.onReplyMessage;
       if (
-        !navigate ||
-        (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+        !(event.key === "Enter" ? reply : navigate) ||
+        !["Enter", "ArrowUp", "ArrowDown"].includes(event.key) ||
         event.altKey ||
         event.ctrlKey ||
         event.metaKey ||
@@ -457,8 +462,10 @@ function useEmailIframe(
         )
       )
         return;
+      if (event.key === "Enter" && target?.closest?.("a, button")) return;
       event.preventDefault();
-      navigate(event.key === "ArrowUp" ? -1 : 1);
+      if (event.key === "Enter") reply?.();
+      else navigate?.(event.key === "ArrowUp" ? -1 : 1);
     };
     const stopObservingDocument = () => {
       observedDocument?.removeEventListener("keydown", navigateMessage);

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -133,7 +133,7 @@ export function HtmlEmail({
         srcDoc={srcDoc}
         className="min-h-0 w-full"
         height={1}
-        style={iframeHeight ? { height: `${iframeHeight + 3}px` } : undefined}
+        style={iframeHeight ? { height: `${iframeHeight}px` } : undefined}
         title="Email content preview"
         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         referrerPolicy="no-referrer"

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -36,11 +36,15 @@ export function HtmlEmail({
   messageId,
   emailAccountId,
   inlineAttachments = NO_INLINE_ATTACHMENTS,
+  onNavigateMessage,
+  onFocusMessage,
 }: {
   html: string;
   messageId: string;
   emailAccountId?: string;
   inlineAttachments?: ParsedMessage["inline"];
+  onNavigateMessage?: (direction: -1 | 1) => void;
+  onFocusMessage?: () => void;
 }) {
   const sanitizedHtml = useMemo(() => sanitizeEmailHtml(html), [html]);
   const [showReplies, setShowReplies] = useState(false);
@@ -117,7 +121,10 @@ export function HtmlEmail({
     [displayedHtml, isDarkMode, documentKey],
   );
 
-  const iframeHeight = useIframeHeight(iframeRef, srcDoc, documentKey);
+  const iframeHeight = useEmailIframe(iframeRef, srcDoc, documentKey, {
+    onNavigateMessage,
+    onFocusMessage,
+  });
 
   return (
     <div className="relative min-w-0 overflow-x-hidden">
@@ -406,11 +413,17 @@ function addDarkModeClass(html: string, isDarkMode: boolean) {
   }
 }
 
-function useIframeHeight(
+function useEmailIframe(
   iframeRef: React.RefObject<HTMLIFrameElement | null>,
   srcDoc: string,
   documentKey: string,
+  callbacks: {
+    onNavigateMessage?: (direction: -1 | 1) => void;
+    onFocusMessage?: () => void;
+  },
 ) {
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
   const [measurement, setMeasurement] = useState<{
     documentKey: string;
     height: number;
@@ -421,6 +434,37 @@ function useIframeHeight(
     if (!iframe) return;
     let animationFrameId: number | undefined;
     let observedRoot: HTMLElement | null = null;
+    let observedDocument: Document | null = null;
+
+    const selectMessage = () => callbacksRef.current.onFocusMessage?.();
+    const navigateMessage = (event: KeyboardEvent) => {
+      const navigate = callbacksRef.current.onNavigateMessage;
+      if (
+        !navigate ||
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        event.isComposing ||
+        observedDocument?.getSelection()?.isCollapsed === false
+      )
+        return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.closest?.(
+          'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+        )
+      )
+        return;
+      event.preventDefault();
+      navigate(event.key === "ArrowUp" ? -1 : 1);
+    };
+    const stopObservingDocument = () => {
+      observedDocument?.removeEventListener("keydown", navigateMessage);
+      observedDocument?.removeEventListener("pointerdown", selectMessage);
+      observedDocument?.removeEventListener("focusin", selectMessage);
+    };
 
     const updateHeight = () => {
       const iframeDocument = iframe.contentDocument;
@@ -450,6 +494,11 @@ function useIframeHeight(
       if (root === observedRoot) return true;
 
       resizeObserver.disconnect();
+      stopObservingDocument();
+      observedDocument = iframeDocument;
+      observedDocument.addEventListener("keydown", navigateMessage);
+      observedDocument.addEventListener("pointerdown", selectMessage);
+      observedDocument.addEventListener("focusin", selectMessage);
       observedRoot = root;
       updateHeight();
       resizeObserver.observe(root);
@@ -488,6 +537,7 @@ function useIframeHeight(
       iframe.removeEventListener("load", onLoad);
       stopWatchingForDocument();
       resizeObserver.disconnect();
+      stopObservingDocument();
     };
   }, [iframeRef, srcDoc, documentKey]);
 

--- a/apps/web/components/email-list/EmailDetails.tsx
+++ b/apps/web/components/email-list/EmailDetails.tsx
@@ -16,14 +16,19 @@ export function EmailDetails({ message }: { message: ThreadMessage }) {
   ];
 
   return (
-    <div className="mb-4 rounded-md bg-muted p-3 text-sm">
+    <div className="mb-4 rounded-md bg-muted/40 p-3 text-xs leading-relaxed">
       <div className="grid gap-1">
         {details.map(
           ({ label, value }) =>
             value && (
-              <div key={label} className="grid grid-cols-[auto,1fr] gap-2">
+              <div
+                key={label}
+                className="grid grid-cols-[3rem_minmax(0,1fr)] gap-2"
+              >
                 <span className="font-medium text-foreground">{label}:</span>
-                <span className="text-muted-foreground">{value}</span>
+                <span className="break-words text-muted-foreground">
+                  {value}
+                </span>
               </div>
             ),
         )}

--- a/apps/web/components/email-list/EmailDetails.tsx
+++ b/apps/web/components/email-list/EmailDetails.tsx
@@ -6,17 +6,12 @@ export function EmailDetails({ message }: { message: ThreadMessage }) {
   const details = [
     { label: "From", value: headers?.from },
     { label: "To", value: headers?.to },
-    { label: "CC", value: headers?.cc },
-    { label: "BCC", value: headers?.bcc },
-    {
-      label: "Date",
-      value: new Date(headers?.date ?? message.date).toLocaleString(),
-    },
-    // { label: "Subject", value: message.headers.subject },
+    { label: "Cc", value: headers?.cc },
+    { label: "Bcc", value: headers?.bcc },
   ];
 
   return (
-    <div className="mb-4 rounded-md bg-muted/40 p-3 text-xs leading-relaxed">
+    <div className="mb-4 text-xs leading-relaxed">
       <div className="grid gap-1">
         {details.map(
           ({ label, value }) =>
@@ -25,13 +20,17 @@ export function EmailDetails({ message }: { message: ThreadMessage }) {
                 key={label}
                 className="grid grid-cols-[3rem_minmax(0,1fr)] gap-2"
               >
-                <span className="font-medium text-foreground">{label}:</span>
-                <span className="break-words text-muted-foreground">
-                  {value}
-                </span>
+                <span className="text-muted-foreground">{label}</span>
+                <span className="break-words text-foreground">{value}</span>
               </div>
             ),
         )}
+      </div>
+      <div className="mt-1 text-muted-foreground">
+        {new Date(headers?.date ?? message.date).toLocaleString(undefined, {
+          dateStyle: "full",
+          timeStyle: "short",
+        })}
       </div>
     </div>
   );

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -119,8 +119,8 @@ export function EmailMessage({
       className={cn(
         "group/message min-w-0 border-l-2 transition-colors",
         expanded
-          ? "my-2 border-border/70 px-4 py-3 focus-within:border-primary sm:px-5"
-          : "border-transparent px-4 py-1.5 hover:bg-muted/40 sm:px-5",
+          ? "my-2 border-border/70 px-2 py-3 focus-within:border-primary sm:px-5"
+          : "border-transparent px-2 py-1.5 hover:bg-muted/40 sm:px-5",
       )}
     >
       <MessageHeader
@@ -535,7 +535,7 @@ function ReplyPanel({
   ]);
 
   return (
-    <div className="mt-4 border-border/50 border-t pt-3" ref={replyRef}>
+    <div className="mt-5" ref={replyRef}>
       {isGeneratingReply ? (
         <div className="flex items-center justify-center">
           <Loading />

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -117,10 +117,10 @@ export function EmailMessage({
   return (
     <li
       className={cn(
-        "group/message min-w-0 rounded-lg transition-[box-shadow,border-color]",
+        "group/message min-w-0 border-l-2 transition-colors",
         expanded
-          ? "my-3 border border-border/70 bg-card p-4 shadow-sm focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/10 sm:p-5"
-          : "px-4 py-1.5 hover:bg-muted/40 sm:px-5",
+          ? "my-2 border-border/70 px-4 py-3 focus-within:border-primary sm:px-5"
+          : "border-transparent px-4 py-1.5 hover:bg-muted/40 sm:px-5",
       )}
     >
       <MessageHeader
@@ -138,7 +138,7 @@ export function EmailMessage({
 
       {expanded && (
         // Aligns the body with the sender's name rather than the avatar.
-        <div className="min-w-0 pt-4 sm:pl-9">
+        <div className="min-w-0 pt-3 sm:pl-9">
           {showDetails && <EmailDetails message={message} />}
 
           {message.textHtml ? (
@@ -535,7 +535,7 @@ function ReplyPanel({
   ]);
 
   return (
-    <div className="mt-5 border-border/70 border-t pt-4" ref={replyRef}>
+    <div className="mt-4 border-border/50 border-t pt-3" ref={replyRef}>
       {isGeneratingReply ? (
         <div className="flex items-center justify-center">
           <Loading />

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -19,7 +19,6 @@ import { formatShortDate } from "@/utils/date";
 import { ComposeEmailFormLazy } from "@/app/(app)/[emailAccountId]/compose/ComposeEmailFormLazy";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import type { ParsedMessage } from "@/utils/types";
 import { forwardEmailHtml, forwardEmailSubject } from "@/utils/gmail/forward";
 import { extractEmailReply } from "@/utils/parse/extract-reply.client";
@@ -54,6 +53,7 @@ export function EmailMessage({
   onSendSuccess,
   onOpenSenderContext,
   generateNudge,
+  hasDraft = false,
 }: {
   message: ThreadMessage;
   draftMessage?: ThreadMessage;
@@ -66,6 +66,7 @@ export function EmailMessage({
   onSendSuccess: (messageId: string, threadId: string) => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   generateNudge?: boolean;
+  hasDraft?: boolean;
 }) {
   const { emailAccountId } = useAccount();
   // `null` follows `defaultShowReply`, which the reader's Reply button flips
@@ -114,7 +115,14 @@ export function EmailMessage({
   }, []);
 
   return (
-    <li className="group/message border-border/60 border-t py-4 first:border-t-0 first:pt-0">
+    <li
+      className={cn(
+        "group/message min-w-0 rounded-lg transition-[box-shadow,border-color]",
+        expanded
+          ? "my-3 border border-border/70 bg-card p-4 shadow-sm focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/10 sm:p-5"
+          : "px-4 py-1.5 hover:bg-muted/40 sm:px-5",
+      )}
+    >
       <MessageHeader
         expanded={expanded}
         message={message}
@@ -125,11 +133,12 @@ export function EmailMessage({
         showDetails={showDetails}
         showReplyButton={showReplyButton}
         toggleDetails={toggleDetails}
+        hasDraft={hasDraft || Boolean(draftMessage)}
       />
 
       {expanded && (
         // Aligns the body with the sender's name rather than the avatar.
-        <div className="min-w-0 pt-3 pl-9">
+        <div className="min-w-0 pt-4 sm:pl-9">
           {showDetails && <EmailDetails message={message} />}
 
           {message.textHtml ? (
@@ -180,6 +189,7 @@ function MessageHeader({
   onForward,
   onOpenSenderContext,
   onToggle,
+  hasDraft,
 }: {
   message: ParsedMessage;
   expanded: boolean;
@@ -190,6 +200,7 @@ function MessageHeader({
   onForward: () => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   onToggle?: () => void;
+  hasDraft: boolean;
 }) {
   const { emailAccount, emailAccountId, userEmail } = useAccount();
 
@@ -199,7 +210,11 @@ function MessageHeader({
     ? "Me"
     : extractNameFromEmail(message.headers.from) || senderEmail;
   const { data: contacts } = useSWR<ContactsResponse>(
-    env.NEXT_PUBLIC_CONTACTS_ENABLED && !isSent && senderEmail && emailAccountId
+    expanded &&
+      env.NEXT_PUBLIC_CONTACTS_ENABLED &&
+      !isSent &&
+      senderEmail &&
+      emailAccountId
       ? [
           `/api/user/contacts?query=${encodeURIComponent(senderEmail)}`,
           emailAccountId,
@@ -253,25 +268,30 @@ function MessageHeader({
         onToggle && "cursor-pointer",
       )}
     >
-      <Avatar aria-hidden className="size-7">
-        <AvatarImage alt="" src={senderImage || undefined} />
-        <AvatarFallback
-          className={cn(
-            "font-semibold text-[10px] tracking-wide",
-            isSent
-              ? "bg-primary/10 text-primary"
-              : "bg-muted text-muted-foreground",
-          )}
-        >
-          {initialsFor(senderName)}
-        </AvatarFallback>
-      </Avatar>
+      {expanded && (
+        <Avatar aria-hidden className="size-7 shrink-0">
+          <AvatarImage alt="" src={senderImage || undefined} />
+          <AvatarFallback
+            className={cn(
+              "font-semibold text-[10px] tracking-wide",
+              isSent
+                ? "bg-primary/10 text-primary"
+                : "bg-muted text-muted-foreground",
+            )}
+          >
+            {initialsFor(senderName)}
+          </AvatarFallback>
+        </Avatar>
+      )}
 
       {canResearchSender ? (
         <Button
           type="button"
           aria-label={`View public profile for ${senderName}`}
-          className="h-7 shrink-0 gap-1 px-1.5"
+          className={cn(
+            "h-7 min-w-0 justify-start gap-1 p-0",
+            expanded ? "max-w-40 shrink" : "w-24 shrink-0 sm:w-28",
+          )}
           onClick={(event) => {
             event.stopPropagation();
             onOpenSenderContext?.(message);
@@ -289,15 +309,17 @@ function MessageHeader({
           >
             {senderName}
           </span>
-          <UserRoundSearchIcon className="size-3.5 text-muted-foreground" />
+          {expanded && (
+            <UserRoundSearchIcon className="hidden size-3.5 shrink-0 text-muted-foreground sm:block" />
+          )}
         </Button>
       ) : (
         <span
           className={cn(
-            "shrink-0 truncate text-sm",
+            "truncate text-sm",
             expanded
-              ? "font-semibold text-foreground"
-              : "font-medium text-secondary-foreground",
+              ? "max-w-40 shrink font-semibold text-foreground"
+              : "w-24 shrink-0 font-medium text-secondary-foreground sm:w-28",
           )}
         >
           {senderName}
@@ -306,17 +328,12 @@ function MessageHeader({
 
       {expanded ? (
         <>
-          {senderEmail && senderEmail !== senderName ? (
-            <span className="truncate text-muted-foreground text-xs">
-              {senderEmail}
-            </span>
-          ) : null}
-          <span className="shrink-0 whitespace-nowrap text-muted-foreground/70 text-xs">
+          <span className="hidden min-w-0 truncate text-muted-foreground text-xs sm:block">
             {recipientSummary(message.headers.to, userEmail)}
           </span>
           <Button
             aria-label={showDetails ? "Hide details" : "Show details"}
-            className="size-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/message:opacity-100"
+            className="size-7 shrink-0 p-0 text-muted-foreground"
             onClick={toggleDetails}
             size="sm"
             variant="ghost"
@@ -334,6 +351,10 @@ function MessageHeader({
         </span>
       )}
 
+      {hasDraft && !expanded && (
+        <span className="shrink-0 text-primary text-xs">Draft</span>
+      )}
+
       <time
         className="ml-auto shrink-0 whitespace-nowrap pl-2.5 text-muted-foreground text-xs"
         dateTime={message.headers.date}
@@ -342,7 +363,12 @@ function MessageHeader({
       </time>
 
       {showReplyButton && (
-        <span className="flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover/message:opacity-100">
+        <span
+          className={cn(
+            "shrink-0 items-center transition-opacity focus-within:opacity-100 group-hover/message:opacity-100",
+            expanded ? "flex sm:opacity-0" : "hidden sm:flex sm:opacity-0",
+          )}
+        >
           <Tooltip content="Reply">
             <Button
               className="size-7 text-muted-foreground"
@@ -509,7 +535,7 @@ function ReplyPanel({
   ]);
 
   return (
-    <Card className="mt-6 rounded-xl p-3" ref={replyRef}>
+    <div className="mt-5 border-border/70 border-t pt-4" ref={replyRef}>
       {isGeneratingReply ? (
         <div className="flex items-center justify-center">
           <Loading />
@@ -527,6 +553,7 @@ function ReplyPanel({
         </div>
       ) : (
         <ComposeEmailFormLazy
+          draftKeyMessageId={message.id}
           onClose={onCloseCompose}
           onDiscard={onDiscard}
           onSuccess={(messageId: string, threadId: string) => {
@@ -537,7 +564,7 @@ function ReplyPanel({
           replyingToEmail={replyingToEmail}
         />
       )}
-    </Card>
+    </div>
   );
 }
 

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -27,14 +27,11 @@ import { createReplyContent } from "@/utils/gmail/reply";
 import { cn } from "@/utils";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { GmailLabel } from "@/utils/gmail/label";
-import { generateNudgeReplyAction } from "@/utils/actions/generate-reply";
 import { deleteDraftAction } from "@/utils/actions/mail";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailDetails } from "@/components/email-list/EmailDetails";
 import { HtmlEmail, PlainEmail } from "@/components/email-list/EmailContents";
 import { EmailAttachments } from "@/components/email-list/EmailAttachments";
-import { Loading } from "@/components/Loading";
-import { MessageText } from "@/components/Typography";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { formatReplySubject } from "@/utils/email/subject";
 import { env } from "@/env";
@@ -52,7 +49,6 @@ export function EmailMessage({
   onToggle,
   onSendSuccess,
   onOpenSenderContext,
-  generateNudge,
   hasDraft = false,
   selected,
   onSelect,
@@ -68,7 +64,6 @@ export function EmailMessage({
   onToggle?: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
-  generateNudge?: boolean;
   hasDraft?: boolean;
   selected?: boolean;
   onSelect?: () => void;
@@ -183,7 +178,6 @@ export function EmailMessage({
             <ReplyPanel
               defaultShowReply={defaultShowReply}
               draftMessage={draftMessage}
-              generateNudge={generateNudge}
               message={message}
               onCloseCompose={onCloseCompose}
               onRestoreCompose={onRestoreCompose}
@@ -431,7 +425,6 @@ function ReplyPanel({
   defaultShowReply,
   showReply,
   draftMessage,
-  generateNudge,
 }: {
   message: ParsedMessage;
   refetch: () => void;
@@ -442,14 +435,11 @@ function ReplyPanel({
   defaultShowReply?: boolean;
   showReply: boolean;
   draftMessage?: ThreadMessage;
-  generateNudge?: boolean;
 }) {
   const { emailAccountId } = useAccount();
 
   const replyRef = useRef<HTMLDivElement>(null);
 
-  const [isGeneratingReply, setIsGeneratingReply] = useState(false);
-  const [reply, setReply] = useState<string | null>(null);
   // scroll to the reply panel when it first opens
   useEffect(() => {
     if (!defaultShowReply || !replyRef.current) return;
@@ -462,63 +452,14 @@ function ReplyPanel({
     return () => clearTimeout(scrollTimeout);
   }, [defaultShowReply]);
 
-  useEffect(() => {
-    async function generateReply() {
-      const isSent = message.labelIds?.includes("SENT");
-
-      // Doesn't need a nudge if it's not sent
-      if (!isSent) return;
-
-      setIsGeneratingReply(true);
-
-      const result = await generateNudgeReplyAction(emailAccountId, {
-        messages: [
-          {
-            id: message.id,
-            textHtml: message.textHtml,
-            textPlain: message.textPlain,
-            date: message.headers.date,
-            from: message.headers.from,
-            to: message.headers.to,
-            subject: message.headers.subject,
-          },
-        ],
-      });
-      if (result?.serverError) {
-        console.error(result);
-        setReply("");
-      } else {
-        setReply(result?.data?.text || "");
-      }
-      setIsGeneratingReply(false);
-    }
-
-    // Only generate a nudge if there's no draft message and generateNudge is true
-    if (generateNudge && !draftMessage) generateReply();
-  }, [generateNudge, message, draftMessage, emailAccountId]);
-
   const replyingToEmail: ReplyingToEmail = useMemo(() => {
     if (showReply) {
       if (draftMessage) return prepareDraftReplyEmail(draftMessage);
 
-      // use nudge if available
-      if (reply) {
-        // Convert nudge text into HTML paragraphs
-        const replyHtml = reply
-          ? reply
-              .split("\n")
-              .filter((line) => line.trim())
-              .map((line) => `<p>${line}</p>`)
-              .join("")
-          : "";
-
-        return prepareReplyingToEmail(message, replyHtml);
-      }
-
       return prepareReplyingToEmail(message);
     }
     return prepareForwardingEmail(message);
-  }, [showReply, message, draftMessage, reply]);
+  }, [showReply, message, draftMessage]);
 
   const { executeAsync: discardDraft } = useAction(
     deleteDraftAction.bind(null, emailAccountId),
@@ -560,34 +501,17 @@ function ReplyPanel({
 
   return (
     <div className="mt-5" ref={replyRef}>
-      {isGeneratingReply ? (
-        <div className="flex items-center justify-center">
-          <Loading />
-          <MessageText>Generating reply...</MessageText>
-          <Button
-            className="ml-4"
-            onClick={() => {
-              setIsGeneratingReply(false);
-            }}
-            size="sm"
-            variant="outline"
-          >
-            Skip
-          </Button>
-        </div>
-      ) : (
-        <ComposeEmailFormLazy
-          draftKeyMessageId={message.id}
-          onClose={onCloseCompose}
-          onDiscard={onDiscard}
-          onSuccess={(messageId: string, threadId: string) => {
-            onSendSuccess(messageId, threadId);
-            onCloseCompose();
-          }}
-          refetch={refetch}
-          replyingToEmail={replyingToEmail}
-        />
-      )}
+      <ComposeEmailFormLazy
+        draftKeyMessageId={message.id}
+        onClose={onCloseCompose}
+        onDiscard={onDiscard}
+        onSuccess={(messageId: string, threadId: string) => {
+          onSendSuccess(messageId, threadId);
+          onCloseCompose();
+        }}
+        refetch={refetch}
+        replyingToEmail={replyingToEmail}
+      />
     </div>
   );
 }

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -119,7 +119,7 @@ export function EmailMessage({
     <li
       data-thread-message-id={message.id}
       data-selected={selected}
-      tabIndex={selected === undefined ? undefined : selected ? 0 : -1}
+      tabIndex={selected === undefined ? undefined : -1}
       aria-current={selected || undefined}
       onFocusCapture={onSelect}
       onClickCapture={onSelect}

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -54,6 +54,9 @@ export function EmailMessage({
   onOpenSenderContext,
   generateNudge,
   hasDraft = false,
+  selected,
+  onSelect,
+  onNavigateMessage,
 }: {
   message: ThreadMessage;
   draftMessage?: ThreadMessage;
@@ -67,6 +70,9 @@ export function EmailMessage({
   onOpenSenderContext?: (message: ThreadMessage) => void;
   generateNudge?: boolean;
   hasDraft?: boolean;
+  selected?: boolean;
+  onSelect?: () => void;
+  onNavigateMessage?: (direction: -1 | 1) => void;
 }) {
   const { emailAccountId } = useAccount();
   // `null` follows `defaultShowReply`, which the reader's Reply button flips
@@ -116,11 +122,28 @@ export function EmailMessage({
 
   return (
     <li
+      data-thread-message-id={message.id}
+      data-selected={selected}
+      tabIndex={selected === undefined ? undefined : selected ? 0 : -1}
+      aria-current={selected || undefined}
+      onFocusCapture={onSelect}
+      onClickCapture={onSelect}
+      onKeyDown={(event) => {
+        if (
+          event.target !== event.currentTarget ||
+          (event.key !== "Enter" && event.key !== " ")
+        )
+          return;
+        event.preventDefault();
+        event.stopPropagation();
+        onToggle?.();
+      }}
       className={cn(
-        "group/message min-w-0 border-l-2 transition-colors",
+        "group/message min-w-0 border-l-2 border-transparent outline-none transition-colors focus-within:border-primary",
+        selected && "border-primary",
         expanded
-          ? "my-2 border-border/70 px-2 py-3 focus-within:border-primary sm:px-5"
-          : "border-transparent px-2 py-1.5 hover:bg-muted/40 sm:px-5",
+          ? "my-2 px-2 py-3 sm:px-5"
+          : "px-2 py-1.5 hover:bg-muted/40 sm:px-5",
       )}
     >
       <MessageHeader
@@ -143,6 +166,8 @@ export function EmailMessage({
 
           {message.textHtml ? (
             <HtmlEmail
+              onNavigateMessage={onNavigateMessage}
+              onFocusMessage={onSelect}
               emailAccountId={emailAccountId}
               html={message.textHtml}
               inlineAttachments={message.inline}
@@ -244,6 +269,7 @@ function MessageHeader({
       if (event.target !== event.currentTarget) return;
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
+      event.stopPropagation();
       onToggle();
     },
     role: "button",

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -384,44 +384,45 @@ function MessageHeader({
         <span className="shrink-0 text-primary text-xs">Draft</span>
       )}
 
-      <time
-        className="ml-auto shrink-0 whitespace-nowrap pl-2.5 text-muted-foreground text-xs"
-        dateTime={message.headers.date}
-      >
-        {formatShortDate(new Date(message.headers.date))}
-      </time>
-
-      {showReplyButton && (
-        <span
-          className={cn(
-            "shrink-0 items-center transition-opacity focus-within:opacity-100 group-hover/message:opacity-100",
-            expanded ? "flex sm:opacity-0" : "hidden sm:flex sm:opacity-0",
-          )}
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        {showReplyButton && (
+          <span
+            className={cn(
+              "shrink-0 items-center transition-opacity focus-within:opacity-100 group-hover/message:opacity-100",
+              expanded ? "flex sm:opacity-0" : "hidden sm:flex sm:opacity-0",
+            )}
+          >
+            <Tooltip content="Reply">
+              <Button
+                className="size-7 text-muted-foreground"
+                onClick={compose(onReply)}
+                size="icon"
+                variant="ghost"
+              >
+                <ReplyIcon className="size-3.5" />
+                <span className="sr-only">Reply</span>
+              </Button>
+            </Tooltip>
+            <Tooltip content="Forward">
+              <Button
+                className="size-7 text-muted-foreground"
+                onClick={compose(onForward)}
+                size="icon"
+                variant="ghost"
+              >
+                <ForwardIcon className="size-3.5" />
+                <span className="sr-only">Forward</span>
+              </Button>
+            </Tooltip>
+          </span>
+        )}
+        <time
+          className="shrink-0 whitespace-nowrap text-muted-foreground text-xs"
+          dateTime={message.headers.date}
         >
-          <Tooltip content="Reply">
-            <Button
-              className="size-7 text-muted-foreground"
-              onClick={compose(onReply)}
-              size="icon"
-              variant="ghost"
-            >
-              <ReplyIcon className="size-3.5" />
-              <span className="sr-only">Reply</span>
-            </Button>
-          </Tooltip>
-          <Tooltip content="Forward">
-            <Button
-              className="size-7 text-muted-foreground"
-              onClick={compose(onForward)}
-              size="icon"
-              variant="ghost"
-            >
-              <ForwardIcon className="size-3.5" />
-              <span className="sr-only">Forward</span>
-            </Button>
-          </Tooltip>
-        </span>
-      )}
+          {formatShortDate(new Date(message.headers.date))}
+        </time>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -131,7 +131,12 @@ export function EmailMessage({
           return;
         event.preventDefault();
         event.stopPropagation();
-        onToggle?.();
+        if (event.key === "Enter" && showReplyButton) {
+          if (!expanded) onToggle?.();
+          onReply();
+        } else {
+          onToggle?.();
+        }
       }}
       className={cn(
         "group/message min-w-0 border-l-2 border-transparent outline-none transition-colors focus-within:border-primary",
@@ -161,6 +166,7 @@ export function EmailMessage({
 
           {message.textHtml ? (
             <HtmlEmail
+              onReplyMessage={showReplyButton ? onReply : undefined}
               onNavigateMessage={onNavigateMessage}
               onFocusMessage={onSelect}
               emailAccountId={emailAccountId}
@@ -264,7 +270,12 @@ function MessageHeader({
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
       event.stopPropagation();
-      onToggle();
+      if (event.key === "Enter" && showReplyButton) {
+        if (!expanded) onToggle();
+        onReply();
+      } else {
+        onToggle();
+      }
     },
     role: "button",
     tabIndex: 0,

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -294,21 +294,19 @@ function MessageHeader({
         onToggle && "cursor-pointer",
       )}
     >
-      {expanded && (
-        <Avatar aria-hidden className="size-7 shrink-0">
-          <AvatarImage alt="" src={senderImage || undefined} />
-          <AvatarFallback
-            className={cn(
-              "font-semibold text-[10px] tracking-wide",
-              isSent
-                ? "bg-primary/10 text-primary"
-                : "bg-muted text-muted-foreground",
-            )}
-          >
-            {initialsFor(senderName)}
-          </AvatarFallback>
-        </Avatar>
-      )}
+      <Avatar aria-hidden className="size-7 shrink-0">
+        <AvatarImage alt="" src={senderImage || undefined} />
+        <AvatarFallback
+          className={cn(
+            "font-semibold text-[10px] tracking-wide",
+            isSent
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {initialsFor(senderName)}
+        </AvatarFallback>
+      </Avatar>
 
       {canResearchSender ? (
         <Button

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -163,9 +163,10 @@ export function EmailThread({
           );
         })}
       </ul>
-      {showReplyButton && threadId && (
+      {threadId && (
         <ThreadDeliveryStatus
           emailAccountId={emailAccountId}
+          canEditReply={showReplyButton}
           threadId={threadId}
           messageIds={messages.map((message) => message.id)}
           refetch={refetch}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -1,6 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailMessage } from "@/components/email-list/EmailMessage";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { useReplyDrafts } from "@/hooks/useReplyDrafts";
+import { ThreadDeliveryStatus } from "@/components/email-list/ThreadDeliveryStatus";
 import { Button } from "@/components/ui/button";
 
 export function EmailThread({
@@ -22,6 +25,9 @@ export function EmailThread({
   onOpenSenderContext?: (message: ThreadMessage) => void;
   withHeader?: boolean;
 }) {
+  const { emailAccountId } = useAccount();
+  const threadId = messages[0]?.threadId ?? "";
+  const { drafts: localDrafts } = useReplyDrafts(emailAccountId, threadId);
   // Place draft messages as replies to their parent message
   const organizedMessages = useMemo(() => {
     const drafts = new Map<string, ThreadMessage>();
@@ -49,14 +55,25 @@ export function EmailThread({
 
   const lastMessageId = organizedMessages.at(-1)?.message.id;
 
-  /** Only the latest message is open: the state every thread starts in. */
-  const latestOnly = () => new Set(lastMessageId ? [lastMessageId] : []);
-
-  const [expandedMessageIds, setExpandedMessageIds] =
-    useState<Set<string>>(latestOnly);
-
-  const allExpanded = organizedMessages.every(({ message }) =>
-    expandedMessageIds.has(message.id),
+  const [expansionOverrides, setExpansionOverrides] = useState<
+    Map<string, boolean>
+  >(() => new Map());
+  const [recoveredReply, setRecoveredReply] = useState<{
+    messageId: string;
+    version: number;
+  }>();
+  useEffect(() => {
+    if (autoOpenReplyForMessageId)
+      setExpansionOverrides((previous) =>
+        new Map(previous).set(autoOpenReplyForMessageId, true),
+      );
+  }, [autoOpenReplyForMessageId]);
+  const expanded = (id: string, hasDraft: boolean) =>
+    expansionOverrides.get(id) ?? (id === lastMessageId || hasDraft);
+  const hasLocalDraft = (id: string) =>
+    localDrafts.some((draft) => draft.messageId === id);
+  const allExpanded = organizedMessages.every(({ message, draftMessage }) =>
+    expanded(message.id, Boolean(draftMessage) || hasLocalDraft(message.id)),
   );
 
   return (
@@ -82,38 +99,48 @@ export function EmailThread({
           <Button
             className="ml-auto"
             onClick={() =>
-              setExpandedMessageIds(
-                allExpanded
-                  ? latestOnly()
-                  : new Set(organizedMessages.map(({ message }) => message.id)),
+              setExpansionOverrides(
+                new Map(
+                  organizedMessages.map(({ message }) => [
+                    message.id,
+                    allExpanded ? message.id === lastMessageId : true,
+                  ]),
+                ),
               )
             }
             size="xs-2"
-            variant="outline"
+            variant="ghost"
           >
             {allExpanded ? "Collapse all" : "Expand all"}
           </Button>
         </div>
       )}
 
-      <ul className="pt-2">
+      <ul className="pt-1">
         {organizedMessages.map(({ message, draftMessage }) => {
           const defaultShowReply =
-            autoOpenReplyForMessageId === message.id || Boolean(draftMessage);
+            autoOpenReplyForMessageId === message.id ||
+            recoveredReply?.messageId === message.id ||
+            Boolean(draftMessage) ||
+            hasLocalDraft(message.id);
           return (
             <EmailMessage
               defaultShowReply={defaultShowReply}
               draftMessage={draftMessage}
-              expanded={expandedMessageIds.has(message.id)}
-              generateNudge={defaultShowReply && !draftMessage?.textHtml}
-              key={message.id}
+              expanded={expanded(message.id, defaultShowReply)}
+              hasDraft={Boolean(draftMessage) || hasLocalDraft(message.id)}
+              generateNudge={
+                defaultShowReply &&
+                !draftMessage?.textHtml &&
+                !hasLocalDraft(message.id)
+              }
+              key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
               onOpenSenderContext={onOpenSenderContext}
               onSendSuccess={(messageId) => {
-                setExpandedMessageIds((prev) => {
-                  if (prev.has(messageId)) return prev;
-                  return new Set(prev).add(messageId);
-                });
+                setExpansionOverrides((prev) =>
+                  new Map(prev).set(messageId, true),
+                );
 
                 onSendSuccess?.(messageId, message.threadId);
               }}
@@ -122,11 +149,12 @@ export function EmailThread({
                 organizedMessages.length === 1
                   ? undefined
                   : () => {
-                      setExpandedMessageIds((prev) => {
-                        const next = new Set(prev);
-                        if (!next.delete(message.id)) next.add(message.id);
-                        return next;
-                      });
+                      setExpansionOverrides((prev) =>
+                        new Map(prev).set(
+                          message.id,
+                          !expanded(message.id, defaultShowReply),
+                        ),
+                      );
                     }
               }
               refetch={refetch}
@@ -135,6 +163,23 @@ export function EmailThread({
           );
         })}
       </ul>
+      {showReplyButton && threadId && (
+        <ThreadDeliveryStatus
+          emailAccountId={emailAccountId}
+          threadId={threadId}
+          messageIds={messages.map((message) => message.id)}
+          refetch={refetch}
+          onEditReply={(messageId) => {
+            setExpansionOverrides((previous) =>
+              new Map(previous).set(messageId, true),
+            );
+            setRecoveredReply((previous) => ({
+              messageId,
+              version: (previous?.version ?? 0) + 1,
+            }));
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { EmailMessage } from "@/components/email-list/EmailMessage";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -92,27 +94,37 @@ export function EmailThread({
       )}
 
       {organizedMessages.length > 1 && (
-        <div className="flex items-center gap-3 pt-4">
-          <span className="text-muted-foreground text-xs">
-            {organizedMessages.length} messages
-          </span>
-          <Button
-            className="ml-auto"
-            onClick={() =>
-              setExpansionOverrides(
-                new Map(
-                  organizedMessages.map(({ message }) => [
-                    message.id,
-                    allExpanded ? message.id === lastMessageId : true,
-                  ]),
-                ),
-              )
+        <div className="flex justify-end pt-2">
+          <Tooltip
+            content={
+              allExpanded ? "Collapse all messages" : "Expand all messages"
             }
-            size="xs-2"
-            variant="ghost"
           >
-            {allExpanded ? "Collapse all" : "Expand all"}
-          </Button>
+            <Button
+              aria-label={
+                allExpanded ? "Collapse all messages" : "Expand all messages"
+              }
+              className="size-7 text-muted-foreground"
+              onClick={() =>
+                setExpansionOverrides(
+                  new Map(
+                    organizedMessages.map(({ message }) => [
+                      message.id,
+                      allExpanded ? message.id === lastMessageId : true,
+                    ]),
+                  ),
+                )
+              }
+              size="icon"
+              variant="ghost"
+            >
+              {allExpanded ? (
+                <ChevronsDownUpIcon className="size-3.5" />
+              ) : (
+                <ChevronsUpDownIcon className="size-3.5" />
+              )}
+            </Button>
+          </Tooltip>
         </div>
       )}
 

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -222,11 +222,6 @@ export function EmailThread({
               draftMessage={draftMessage}
               expanded={expanded(message.id, defaultShowReply)}
               hasDraft={Boolean(draftMessage) || hasLocalDraft(message.id)}
-              generateNudge={
-                defaultShowReply &&
-                !draftMessage?.textHtml &&
-                !hasLocalDraft(message.id)
-              }
               key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
               onOpenSenderContext={onOpenSenderContext}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -137,7 +137,7 @@ export function EmailThread({
       scopes: ["mail"],
       useKey: true,
       preventDefault: true,
-      ignoreEventWhen: (event) =>
+      ignoreEventWhen: (event: KeyboardEvent) =>
         event.isComposing ||
         window.getSelection()?.isCollapsed === false ||
         isTypingTarget(event.target) ||

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useRef, type ReactNode } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { isTypingTarget } from "@/lib/shortcuts/registry";
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import type { ThreadMessage } from "@/components/email-list/types";
@@ -17,6 +19,8 @@ export function EmailThread({
   onSendSuccess,
   onOpenSenderContext,
   withHeader,
+  renderToolbar,
+  enableMessageNavigation = false,
 }: {
   messages: ThreadMessage[];
   refetch: () => void;
@@ -26,6 +30,12 @@ export function EmailThread({
   onSendSuccess?: (messageId: string, threadId: string) => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   withHeader?: boolean;
+  enableMessageNavigation?: boolean;
+  renderToolbar?: (controls: {
+    allExpanded: boolean;
+    canExpand: boolean;
+    onToggleAll: () => void;
+  }) => ReactNode;
 }) {
   const { emailAccountId } = useAccount();
   const threadId = messages[0]?.threadId ?? "";
@@ -75,13 +85,80 @@ export function EmailThread({
   const hasLocalDraft = (id: string) =>
     localDrafts.some((draft) => draft.messageId === id);
   const allExpanded = organizedMessages.every(({ message, draftMessage }) =>
-    expanded(message.id, Boolean(draftMessage) || hasLocalDraft(message.id)),
+    expanded(
+      message.id,
+      autoOpenReplyForMessageId === message.id ||
+        recoveredReply?.messageId === message.id ||
+        Boolean(draftMessage) ||
+        hasLocalDraft(message.id),
+    ),
+  );
+
+  const toggleAll = () =>
+    setExpansionOverrides(
+      new Map(
+        organizedMessages.map(({ message }) => [
+          message.id,
+          allExpanded ? message.id === lastMessageId : true,
+        ]),
+      ),
+    );
+  const [selectedMessageId, setSelectedMessageId] = useState<string>();
+  const selectedId = organizedMessages.some(
+    ({ message }) => message.id === selectedMessageId,
+  )
+    ? selectedMessageId
+    : lastMessageId;
+  const threadRef = useRef<HTMLDivElement>(null);
+  const selectRelativeMessage = (direction: -1 | 1, fromId = selectedId) => {
+    const currentIndex = organizedMessages.findIndex(
+      ({ message }) => message.id === fromId,
+    );
+    const nextIndex = Math.max(
+      0,
+      Math.min(organizedMessages.length - 1, currentIndex + direction),
+    );
+    const nextId = organizedMessages[nextIndex]?.message.id;
+    if (!nextId) return;
+    setSelectedMessageId(nextId);
+    const element = Array.from(
+      threadRef.current?.querySelectorAll<HTMLElement>(
+        "[data-thread-message-id]",
+      ) ?? [],
+    ).find((item) => item.dataset.threadMessageId === nextId);
+    element?.focus({ preventScroll: true });
+    element?.scrollIntoView({ block: "nearest" });
+  };
+  useHotkeys(
+    "arrowup,arrowdown",
+    (event) => selectRelativeMessage(event.key === "ArrowUp" ? -1 : 1),
+    {
+      enabled: enableMessageNavigation,
+      scopes: ["mail"],
+      useKey: true,
+      preventDefault: true,
+      ignoreEventWhen: (event) =>
+        event.isComposing ||
+        window.getSelection()?.isCollapsed === false ||
+        isTypingTarget(event.target) ||
+        (event.target instanceof Element &&
+          Boolean(
+            event.target.closest(
+              '[role="dialog"], [role="menu"], [role="listbox"]',
+            ),
+          )),
+    },
   );
 
   return (
     // White regardless of the surface it is dropped on: an email body renders
     // on white inside its iframe, so anything else leaves each message boxed.
-    <div className="min-w-0 bg-card">
+    <div className="min-w-0 bg-card" ref={threadRef}>
+      {renderToolbar?.({
+        allExpanded,
+        canExpand: organizedMessages.length > 1,
+        onToggleAll: toggleAll,
+      })}
       {withHeader && (
         <div className="flex items-center justify-between">
           <div className="font-semibold text-2xl text-foreground">
@@ -93,7 +170,7 @@ export function EmailThread({
         </div>
       )}
 
-      {organizedMessages.length > 1 && (
+      {!renderToolbar && organizedMessages.length > 1 && (
         <div className="flex justify-end pt-2">
           <Tooltip
             content={
@@ -105,16 +182,7 @@ export function EmailThread({
                 allExpanded ? "Collapse all messages" : "Expand all messages"
               }
               className="size-7 text-muted-foreground"
-              onClick={() =>
-                setExpansionOverrides(
-                  new Map(
-                    organizedMessages.map(({ message }) => [
-                      message.id,
-                      allExpanded ? message.id === lastMessageId : true,
-                    ]),
-                  ),
-                )
-              }
+              onClick={toggleAll}
               size="icon"
               variant="ghost"
             >
@@ -137,6 +205,19 @@ export function EmailThread({
             hasLocalDraft(message.id);
           return (
             <EmailMessage
+              onNavigateMessage={
+                enableMessageNavigation
+                  ? (direction) => selectRelativeMessage(direction, message.id)
+                  : undefined
+              }
+              selected={
+                enableMessageNavigation ? message.id === selectedId : undefined
+              }
+              onSelect={
+                enableMessageNavigation
+                  ? () => setSelectedMessageId(message.id)
+                  : undefined
+              }
               defaultShowReply={defaultShowReply}
               draftMessage={draftMessage}
               expanded={expanded(message.id, defaultShowReply)}

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useSWR from "swr";
+import { restoreReplyFromOutbox } from "@/utils/email-cache/reply-drafts";
+import { Button } from "@/components/ui/button";
+import {
+  getEmailCacheDatabase,
+  type StoredMailMutation,
+} from "@/utils/email-cache/database";
+import { subscribeToMailMutations } from "@/utils/email-cache/mail-mutations";
+import type { ScheduledEmailsResponse } from "@/app/api/user/scheduled-emails/route";
+import {
+  cancelScheduledEmailAction,
+  cancelEmailReminderAction,
+  retryScheduledEmailAction,
+} from "@/utils/actions/scheduled-email";
+import { getActionErrorMessage } from "@/utils/error";
+
+export function ThreadDeliveryStatus({
+  emailAccountId,
+  threadId,
+  messageIds,
+  onEditReply,
+  refetch,
+}: {
+  emailAccountId: string;
+  threadId: string;
+  messageIds: string[];
+  onEditReply: (messageId: string) => void;
+  refetch: () => void;
+}) {
+  const [actionError, setActionError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const { data: outbox = [], mutate: refreshOutbox } = useSWR(
+    ["thread-deliveries", emailAccountId, threadId],
+    async () => {
+      const db = await getEmailCacheDatabase();
+      const rows = await db?.getAllFromIndex(
+        "mailMutations",
+        "byAccountThread",
+        [emailAccountId, threadId],
+      );
+      return (rows ?? [])
+        .filter((row) => row.kind === "reply")
+        .sort((a, b) => b.createdAt - a.createdAt);
+    },
+  );
+  useEffect(
+    () =>
+      subscribeToMailMutations(() => {
+        refreshOutbox();
+      }),
+    [refreshOutbox],
+  );
+  const { data, error, mutate } = useSWR<ScheduledEmailsResponse>(
+    [
+      `/api/user/scheduled-emails?threadId=${encodeURIComponent(threadId)}`,
+      emailAccountId,
+    ],
+    {
+      refreshInterval: (current) => {
+        const rows = current?.scheduledEmails ?? [];
+        if (
+          rows.some(
+            (row) =>
+              row.status === "PROCESSING" ||
+              row.reminderStatus === "PROCESSING",
+          )
+        )
+          return 5000;
+        const dueTimes = rows.flatMap((row) => [
+          ...(row.status === "PENDING" ? [new Date(row.sendAt).getTime()] : []),
+          ...(row.status === "SENT" &&
+          row.reminderStatus === "PENDING" &&
+          row.remindAt
+            ? [new Date(row.remindAt).getTime()]
+            : []),
+        ]);
+        return dueTimes.length
+          ? Math.min(60_000, Math.max(5000, Math.min(...dueTimes) - Date.now()))
+          : 0;
+      },
+    },
+  );
+  const latestScheduledSendId =
+    data?.scheduledEmails.find((row) => row.status === "SENT")?.id ?? "";
+  const latestOutboxSendId =
+    outbox.find((row) => row.status === "succeeded")?.id ?? "";
+  const completedSendKey = `${latestScheduledSendId}:${latestOutboxSendId}`;
+  const refreshedSendKey = useRef(":");
+  useEffect(() => {
+    if (
+      completedSendKey === ":" ||
+      completedSendKey === refreshedSendKey.current
+    )
+      return;
+    refreshedSendKey.current = completedSendKey;
+    refetch();
+  }, [completedSendKey, refetch]);
+  const act = async (action: () => Promise<unknown>) => {
+    setBusy(true);
+    setActionError("");
+    try {
+      await action();
+      await mutate();
+      await refreshOutbox();
+    } catch (failure) {
+      setActionError(
+        failure instanceof Error
+          ? failure.message
+          : "Could not update delivery.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+  const scheduledAction = async (
+    action: typeof cancelScheduledEmailAction,
+    id: string,
+  ) => {
+    const result = await action(emailAccountId, { id });
+    if (result?.serverError || result?.validationErrors)
+      throw new Error(getActionErrorMessage(result));
+  };
+  const visible = outbox.filter(
+    (row, index) =>
+      row.status !== "succeeded" ||
+      (index === 0 &&
+        !messageIds.includes(
+          (row.result as { messageId?: string } | undefined)?.messageId ?? "",
+        )),
+  );
+  return (
+    <section className="space-y-2" aria-label="Reply delivery status">
+      {visible.map((row) => (
+        <div
+          key={row.id}
+          className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm"
+        >
+          <p role="status" className="font-medium">
+            {deliveryLabel(row)}
+          </p>
+          {row.status !== "succeeded" && (
+            <p className="mt-1 text-muted-foreground text-xs">
+              {row.lastError ||
+                "Your reply is saved in the outbox on this device."}
+            </p>
+          )}
+          {row.status === "uncertain" && (
+            <a
+              className="mt-2 inline-block underline"
+              href={`/${emailAccountId}/mail?type=sent`}
+            >
+              Check Sent
+            </a>
+          )}
+          {["pending", "retry_wait", "blocked_auth", "failed"].includes(
+            row.status,
+          ) && (
+            <Button
+              disabled={busy}
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                act(async () => {
+                  await restoreReplyFromOutbox(row.id);
+                  onEditReply(row.messageIds[0]);
+                })
+              }
+            >
+              Edit reply
+            </Button>
+          )}
+        </div>
+      ))}
+      {data?.scheduledEmails
+        .filter(
+          (row, index) =>
+            row.status !== "SENT" ||
+            index === 0 ||
+            ["PENDING", "PROCESSING"].includes(row.reminderStatus),
+        )
+        .map((row) => (
+          <div
+            key={row.id}
+            className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm"
+          >
+            <p role="status" className="font-medium">
+              {scheduledDeliveryLabel(row)}
+            </p>
+            {row.error && (
+              <p className="mt-1 text-destructive text-xs">{row.error}</p>
+            )}
+            {row.remindAt &&
+              ["PENDING", "PROCESSING"].includes(row.reminderStatus) && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Remind me {formatTime(row.remindAt)} if no reply.
+                </p>
+              )}
+            <div className="mt-1 flex flex-wrap gap-1">
+              {["PENDING", "BLOCKED_AUTH", "FAILED"].includes(row.status) && (
+                <Button
+                  disabled={busy}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() =>
+                    act(() =>
+                      scheduledAction(cancelScheduledEmailAction, row.id),
+                    )
+                  }
+                >
+                  Cancel send
+                </Button>
+              )}
+              {["BLOCKED_AUTH", "FAILED"].includes(row.status) && (
+                <Button
+                  disabled={busy}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() =>
+                    act(() =>
+                      scheduledAction(retryScheduledEmailAction, row.id),
+                    )
+                  }
+                >
+                  Retry send
+                </Button>
+              )}
+              {row.reminderStatus === "PENDING" && (
+                <Button
+                  disabled={busy}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() =>
+                    act(() =>
+                      scheduledAction(cancelEmailReminderAction, row.id),
+                    )
+                  }
+                >
+                  Cancel reminder
+                </Button>
+              )}
+              {row.status === "UNCERTAIN" && (
+                <a
+                  className="p-2 underline"
+                  href={`/${emailAccountId}/mail?type=sent`}
+                >
+                  Check Sent
+                </a>
+              )}
+            </div>
+          </div>
+        ))}
+      {(actionError || error) && (
+        <p role="alert" className="text-destructive text-xs">
+          {actionError || "Could not load scheduled replies."}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function formatTime(value: string | Date) {
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function deliveryLabel(row: StoredMailMutation) {
+  switch (row.status) {
+    case "succeeded":
+      return "Reply sent";
+    case "processing":
+      return "Sending…";
+    case "uncertain":
+      return "Delivery uncertain";
+    case "failed":
+      return "Reply could not be sent";
+    case "blocked_auth":
+      return "Reconnect your account to send this reply";
+    default:
+      return "Reply queued";
+  }
+}
+
+function scheduledDeliveryLabel(
+  row: ScheduledEmailsResponse["scheduledEmails"][number],
+) {
+  switch (row.status) {
+    case "PENDING":
+      return `Scheduled for ${formatTime(row.sendAt)}`;
+    case "PROCESSING":
+      return "Sending…";
+    case "SENT":
+      return "Reply sent";
+    case "UNCERTAIN":
+      return "Delivery uncertain";
+    default:
+      return "Reply needs attention";
+  }
+}

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  AlertCircleIcon,
+  CheckIcon,
+  ClockIcon,
+  LoaderCircleIcon,
+  WifiOffIcon,
+} from "lucide-react";
 import useSWR from "swr";
 import { restoreReplyFromOutbox } from "@/utils/email-cache/reply-drafts";
 import { Button } from "@/components/ui/button";
@@ -33,6 +40,11 @@ export function ThreadDeliveryStatus({
   refetch: () => void;
   canEditReply: boolean;
 }) {
+  const online = useSyncExternalStore(
+    subscribeToConnectivity,
+    () => navigator.onLine,
+    () => true,
+  );
   const [actionError, setActionError] = useState("");
   const [busy, setBusy] = useState(false);
   const { data: outbox = [], mutate: refreshOutbox } = useSWR(
@@ -136,24 +148,27 @@ export function ThreadDeliveryStatus({
         )),
   );
   return (
-    <section className="space-y-2" aria-label="Reply delivery status">
+    <section className="space-y-1" aria-label="Reply delivery status">
       {visible.map((row) => (
         <div
           key={row.id}
-          className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm"
+          className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 py-2 text-xs text-muted-foreground"
         >
-          <p role="status" className="font-medium">
-            {deliveryLabel(row)}
+          <p
+            role="status"
+            className="flex items-center gap-2 font-medium text-foreground"
+          >
+            <DeliveryIcon status={row.status} offline={!online} />
+            {deliveryLabel(row, online)}
           </p>
-          {row.status !== "succeeded" && (
-            <p className="mt-1 text-muted-foreground text-xs">
-              {row.lastError ||
-                "Your reply is saved in the outbox on this device."}
+          {row.status !== "succeeded" && row.lastError && (
+            <p className="order-last basis-full pl-5 text-muted-foreground">
+              {row.lastError}
             </p>
           )}
           {row.status === "uncertain" && (
             <a
-              className="mt-2 inline-block underline"
+              className="underline underline-offset-4"
               href={`/${emailAccountId}/mail?type=sent`}
             >
               Check Sent
@@ -167,6 +182,7 @@ export function ThreadDeliveryStatus({
                 disabled={busy}
                 type="button"
                 variant="ghost"
+                className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
                 size="sm"
                 onClick={() =>
                   act(async () => {
@@ -190,26 +206,33 @@ export function ThreadDeliveryStatus({
         .map((row) => (
           <div
             key={row.id}
-            className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm"
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 py-2 text-xs text-muted-foreground"
           >
-            <p role="status" className="font-medium">
+            <p
+              role="status"
+              className="flex items-center gap-2 font-medium text-foreground"
+            >
+              <DeliveryIcon status={row.status.toLowerCase()} />
               {scheduledDeliveryLabel(row)}
             </p>
             {row.error && (
-              <p className="mt-1 text-destructive text-xs">{row.error}</p>
+              <p className="order-last basis-full pl-5 text-destructive">
+                {row.error}
+              </p>
             )}
             {row.remindAt &&
               ["PENDING", "PROCESSING"].includes(row.reminderStatus) && (
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="order-last basis-full pl-5 text-muted-foreground">
                   Remind me {formatTime(row.remindAt)} if no reply.
                 </p>
               )}
-            <div className="mt-1 flex flex-wrap gap-1">
+            <div className="contents">
               {["PENDING", "BLOCKED_AUTH", "FAILED"].includes(row.status) && (
                 <Button
                   disabled={busy}
                   size="sm"
                   variant="ghost"
+                  className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
                   onClick={() =>
                     act(() =>
                       scheduledAction(cancelScheduledEmailAction, row.id),
@@ -224,6 +247,7 @@ export function ThreadDeliveryStatus({
                   disabled={busy}
                   size="sm"
                   variant="ghost"
+                  className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
                   onClick={() =>
                     act(() =>
                       scheduledAction(retryScheduledEmailAction, row.id),
@@ -238,6 +262,7 @@ export function ThreadDeliveryStatus({
                   disabled={busy}
                   size="sm"
                   variant="ghost"
+                  className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
                   onClick={() =>
                     act(() =>
                       scheduledAction(cancelEmailReminderAction, row.id),
@@ -249,7 +274,7 @@ export function ThreadDeliveryStatus({
               )}
               {row.status === "UNCERTAIN" && (
                 <a
-                  className="p-2 underline"
+                  className="underline underline-offset-4"
                   href={`/${emailAccountId}/mail?type=sent`}
                 >
                   Check Sent
@@ -276,7 +301,7 @@ function formatTime(value: string | Date) {
   });
 }
 
-function deliveryLabel(row: StoredMailMutation) {
+function deliveryLabel(row: StoredMailMutation, online: boolean) {
   switch (row.status) {
     case "succeeded":
       return "Reply sent";
@@ -289,7 +314,7 @@ function deliveryLabel(row: StoredMailMutation) {
     case "blocked_auth":
       return "Reconnect your account to send this reply";
     default:
-      return "Reply queued";
+      return online ? "Waiting to send" : "Waiting for connection";
   }
 }
 
@@ -308,4 +333,56 @@ function scheduledDeliveryLabel(
     default:
       return "Reply needs attention";
   }
+}
+
+function DeliveryIcon({
+  status,
+  offline = false,
+}: {
+  status: string;
+  offline?: boolean;
+}) {
+  if (status === "processing")
+    return (
+      <LoaderCircleIcon
+        aria-hidden
+        className="size-3.5 shrink-0 motion-safe:animate-spin text-muted-foreground"
+      />
+    );
+  if (status === "succeeded" || status === "sent")
+    return (
+      <CheckIcon
+        aria-hidden
+        className="size-3.5 shrink-0 text-muted-foreground"
+      />
+    );
+  if (["uncertain", "failed", "blocked_auth"].includes(status))
+    return (
+      <AlertCircleIcon
+        aria-hidden
+        className="size-3.5 shrink-0 text-destructive"
+      />
+    );
+  if (offline)
+    return (
+      <WifiOffIcon
+        aria-hidden
+        className="size-3.5 shrink-0 text-muted-foreground"
+      />
+    );
+  return (
+    <ClockIcon
+      aria-hidden
+      className="size-3.5 shrink-0 text-muted-foreground"
+    />
+  );
+}
+
+function subscribeToConnectivity(onChange: () => void) {
+  window.addEventListener("online", onChange);
+  window.addEventListener("offline", onChange);
+  return () => {
+    window.removeEventListener("online", onChange);
+    window.removeEventListener("offline", onChange);
+  };
 }

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -16,6 +16,7 @@ import {
   retryScheduledEmailAction,
 } from "@/utils/actions/scheduled-email";
 import { getActionErrorMessage } from "@/utils/error";
+import { getLatestScheduledSendId } from "@/components/email-list/latest-scheduled-send";
 
 export function ThreadDeliveryStatus({
   emailAccountId,
@@ -85,8 +86,9 @@ export function ThreadDeliveryStatus({
       },
     },
   );
-  const latestScheduledSendId =
-    data?.scheduledEmails.find((row) => row.status === "SENT")?.id ?? "";
+  const latestScheduledSendId = getLatestScheduledSendId(
+    data?.scheduledEmails ?? [],
+  );
   const latestOutboxSendId =
     outbox.find((row) => row.status === "succeeded")?.id ?? "";
   const completedSendKey = `${latestScheduledSendId}:${latestOutboxSendId}`;

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -23,12 +23,14 @@ export function ThreadDeliveryStatus({
   messageIds,
   onEditReply,
   refetch,
+  canEditReply,
 }: {
   emailAccountId: string;
   threadId: string;
   messageIds: string[];
   onEditReply: (messageId: string) => void;
   refetch: () => void;
+  canEditReply: boolean;
 }) {
   const [actionError, setActionError] = useState("");
   const [busy, setBusy] = useState(false);
@@ -155,31 +157,32 @@ export function ThreadDeliveryStatus({
               Check Sent
             </a>
           )}
-          {["pending", "retry_wait", "blocked_auth", "failed"].includes(
-            row.status,
-          ) && (
-            <Button
-              disabled={busy}
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() =>
-                act(async () => {
-                  await restoreReplyFromOutbox(row.id);
-                  onEditReply(row.messageIds[0]);
-                })
-              }
-            >
-              Edit reply
-            </Button>
-          )}
+          {canEditReply &&
+            ["pending", "retry_wait", "blocked_auth", "failed"].includes(
+              row.status,
+            ) && (
+              <Button
+                disabled={busy}
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  act(async () => {
+                    await restoreReplyFromOutbox(row.id, emailAccountId);
+                    onEditReply(row.messageIds[0]);
+                  })
+                }
+              >
+                Edit reply
+              </Button>
+            )}
         </div>
       ))}
       {data?.scheduledEmails
         .filter(
-          (row, index) =>
+          (row) =>
             row.status !== "SENT" ||
-            index === 0 ||
+            row.id === latestScheduledSendId ||
             ["PENDING", "PROCESSING"].includes(row.reminderStatus),
         )
         .map((row) => (

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -158,7 +158,12 @@ export function ThreadDeliveryStatus({
             role="status"
             className="flex items-center gap-2 font-medium text-foreground"
           >
-            <DeliveryIcon status={row.status} offline={!online} />
+            <DeliveryIcon
+              status={
+                online && row.status === "pending" ? "processing" : row.status
+              }
+              offline={!online}
+            />
             {deliveryLabel(row, online)}
           </p>
           {row.status !== "succeeded" && row.lastError && (
@@ -175,6 +180,7 @@ export function ThreadDeliveryStatus({
             </a>
           )}
           {canEditReply &&
+            !(online && row.status === "pending") &&
             ["pending", "retry_wait", "blocked_auth", "failed"].includes(
               row.status,
             ) && (
@@ -314,7 +320,7 @@ function deliveryLabel(row: StoredMailMutation, online: boolean) {
     case "blocked_auth":
       return "Reconnect your account to send this reply";
     default:
-      return online ? "Waiting to send" : "Waiting for connection";
+      return online ? "Sending…" : "Waiting for connection";
   }
 }
 

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -235,6 +235,7 @@ export function ThreadDeliveryStatus({
             <div className="contents">
               {["PENDING", "BLOCKED_AUTH", "FAILED"].includes(row.status) && (
                 <Button
+                  type="button"
                   disabled={busy}
                   size="sm"
                   variant="ghost"
@@ -250,6 +251,7 @@ export function ThreadDeliveryStatus({
               )}
               {["BLOCKED_AUTH", "FAILED"].includes(row.status) && (
                 <Button
+                  type="button"
                   disabled={busy}
                   size="sm"
                   variant="ghost"
@@ -265,6 +267,7 @@ export function ThreadDeliveryStatus({
               )}
               {row.reminderStatus === "PENDING" && (
                 <Button
+                  type="button"
                   disabled={busy}
                   size="sm"
                   variant="ghost"

--- a/apps/web/components/email-list/latest-scheduled-send.test.ts
+++ b/apps/web/components/email-list/latest-scheduled-send.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { getLatestScheduledSendId } from "./latest-scheduled-send";
+
+describe("getLatestScheduledSendId", () => {
+  it("changes the completed identity when an older-created reply sends later", () => {
+    const rows = [
+      { id: "newer", status: "SENT", sentAt: "2026-09-05T10:00:00Z" },
+      { id: "older", status: "PENDING", sentAt: null },
+    ];
+    expect(getLatestScheduledSendId(rows)).toBe("newer");
+    expect(
+      getLatestScheduledSendId([
+        rows[0],
+        { id: "older", status: "SENT", sentAt: "2026-09-05T11:00:00Z" },
+      ]),
+    ).toBe("older");
+  });
+
+  it("does not identify an incomplete delivery as sent", () => {
+    expect(
+      getLatestScheduledSendId([
+        { id: "queued", status: "PENDING", sentAt: null },
+        { id: "processing", status: "PROCESSING", sentAt: null },
+      ]),
+    ).toBe("");
+  });
+});

--- a/apps/web/components/email-list/latest-scheduled-send.ts
+++ b/apps/web/components/email-list/latest-scheduled-send.ts
@@ -1,0 +1,19 @@
+export function getLatestScheduledSendId(
+  rows: readonly {
+    id: string;
+    status: string;
+    sentAt: Date | string | null;
+  }[],
+) {
+  let latestId = "";
+  let latestSentAt = Number.NEGATIVE_INFINITY;
+  for (const row of rows) {
+    if (row.status !== "SENT" || !row.sentAt) continue;
+    const sentAt = new Date(row.sentAt).getTime();
+    if (sentAt > latestSentAt) {
+      latestId = row.id;
+      latestSentAt = sentAt;
+    }
+  }
+  return latestId;
+}

--- a/apps/web/hooks/useLocalReplyDraft.ts
+++ b/apps/web/hooks/useLocalReplyDraft.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getReplyDraft,
+  type ReplyDraftIdentity,
+} from "@/utils/email-cache/reply-drafts";
+import type { StoredReplyDraft } from "@/utils/email-cache/database";
+
+export function useLocalReplyDraft(identity: ReplyDraftIdentity | undefined) {
+  const key = identity ? JSON.stringify(identity) : "";
+  const [loaded, setLoaded] = useState<{
+    key: string;
+    draft?: StoredReplyDraft;
+    error?: Error;
+  }>();
+  useEffect(() => {
+    if (!key) return;
+    let cancelled = false;
+    getReplyDraft(JSON.parse(key)).then(
+      (draft) => {
+        if (!cancelled) setLoaded({ key, draft });
+      },
+      (error) => {
+        if (!cancelled) setLoaded({ key, error });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+  return {
+    isLoading: Boolean(key && loaded?.key !== key),
+    draft: loaded?.key === key ? loaded.draft : undefined,
+    error: loaded?.key === key ? loaded.error : undefined,
+  };
+}

--- a/apps/web/hooks/useReplyDrafts.ts
+++ b/apps/web/hooks/useReplyDrafts.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import useSWR from "swr";
+import {
+  getReplyDrafts,
+  subscribeToReplyDrafts,
+} from "@/utils/email-cache/reply-drafts";
+
+export function useReplyDrafts(emailAccountId: string, threadId: string) {
+  const { data, error, isLoading, mutate } = useSWR(
+    ["local-reply-drafts", emailAccountId, threadId],
+    () => getReplyDrafts(emailAccountId, threadId),
+  );
+  useEffect(
+    () =>
+      subscribeToReplyDrafts(() => {
+        mutate();
+      }),
+    [mutate],
+  );
+  return { drafts: data ?? [], error, isLoading };
+}

--- a/apps/web/hooks/useReplyDrafts.ts
+++ b/apps/web/hooks/useReplyDrafts.ts
@@ -14,10 +14,14 @@ export function useReplyDrafts(emailAccountId: string, threadId: string) {
   );
   useEffect(
     () =>
-      subscribeToReplyDrafts(() => {
-        mutate();
+      subscribeToReplyDrafts((scope) => {
+        if (
+          scope.emailAccountId === emailAccountId &&
+          scope.threadId === threadId
+        )
+          mutate();
       }),
-    [mutate],
+    [emailAccountId, threadId, mutate],
   );
   return { drafts: data ?? [], error, isLoading };
 }

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -211,13 +211,6 @@ const SHORTCUT_DEFINITIONS = [
     label: "List view / split view",
   },
   {
-    id: "focusMode",
-    keys: ["f"],
-    scope: "mail",
-    group: "View",
-    label: "Focus mode (full screen)",
-  },
-  {
     id: "help",
     keys: ["shift+?", "?"],
     display: ["?"],

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -82,6 +82,8 @@ export default defineConfig({
       ],
   use: {
     baseURL,
+    actionTimeout: 30_000,
+    navigationTimeout: 60_000,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/apps/web/prisma/migrations/20260905210000_scheduled_email_replies/migration.sql
+++ b/apps/web/prisma/migrations/20260905210000_scheduled_email_replies/migration.sql
@@ -25,3 +25,5 @@ CREATE INDEX "ScheduledEmail_status_sendAt_idx" ON "ScheduledEmail"("status", "s
 CREATE INDEX "ScheduledEmail_reminderStatus_remindAt_idx" ON "ScheduledEmail"("reminderStatus", "remindAt");
 CREATE INDEX "ScheduledEmail_emailAccountId_threadId_idx" ON "ScheduledEmail"("emailAccountId", "threadId");
 ALTER TABLE "ScheduledEmail" ADD CONSTRAINT "ScheduledEmail_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+CREATE INDEX "ScheduledEmail_status_processingStartedAt_idx" ON "ScheduledEmail"("status", "processingStartedAt");
+CREATE INDEX "ScheduledEmail_reminderStatus_reminderStartedAt_idx" ON "ScheduledEmail"("reminderStatus", "reminderStartedAt");

--- a/apps/web/prisma/migrations/20260905210000_scheduled_email_replies/migration.sql
+++ b/apps/web/prisma/migrations/20260905210000_scheduled_email_replies/migration.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "ScheduledEmailStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'BLOCKED_AUTH', 'UNCERTAIN', 'FAILED', 'CANCELLED');
+CREATE TYPE "EmailReminderStatus" AS ENUM ('NONE', 'PENDING', 'PROCESSING', 'COMPLETED', 'CANCELLED');
+CREATE TABLE "ScheduledEmail" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+    "clientMutationId" TEXT NOT NULL,
+    "payloadHash" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "sendAt" TIMESTAMP(3) NOT NULL,
+    "status" "ScheduledEmailStatus" NOT NULL DEFAULT 'PENDING',
+    "processingStartedAt" TIMESTAMP(3),
+    "executionQueuedAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "error" TEXT,
+    "remindAt" TIMESTAMP(3),
+    "reminderStatus" "EmailReminderStatus" NOT NULL DEFAULT 'NONE',
+    "reminderStartedAt" TIMESTAMP(3),
+    CONSTRAINT "ScheduledEmail_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "ScheduledEmail_emailAccountId_clientMutationId_key" ON "ScheduledEmail"("emailAccountId", "clientMutationId");
+CREATE INDEX "ScheduledEmail_status_sendAt_idx" ON "ScheduledEmail"("status", "sendAt");
+CREATE INDEX "ScheduledEmail_reminderStatus_remindAt_idx" ON "ScheduledEmail"("reminderStatus", "remindAt");
+CREATE INDEX "ScheduledEmail_emailAccountId_threadId_idx" ON "ScheduledEmail"("emailAccountId", "threadId");
+ALTER TABLE "ScheduledEmail" ADD CONSTRAINT "ScheduledEmail_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -850,7 +850,9 @@ model ScheduledEmail {
 
   @@unique([emailAccountId, clientMutationId])
   @@index([status, sendAt])
+  @@index([status, processingStartedAt])
   @@index([reminderStatus, remindAt])
+  @@index([reminderStatus, reminderStartedAt])
   @@index([emailAccountId, threadId])
 }
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -187,28 +187,29 @@ model EmailAccount {
   accountId String  @unique
   account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
 
-  labels               Label[]
-  rules                Rule[]
-  executedRules        ExecutedRule[]
-  newsletters          Newsletter[]
-  coldEmails           ColdEmail[] // @deprecated - kept for backward compatibility during migration
-  groups               Group[]
-  categories           Category[]
-  threadTrackers       ThreadTracker[]
-  cleanupJobs          CleanupJob[]
-  cleanupThreads       CleanupThread[]
-  emailMessages        EmailMessage[]
-  emailTokens          EmailToken[]
-  knowledge            Knowledge[]
-  replyMemories        ReplyMemory[]
-  chats                Chat[]
-  chatMemories         ChatMemory[]
-  digests              Digest[]
-  scheduledActions     ScheduledAction[]
-  snoozedThreads       SnoozedThread[]
+  labels              Label[]
+  rules               Rule[]
+  executedRules       ExecutedRule[]
+  newsletters         Newsletter[]
+  coldEmails          ColdEmail[] // @deprecated - kept for backward compatibility during migration
+  groups              Group[]
+  categories          Category[]
+  threadTrackers      ThreadTracker[]
+  cleanupJobs         CleanupJob[]
+  cleanupThreads      CleanupThread[]
+  emailMessages       EmailMessage[]
+  emailTokens         EmailToken[]
+  knowledge           Knowledge[]
+  replyMemories       ReplyMemory[]
+  chats               Chat[]
+  chatMemories        ChatMemory[]
+  digests             Digest[]
+  scheduledActions    ScheduledAction[]
+  snoozedThreads      SnoozedThread[]
   emailSendOperations EmailSendOperation[]
-  responseTimes        ResponseTime[]
-  actions              Action[]
+  scheduledEmails     ScheduledEmail[]
+  responseTimes       ResponseTime[]
+  actions             Action[]
 
   members                Member[]
   invitations            Invitation[]
@@ -825,6 +826,50 @@ model SnoozedThread {
   @@unique([emailAccountId, clientMutationId])
   @@index([status, scheduledFor])
   @@index([emailAccountId, threadId, status])
+}
+
+model ScheduledEmail {
+  id                  String               @id @default(cuid())
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+  emailAccountId      String
+  emailAccount        EmailAccount         @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  clientMutationId    String
+  payloadHash         String
+  payload             Json
+  threadId            String
+  sendAt              DateTime
+  status              ScheduledEmailStatus @default(PENDING)
+  processingStartedAt DateTime?
+  executionQueuedAt   DateTime?
+  sentAt              DateTime?
+  error               String?
+  remindAt            DateTime?
+  reminderStatus      EmailReminderStatus  @default(NONE)
+  reminderStartedAt   DateTime?
+
+  @@unique([emailAccountId, clientMutationId])
+  @@index([status, sendAt])
+  @@index([reminderStatus, remindAt])
+  @@index([emailAccountId, threadId])
+}
+
+enum ScheduledEmailStatus {
+  PENDING
+  PROCESSING
+  SENT
+  BLOCKED_AUTH
+  UNCERTAIN
+  FAILED
+  CANCELLED
+}
+
+enum EmailReminderStatus {
+  NONE
+  PENDING
+  PROCESSING
+  COMPLETED
+  CANCELLED
 }
 
 model EmailSendOperation {

--- a/apps/web/utils/actions/scheduled-email.ts
+++ b/apps/web/utils/actions/scheduled-email.ts
@@ -8,6 +8,7 @@ import {
 import {
   scheduleEmail,
   cancelScheduledEmail,
+  retryScheduledEmail,
   processScheduledEmail,
 } from "@/utils/scheduled-email/service";
 import prisma from "@/utils/prisma";
@@ -33,12 +34,7 @@ export const retryScheduledEmailAction = actionClient
   .metadata({ name: "retryScheduledEmail" })
   .inputSchema(scheduledEmailIdBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
-    const result = await prisma.scheduledEmail.updateMany({
-      where: { id, emailAccountId, status: { in: ["BLOCKED_AUTH", "FAILED"] } },
-      data: { status: "PENDING", sendAt: new Date(), error: null },
-    });
-    if (!result.count)
-      throw new SafeError("This email cannot be retried safely.");
+    await retryScheduledEmail(emailAccountId, id);
   });
 
 export const cancelEmailReminderAction = actionClient

--- a/apps/web/utils/actions/scheduled-email.ts
+++ b/apps/web/utils/actions/scheduled-email.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { actionClient } from "@/utils/actions/safe-action";
+import {
+  scheduleEmailBody,
+  scheduledEmailIdBody,
+} from "@/utils/actions/scheduled-email.validation";
+import {
+  scheduleEmail,
+  cancelScheduledEmail,
+  processScheduledEmail,
+} from "@/utils/scheduled-email/service";
+import prisma from "@/utils/prisma";
+import { SafeError } from "@/utils/error";
+
+export const scheduleEmailAction = actionClient
+  .metadata({ name: "scheduleEmail" })
+  .inputSchema(scheduleEmailBody)
+  .action(async ({ ctx: { emailAccountId, logger }, parsedInput }) => {
+    const row = await scheduleEmail(emailAccountId, parsedInput);
+    if (!parsedInput.sendAt) await processScheduledEmail(row.id, logger);
+    return { id: row.id };
+  });
+
+export const cancelScheduledEmailAction = actionClient
+  .metadata({ name: "cancelScheduledEmail" })
+  .inputSchema(scheduledEmailIdBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
+    await cancelScheduledEmail(emailAccountId, id);
+  });
+
+export const retryScheduledEmailAction = actionClient
+  .metadata({ name: "retryScheduledEmail" })
+  .inputSchema(scheduledEmailIdBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
+    const result = await prisma.scheduledEmail.updateMany({
+      where: { id, emailAccountId, status: { in: ["BLOCKED_AUTH", "FAILED"] } },
+      data: { status: "PENDING", sendAt: new Date(), error: null },
+    });
+    if (!result.count)
+      throw new SafeError("This email cannot be retried safely.");
+  });
+
+export const cancelEmailReminderAction = actionClient
+  .metadata({ name: "cancelEmailReminder" })
+  .inputSchema(scheduledEmailIdBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
+    const result = await prisma.scheduledEmail.updateMany({
+      where: { id, emailAccountId, reminderStatus: "PENDING" },
+      data: { reminderStatus: "CANCELLED" },
+    });
+    if (!result.count)
+      throw new SafeError(
+        "This reminder has already started or is no longer pending.",
+      );
+  });

--- a/apps/web/utils/actions/scheduled-email.validation.ts
+++ b/apps/web/utils/actions/scheduled-email.validation.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { sendEmailBody } from "@/utils/types/mail";
+
+export const scheduleEmailBody = z.object({
+  clientMutationId: z.string().uuid(),
+  threadId: z.string().min(1).max(512),
+  messageIds: z.array(z.string().min(1).max(512)).min(1).max(1000),
+  email: sendEmailBody,
+  sendAt: z.iso.datetime().nullable(),
+  remindAt: z.iso.datetime().nullable(),
+});
+
+export const scheduledEmailIdBody = z.object({ id: z.string().min(1) });

--- a/apps/web/utils/email-cache/database.ts
+++ b/apps/web/utils/email-cache/database.ts
@@ -1,8 +1,9 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import type { ReplyDraftContent } from "./reply-drafts";
 import type { ParsedMessage } from "@/utils/types";
 
 const DATABASE_NAME = "inbox-zero-email-cache";
-const DATABASE_VERSION = 4;
+const DATABASE_VERSION = 5;
 
 export type CachedThreadRow = {
   emailAccountId: string;
@@ -94,6 +95,15 @@ export type StoredMailMutation = {
   result?: unknown;
 };
 
+export type StoredReplyDraft = {
+  emailAccountId: string;
+  threadId: string;
+  messageId: string;
+  revision: number;
+  content: ReplyDraftContent | null;
+  updatedAt: number;
+};
+
 interface EmailCacheSchema extends DBSchema {
   mailboxMessages: {
     key: [emailAccountId: string, messageId: string];
@@ -119,6 +129,11 @@ interface EmailCacheSchema extends DBSchema {
       byNextAttempt: [status: string, nextAttemptAt: number];
       byUpdatedAt: number;
     };
+  };
+  replyDrafts: {
+    key: [emailAccountId: string, threadId: string, messageId: string];
+    value: StoredReplyDraft;
+    indexes: { byAccount: string; byAccountThread: [string, string] };
   };
   threadDetails: {
     key: [emailAccountId: string, threadId: string, variant: string];
@@ -193,6 +208,14 @@ export function getEmailCacheDatabase() {
           .createIndex("byAccountReceivedAt", ["emailAccountId", "receivedAt"]);
       }
 
+      if (oldVersion < 5) {
+        const drafts = database.createObjectStore("replyDrafts", {
+          keyPath: ["emailAccountId", "threadId", "messageId"],
+        });
+        drafts.createIndex("byAccount", "emailAccountId");
+        drafts.createIndex("byAccountThread", ["emailAccountId", "threadId"]);
+      }
+
       if (oldVersion < 4) {
         const mutations = database.createObjectStore("mailMutations", {
           keyPath: "id",
@@ -256,6 +279,7 @@ export async function clearEmailCache() {
         "mailboxMessages",
         "mailboxSyncStates",
         "mailMutations",
+        "replyDrafts",
       ],
       "readwrite",
     );
@@ -266,6 +290,7 @@ export async function clearEmailCache() {
       transaction.objectStore("mailboxMessages").clear(),
       transaction.objectStore("mailboxSyncStates").clear(),
       transaction.objectStore("mailMutations").clear(),
+      transaction.objectStore("replyDrafts").clear(),
       transaction.done,
     ]);
   } catch {
@@ -296,6 +321,7 @@ export async function clearEmailCacheForAccount(emailAccountId: string) {
         "mailboxMessages",
         "mailboxSyncStates",
         "mailMutations",
+        "replyDrafts",
       ],
       "readwrite",
     );
@@ -304,20 +330,29 @@ export async function clearEmailCacheForAccount(emailAccountId: string) {
     const details = transaction.objectStore("threadDetails");
     const messages = transaction.objectStore("mailboxMessages");
     const mutations = transaction.objectStore("mailMutations");
-    const [rowKeys, viewKeys, detailKeys, messageKeys, mutationKeys] =
-      await Promise.all([
-        rows.index("byAccount").getAllKeys(emailAccountId),
-        views.index("byAccount").getAllKeys(emailAccountId),
-        details.index("byAccount").getAllKeys(emailAccountId),
-        messages.index("byAccount").getAllKeys(emailAccountId),
-        mutations.index("byAccount").getAllKeys(emailAccountId),
-      ]);
+    const drafts = transaction.objectStore("replyDrafts");
+    const [
+      rowKeys,
+      viewKeys,
+      detailKeys,
+      messageKeys,
+      mutationKeys,
+      draftKeys,
+    ] = await Promise.all([
+      rows.index("byAccount").getAllKeys(emailAccountId),
+      views.index("byAccount").getAllKeys(emailAccountId),
+      details.index("byAccount").getAllKeys(emailAccountId),
+      messages.index("byAccount").getAllKeys(emailAccountId),
+      mutations.index("byAccount").getAllKeys(emailAccountId),
+      drafts.index("byAccount").getAllKeys(emailAccountId),
+    ]);
     await Promise.all([
       ...rowKeys.map((key) => rows.delete(key)),
       ...viewKeys.map((key) => views.delete(key)),
       ...detailKeys.map((key) => details.delete(key)),
       ...messageKeys.map((key) => messages.delete(key)),
       ...mutationKeys.map((key) => mutations.delete(key)),
+      ...draftKeys.map((key) => drafts.delete(key)),
       transaction.objectStore("mailboxSyncStates").delete(emailAccountId),
     ]);
     await transaction.done;

--- a/apps/web/utils/email-cache/mail-mutations.test.ts
+++ b/apps/web/utils/email-cache/mail-mutations.test.ts
@@ -36,6 +36,36 @@ import {
 describe("mail mutation outbox", () => {
   beforeEach(clearEmailCache);
 
+  it("sends a reply while an applied read action awaits cache sync", async () => {
+    await enqueueMailMutation(
+      {
+        id: "read",
+        emailAccountId: "account",
+        threadId: "thread",
+        messageIds: ["message"],
+        kind: "set_read_state",
+        read: true,
+      },
+      10,
+    );
+    await claimNextMailMutation({ ownerId: "worker", leaseMs: 100, now: 10 });
+    await markMailMutationAwaitingSync("read", undefined, "worker");
+    await enqueueMailMutation(
+      {
+        id: "reply",
+        emailAccountId: "account",
+        threadId: "thread",
+        messageIds: ["message"],
+        kind: "reply",
+        email: { to: "to@example.com", subject: "Hi", messageHtml: "Hi" },
+      },
+      20,
+    );
+    await expect(
+      claimNextMailMutation({ ownerId: "sender", leaseMs: 100, now: 30 }),
+    ).resolves.toMatchObject({ id: "reply" });
+  });
+
   it("classifies every durable nonterminal status as active", () => {
     for (const status of [
       "pending",

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -756,7 +756,9 @@ export function subscribeToMailMutations(
   listener: (mutations?: MailMutation[]) => void,
 ) {
   listeners.add(listener);
-  return () => listeners.delete(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 async function enqueueInStore(

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -997,7 +997,7 @@ function readActiveStoredMutations(index: {
   ).then((mutations) => mutations.flat());
 }
 
-function notifyMailMutationChange(mutations?: MailMutation[]) {
+export function notifyMailMutationChange(mutations?: MailMutation[]) {
   notifyListeners(mutations);
   channel?.postMessage(
     mutations?.length

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -272,6 +272,7 @@ export async function claimNextMailMutationBatch({
     await readActiveStoredMutations(store.index("byNextAttempt"))
   ).sort(compareMutations);
   const blockedThreads = new Set<string>();
+  const syncingThreads = new Set<string>();
   const claimed: StoredMailMutation[] = [];
   const rejected: StoredMailMutation[] = [];
   const claimedMessageIds = new Set<string>();
@@ -291,6 +292,11 @@ export async function claimNextMailMutationBatch({
     }
 
     if (isSyncMailMutationStatus(mutation.status)) {
+      syncingThreads.add(threadKey);
+      continue;
+    }
+    // Sending does not depend on refreshing an already-applied mailbox action.
+    if (syncingThreads.has(threadKey) && mutation.kind !== "reply") {
       blockedThreads.add(threadKey);
       continue;
     }

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -5,6 +5,7 @@ import {
   claimNextMailMutation,
 } from "./mail-mutations";
 import "fake-indexeddb/auto";
+import { validateEmailAttachments } from "@inboxzero/email-editor/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { clearEmailCache, clearEmailCacheForAccount } from "./database";
 import {
@@ -63,6 +64,41 @@ describe("local reply drafts", () => {
       "private@example.com",
     );
   });
+  it("does not hydrate drafts from reads overlapping account cleanup", async () => {
+    await createReplyDraftWriter(identity).save(content);
+    const read = getReplyDraft(identity);
+    const list = getReplyDrafts(identity.emailAccountId, identity.threadId);
+    const assertions = Promise.all([
+      expect(read).rejects.toThrow("cleared"),
+      expect(list).rejects.toThrow("cleared"),
+    ]);
+    await clearEmailCacheForAccount(identity.emailAccountId);
+    await assertions;
+  });
+
+  it("does not recreate an outbox draft when recovery overlaps account cleanup", async () => {
+    const queued = await enqueueMailMutation({
+      ...identity,
+      messageIds: [identity.messageId],
+      kind: "reply",
+      email: {
+        to: "person@example.com",
+        subject: "Reply",
+        messageHtml: "<p>Private draft</p>",
+      },
+    });
+    const restoring = restoreReplyFromOutbox(
+      queued.id,
+      identity.emailAccountId,
+    );
+    const assertion = expect(restoring).rejects.toThrow("cleared");
+    await clearEmailCacheForAccount(identity.emailAccountId);
+    await assertion;
+    expect(
+      await getReplyDrafts(identity.emailAccountId, identity.threadId),
+    ).toEqual([]);
+  });
+
   it("serializes pending saves before clearing and rejects stale tabs", async () => {
     const writer = createReplyDraftWriter(identity);
     const stale = createReplyDraftWriter(identity);
@@ -82,13 +118,20 @@ describe("local reply drafts", () => {
         to: "person@example.com",
         subject: "Reply",
         messageHtml: "<p>Keep this text</p>",
+        attachments: [
+          { filename: "note.txt", contentType: "text/plain", content: "aGk=" },
+        ],
       },
     });
-    await restoreReplyFromOutbox(queued.id);
+    await restoreReplyFromOutbox(queued.id, identity.emailAccountId);
     expect(await getMailMutation(queued.id)).toBeUndefined();
     expect(
       (await getReplyDraft(identity))?.content?.draft.editableHtml,
     ).toContain("Keep this text");
+    const attachments =
+      (await getReplyDraft(identity))?.content?.attachments ?? [];
+    expect(attachments).toHaveLength(1);
+    expect(validateEmailAttachments(attachments).valid).toBe(true);
   });
   it("does not restore a reply already claimed for sending", async () => {
     const queued = await enqueueMailMutation({
@@ -102,9 +145,9 @@ describe("local reply drafts", () => {
       },
     });
     await claimNextMailMutation({ ownerId: "worker", leaseMs: 30_000 });
-    await expect(restoreReplyFromOutbox(queued.id)).rejects.toThrow(
-      "already started",
-    );
+    await expect(
+      restoreReplyFromOutbox(queued.id, identity.emailAccountId),
+    ).rejects.toThrow("already started");
     expect((await getMailMutation(queued.id))?.status).toBe("processing");
     expect(await getReplyDraft(identity)).toBeUndefined();
   });

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import {
+  enqueueMailMutation,
+  getMailMutation,
+  claimNextMailMutation,
+} from "./mail-mutations";
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearEmailCache, clearEmailCacheForAccount } from "./database";
+import {
+  restoreReplyFromOutbox,
+  createReplyDraftWriter,
+  getReplyDraft,
+  getReplyDrafts,
+  type ReplyDraftContent,
+} from "./reply-drafts";
+
+const identity = {
+  emailAccountId: "account",
+  threadId: "thread",
+  messageId: "parent",
+};
+const content: ReplyDraftContent = {
+  values: {
+    to: "someone@example.com",
+    subject: "Reply",
+    cc: "other@example.com",
+  },
+  draft: {
+    editableHtml: "<p>My reply</p>",
+    mode: "rich",
+    quotedHtml: "",
+    signatureHtml: "",
+    unsupported: [],
+  },
+  preservedBlocks: [
+    { id: "quote", kind: "quote", html: "<p>Original</p>", collapsed: true },
+  ],
+  attachments: [
+    {
+      id: "file",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      contentBase64: "aGk=",
+      size: 2,
+      disposition: "attachment",
+    },
+  ],
+};
+
+describe("local reply drafts", () => {
+  beforeEach(clearEmailCache);
+  it("restores body, recipients, quote and attachments after the writer is replaced", async () => {
+    await createReplyDraftWriter(identity).save(content);
+    const saved = await getReplyDraft(identity);
+    expect(saved?.content).toEqual(content);
+    const replacement = createReplyDraftWriter(identity, saved?.revision);
+    await replacement.save({
+      ...content,
+      values: { ...content.values, bcc: "private@example.com" },
+    });
+    expect((await getReplyDraft(identity))?.content?.values.bcc).toBe(
+      "private@example.com",
+    );
+  });
+  it("serializes pending saves before clearing and rejects stale tabs", async () => {
+    const writer = createReplyDraftWriter(identity);
+    const stale = createReplyDraftWriter(identity);
+    const pending = writer.save(content);
+    const clearing = writer.clear();
+    await Promise.all([pending, clearing]);
+    await expect(writer.save(content)).rejects.toThrow("closed");
+    await expect(stale.save(content)).rejects.toThrow("another tab");
+    expect(await getReplyDrafts("account", "thread")).toEqual([]);
+  });
+  it("restores a queued reply for editing atomically without losing its body", async () => {
+    const queued = await enqueueMailMutation({
+      ...identity,
+      messageIds: [identity.messageId],
+      kind: "reply",
+      email: {
+        to: "person@example.com",
+        subject: "Reply",
+        messageHtml: "<p>Keep this text</p>",
+      },
+    });
+    await restoreReplyFromOutbox(queued.id);
+    expect(await getMailMutation(queued.id)).toBeUndefined();
+    expect(
+      (await getReplyDraft(identity))?.content?.draft.editableHtml,
+    ).toContain("Keep this text");
+  });
+  it("does not restore a reply already claimed for sending", async () => {
+    const queued = await enqueueMailMutation({
+      ...identity,
+      messageIds: [identity.messageId],
+      kind: "reply",
+      email: {
+        to: "person@example.com",
+        subject: "Reply",
+        messageHtml: "<p>In flight</p>",
+      },
+    });
+    await claimNextMailMutation({ ownerId: "worker", leaseMs: 30_000 });
+    await expect(restoreReplyFromOutbox(queued.id)).rejects.toThrow(
+      "already started",
+    );
+    expect((await getMailMutation(queued.id))?.status).toBe("processing");
+    expect(await getReplyDraft(identity)).toBeUndefined();
+  });
+
+  it("isolates accounts and prevents writes after account cleanup", async () => {
+    const writer = createReplyDraftWriter(identity);
+    await writer.save(content);
+    await createReplyDraftWriter({ ...identity, emailAccountId: "other" }).save(
+      content,
+    );
+    await clearEmailCacheForAccount("account");
+    await expect(writer.save(content)).rejects.toThrow("cleared");
+    expect(await getReplyDraft(identity)).toBeUndefined();
+    expect(await getReplyDrafts("other", "thread")).toHaveLength(1);
+  });
+});

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -1,0 +1,204 @@
+import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
+import { notifyMailMutationChange } from "./mail-mutations";
+import { sendEmailBody } from "@/utils/types/mail";
+import {
+  prepareEmailDraft,
+  type EmailComposerAttachment,
+  type PreparedEmailDraft,
+} from "@inboxzero/email-editor/core";
+import type { EmailEditorPreservedBlock } from "@inboxzero/email-editor/web";
+import type { SendEmailBody } from "@/utils/types/mail";
+import {
+  captureEmailCacheEpoch,
+  getEmailCacheDatabase,
+  isEmailCacheEpochCurrent,
+  type StoredReplyDraft,
+} from "./database";
+
+export type ReplyDraftContent = {
+  requestId?: string;
+  deliveryPath?: "scheduled" | "outbox";
+  values: Omit<SendEmailBody, "attachments" | "messageHtml">;
+  draft: PreparedEmailDraft;
+  preservedBlocks: EmailEditorPreservedBlock[];
+  attachments: EmailComposerAttachment[];
+  sendAt?: string;
+  remindAt?: string;
+};
+
+export type ReplyDraftIdentity = Pick<
+  StoredReplyDraft,
+  "emailAccountId" | "threadId" | "messageId"
+>;
+const listeners = new Set<() => void>();
+const channel =
+  typeof window !== "undefined" && typeof BroadcastChannel !== "undefined"
+    ? new BroadcastChannel("inbox-zero-reply-drafts")
+    : null;
+channel?.addEventListener("message", () => {
+  for (const listener of listeners) listener();
+});
+
+export function subscribeToReplyDrafts(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function getReplyDraft(identity: ReplyDraftIdentity) {
+  const database = await getEmailCacheDatabase();
+  if (!database)
+    throw new Error("Draft storage is unavailable on this device.");
+  return database.get("replyDrafts", [
+    identity.emailAccountId,
+    identity.threadId,
+    identity.messageId,
+  ]);
+}
+
+export async function getReplyDrafts(emailAccountId: string, threadId: string) {
+  const database = await getEmailCacheDatabase();
+  if (!database)
+    throw new Error("Draft storage is unavailable on this device.");
+  const drafts = await database.getAllFromIndex(
+    "replyDrafts",
+    "byAccountThread",
+    [emailAccountId, threadId],
+  );
+  return drafts.filter((draft) => draft.content !== null);
+}
+
+export function createReplyDraftWriter(
+  identity: ReplyDraftIdentity,
+  initialRevision = 0,
+) {
+  let revision = initialRevision;
+  let stopped = false;
+  let pending: Promise<unknown> = Promise.resolve();
+  const epoch = captureEmailCacheEpoch(identity.emailAccountId);
+  const write = (content: ReplyDraftContent | null) => {
+    const operation = pending
+      .catch(() => {})
+      .then(async () => {
+        if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+          throw new Error("This account's local draft storage was cleared.");
+        const database = await getEmailCacheDatabase();
+        if (!database)
+          throw new Error("Draft storage is unavailable on this device.");
+        if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+          throw new Error("This account's local draft storage was cleared.");
+        const transaction = database.transaction("replyDrafts", "readwrite");
+        const key: [string, string, string] = [
+          identity.emailAccountId,
+          identity.threadId,
+          identity.messageId,
+        ];
+        const previous = await transaction.store.get(key);
+        if ((previous?.revision ?? 0) !== revision) {
+          await transaction.done;
+          throw new Error(
+            "This draft changed in another tab. Reopen the reply to load that version.",
+          );
+        }
+        await transaction.store.put({
+          ...identity,
+          content,
+          revision: revision + 1,
+          updatedAt: Date.now(),
+        });
+        await transaction.done;
+        revision += 1;
+        if (Boolean(previous?.content) !== Boolean(content)) {
+          for (const listener of listeners) listener();
+          channel?.postMessage(null);
+        }
+      });
+    pending = operation;
+    return operation;
+  };
+  return {
+    save(content: ReplyDraftContent) {
+      if (stopped)
+        return Promise.reject(
+          new Error("This draft is closed. Reopen the reply before editing."),
+        );
+      return write(content);
+    },
+    clear() {
+      stopped = true;
+      // Keep a revision tombstone so an older tab cannot resurrect a sent draft.
+      return write(null);
+    },
+  };
+}
+
+export async function restoreReplyFromOutbox(id: string) {
+  const database = await getEmailCacheDatabase();
+  if (!database)
+    throw new Error("Draft storage is unavailable on this device.");
+  const row = await database.get("mailMutations", id);
+  if (row?.kind !== "reply") throw new Error("Queued reply was not found.");
+  const email = sendEmailBody.parse((row.payload as { email: unknown }).email);
+  const draft = prepareEmailDraft({ html: email.messageHtml });
+  const { attachments, messageHtml: _messageHtml, ...values } = email;
+  const content: ReplyDraftContent = {
+    values,
+    draft,
+    preservedBlocks: createPreservedEmailBlocks(draft),
+    attachments: (attachments ?? []).map((file, index) => ({
+      id: file.id ?? String(index),
+      filename: file.filename,
+      mimeType: file.contentType,
+      contentBase64: file.content,
+      size: file.size ?? Math.floor((file.content.length * 3) / 4),
+      disposition: file.disposition ?? "attachment",
+      contentId: file.contentId,
+    })),
+  };
+  const identity = {
+    emailAccountId: row.emailAccountId,
+    threadId: row.threadId,
+    messageId: row.messageIds[0],
+  };
+  if (!identity.messageId)
+    throw new Error("The reply's original message is unavailable.");
+  const transaction = database.transaction(
+    ["mailMutations", "replyDrafts"],
+    "readwrite",
+  );
+  const current = await transaction.objectStore("mailMutations").get(id);
+  const key: [string, string, string] = [
+    identity.emailAccountId,
+    identity.threadId,
+    identity.messageId,
+  ];
+  const previous = await transaction.objectStore("replyDrafts").get(key);
+  if (
+    !current ||
+    current.updatedAt !== row.updatedAt ||
+    current.leaseOwner ||
+    !["pending", "retry_wait", "blocked_auth", "failed"].includes(
+      current.status,
+    ) ||
+    previous?.content
+  ) {
+    await transaction.done;
+    throw new Error(
+      previous?.content
+        ? "Finish or discard the current draft first."
+        : "Sending has already started. This reply cannot be edited safely.",
+    );
+  }
+  await transaction.objectStore("replyDrafts").put({
+    ...identity,
+    content,
+    revision: (previous?.revision ?? 0) + 1,
+    updatedAt: Date.now(),
+  });
+  await transaction.objectStore("mailMutations").delete(id);
+  await transaction.done;
+  for (const listener of listeners) listener();
+  channel?.postMessage(null);
+  notifyMailMutationChange();
+}

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -1,6 +1,6 @@
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { notifyMailMutationChange } from "./mail-mutations";
-import { sendEmailBody } from "@/utils/types/mail";
+import { decodedBase64Size, sendEmailBody } from "@/utils/types/mail";
 import {
   prepareEmailDraft,
   type EmailComposerAttachment,
@@ -30,16 +30,25 @@ export type ReplyDraftIdentity = Pick<
   StoredReplyDraft,
   "emailAccountId" | "threadId" | "messageId"
 >;
-const listeners = new Set<() => void>();
+type ReplyDraftScope = Pick<ReplyDraftIdentity, "emailAccountId" | "threadId">;
+const listeners = new Set<(scope: ReplyDraftScope) => void>();
 const channel =
   typeof window !== "undefined" && typeof BroadcastChannel !== "undefined"
     ? new BroadcastChannel("inbox-zero-reply-drafts")
     : null;
-channel?.addEventListener("message", () => {
-  for (const listener of listeners) listener();
+channel?.addEventListener("message", (event) => {
+  const scope = event.data;
+  if (
+    typeof scope?.emailAccountId !== "string" ||
+    typeof scope?.threadId !== "string"
+  )
+    return;
+  for (const listener of listeners) listener(scope);
 });
 
-export function subscribeToReplyDrafts(listener: () => void) {
+export function subscribeToReplyDrafts(
+  listener: (scope: ReplyDraftScope) => void,
+) {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
@@ -47,17 +56,22 @@ export function subscribeToReplyDrafts(listener: () => void) {
 }
 
 export async function getReplyDraft(identity: ReplyDraftIdentity) {
+  const epoch = captureEmailCacheEpoch(identity.emailAccountId);
   const database = await getEmailCacheDatabase();
   if (!database)
     throw new Error("Draft storage is unavailable on this device.");
-  return database.get("replyDrafts", [
+  const draft = await database.get("replyDrafts", [
     identity.emailAccountId,
     identity.threadId,
     identity.messageId,
   ]);
+  if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+    throw new Error("This account’s local draft storage was cleared.");
+  return draft;
 }
 
 export async function getReplyDrafts(emailAccountId: string, threadId: string) {
+  const epoch = captureEmailCacheEpoch(emailAccountId);
   const database = await getEmailCacheDatabase();
   if (!database)
     throw new Error("Draft storage is unavailable on this device.");
@@ -66,6 +80,8 @@ export async function getReplyDrafts(emailAccountId: string, threadId: string) {
     "byAccountThread",
     [emailAccountId, threadId],
   );
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch))
+    throw new Error("This account’s local draft storage was cleared.");
   return drafts.filter((draft) => draft.content !== null);
 }
 
@@ -110,8 +126,8 @@ export function createReplyDraftWriter(
         await transaction.done;
         revision += 1;
         if (Boolean(previous?.content) !== Boolean(content)) {
-          for (const listener of listeners) listener();
-          channel?.postMessage(null);
+          for (const listener of listeners) listener(identity);
+          channel?.postMessage(identity);
         }
       });
     pending = operation;
@@ -133,12 +149,19 @@ export function createReplyDraftWriter(
   };
 }
 
-export async function restoreReplyFromOutbox(id: string) {
+export async function restoreReplyFromOutbox(
+  id: string,
+  emailAccountId: string,
+) {
+  const epoch = captureEmailCacheEpoch(emailAccountId);
   const database = await getEmailCacheDatabase();
   if (!database)
     throw new Error("Draft storage is unavailable on this device.");
   const row = await database.get("mailMutations", id);
-  if (row?.kind !== "reply") throw new Error("Queued reply was not found.");
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch))
+    throw new Error("This account’s local draft storage was cleared.");
+  if (row?.kind !== "reply" || row.emailAccountId !== emailAccountId)
+    throw new Error("Queued reply was not found.");
   const email = sendEmailBody.parse((row.payload as { email: unknown }).email);
   const draft = prepareEmailDraft({ html: email.messageHtml });
   const { attachments, messageHtml: _messageHtml, ...values } = email;
@@ -151,7 +174,7 @@ export async function restoreReplyFromOutbox(id: string) {
       filename: file.filename,
       mimeType: file.contentType,
       contentBase64: file.content,
-      size: file.size ?? Math.floor((file.content.length * 3) / 4),
+      size: file.size ?? decodedBase64Size(file.content),
       disposition: file.disposition ?? "attachment",
       contentId: file.contentId,
     })),
@@ -163,6 +186,8 @@ export async function restoreReplyFromOutbox(id: string) {
   };
   if (!identity.messageId)
     throw new Error("The reply's original message is unavailable.");
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch))
+    throw new Error("This account’s local draft storage was cleared.");
   const transaction = database.transaction(
     ["mailMutations", "replyDrafts"],
     "readwrite",
@@ -198,7 +223,7 @@ export async function restoreReplyFromOutbox(id: string) {
   });
   await transaction.objectStore("mailMutations").delete(id);
   await transaction.done;
-  for (const listener of listeners) listener();
-  channel?.postMessage(null);
+  for (const listener of listeners) listener(identity);
+  channel?.postMessage(identity);
   notifyMailMutationChange();
 }

--- a/apps/web/utils/email/preserved-blocks.ts
+++ b/apps/web/utils/email/preserved-blocks.ts
@@ -1,0 +1,25 @@
+import type { PreparedEmailDraft } from "@inboxzero/email-editor/core";
+import type { EmailEditorPreservedBlock } from "@inboxzero/email-editor/web";
+
+export function createPreservedEmailBlocks(
+  draft: Pick<PreparedEmailDraft, "signatureHtml" | "quotedHtml">,
+): EmailEditorPreservedBlock[] {
+  const blocks: EmailEditorPreservedBlock[] = [];
+  if (draft.signatureHtml) {
+    blocks.push({
+      id: "signature",
+      kind: "signature",
+      html: draft.signatureHtml,
+      collapsed: false,
+    });
+  }
+  if (draft.quotedHtml) {
+    blocks.push({
+      id: "quote",
+      kind: "quote",
+      html: draft.quotedHtml,
+      collapsed: true,
+    });
+  }
+  return blocks;
+}

--- a/apps/web/utils/email/split-email-content.client.test.ts
+++ b/apps/web/utils/email/split-email-content.client.test.ts
@@ -4,6 +4,20 @@ import { describe, expect, it } from "vitest";
 import { splitEmailContent } from "./split-email-content.client";
 
 describe("splitEmailContent", () => {
+  it("removes blank quote spacing without removing reply content", () => {
+    const result = splitEmailContent(
+      '<p>Reply</p><br><div dir="ltr"></div><br><div class="gmail_quote">History</div>',
+    );
+    expect(result.mainContent).toBe("<p>Reply</p>");
+  });
+  it("preserves trailing images and styled content before a quote", () => {
+    const content =
+      '<div><img src="cid:signature"></div><div style="height:20px"></div>';
+    expect(
+      splitEmailContent(`${content}<div class="gmail_quote">History</div>`)
+        .mainContent,
+    ).toBe(content);
+  });
   it("collapses a Gmail quote container", () => {
     const result = splitEmailContent(
       '<div>Current reply</div><div class="gmail_quote_container"><div>Earlier message</div></div>',

--- a/apps/web/utils/email/split-email-content.client.ts
+++ b/apps/web/utils/email/split-email-content.client.ts
@@ -21,6 +21,7 @@ export function splitEmailContent(html: string): {
   }
 
   removeBoundaryAndFollowingContent(quoteBoundary, doc.body);
+  trimQuoteSpacing(doc.body);
 
   return {
     mainContent: doc.body.innerHTML,
@@ -78,5 +79,24 @@ function removeBoundaryAndFollowingContent(
 
     if (current === boundary) parent.removeChild(current);
     current = parent;
+  }
+}
+
+function trimQuoteSpacing(parent: Element) {
+  while (parent.lastChild) {
+    const node = parent.lastChild;
+    if (node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()) {
+      node.remove();
+      continue;
+    }
+    if (!(node instanceof Element)) break;
+    if (
+      !node.matches("br, div, p") ||
+      Array.from(node.attributes).some((attribute) => attribute.name !== "dir")
+    )
+      break;
+    trimQuoteSpacing(node);
+    if (node.childNodes.length) break;
+    node.remove();
   }
 }

--- a/apps/web/utils/playwright/emulated-suite-sharding.mjs
+++ b/apps/web/utils/playwright/emulated-suite-sharding.mjs
@@ -1,0 +1,19 @@
+export function shardPlaywrightTargets(targets, shard) {
+  if (!shard) return targets;
+
+  const match = /^(\d+)\/(\d+)$/.exec(shard);
+  const index = Number(match?.[1]);
+  const count = Number(match?.[2]);
+  if (
+    !Number.isSafeInteger(index) ||
+    !Number.isSafeInteger(count) ||
+    index < 1 ||
+    count < 1 ||
+    index > count
+  ) {
+    throw new Error("PLAYWRIGHT_SHARD must be a valid one-based index/count.");
+  }
+
+  // Keep each area's shared mailbox and test ordering on one isolated runner.
+  return targets.filter((_, targetIndex) => targetIndex % count === index - 1);
+}

--- a/apps/web/utils/playwright/emulated-suite-sharding.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-sharding.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { shardPlaywrightTargets } from "./emulated-suite-sharding.mjs";
+
+describe("Playwright target sharding", () => {
+  test("runs every target exactly once across isolated shards", () => {
+    const targets = Array.from({ length: 13 }, (_, id) => ({ id }));
+    const shards = [1, 2, 3, 4].map((index) =>
+      shardPlaywrightTargets(targets, `${index}/4`),
+    );
+    expect(shards.map((shard) => shard.length)).toEqual([4, 3, 3, 3]);
+    expect(shards.flat().sort((a, b) => a.id - b.id)).toEqual(targets);
+    for (const shard of shards) {
+      expect(shard.map(({ id }) => id)).toEqual(
+        shard.map(({ id }) => id).sort((a, b) => a - b),
+      );
+    }
+  });
+
+  test("keeps unsharded local runs and empty shard assignments valid", () => {
+    const targets = [{ id: "mail" }];
+    expect(shardPlaywrightTargets(targets)).toEqual(targets);
+    expect(shardPlaywrightTargets(targets, "4/4")).toEqual([]);
+  });
+
+  test.each([
+    "0/4",
+    "5/4",
+    "1/0",
+    "1",
+    "x/4",
+    "1/2.5",
+  ])("rejects invalid shard %s instead of silently skipping tests", (shard) => {
+    expect(() => shardPlaywrightTargets([], shard)).toThrow(/index\/count/);
+  });
+});

--- a/apps/web/utils/scheduled-email/service.test.ts
+++ b/apps/web/utils/scheduled-email/service.test.ts
@@ -1,0 +1,381 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+import { createEmailProvider } from "@/utils/email/provider";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import { executeDurableEmailSend } from "@/utils/email/durable-email-send";
+import {
+  scheduleEmail,
+  cancelScheduledEmail,
+  processScheduledEmail,
+  hasReplySince,
+  processDueScheduledEmails,
+} from "./service";
+import type { ScheduledEmail } from "@/generated/prisma/client";
+import type { ParsedMessage } from "@/utils/types";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({ createEmailProvider: vi.fn() }));
+vi.mock("@/utils/email/durable-email-send", () => ({
+  executeDurableEmailSend: vi.fn(),
+}));
+const now = new Date("2026-09-05T10:00:00Z");
+const logger = createScopedLogger("scheduled-email-test");
+const input = {
+  clientMutationId: "827f1b38-2032-4bfd-bc2c-cbba02746b04",
+  threadId: "thread",
+  messageIds: ["message"],
+  email: {
+    to: "person@example.com",
+    subject: "Reply",
+    messageHtml: "<p>Hello</p>",
+  },
+  sendAt: "2026-09-06T09:00:00Z",
+  remindAt: "2026-09-08T09:00:00Z",
+};
+
+describe("scheduled replies", () => {
+  beforeEach(() => vi.resetAllMocks());
+  it("rejects past sends and reminders before delivery", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(null);
+    await expect(
+      scheduleEmail("account", { ...input, sendAt: now.toISOString() }, now),
+    ).rejects.toThrow("future");
+    await expect(
+      scheduleEmail("account", { ...input, remindAt: now.toISOString() }, now),
+    ).rejects.toThrow("after");
+    expect(prisma.scheduledEmail.create).not.toHaveBeenCalled();
+  });
+  it("does not cancel an executing send", async () => {
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });
+    await expect(cancelScheduledEmail("account", "id")).rejects.toThrow(
+      "started",
+    );
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "id",
+          emailAccountId: "account",
+          status: { in: ["PENDING", "BLOCKED_AUTH", "FAILED"] },
+        },
+      }),
+    );
+  });
+  it("does not send twice when another worker holds the claim", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(row());
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });
+    await processScheduledEmail("id", logger, now);
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+  });
+  it("reuses exact durable identity after a crash and leaves uncertain delivery terminal", async () => {
+    const queuedAt = new Date(now.getTime() - 10 * 60_000);
+    prisma.scheduledEmail.findUnique.mockResolvedValue(
+      row({ executionQueuedAt: queuedAt }),
+    );
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "microsoft" },
+    } as never);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({
+      status: "uncertain",
+    });
+    await processScheduledEmail("id", logger, now);
+    expect(executeDurableEmailSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "microsoft",
+        input: expect.objectContaining({
+          mutationId: input.clientMutationId,
+          queuedAt: queuedAt.getTime(),
+          email: input.email,
+        }),
+      }),
+    );
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "UNCERTAIN" }),
+      }),
+    );
+  });
+  it("persists future replies without sending and accepts an identical retry after its date passes", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(null);
+    prisma.scheduledEmail.create.mockResolvedValue(row());
+    await scheduleEmail("account", input, now);
+    const saved = prisma.scheduledEmail.create.mock.calls[0][0].data;
+    expect(saved).toMatchObject({
+      emailAccountId: "account",
+      payload: input,
+      sendAt: new Date(input.sendAt),
+      remindAt: new Date(input.remindAt),
+      reminderStatus: "PENDING",
+    });
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+
+    const persisted = row({ payloadHash: saved.payloadHash });
+    prisma.scheduledEmail.findUnique.mockResolvedValue(persisted);
+    expect(await scheduleEmail("account", input, new Date("2026-09-10"))).toBe(
+      persisted,
+    );
+    expect(prisma.scheduledEmail.create).toHaveBeenCalledTimes(1);
+    await expect(
+      scheduleEmail(
+        "account",
+        {
+          ...input,
+          email: { ...input.email, messageHtml: "Changed reply" },
+        },
+        now,
+      ),
+    ).rejects.toThrow("different email");
+    expect(prisma.scheduledEmail.create).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "applied",
+    "already_applied",
+  ] as const)("records %s delivery using the persisted send timestamp", async (status) => {
+    const sentAt = new Date(now.getTime() - 30_000);
+    prisma.scheduledEmail.findUnique.mockResolvedValue(row());
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "google" },
+    } as never);
+    prisma.emailSendOperation.findUniqueOrThrow.mockResolvedValue({
+      processingStartedAt: sentAt,
+    } as never);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({
+      status,
+      result: { messageId: "sent-message", threadId: "thread" },
+    });
+
+    await processScheduledEmail("id", logger, now);
+
+    expect(executeDurableEmailSend).toHaveBeenCalledTimes(1);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenLastCalledWith({
+      where: { id: "id", status: "PROCESSING", processingStartedAt: now },
+      data: { status: "SENT", sentAt, error: null },
+    });
+  });
+
+  it("delays a known-unsent retry without replacing its durable identity", async () => {
+    const queuedAt = new Date(now.getTime() - 60_000);
+    prisma.scheduledEmail.findUnique.mockResolvedValue(
+      row({ executionQueuedAt: queuedAt }),
+    );
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "google" },
+    } as never);
+    prisma.emailSendOperation.findUnique.mockResolvedValue(null);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({ status: "retry" });
+    await processScheduledEmail("id", logger, now);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "PENDING",
+          sendAt: new Date(now.getTime() + 60_000),
+        }),
+      }),
+    );
+    expect(executeDurableEmailSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          mutationId: input.clientMutationId,
+          queuedAt: queuedAt.getTime(),
+        }),
+      }),
+    );
+  });
+
+  it("keeps a live durable send non-cancellable when it asks another worker to retry", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(row());
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "google" },
+    } as never);
+    prisma.emailSendOperation.findUnique.mockResolvedValue({
+      id: "live-operation",
+    } as never);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({ status: "retry" });
+    await processScheduledEmail("id", logger, now);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "PROCESSING" }),
+      }),
+    );
+  });
+
+  it("retains the claim when recording a successful delivery fails", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(row());
+    prisma.scheduledEmail.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockRejectedValueOnce(new Error("database unavailable"));
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "google" },
+    } as never);
+    prisma.emailSendOperation.findUniqueOrThrow.mockResolvedValue({
+      processingStartedAt: now,
+    } as never);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({
+      status: "applied",
+      result: { messageId: "sent-message", threadId: "thread" },
+    });
+    await processScheduledEmail("id", logger, now);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledTimes(2);
+    expect(executeDurableEmailSend).toHaveBeenCalledTimes(1);
+  });
+
+  describe.each(["google", "microsoft"])("%s due reminders", (providerName) => {
+    beforeEach(() => {
+      prisma.scheduledEmail.findMany.mockResolvedValue([
+        row({
+          status: "SENT",
+          sentAt: new Date(now.getTime() - 60_000),
+          remindAt: now,
+          reminderStatus: "PENDING",
+        }),
+      ]);
+      prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+      prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+        email: "me@example.com",
+        account: { provider: providerName },
+      } as never);
+    });
+
+    it("returns an unanswered conversation to the inbox", async () => {
+      const provider = createMockEmailProvider({
+        getThreadMessages: vi.fn().mockResolvedValue([]),
+      });
+      vi.mocked(createEmailProvider).mockResolvedValue(provider);
+      await processDueScheduledEmails(logger, now);
+      expect(provider.unarchiveThread).toHaveBeenCalledWith("thread");
+      expect(prisma.scheduledEmail.updateMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: { reminderStatus: "COMPLETED" },
+        }),
+      );
+      expect(executeDurableEmailSend).not.toHaveBeenCalled();
+    });
+
+    it("completes without restoring when a reply arrived", async () => {
+      const provider = createMockEmailProvider({
+        getThreadMessages: vi.fn().mockResolvedValue([
+          {
+            headers: { from: "person@example.com", date: now.toISOString() },
+            labelIds: ["INBOX"],
+          },
+        ]),
+      });
+      vi.mocked(createEmailProvider).mockResolvedValue(provider);
+      await processDueScheduledEmails(logger, now);
+      expect(provider.unarchiveThread).not.toHaveBeenCalled();
+      expect(prisma.scheduledEmail.updateMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: { reminderStatus: "COMPLETED" },
+        }),
+      );
+    });
+
+    it("does not restore when reply lookup fails", async () => {
+      const provider = createMockEmailProvider({
+        getThreadMessages: vi
+          .fn()
+          .mockRejectedValue(new Error("provider unavailable")),
+      });
+      vi.mocked(createEmailProvider).mockResolvedValue(provider);
+      await processDueScheduledEmails(logger, now);
+      expect(provider.unarchiveThread).not.toHaveBeenCalled();
+      expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing after losing the reminder claim", async () => {
+      prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });
+      await processDueScheduledEmails(logger, now);
+      expect(createEmailProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  it("uses provider receipt time over a skewed sender Date header", () => {
+    const receivedAt = new Date(now.getTime() + 60_000);
+    const message = {
+      internalDate: String(receivedAt.getTime()),
+      headers: { from: "person@example.com", date: "2020-01-01T00:00:00Z" },
+      labelIds: ["INBOX"],
+    } as ParsedMessage;
+    expect(hasReplySince([message], "me@example.com", now)).toBe(true);
+    expect(
+      hasReplySince(
+        [
+          {
+            ...message,
+            internalDate: String(now.getTime() - 60_000),
+            headers: { ...message.headers, date: "2030-01-01T00:00:00Z" },
+          },
+        ],
+        "me@example.com",
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("counts only newer incoming non-draft replies", () => {
+    const incoming = {
+      headers: {
+        from: "Person <person@example.com>",
+        date: "2026-09-05T11:00:00Z",
+      },
+      labelIds: ["INBOX"],
+    } as ParsedMessage;
+    expect(hasReplySince([incoming], "me@example.com", now)).toBe(true);
+    expect(
+      hasReplySince(
+        [{ ...incoming, labelIds: ["DRAFT"] }],
+        "me@example.com",
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      hasReplySince(
+        [
+          {
+            ...incoming,
+            headers: { ...incoming.headers, from: "Me <me@example.com>" },
+          },
+        ],
+        "me@example.com",
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      hasReplySince(
+        [incoming],
+        "me@example.com",
+        new Date("2026-09-05T12:00:00Z"),
+      ),
+    ).toBe(false);
+  });
+});
+
+function row(overrides: Partial<ScheduledEmail> = {}): ScheduledEmail {
+  return {
+    id: "id",
+    emailAccountId: "account",
+    threadId: "thread",
+    clientMutationId: input.clientMutationId,
+    payload: input,
+    payloadHash: "hash",
+    status: "PENDING",
+    sendAt: now,
+    createdAt: now,
+    updatedAt: now,
+    processingStartedAt: null,
+    executionQueuedAt: null,
+    sentAt: null,
+    error: null,
+    remindAt: null,
+    reminderStatus: "NONE",
+    reminderStartedAt: null,
+    ...overrides,
+  };
+}

--- a/apps/web/utils/scheduled-email/service.test.ts
+++ b/apps/web/utils/scheduled-email/service.test.ts
@@ -168,6 +168,43 @@ describe("scheduled replies", () => {
     expect(provider.unarchiveThread).toHaveBeenCalledTimes(12);
   });
 
+  it("settles the remaining reminders when one initial claim fails", async () => {
+    prisma.scheduledEmail.findMany.mockResolvedValue(
+      Array.from({ length: 8 }, (_, index) =>
+        row({
+          id: `reminder-${index}`,
+          status: "SENT",
+          sentAt: new Date(now.getTime() - 60_000),
+          remindAt: now,
+          reminderStatus: "PENDING",
+        }),
+      ),
+    );
+    prisma.scheduledEmail.updateMany.mockImplementation(async (args) => {
+      if (args.where.id === "reminder-0")
+        throw new Error("claim database unavailable");
+      return { count: 1 };
+    });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      email: "me@example.com",
+      account: { provider: "google" },
+    } as never);
+    let completed = 0;
+    const provider = createMockEmailProvider({
+      getThreadMessages: vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        completed += 1;
+        return [];
+      }),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    await expect(processDueScheduledEmails(logger, now)).resolves.toEqual({
+      processed: 8,
+    });
+    expect(completed).toBe(7);
+    expect(provider.unarchiveThread).toHaveBeenCalledTimes(7);
+  });
+
   it("does not send twice when another worker holds the claim", async () => {
     prisma.scheduledEmail.findUnique.mockResolvedValue(row());
     prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });

--- a/apps/web/utils/scheduled-email/service.test.ts
+++ b/apps/web/utils/scheduled-email/service.test.ts
@@ -7,6 +7,7 @@ import { executeDurableEmailSend } from "@/utils/email/durable-email-send";
 import {
   scheduleEmail,
   cancelScheduledEmail,
+  retryScheduledEmail,
   processScheduledEmail,
   hasReplySince,
   processDueScheduledEmails,
@@ -62,6 +63,111 @@ describe("scheduled replies", () => {
       }),
     );
   });
+  it.each([
+    "PROCESSING",
+    "SENT",
+    "UNCERTAIN",
+  ] as const)("rejects explicit retry while a durable %s operation exists", async (status) => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(
+      row({ status: "FAILED" }),
+    );
+    prisma.emailSendOperation.findUnique.mockResolvedValue({
+      id: "operation",
+      status,
+    } as never);
+    await expect(retryScheduledEmail("account", "id", now)).rejects.toThrow(
+      "safely",
+    );
+    expect(prisma.scheduledEmail.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("restarts an expired known-unsent retry with a fresh execution clock", async () => {
+    const expired = row({
+      status: "FAILED",
+      executionQueuedAt: new Date("2026-07-01"),
+    });
+    prisma.scheduledEmail.findUnique.mockResolvedValue(expired);
+    prisma.emailSendOperation.findUnique.mockResolvedValue(null);
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    await retryScheduledEmail("account", "id", now);
+    expect(prisma.scheduledEmail.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "id",
+        emailAccountId: "account",
+        updatedAt: expired.updatedAt,
+        status: "FAILED",
+      },
+      data: {
+        status: "PENDING",
+        sendAt: now,
+        executionQueuedAt: null,
+        processingStartedAt: null,
+        error: null,
+      },
+    });
+    prisma.scheduledEmail.findUnique.mockResolvedValue(
+      row({ executionQueuedAt: null }),
+    );
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      account: { provider: "google" },
+    } as never);
+    vi.mocked(executeDurableEmailSend).mockResolvedValue({
+      status: "uncertain",
+    });
+    await processScheduledEmail("id", logger, now);
+    expect(executeDurableEmailSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ queuedAt: now.getTime() }),
+      }),
+    );
+  });
+
+  it("rejects retry if the failed row changed during the durable-operation lookup", async () => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(
+      row({ status: "FAILED" }),
+    );
+    prisma.emailSendOperation.findUnique.mockResolvedValue(null);
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });
+    await expect(retryScheduledEmail("account", "id", now)).rejects.toThrow(
+      "safely",
+    );
+  });
+
+  it("processes due reminders concurrently with at most five provider requests in flight", async () => {
+    prisma.scheduledEmail.findMany.mockResolvedValue(
+      Array.from({ length: 12 }, (_, index) =>
+        row({
+          id: `reminder-${index}`,
+          status: "SENT",
+          sentAt: new Date(now.getTime() - 60_000),
+          remindAt: now,
+          reminderStatus: "PENDING",
+        }),
+      ),
+    );
+    prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 1 });
+    prisma.emailAccount.findUniqueOrThrow.mockResolvedValue({
+      email: "me@example.com",
+      account: { provider: "google" },
+    } as never);
+    let active = 0;
+    let peak = 0;
+    const provider = createMockEmailProvider({
+      getThreadMessages: vi.fn().mockImplementation(async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return [];
+      }),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    await processDueScheduledEmails(logger, now);
+    expect(peak).toBe(5);
+    expect(active).toBe(0);
+    expect(provider.unarchiveThread).toHaveBeenCalledTimes(12);
+  });
+
   it("does not send twice when another worker holds the claim", async () => {
     prisma.scheduledEmail.findUnique.mockResolvedValue(row());
     prisma.scheduledEmail.updateMany.mockResolvedValue({ count: 0 });

--- a/apps/web/utils/scheduled-email/service.test.ts
+++ b/apps/web/utils/scheduled-email/service.test.ts
@@ -11,7 +11,7 @@ import {
   hasReplySince,
   processDueScheduledEmails,
 } from "./service";
-import type { ScheduledEmail } from "@/generated/prisma/client";
+import { Prisma, type ScheduledEmail } from "@/generated/prisma/client";
 import type { ParsedMessage } from "@/utils/types";
 
 vi.mock("server-only", () => ({}));
@@ -97,7 +97,10 @@ describe("scheduled replies", () => {
       }),
     );
   });
-  it("persists future replies without sending and accepts an identical retry after its date passes", async () => {
+  it.each([
+    "PENDING",
+    "SENT",
+  ] as const)("preserves %s idempotency after the scheduled date passes", async (status) => {
     prisma.scheduledEmail.findUnique.mockResolvedValue(null);
     prisma.scheduledEmail.create.mockResolvedValue(row());
     await scheduleEmail("account", input, now);
@@ -111,7 +114,7 @@ describe("scheduled replies", () => {
     });
     expect(executeDurableEmailSend).not.toHaveBeenCalled();
 
-    const persisted = row({ payloadHash: saved.payloadHash });
+    const persisted = row({ payloadHash: saved.payloadHash, status });
     prisma.scheduledEmail.findUnique.mockResolvedValue(persisted);
     expect(await scheduleEmail("account", input, new Date("2026-09-10"))).toBe(
       persisted,
@@ -128,6 +131,39 @@ describe("scheduled replies", () => {
       ),
     ).rejects.toThrow("different email");
     expect(prisma.scheduledEmail.create).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    false,
+    true,
+  ])("rejects a cancelled request even when discovered after a create race (%s)", async (createRace) => {
+    prisma.scheduledEmail.findUnique.mockResolvedValue(null);
+    prisma.scheduledEmail.create.mockResolvedValue(row());
+    await scheduleEmail("account", input, now);
+    const payloadHash =
+      prisma.scheduledEmail.create.mock.calls[0][0].data.payloadHash;
+    const cancelled = row({ status: "CANCELLED", payloadHash });
+    vi.resetAllMocks();
+    if (createRace) {
+      prisma.scheduledEmail.findUnique.mockResolvedValue(null);
+      prisma.scheduledEmail.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("duplicate", {
+          code: "P2002",
+          clientVersion: "test",
+        }),
+      );
+      prisma.scheduledEmail.findUniqueOrThrow.mockResolvedValue(cancelled);
+    } else {
+      prisma.scheduledEmail.findUnique.mockResolvedValue(cancelled);
+    }
+    await expect(scheduleEmail("account", input, now)).rejects.toThrow(
+      "Start a new reply",
+    );
+    expect(executeDurableEmailSend).not.toHaveBeenCalled();
+    expect(prisma.scheduledEmail.updateMany).not.toHaveBeenCalled();
+    expect(prisma.scheduledEmail.create).toHaveBeenCalledTimes(
+      createRace ? 1 : 0,
+    );
   });
 
   it.each([

--- a/apps/web/utils/scheduled-email/service.ts
+++ b/apps/web/utils/scheduled-email/service.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { mapWithConcurrency } from "@/utils/async";
 import type { z } from "zod";
 import type { ScheduledEmail } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
@@ -86,6 +87,43 @@ export async function cancelScheduledEmail(emailAccountId: string, id: string) {
     throw new SafeError(
       "This email has started sending or is no longer scheduled.",
     );
+}
+
+export async function retryScheduledEmail(
+  emailAccountId: string,
+  id: string,
+  now = new Date(),
+) {
+  const row = await prisma.scheduledEmail.findUnique({
+    where: { id, emailAccountId },
+  });
+  if (!row || (row.status !== "FAILED" && row.status !== "BLOCKED_AUTH"))
+    throw new SafeError("This email cannot be retried safely.");
+  const operation = await prisma.emailSendOperation.findUnique({
+    where: {
+      emailAccountId_clientMutationId: {
+        emailAccountId,
+        clientMutationId: row.clientMutationId,
+      },
+    },
+    select: { id: true },
+  });
+  if (operation)
+    throw new SafeError(
+      "This email cannot be retried safely. Check Sent before sending again.",
+    );
+  const result = await prisma.scheduledEmail.updateMany({
+    where: { id, emailAccountId, updatedAt: row.updatedAt, status: row.status },
+    data: {
+      status: "PENDING",
+      sendAt: now,
+      executionQueuedAt: null,
+      processingStartedAt: null,
+      error: null,
+    },
+  });
+  if (!result.count)
+    throw new SafeError("This email cannot be retried safely.");
 }
 
 export async function processScheduledEmail(
@@ -293,14 +331,14 @@ export async function processDueScheduledEmails(
     orderBy: { sendAt: "asc" },
     take: 100,
   });
-  for (const row of rows) {
+  await mapWithConcurrency(rows, 5, async (row) => {
     const scopedLogger = logger.with({
       emailAccountId: row.emailAccountId,
       scheduledEmailId: row.id,
     });
     if (row.status === "SENT") await processReminder(row, scopedLogger, now);
     else await processScheduledEmail(row.id, scopedLogger, now);
-  }
+  });
   return { processed: rows.length };
 }
 

--- a/apps/web/utils/scheduled-email/service.ts
+++ b/apps/web/utils/scheduled-email/service.ts
@@ -31,10 +31,7 @@ export async function scheduleEmail(
     },
   });
   if (existing) {
-    if (existing.payloadHash !== payloadHash)
-      throw new SafeError(
-        "This send request was already used for a different email.",
-      );
+    assertReusableRequest(existing, payloadHash);
     return existing;
   }
   const sendAt = input.sendAt ? new Date(input.sendAt) : now;
@@ -71,10 +68,7 @@ export async function scheduleEmail(
         },
       },
     });
-    if (duplicate.payloadHash !== payloadHash)
-      throw new SafeError(
-        "This send request was already used for a different email.",
-      );
+    assertReusableRequest(duplicate, payloadHash);
     return duplicate;
   }
 }
@@ -308,4 +302,18 @@ export async function processDueScheduledEmails(
     else await processScheduledEmail(row.id, scopedLogger, now);
   }
   return { processed: rows.length };
+}
+
+function assertReusableRequest(
+  row: Pick<ScheduledEmail, "payloadHash" | "status">,
+  payloadHash: string,
+) {
+  if (row.payloadHash !== payloadHash)
+    throw new SafeError(
+      "This send request was already used for a different email.",
+    );
+  if (row.status === "CANCELLED")
+    throw new SafeError(
+      "This scheduled reply was cancelled. Start a new reply to send this message.",
+    );
 }

--- a/apps/web/utils/scheduled-email/service.ts
+++ b/apps/web/utils/scheduled-email/service.ts
@@ -1,0 +1,311 @@
+import { createHash } from "node:crypto";
+import type { z } from "zod";
+import type { ScheduledEmail } from "@/generated/prisma/client";
+import prisma from "@/utils/prisma";
+import { isDuplicateError } from "@/utils/prisma-helpers";
+import { SafeError } from "@/utils/error";
+import { scheduleEmailBody } from "@/utils/actions/scheduled-email.validation";
+import { executeDurableEmailSend } from "@/utils/email/durable-email-send";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { EmailProvider } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import { isSameEmailAddress } from "@/utils/email";
+import { getMessageTimestamp } from "@/utils/email/message-timestamp";
+
+const LEASE_MS = 5 * 60 * 1000;
+
+export async function scheduleEmail(
+  emailAccountId: string,
+  input: z.infer<typeof scheduleEmailBody>,
+  now = new Date(),
+) {
+  const payloadHash = createHash("sha256")
+    .update(JSON.stringify(input))
+    .digest("hex");
+  const existing = await prisma.scheduledEmail.findUnique({
+    where: {
+      emailAccountId_clientMutationId: {
+        emailAccountId,
+        clientMutationId: input.clientMutationId,
+      },
+    },
+  });
+  if (existing) {
+    if (existing.payloadHash !== payloadHash)
+      throw new SafeError(
+        "This send request was already used for a different email.",
+      );
+    return existing;
+  }
+  const sendAt = input.sendAt ? new Date(input.sendAt) : now;
+  const remindAt = input.remindAt ? new Date(input.remindAt) : null;
+  if (input.sendAt && sendAt <= now)
+    throw new SafeError("Choose a future send time.");
+  if (remindAt && remindAt <= sendAt)
+    throw new SafeError("The reminder must be after the send time.");
+  if (
+    input.email.replyToEmail &&
+    input.email.replyToEmail.threadId !== input.threadId
+  )
+    throw new SafeError("The reply belongs to a different conversation.");
+  try {
+    return await prisma.scheduledEmail.create({
+      data: {
+        emailAccountId,
+        clientMutationId: input.clientMutationId,
+        payloadHash,
+        payload: input,
+        threadId: input.threadId,
+        sendAt,
+        remindAt,
+        reminderStatus: remindAt ? "PENDING" : "NONE",
+      },
+    });
+  } catch (error) {
+    if (!isDuplicateError(error)) throw error;
+    const duplicate = await prisma.scheduledEmail.findUniqueOrThrow({
+      where: {
+        emailAccountId_clientMutationId: {
+          emailAccountId,
+          clientMutationId: input.clientMutationId,
+        },
+      },
+    });
+    if (duplicate.payloadHash !== payloadHash)
+      throw new SafeError(
+        "This send request was already used for a different email.",
+      );
+    return duplicate;
+  }
+}
+
+export async function cancelScheduledEmail(emailAccountId: string, id: string) {
+  const result = await prisma.scheduledEmail.updateMany({
+    where: {
+      id,
+      emailAccountId,
+      status: { in: ["PENDING", "BLOCKED_AUTH", "FAILED"] },
+    },
+    data: { status: "CANCELLED", reminderStatus: "CANCELLED", error: null },
+  });
+  if (!result.count)
+    throw new SafeError(
+      "This email has started sending or is no longer scheduled.",
+    );
+}
+
+export async function processScheduledEmail(
+  id: string,
+  logger: Logger,
+  now = new Date(),
+) {
+  const row = await prisma.scheduledEmail.findUnique({ where: { id } });
+  if (!row || row.sendAt > now) return;
+  const claim = await prisma.scheduledEmail.updateMany({
+    where: {
+      id,
+      updatedAt: row.updatedAt,
+      OR: [
+        { status: "PENDING" },
+        {
+          status: "PROCESSING",
+          processingStartedAt: { lte: new Date(now.getTime() - LEASE_MS) },
+        },
+      ],
+    },
+    data: {
+      status: "PROCESSING",
+      processingStartedAt: now,
+      executionQueuedAt: row.executionQueuedAt ?? now,
+    },
+  });
+  if (!claim.count) return;
+  const claimedWhere = {
+    id,
+    status: "PROCESSING" as const,
+    processingStartedAt: now,
+  };
+  try {
+    const input = scheduleEmailBody.parse(row.payload);
+    const account = await prisma.emailAccount.findUniqueOrThrow({
+      where: { id: row.emailAccountId },
+      include: { account: true },
+    });
+    const outcome = await executeDurableEmailSend({
+      emailAccountId: row.emailAccountId,
+      provider: account.account.provider,
+      getEmailProvider: () =>
+        createEmailProvider({
+          emailAccountId: row.emailAccountId,
+          provider: account.account.provider,
+          logger,
+        }),
+      input: {
+        mutationId: row.clientMutationId,
+        threadId: row.threadId,
+        messageIds: input.messageIds,
+        email: input.email,
+        queuedAt: (row.executionQueuedAt ?? now).getTime(),
+      },
+    });
+    if (outcome.status === "applied" || outcome.status === "already_applied") {
+      const sentOperation = await prisma.emailSendOperation.findUniqueOrThrow({
+        where: {
+          emailAccountId_clientMutationId: {
+            emailAccountId: row.emailAccountId,
+            clientMutationId: row.clientMutationId,
+          },
+        },
+        select: { processingStartedAt: true },
+      });
+      await prisma.scheduledEmail.updateMany({
+        where: claimedWhere,
+        data: {
+          status: "SENT",
+          sentAt: sentOperation.processingStartedAt,
+          error: null,
+        },
+      });
+    } else if (outcome.status === "retry") {
+      const operation = await prisma.emailSendOperation.findUnique({
+        where: {
+          emailAccountId_clientMutationId: {
+            emailAccountId: row.emailAccountId,
+            clientMutationId: row.clientMutationId,
+          },
+        },
+        select: { id: true },
+      });
+      // A durable worker may still be sending. Only absent operations are known unsent.
+      if (operation) return;
+      await prisma.scheduledEmail.updateMany({
+        where: claimedWhere,
+        data: {
+          status: "PENDING",
+          sendAt: new Date(now.getTime() + 60_000),
+          error: "Delivery delayed. Retrying shortly.",
+        },
+      });
+    } else {
+      await prisma.scheduledEmail.updateMany({
+        where: claimedWhere,
+        data: {
+          status:
+            outcome.status === "blocked_auth"
+              ? "BLOCKED_AUTH"
+              : outcome.status === "uncertain"
+                ? "UNCERTAIN"
+                : "FAILED",
+          error:
+            outcome.status === "blocked_auth"
+              ? "Reconnect your email account to send this reply."
+              : outcome.status === "uncertain"
+                ? "This email may have sent. Check Sent before sending again."
+                : outcome.error,
+        },
+      });
+    }
+  } catch (error) {
+    // Keep the lease: the durable operation may have sent before a DB failure.
+    // A later cron reconciles the same immutable operation, never a new send.
+    logger.error("Scheduled email execution failed", {
+      error,
+      scheduledEmailId: id,
+    });
+  }
+}
+
+export function hasReplySince(
+  messages: Awaited<ReturnType<EmailProvider["getThreadMessages"]>>,
+  ownerEmail: string,
+  sentAt: Date,
+) {
+  return messages.some(
+    (message) =>
+      !message.labelIds?.includes("DRAFT") &&
+      !message.labelIds?.includes("SENT") &&
+      !isSameEmailAddress(message.headers.from, ownerEmail) &&
+      getMessageTimestamp({
+        ...message,
+        date: message.date || message.headers.date,
+      }) > sentAt.getTime(),
+  );
+}
+
+async function processReminder(row: ScheduledEmail, logger: Logger, now: Date) {
+  if (!row.sentAt) return;
+  const claim = await prisma.scheduledEmail.updateMany({
+    where: {
+      id: row.id,
+      status: "SENT",
+      OR: [
+        { reminderStatus: "PENDING" },
+        {
+          reminderStatus: "PROCESSING",
+          reminderStartedAt: { lte: new Date(now.getTime() - LEASE_MS) },
+        },
+      ],
+    },
+    data: { reminderStatus: "PROCESSING", reminderStartedAt: now },
+  });
+  if (!claim.count) return;
+  const where = {
+    id: row.id,
+    reminderStatus: "PROCESSING" as const,
+    reminderStartedAt: now,
+  };
+  try {
+    const account = await prisma.emailAccount.findUniqueOrThrow({
+      where: { id: row.emailAccountId },
+      include: { account: true },
+    });
+    const provider = await createEmailProvider({
+      emailAccountId: row.emailAccountId,
+      provider: account.account.provider,
+      logger,
+    });
+    const messages = await provider.getThreadMessages(row.threadId);
+    if (!hasReplySince(messages, account.email, row.sentAt))
+      await provider.unarchiveThread(row.threadId);
+    await prisma.scheduledEmail.updateMany({
+      where,
+      data: { reminderStatus: "COMPLETED" },
+    });
+  } catch (error) {
+    logger.error("Email reminder failed", { error, scheduledEmailId: row.id });
+    // Retain the lease to avoid tight retries and recover on the next stale scan.
+  }
+}
+
+export async function processDueScheduledEmails(
+  logger: Logger,
+  now = new Date(),
+) {
+  const stale = new Date(now.getTime() - LEASE_MS);
+  const rows = await prisma.scheduledEmail.findMany({
+    where: {
+      OR: [
+        { status: "PENDING", sendAt: { lte: now } },
+        { status: "PROCESSING", processingStartedAt: { lte: stale } },
+        { status: "SENT", remindAt: { lte: now }, reminderStatus: "PENDING" },
+        {
+          status: "SENT",
+          remindAt: { lte: now },
+          reminderStatus: "PROCESSING",
+          reminderStartedAt: { lte: stale },
+        },
+      ],
+    },
+    orderBy: { sendAt: "asc" },
+    take: 100,
+  });
+  for (const row of rows) {
+    const scopedLogger = logger.with({
+      emailAccountId: row.emailAccountId,
+      scheduledEmailId: row.id,
+    });
+    if (row.status === "SENT") await processReminder(row, scopedLogger, now);
+    else await processScheduledEmail(row.id, scopedLogger, now);
+  }
+  return { processed: rows.length };
+}

--- a/apps/web/utils/scheduled-email/service.ts
+++ b/apps/web/utils/scheduled-email/service.ts
@@ -336,8 +336,12 @@ export async function processDueScheduledEmails(
       emailAccountId: row.emailAccountId,
       scheduledEmailId: row.id,
     });
-    if (row.status === "SENT") await processReminder(row, scopedLogger, now);
-    else await processScheduledEmail(row.id, scopedLogger, now);
+    try {
+      if (row.status === "SENT") await processReminder(row, scopedLogger, now);
+      else await processScheduledEmail(row.id, scopedLogger, now);
+    } catch (error) {
+      scopedLogger.error("Failed to process scheduled email", { error });
+    }
   });
   return { processed: rows.length };
 }

--- a/apps/web/utils/types/mail.ts
+++ b/apps/web/utils/types/mail.ts
@@ -116,7 +116,7 @@ export function validateSendEmailPayloadSize(
   };
 }
 
-function decodedBase64Size(value: string) {
+export function decodedBase64Size(value: string) {
   const normalized = value.trim();
   const padding = normalized.endsWith("==")
     ? 2

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -32,7 +32,7 @@
 }
 
 .editor [data-email-editor-content] {
-  min-height: 200px;
+  min-height: var(--email-editor-content-min-height, 200px);
   padding: 0.75rem;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -48,7 +48,7 @@
   .editor
   [data-email-editor-content] {
   flex: 1;
-  padding: 1rem;
+  padding: var(--email-editor-content-padding, 1rem);
   font-size: 0.9375rem;
   line-height: 1.6;
 }
@@ -222,7 +222,7 @@
 }
 
 .fallbackEditor {
-  min-height: 200px;
+  min-height: var(--email-editor-content-min-height, 200px);
   padding: 0.75rem;
   outline: none;
 }
@@ -296,6 +296,6 @@
 
   .editor [data-email-editor-content],
   .fallbackEditor {
-    min-height: 160px;
+    min-height: var(--email-editor-content-min-height, 160px);
   }
 }

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -21,6 +21,10 @@
   border-radius: 0;
 }
 
+[data-inline-reply="true"] .surface {
+  background: transparent;
+}
+
 .editor {
   flex: 1;
   min-height: 0;
@@ -104,7 +108,11 @@
 
 .editor
   [data-email-editor-content]
-  p[class~="is-editor-empty"]:first-child::before {
+  p[class~="is-editor-empty"]:first-child::before,
+[data-inline-reply="true"]
+  .editor
+  [data-email-editor-content]
+  p[class~="is-empty"]:first-child::before {
   float: left;
   height: 0;
   color: var(--email-editor-muted-foreground);

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -108,11 +108,7 @@
 
 .editor
   [data-email-editor-content]
-  p[class~="is-editor-empty"]:first-child::before,
-[data-inline-reply="true"]
-  .editor
-  [data-email-editor-content]
-  p[class~="is-empty"]:first-child::before {
+  p[class~="is-editor-empty"]:first-child::before {
   float: left;
   height: 0;
   color: var(--email-editor-muted-foreground);
@@ -247,6 +243,11 @@
   border-top: 1px solid var(--email-editor-border);
 }
 
+[data-inline-reply="true"] .preservedBlock {
+  margin: 0;
+  border-top: 0;
+}
+
 .preservedSummary {
   display: flex;
   gap: 0.45rem;
@@ -257,6 +258,10 @@
   cursor: pointer;
   user-select: none;
   list-style: none;
+}
+
+[data-inline-reply="true"] .preservedSummary {
+  min-height: 1.5rem;
 }
 
 .preservedSummary::-webkit-details-marker {

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -126,10 +126,10 @@
   max-width: calc(100vw - 1rem);
   padding: 0.35rem;
   overflow-x: auto;
-  color: #fff;
-  background: #34373d;
+  color: #c9c9c9;
+  background: #383837;
   border-radius: 0.5rem;
-  box-shadow: 0 8px 24px rgb(0 0 0 / 25%);
+  box-shadow: 0 3px 10px rgb(0 0 0 / 14%);
 }
 
 .toolbarButton {
@@ -311,4 +311,17 @@
   .fallbackEditor {
     min-height: var(--email-editor-content-min-height, 160px);
   }
+}
+
+.bubbleToolbar .toolbarButton {
+  width: 1.75rem;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-size: 1rem;
+}
+.bubbleToolbar .separator {
+  height: 1rem;
+  margin: 0 0.125rem;
+  background: rgb(255 255 255 / 15%);
 }

--- a/packages/email-editor/src/web/EmailEditor.tsx
+++ b/packages/email-editor/src/web/EmailEditor.tsx
@@ -15,6 +15,7 @@ import {
   useEditorState,
   type Editor,
 } from "@tiptap/react";
+import { TextSelection } from "@tiptap/pm/state";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { DOMSerializer, Fragment, type Node } from "@tiptap/pm/model";
 import {
@@ -386,7 +387,12 @@ const RichEmailEditor = forwardRef<
       <BubbleMenu
         editor={editor}
         options={{ offset: 8, placement: "bottom" }}
-        shouldShow={({ from, to }) => from !== to || editor.isActive("link")}
+        shouldShow={({ state, from, to }) =>
+          editor.isFocused &&
+          state.selection instanceof TextSelection &&
+          from !== to &&
+          Boolean(state.doc.textBetween(from, to).trim())
+        }
       >
         <div
           aria-label="Selection formatting"
@@ -404,21 +410,21 @@ const RichEmailEditor = forwardRef<
             label="Bulleted list"
             onPress={() => editor.chain().focus().toggleBulletList().run()}
           >
-            •
+            <FormattingIcon kind="bullets" />
           </ToolbarButton>
           <ToolbarButton
             active={toolbarState?.orderedList}
             label="Numbered list"
             onPress={() => editor.chain().focus().toggleOrderedList().run()}
           >
-            1.
+            <FormattingIcon kind="numbers" />
           </ToolbarButton>
           <ToolbarButton
             active={toolbarState?.blockquote}
             label="Block quote"
             onPress={() => editor.chain().focus().toggleBlockquote().run()}
           >
-            “ ”
+            <FormattingIcon kind="quote" />
           </ToolbarButton>
           <span aria-hidden className={styles.separator} />
           <ToolbarButton
@@ -426,14 +432,14 @@ const RichEmailEditor = forwardRef<
             label="Left-to-right text"
             onPress={() => setBlockDirection(editor, "ltr")}
           >
-            LTR
+            <FormattingIcon kind="ltr" />
           </ToolbarButton>
           <ToolbarButton
             active={toolbarState?.direction === "rtl"}
             label="Right-to-left text"
             onPress={() => setBlockDirection(editor, "rtl")}
           >
-            RTL
+            <FormattingIcon kind="rtl" />
           </ToolbarButton>
         </div>
       </BubbleMenu>
@@ -660,7 +666,7 @@ function MarkButtons({
         label="Add or edit link"
         onPress={onLink}
       >
-        Link
+        <FormattingIcon kind="link" />
       </ToolbarButton>
     </>
   );
@@ -806,4 +812,34 @@ function emptyEditorValue(
     mode,
     preservedBlockIds: [],
   };
+}
+
+function FormattingIcon({
+  kind,
+}: {
+  kind: "bullets" | "numbers" | "quote" | "ltr" | "rtl" | "link";
+}) {
+  const paths = {
+    bullets: "M9 6h12M9 12h12M9 18h12M3 6h.01M3 12h.01M3 18h.01",
+    numbers: "M10 6h11M10 12h11M10 18h11M3 4h1v5M3 9h2M3 14c3-2 4 1 1 3l-1 2h3",
+    quote: "M9 5H3v7h5c0 4-2 6-5 7M21 5h-6v7h5c0 4-2 6-5 7",
+    ltr: "M4 4h16M4 9h10M4 14h16M4 20h14M15 17l3 3-3 3",
+    rtl: "M4 4h16M10 9h10M4 14h16M6 20h14M9 17l-3 3 3 3",
+    link: "M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-2 2M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l2-2",
+  };
+  return (
+    <svg
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={paths[kind]} />
+    </svg>
+  );
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260906-001020_pr-3509_3d89bf2322ac/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Thread replies now stay attached to the message being answered, with compact history and local drafts that survive reloads and navigation. Enter opens an empty reply, arrow keys move between messages, and the toolbar expands or collapses the thread.

- Simplify the reader and composer: aligned avatars, dates at the far right, a slim selection accent, editable recipient/subject fields, and subtle secondary actions. Show formatting controls only when text is selected.
- Persist reply content, recipients, attachments, and delivery options in account-scoped IndexedDB. Immediate replies enter the durable send flow; offline, failed, and uncertain sends retain recovery states.
- Add server-persisted Send later and Remind me, using the existing durable-send operation and cron. Includes a Prisma migration.
- Run E2E groups across four isolated CI shards, retain a combined report and required check, and cap stalled browser actions/navigation separately from whole-test timeouts. Record group durations for diagnosis.
- Validation: focused unit tests and emulator browser checks cover navigation, formatting, reader details, scheduling, cancellation, failure recovery, and actual send-with-reminder delivery. Generated screenshots were inspected. Changed-file Biome checks pass.

Performance: draft saves are debounced locally without serializing attachment bytes while typing. Only active delivery states poll; future scheduled sends poll less frequently. Scheduled sends and reminders use server storage and cron processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Schedule email replies and reminders, with options to edit, cancel, retry, and track delivery.
  - Draft inline replies are automatically saved and restored, including attachments and formatting.
  - Offline replies now remain queued and can resume sending when connectivity returns.
  - Added clearer delivery statuses for queued, sending, sent, failed, and offline messages.
  - Added scheduled-reply visibility and status details within conversations.

- **Improvements**
  - Streamlined message layouts, reply panels, delivery controls, and thread expansion.
  - Moved conversation deletion into the More actions menu.
  - Improved date/time validation for scheduled sends and reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->