### PR TITLE
security: Reject credential writes without encryption keys

### DIFF
--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -103,8 +103,8 @@ const parsedEnv = createEnv({
           .map((entry) => entry.trim())
           .filter(Boolean),
       ),
-    EMAIL_ENCRYPT_SECRET: z.string(),
-    EMAIL_ENCRYPT_SALT: z.string(),
+    EMAIL_ENCRYPT_SECRET: z.string().min(1),
+    EMAIL_ENCRYPT_SALT: z.string().min(1),
 
     DEFAULT_LLMS: defaultLlmsEnv, // Ordered provider:model chain; first valid entry is primary, later entries are fallbacks
     ECONOMY_LLMS: llmsEnv(legacyLlmsEnv.ECONOMY_LLMS), // Ordered provider:model chain for economy model plus fallbacks

--- a/apps/web/utils/encryption-missing-env.test.ts
+++ b/apps/web/utils/encryption-missing-env.test.ts
@@ -17,7 +17,7 @@ describe("encryption without env", () => {
 
     const { encryptToken, decryptToken } = await import("./encryption");
 
-    expect(encryptToken("secret")).toBeNull();
+    expect(() => encryptToken("secret")).toThrow(/not configured/);
     expect(decryptToken("deadbeef")).toBeNull();
   });
 });

--- a/apps/web/utils/encryption.test.ts
+++ b/apps/web/utils/encryption.test.ts
@@ -44,7 +44,11 @@ describe("Encryption Utilities", () => {
       "EMAIL_ENCRYPT_SALT",
     ] as const)("rejects writes when %s is empty, even after caching a key", (setting) => {
       encryptToken("warm-cache");
-      env[setting] = "";
+      if (setting === "EMAIL_ENCRYPT_SECRET") {
+        env.EMAIL_ENCRYPT_SECRET = "";
+      } else {
+        env.EMAIL_ENCRYPT_SALT = "";
+      }
       expect(() => encryptToken("refresh-token")).toThrow(/not configured/);
       expect(encryptToken(null)).toBeNull();
     });

--- a/apps/web/utils/encryption.test.ts
+++ b/apps/web/utils/encryption.test.ts
@@ -1,5 +1,6 @@
 import { createCipheriv, randomBytes, scryptSync } from "node:crypto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "@/env";
 import { decryptToken, encryptToken } from "./encryption";
 
 const { TEST_SECRET, TEST_SALT } = vi.hoisted(() => ({
@@ -32,7 +33,21 @@ describe("Encryption Utilities", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    env.EMAIL_ENCRYPT_SECRET = TEST_SECRET;
+    env.EMAIL_ENCRYPT_SALT = TEST_SALT;
+  });
+
   describe("encryptToken", () => {
+    it.each([
+      "EMAIL_ENCRYPT_SECRET",
+      "EMAIL_ENCRYPT_SALT",
+    ] as const)("rejects writes when %s is empty, even after caching a key", (setting) => {
+      encryptToken("warm-cache");
+      env[setting] = "";
+      expect(() => encryptToken("refresh-token")).toThrow(/not configured/);
+      expect(encryptToken(null)).toBeNull();
+    });
     it("returns null for null input", () => {
       expect(encryptToken(null)).toBeNull();
     });

--- a/apps/web/utils/encryption.ts
+++ b/apps/web/utils/encryption.ts
@@ -39,8 +39,7 @@ const keyCache = new Map<KeyVersion, Buffer>();
 export function encryptToken(text: string | null): string | null {
   if (text === null || text === undefined) return null;
   if (!isConfigured(ACTIVE_VERSION)) {
-    logger.error("Encryption key not configured; refusing to encrypt");
-    return null;
+    throw new Error("Encryption key is not configured");
   }
 
   const iv = randomBytes(IV_LENGTH);


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260905-183037_pr-3510_222ed97e4e9b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Empty encryption settings could make credential writes succeed with a null value, discarding the supplied secret. Reject those writes and validate nonempty encryption settings at startup.

- Regression tests cover missing secret and salt after a key has already been cached, while preserving explicit null inputs.
- Validation: regression cases failed before the fix; all 32 encryption and Prisma extension tests now pass. Formatting checked by the commit hook.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty encryption configuration values are now rejected during application startup or configuration validation.
  - Encryption requests now report a clear configuration error when required encryption settings are unavailable, instead of silently returning no result.
  - Valid encryption behavior remains unchanged when configuration is properly set.
  - Input values that are intentionally empty or absent continue to be handled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->