### PR TITLE
drive: Preserve existing files during OneDrive uploads

### DIFF
--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -68,7 +68,8 @@ describe("OneDriveProvider", () => {
       size: content.length,
     }));
     const header = vi.fn(() => ({ put }));
-    const api = vi.fn(() => ({ header }));
+    const query = vi.fn(() => ({ header }));
+    const api = vi.fn(() => ({ header, query }));
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
@@ -98,7 +99,8 @@ describe("OneDriveProvider", () => {
       size: content.length,
     }));
     const header = vi.fn(() => ({ put }));
-    const api = vi.fn(() => ({ header }));
+    const query = vi.fn(() => ({ header }));
+    const api = vi.fn(() => ({ header, query }));
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
@@ -127,11 +129,12 @@ describe("OneDriveProvider", () => {
       parentReference: { id: "folder-1" },
     }));
     const header = vi.fn(() => ({ put }));
+    const query = vi.fn(() => ({ header }));
     const api = vi.fn((path: string) => {
       if (path.endsWith("/createUploadSession")) {
         throw new Error("Should not create an upload session for 4MB files");
       }
-      return { header };
+      return { header, query };
     });
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
@@ -150,6 +153,42 @@ describe("OneDriveProvider", () => {
     );
     expect(put).toHaveBeenCalledTimes(1);
     expect(put.mock.calls[0]?.[0]).toHaveLength(4 * 1024 * 1024);
+  });
+
+  it.each([
+    1,
+    4 * 1024 * 1024,
+  ])("requests a renamed file instead of replacing existing content for a %i-byte upload", async (size) => {
+    const content = Buffer.alloc(size);
+    const put = vi.fn(async (_content: Buffer) => ({
+      id: "new-file",
+      name: "invoice 1.pdf",
+      file: { mimeType: "application/pdf" },
+      parentReference: { id: "folder-1" },
+      size,
+    }));
+    const header = vi.fn(() => ({ put }));
+    const query = vi.fn(() => ({ header }));
+    const api = vi.fn(() => ({ header, query }));
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider("token", createTestLogger());
+    const file = await provider.uploadFile({
+      filename: "invoice.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      "/me/drive/items/folder-1:/invoice.pdf:/content",
+    );
+    expect(query).toHaveBeenCalledWith({
+      "@microsoft.graph.conflictBehavior": "rename",
+    });
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put.mock.calls[0]?.[0]).toBe(content);
+    expect(file).toMatchObject({ id: "new-file", name: "invoice 1.pdf" });
   });
 
   it("uploads files larger than 4MB via an upload session in chunks", async () => {

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -170,7 +170,7 @@ describe("OneDriveProvider", () => {
     const header = vi.fn(() => ({ put }));
     const query = vi.fn(() => ({ header }));
     const api = vi.fn(() => ({ header, query }));
-    vi.mocked(Client.init).mockReturnValue({ api } as any);
+    vi.mocked(Client.init).mockReturnValue({ api } as unknown as Client);
 
     const provider = new OneDriveProvider("token", createTestLogger());
     const file = await provider.uploadFile({
@@ -187,7 +187,7 @@ describe("OneDriveProvider", () => {
       "@microsoft.graph.conflictBehavior": "rename",
     });
     expect(put).toHaveBeenCalledTimes(1);
-    expect(put.mock.calls[0]?.[0]).toBe(content);
+    expect(put.mock.calls.at(0)?.at(0)).toBe(content);
     expect(file).toMatchObject({ id: "new-file", name: "invoice 1.pdf" });
   });
 

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -169,6 +169,7 @@ export class OneDriveProvider implements DriveProvider {
         .api(
           `/me/drive/items/${folderId}:/${encodeURIComponent(normalizedFilename)}:/content`,
         )
+        .query({ "@microsoft.graph.conflictBehavior": "rename" })
         .header("Content-Type", mimeType)
         .put(content);
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-084650_pr-3514_61baed00cbd7/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Small OneDrive attachment uploads used a filename-addressed PUT with the default replacement behavior, so filing another `invoice.pdf` into the same folder could overwrite an existing document. Request rename-on-conflict for simple uploads, matching the protection already used by upload sessions, and return the new file metadata.

- Regression tests cover a small file and the inclusive 4 MiB simple-upload boundary. Both failed before the fix because the conflict policy was absent; all 11 provider tests pass after the fix.
- Validation: `pnpm test utils/drive/providers/microsoft.test.ts`, focused Biome checks, and `git diff --check`.
- Same upload request and payload; no additional database calls or network requests. Tests mock Graph; no live account was modified.

Microsoft documents that PUT defaults to replacing conflicts and that the conflict policy belongs in the request URL: [driveItem conflict behavior](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#instance-attributes).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OneDrive uploads now automatically rename new files when a file with the same name already exists, preventing conflicts while preserving the uploaded content.
  * Simple uploads now handle both small and larger files consistently with resumable uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->