### PR TITLE
gmail: Preserve attachments when editing drafts

### DIFF
--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -548,6 +548,88 @@ describe("GmailProvider.searchThreads", () => {
 });
 
 describe("GmailProvider.updateDraft", () => {
+  it("preserves files, inline image content IDs, and the sender when editing", async () => {
+    const update = vi.fn().mockResolvedValue({ data: {} });
+    const get = vi.fn().mockResolvedValue({
+      data: { data: Buffer.from("attachment bytes").toString("base64url") },
+    });
+    const provider = new GmailProvider({
+      users: { drafts: { update }, messages: { attachments: { get } } },
+    } as any);
+    gmailDraftMock.getDraft.mockResolvedValueOnce({
+      ...createParsedMessage({
+        id: "draft-message-1",
+        internalDate: "1000",
+        headers: { from: "alias@example.com" },
+      }),
+      payload: {
+        mimeType: "multipart/mixed",
+        parts: [
+          { mimeType: "text/html", body: { data: "PHA-T2xkPC9wPg" } },
+          {
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+            body: { attachmentId: "file-1" },
+            headers: [{ name: "Content-Disposition", value: "attachment" }],
+          },
+          {
+            mimeType: "image/png",
+            filename: "logo.png",
+            body: { data: Buffer.from("inline bytes").toString("base64url") },
+            headers: [
+              { name: "Content-Disposition", value: "inline" },
+              { name: "Content-ID", value: "<logo@example.com>" },
+            ],
+          },
+        ],
+      },
+    });
+
+    await provider.updateDraft("r-123", {
+      messageHtml: '<p>Edited</p><img src="cid:logo@example.com">',
+    });
+
+    const mime = decodeBase64Url(
+      update.mock.calls[0][0].requestBody.message.raw,
+    );
+    expect(mime).toContain("From: alias@example.com");
+    expect(mime).toContain("filename=report.pdf");
+    expect(mime).toContain(Buffer.from("attachment bytes").toString("base64"));
+    expect(mime).toContain("Content-ID: <logo@example.com>");
+    expect(mime).toContain(Buffer.from("inline bytes").toString("base64"));
+    expect(get).toHaveBeenCalledWith({
+      userId: "me",
+      messageId: "draft-message-1",
+      id: "file-1",
+    });
+  });
+
+  it("does not replace a draft when attachment bytes cannot be loaded", async () => {
+    const update = vi.fn();
+    const get = vi.fn().mockResolvedValue({ data: {} });
+    const provider = new GmailProvider({
+      users: { drafts: { update }, messages: { attachments: { get } } },
+    } as any);
+    gmailDraftMock.getDraft.mockResolvedValueOnce({
+      ...createParsedMessage({ id: "draft-message-1", internalDate: "1000" }),
+      payload: {
+        mimeType: "multipart/mixed",
+        parts: [
+          {
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+            body: { attachmentId: "file-1" },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      provider.updateDraft("r-123", { messageHtml: "<p>Edited</p>" }),
+    ).rejects.toThrow("Missing Gmail attachment data");
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it("keeps Gmail threading metadata and MIME-encodes non-ASCII subjects", async () => {
     const update = vi.fn().mockResolvedValue({ data: {} });
     const provider = new GmailProvider({

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { gmail_v1 } from "@googleapis/gmail";
+import { gmail_v1 } from "@googleapis/gmail";
 import type { EmailThread } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { GmailLabel } from "@/utils/gmail/label";
@@ -553,9 +553,10 @@ describe("GmailProvider.updateDraft", () => {
     const get = vi.fn().mockResolvedValue({
       data: { data: Buffer.from("attachment bytes").toString("base64url") },
     });
-    const provider = new GmailProvider({
-      users: { drafts: { update }, messages: { attachments: { get } } },
-    } as any);
+    const client = new gmail_v1.Gmail({});
+    client.users.drafts.update = update;
+    client.users.messages.attachments.get = get;
+    const provider = new GmailProvider(client);
     gmailDraftMock.getDraft.mockResolvedValueOnce({
       ...createParsedMessage({
         id: "draft-message-1",
@@ -607,9 +608,10 @@ describe("GmailProvider.updateDraft", () => {
   it("does not replace a draft when attachment bytes cannot be loaded", async () => {
     const update = vi.fn();
     const get = vi.fn().mockResolvedValue({ data: {} });
-    const provider = new GmailProvider({
-      users: { drafts: { update }, messages: { attachments: { get } } },
-    } as any);
+    const client = new gmail_v1.Gmail({});
+    client.users.drafts.update = update;
+    client.users.messages.attachments.get = get;
+    const provider = new GmailProvider(client);
     gmailDraftMock.getDraft.mockResolvedValueOnce({
       ...createParsedMessage({ id: "draft-message-1", internalDate: "1000" }),
       payload: {

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -548,7 +548,10 @@ describe("GmailProvider.searchThreads", () => {
 });
 
 describe("GmailProvider.updateDraft", () => {
-  it("preserves files, inline image content IDs, and the sender when editing", async () => {
+  it.each([
+    true,
+    false,
+  ])("preserves attachments and inline images (explicit disposition: %s)", async (explicitDisposition) => {
     const update = vi.fn().mockResolvedValue({ data: {} });
     const get = vi.fn().mockResolvedValue({
       data: { data: Buffer.from("attachment bytes").toString("base64url") },
@@ -566,7 +569,11 @@ describe("GmailProvider.updateDraft", () => {
       payload: {
         mimeType: "multipart/mixed",
         parts: [
-          { mimeType: "text/html", body: { data: "PHA-T2xkPC9wPg" } },
+          {
+            mimeType: "text/html",
+            body: { data: "PHA-T2xkPC9wPg" },
+            headers: [{ name: "Content-ID", value: "<body@example.com>" }],
+          },
           {
             mimeType: "application/pdf",
             filename: "report.pdf",
@@ -578,7 +585,9 @@ describe("GmailProvider.updateDraft", () => {
             filename: "logo.png",
             body: { data: Buffer.from("inline bytes").toString("base64url") },
             headers: [
-              { name: "Content-Disposition", value: "inline" },
+              ...(explicitDisposition
+                ? [{ name: "Content-Disposition", value: "inline" }]
+                : []),
               { name: "Content-ID", value: "<logo@example.com>" },
             ],
           },
@@ -597,6 +606,8 @@ describe("GmailProvider.updateDraft", () => {
     expect(mime).toContain("filename=report.pdf");
     expect(mime).toContain(Buffer.from("attachment bytes").toString("base64"));
     expect(mime).toContain("Content-ID: <logo@example.com>");
+    expect(mime).toContain("Content-Disposition: inline;");
+    expect(mime).not.toContain("Content-ID: <body@example.com>");
     expect(mime).toContain(Buffer.from("inline bytes").toString("base64"));
     expect(get).toHaveBeenCalledWith({
       userId: "me",

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -60,7 +60,10 @@ import {
   getContactsClient,
 } from "@/utils/gmail/client";
 import { searchContacts } from "@/utils/gmail/contact";
-import { getGmailAttachment } from "@/utils/gmail/attachment";
+import {
+  getGmailAttachment,
+  getGmailDraftAttachments,
+} from "@/utils/gmail/attachment";
 import {
   getThreadsBatch,
   getThreadsWithNextPageToken,
@@ -960,17 +963,23 @@ export class GmailProvider implements EmailProvider {
   ): Promise<void> {
     this.logger.info("Updating Gmail draft", { draftId });
 
-    // Get the current draft to preserve some fields
     const currentDraft = await getDraft(draftId, this.client);
     if (!currentDraft) {
       throw new Error(`Draft ${draftId} not found`);
     }
 
-    const subject = params.subject || currentDraft.subject || "";
-    const content = params.messageHtml || currentDraft.textHtml || "";
+    const subject = params.subject ?? currentDraft.subject ?? "";
+    const content = params.messageHtml ?? currentDraft.textHtml ?? "";
+    const attachments = await getGmailDraftAttachments(
+      this.client,
+      currentDraft.id,
+      currentDraft.payload,
+    );
 
     const encodedMessage = await createMail({
+      from: currentDraft.headers?.from,
       to: currentDraft.headers?.to || "",
+      attachments,
       cc: currentDraft.headers?.cc,
       bcc: currentDraft.headers?.bcc,
       replyTo: currentDraft.headers?.["reply-to"],

--- a/apps/web/utils/gmail/attachment.ts
+++ b/apps/web/utils/gmail/attachment.ts
@@ -1,3 +1,4 @@
+import type { Attachment } from "nodemailer/lib/mailer";
 import type { gmail_v1 } from "@googleapis/gmail";
 import { withGmailRetry } from "@/utils/gmail/retry";
 
@@ -15,4 +16,52 @@ export async function getGmailAttachment(
   );
   const attachmentData = attachment.data;
   return attachmentData;
+}
+
+export async function getGmailDraftAttachments(
+  gmail: gmail_v1.Gmail,
+  messageId: string,
+  payload: gmail_v1.Schema$MessagePart | null | undefined,
+): Promise<Attachment[]> {
+  if (!payload) return [];
+  if (payload.parts?.length) {
+    const attachments = [];
+    for (const part of payload.parts) {
+      attachments.push(
+        ...(await getGmailDraftAttachments(gmail, messageId, part)),
+      );
+    }
+    return attachments;
+  }
+
+  const headers = new Map(
+    payload.headers?.map(({ name, value }) => [name?.toLowerCase(), value]),
+  );
+  const disposition = headers
+    .get("content-disposition")
+    ?.split(";")[0]
+    .trim()
+    .toLowerCase();
+  const contentId = headers.get("content-id");
+  const isBody =
+    payload.mimeType === "text/plain" || payload.mimeType === "text/html";
+  if (isBody && !payload.filename && !contentId && disposition !== "attachment")
+    return [];
+  if (!payload.mimeType || payload.mimeType.startsWith("multipart/")) return [];
+
+  const data = payload.body?.attachmentId
+    ? (await getGmailAttachment(gmail, messageId, payload.body.attachmentId))
+        .data
+    : payload.body?.data;
+  if (data == null) throw new Error("Missing Gmail attachment data");
+
+  return [
+    {
+      filename: payload.filename || undefined,
+      contentType: payload.mimeType,
+      content: Buffer.from(data, "base64url"),
+      contentDisposition: disposition === "inline" ? "inline" : "attachment",
+      cid: contentId?.replace(/^<|>$/g, ""),
+    },
+  ];
 }

--- a/apps/web/utils/gmail/attachment.ts
+++ b/apps/web/utils/gmail/attachment.ts
@@ -45,8 +45,7 @@ export async function getGmailDraftAttachments(
   const contentId = headers.get("content-id");
   const isBody =
     payload.mimeType === "text/plain" || payload.mimeType === "text/html";
-  if (isBody && !payload.filename && !contentId && disposition !== "attachment")
-    return [];
+  if (isBody && !payload.filename && disposition !== "attachment") return [];
   if (!payload.mimeType || payload.mimeType.startsWith("multipart/")) return [];
 
   const data = payload.body?.attachmentId
@@ -60,7 +59,10 @@ export async function getGmailDraftAttachments(
       filename: payload.filename || undefined,
       contentType: payload.mimeType,
       content: Buffer.from(data, "base64url"),
-      contentDisposition: disposition === "inline" ? "inline" : "attachment",
+      contentDisposition:
+        disposition === "inline" || (!disposition && contentId)
+          ? "inline"
+          : "attachment",
       cid: contentId?.replace(/^<|>$/g, ""),
     },
   ];

--- a/apps/web/utils/gmail/draft.ts
+++ b/apps/web/utils/gmail/draft.ts
@@ -51,7 +51,7 @@ export async function getDraft(draftId: string, gmail: gmail_v1.Gmail) {
       return null;
     }
 
-    return message;
+    return { ...message, payload: response.data.message?.payload };
   } catch (error) {
     if (isNotFoundError(error)) {
       logger.info("Draft not found, returning null.", { draftId });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-084433_pr-3513_d890b1c9ddf6/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Editing a Gmail draft rebuilt its MIME message without files or inline images. Preserve the existing sender, attachment bytes, MIME types, filenames, and inline content IDs when replacing the body or subject, and stop the edit if attachment data is unavailable.

- Read attachment parts from the original MIME payload, including inline data and remotely stored parts.
- Regression tests failed before the fix; `pnpm test utils/email/google.test.ts utils/gmail/draft.test.ts` passes all 37 tests.
- Biome checks pass. Attachment-bearing edits add one Gmail read per externally stored attachment; ordinary draft edits add no network calls.