### PR TITLE
database: Keep migrations on the preview database

### DIFF
--- a/apps/web/prisma.config.test.ts
+++ b/apps/web/prisma.config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("dotenv/config", () => ({}));
+
+beforeEach(() => {
+  vi.resetModules();
+  for (const key of [
+    "PREVIEW_DATABASE_URL_UNPOOLED",
+    "PREVIEW_DATABASE_URL",
+    "DIRECT_URL",
+    "DATABASE_URL_UNPOOLED",
+    "DATABASE_URL",
+  ]) {
+    vi.stubEnv(key, "");
+  }
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("migration database selection", () => {
+  it("keeps migrations on the preview database when only its pooled URL is configured", async () => {
+    vi.stubEnv("PREVIEW_DATABASE_URL", "postgresql://preview/db");
+    vi.stubEnv("DIRECT_URL", "postgresql://primary/db");
+    const { default: config } = await import("./prisma.config");
+    expect(config.datasource?.url).toBe("postgresql://preview/db");
+  });
+
+  it("prefers the preview direct URL when available", async () => {
+    vi.stubEnv(
+      "PREVIEW_DATABASE_URL_UNPOOLED",
+      "postgresql://preview-direct/db",
+    );
+    vi.stubEnv("PREVIEW_DATABASE_URL", "postgresql://preview/db");
+    const { default: config } = await import("./prisma.config");
+    expect(config.datasource?.url).toBe("postgresql://preview-direct/db");
+  });
+
+  it("preserves direct primary connections outside preview deployments", async () => {
+    vi.stubEnv("DIRECT_URL", "postgresql://primary-direct/db");
+    vi.stubEnv("DATABASE_URL", "postgresql://primary/db");
+    const { default: config } = await import("./prisma.config");
+    expect(config.datasource?.url).toBe("postgresql://primary-direct/db");
+  });
+});

--- a/apps/web/prisma.config.test.ts
+++ b/apps/web/prisma.config.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs());
 
 describe("migration database selection", () => {
-  it("keeps migrations on the preview database when only its pooled URL is configured", async () => {
+  it("prefers the preview pooled URL over the primary direct URL", async () => {
     vi.stubEnv("PREVIEW_DATABASE_URL", "postgresql://preview/db");
     vi.stubEnv("DIRECT_URL", "postgresql://primary/db");
     const { default: config } = await import("./prisma.config");

--- a/apps/web/prisma.config.ts
+++ b/apps/web/prisma.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "prisma/config";
 
 const migrationUrl =
   process.env.PREVIEW_DATABASE_URL_UNPOOLED ||
+  process.env.PREVIEW_DATABASE_URL ||
   process.env.DIRECT_URL ||
   process.env.DATABASE_URL_UNPOOLED ||
   process.env.DATABASE_URL;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260905-192240_pr-3511_c8878377f26a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

When only PREVIEW_DATABASE_URL is set, migration commands currently fall through to primary-database credentials even though the app uses the preview database. Prefer the preview URL before primary connection settings while retaining the unpooled preview URL's priority.

- Regression reproduced migrations selecting the primary URL, then passed after the fix.
- Validation: all 3 focused database-selection tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration handling for preview deployments by using the available pooled preview connection when an unpooled connection is unavailable.
  * Preserved direct database connections for non-preview deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->