### PR TITLE
cli: Preserve encryption keys during reconfiguration

### DIFF
--- a/packages/cli/src/aws-setup/aws-cli.test.ts
+++ b/packages/cli/src/aws-setup/aws-cli.test.ts
@@ -9,6 +9,12 @@ beforeEach(() => vi.clearAllMocks());
 describe("preserving SSM secrets", () => {
   it("does not overwrite an existing secret and accepts ParameterAlreadyExists", () => {
     vi.mocked(spawnSync).mockImplementation((_command, args) => {
+      if (args?.includes("add-tags-to-resource"))
+        return {
+          status: 0,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from(""),
+        } as ReturnType<typeof spawnSync>;
       const overwrites = args?.includes("--overwrite");
       return {
         status: overwrites ? 0 : 1,
@@ -57,4 +63,31 @@ describe("preserving SSM secrets", () => {
       }),
     ).toEqual({ success: false, error: "AccessDeniedException" });
   });
+});
+
+it("reports tag failures for existing parameters", () => {
+  vi.mocked(spawnSync).mockImplementation(
+    (_command, args) =>
+      ({
+        status: 1,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(
+          args?.includes("put-parameter")
+            ? "(ParameterAlreadyExists)"
+            : "AccessDeniedException",
+        ),
+      }) as ReturnType<typeof spawnSync>,
+  );
+  expect(
+    putSsmParameterWithTags({
+      env: {},
+      appName: "app",
+      envName: "test",
+      name: "/secret",
+      value: "replacement",
+      type: "SecureString",
+      errorMessage: "failed",
+      overwrite: false,
+    }),
+  ).toEqual({ success: false, error: "AccessDeniedException" });
 });

--- a/packages/cli/src/aws-setup/aws-cli.test.ts
+++ b/packages/cli/src/aws-setup/aws-cli.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { putSsmParameterWithTags } from "./aws-cli";
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("preserving SSM secrets", () => {
+  it("does not overwrite an existing secret and accepts ParameterAlreadyExists", () => {
+    vi.mocked(spawnSync).mockImplementation((_command, args) => {
+      const overwrites = args?.includes("--overwrite");
+      return {
+        status: overwrites ? 0 : 1,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from(
+          overwrites
+            ? ""
+            : "An error occurred (ParameterAlreadyExists) when calling PutParameter",
+        ),
+      } as ReturnType<typeof spawnSync>;
+    });
+    expect(
+      putSsmParameterWithTags({
+        env: {},
+        appName: "app",
+        envName: "test",
+        name: "/secret",
+        value: "replacement",
+        type: "SecureString",
+        errorMessage: "failed",
+        overwrite: false,
+      }),
+    ).toEqual({ success: true });
+    const put = vi
+      .mocked(spawnSync)
+      .mock.calls.find(([, args]) => args?.includes("put-parameter"));
+    expect(put?.[1]).not.toContain("--overwrite");
+  });
+
+  it("propagates access failures instead of treating them as existing parameters", () => {
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 1,
+      stdout: Buffer.from(""),
+      stderr: Buffer.from("AccessDeniedException"),
+    } as ReturnType<typeof spawnSync>);
+    expect(
+      putSsmParameterWithTags({
+        env: {},
+        appName: "app",
+        envName: "test",
+        name: "/secret",
+        value: "replacement",
+        type: "SecureString",
+        errorMessage: "failed",
+        overwrite: false,
+      }),
+    ).toEqual({ success: false, error: "AccessDeniedException" });
+  });
+});

--- a/packages/cli/src/aws-setup/aws-cli.ts
+++ b/packages/cli/src/aws-setup/aws-cli.ts
@@ -56,6 +56,7 @@ export function putSsmParameterWithTags(params: {
   value: string;
   type: "String" | "SecureString";
   errorMessage: string;
+  overwrite?: boolean;
 }): { success: boolean; error?: string } {
   const result = runAwsCommand(params.env, [
     "ssm",
@@ -66,9 +67,21 @@ export function putSsmParameterWithTags(params: {
     params.type,
     "--value",
     params.value,
-    "--overwrite",
+    ...(params.overwrite === false ? [] : ["--overwrite"]),
   ]);
   if (!result.success) {
+    if (
+      params.overwrite === false &&
+      result.stderr.includes("(ParameterAlreadyExists)")
+    ) {
+      addSsmParameterTags(
+        params.env,
+        params.appName,
+        params.envName,
+        params.name,
+      );
+      return { success: true };
+    }
     return { success: false, error: result.stderr || params.errorMessage };
   }
 

--- a/packages/cli/src/aws-setup/aws-cli.ts
+++ b/packages/cli/src/aws-setup/aws-cli.ts
@@ -34,8 +34,8 @@ export function addSsmParameterTags(
   appName: string,
   envName: string,
   paramName: string,
-): void {
-  runAwsCommand(env, [
+): { success: boolean; error?: string } {
+  const result = runAwsCommand(env, [
     "ssm",
     "add-tags-to-resource",
     "--resource-type",
@@ -46,6 +46,12 @@ export function addSsmParameterTags(
     `Key=copilot-application,Value=${appName}`,
     `Key=copilot-environment,Value=${envName}`,
   ]);
+  if (!result.success)
+    return {
+      success: false,
+      error: result.stderr || "Failed to tag SSM parameter",
+    };
+  return { success: true };
 }
 
 export function putSsmParameterWithTags(params: {
@@ -74,19 +80,22 @@ export function putSsmParameterWithTags(params: {
       params.overwrite === false &&
       result.stderr.includes("(ParameterAlreadyExists)")
     ) {
-      addSsmParameterTags(
+      return addSsmParameterTags(
         params.env,
         params.appName,
         params.envName,
         params.name,
       );
-      return { success: true };
     }
     return { success: false, error: result.stderr || params.errorMessage };
   }
 
-  addSsmParameterTags(params.env, params.appName, params.envName, params.name);
-  return { success: true };
+  return addSsmParameterTags(
+    params.env,
+    params.appName,
+    params.envName,
+    params.name,
+  );
 }
 
 export function readSecretJson<T extends Record<string, string | undefined>>(

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -604,7 +604,7 @@ async function runSetupQuick(options: { name?: string }) {
     REDIS_PORT: redisPort,
     REDIS_HTTP_PORT: redisHttpPort,
     WEB_PORT: webPort,
-    DATABASE_URL: `postgresql://postgres:${dbPassword}@db:5432/inboxzero`,
+    DATABASE_URL: `postgresql://postgres:${encodeURIComponent(dbPassword)}@db:5432/inboxzero`,
     UPSTASH_REDIS_TOKEN: redisToken,
     UPSTASH_REDIS_URL: "http://serverless-redis-http:80",
     QUEUE_BACKEND: "internal",
@@ -1132,13 +1132,13 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
 
     if (runWebInDocker) {
       // Web app runs in Docker: use container hostnames
-      env.DATABASE_URL = `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@db:5432/${env.POSTGRES_DB}`;
+      env.DATABASE_URL = `postgresql://${encodeURIComponent(env.POSTGRES_USER)}:${encodeURIComponent(env.POSTGRES_PASSWORD)}@db:5432/${env.POSTGRES_DB}`;
       env.DIRECT_URL = env.DATABASE_URL;
       env.UPSTASH_REDIS_URL = "http://serverless-redis-http:80";
       env.INTERNAL_API_URL = "http://web:3000";
     } else {
       // Web app runs on host: containers expose ports to localhost
-      env.DATABASE_URL = `postgresql://${env.POSTGRES_USER}:${env.POSTGRES_PASSWORD}@localhost:${postgresPort}/${env.POSTGRES_DB}`;
+      env.DATABASE_URL = `postgresql://${encodeURIComponent(env.POSTGRES_USER)}:${encodeURIComponent(env.POSTGRES_PASSWORD)}@localhost:${postgresPort}/${env.POSTGRES_DB}`;
       env.DIRECT_URL = env.DATABASE_URL;
       env.UPSTASH_REDIS_URL = `http://localhost:${redisHttpPort}`;
       env.INTERNAL_API_URL = `http://localhost:${webPort}`;

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -8,6 +8,7 @@ import { program } from "commander";
 import * as p from "@clack/prompts";
 import {
   generateSecret,
+  generateEncryptionSecrets,
   generateEnvFile,
   isSensitiveKey,
   parseEnvFile,
@@ -589,10 +590,10 @@ async function runSetupQuick(options: { name?: string }) {
   spinner.start("Generating configuration...");
 
   // Reuse existing database password to avoid mismatch with Docker volume
-  const existingDbPassword = readExistingDbPassword(envFile);
+  const existingEnv = readExistingEnv(envFile);
 
   const redisToken = generateSecret(32);
-  const dbPassword = existingDbPassword || generateSecret(16);
+  const dbPassword = existingEnv.POSTGRES_PASSWORD || generateSecret(16);
   const env: EnvConfig = {
     NODE_ENV: "production",
     // Database (Docker internal networking)
@@ -610,8 +611,7 @@ async function runSetupQuick(options: { name?: string }) {
     INTERNAL_API_URL: "http://web:3000",
     // Secrets
     AUTH_SECRET: generateSecret(32),
-    EMAIL_ENCRYPT_SECRET: generateSecret(32),
-    EMAIL_ENCRYPT_SALT: generateSecret(16),
+    ...generateEncryptionSecrets(existingEnv),
     INTERNAL_API_KEY: generateSecret(32),
     API_KEY_SALT: generateSecret(32),
     CRON_SECRET: generateSecret(32),
@@ -909,6 +909,7 @@ async function runSetupAdvanced(options: { name?: string }) {
     }
   }
 
+  const existingEnv = readExistingEnv(envFile);
   const env: EnvConfig = {};
   const { webPort, postgresPort, redisPort, redisHttpPort, changedPorts } =
     await resolveSetupPorts({ useDockerInfra });
@@ -1119,7 +1120,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
     // Using Docker Compose for Postgres/Redis
     env.POSTGRES_USER = "postgres";
     env.POSTGRES_PASSWORD =
-      readExistingDbPassword(envFile) ||
+      existingEnv.POSTGRES_PASSWORD ||
       (isDevMode ? "password" : generateSecret(16));
     env.POSTGRES_DB = "inboxzero";
     env.POSTGRES_PORT = postgresPort;
@@ -1152,8 +1153,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
 
   // Secrets (same for both modes)
   env.AUTH_SECRET = generateSecret(32);
-  env.EMAIL_ENCRYPT_SECRET = generateSecret(32);
-  env.EMAIL_ENCRYPT_SALT = generateSecret(16);
+  Object.assign(env, generateEncryptionSecrets(existingEnv));
   env.INTERNAL_API_KEY = generateSecret(32);
   env.API_KEY_SALT = generateSecret(32);
   env.CRON_SECRET = generateSecret(32);
@@ -1827,10 +1827,9 @@ function logPortConflictGuidance() {
   );
 }
 
-function readExistingDbPassword(envFile: string): string | undefined {
-  if (!existsSync(envFile)) return;
-  const existing = parseEnvFile(readFileSync(envFile, "utf-8"));
-  return existing.POSTGRES_PASSWORD || undefined;
+function readExistingEnv(envFile: string): EnvConfig {
+  if (!existsSync(envFile)) return {};
+  return parseEnvFile(readFileSync(envFile, "utf-8"));
 }
 
 function checkContainersRunning(composeArgs: string[]): boolean {

--- a/packages/cli/src/setup-aws.ts
+++ b/packages/cli/src/setup-aws.ts
@@ -1787,6 +1787,7 @@ function storeSecretInSsm(
     value,
     type: "SecureString",
     errorMessage: `Failed to store ${name}`,
+    overwrite: name !== "EMAIL_ENCRYPT_SECRET" && name !== "EMAIL_ENCRYPT_SALT",
   });
 
   if (!result.success) {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -718,3 +718,9 @@ it("preserves hashes in unquoted Compose database passwords", () => {
     parseEnvFile("POSTGRES_PASSWORD=abc#def # comment").POSTGRES_PASSWORD,
   ).toBe("abc#def");
 });
+
+it("keeps a commented empty database password empty", () => {
+  expect(
+    parseEnvFile("POSTGRES_PASSWORD= # set a password").POSTGRES_PASSWORD,
+  ).toBe("");
+});

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   generateSecret,
+  generateEncryptionSecrets,
   generateEnvFile,
   getEnvFileName,
   isSensitiveKey,
@@ -683,5 +684,31 @@ describe("parsePortConflict", () => {
     expect(parsePortConflict("image not found")).toBeNull();
     expect(parsePortConflict("network timeout")).toBeNull();
     expect(parsePortConflict("")).toBeNull();
+  });
+});
+
+describe("setup encryption secrets", () => {
+  it("preserves existing encryption material when reconfiguring", () => {
+    const existing = parseEnvFile(
+      'EMAIL_ENCRYPT_SECRET="existing#secret" # keep\nEMAIL_ENCRYPT_SALT=existing-salt # keep',
+    );
+    expect(generateEncryptionSecrets(existing)).toEqual({
+      EMAIL_ENCRYPT_SECRET: "existing#secret",
+      EMAIL_ENCRYPT_SALT: "existing-salt",
+    });
+  });
+
+  it("generates missing material for a fresh installation", () => {
+    expect(generateEncryptionSecrets({})).toEqual({
+      EMAIL_ENCRYPT_SECRET: expect.stringMatching(/^[a-f0-9]{64}$/),
+      EMAIL_ENCRYPT_SALT: expect.stringMatching(/^[a-f0-9]{32}$/),
+    });
+  });
+
+  it("ignores inline comments when reusing a database password", () => {
+    expect(
+      parseEnvFile("POSTGRES_PASSWORD=password # change this for production")
+        .POSTGRES_PASSWORD,
+    ).toBe("password");
   });
 });

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -712,3 +712,9 @@ describe("setup encryption secrets", () => {
     ).toBe("password");
   });
 });
+
+it("preserves hashes in unquoted Compose database passwords", () => {
+  expect(
+    parseEnvFile("POSTGRES_PASSWORD=abc#def # comment").POSTGRES_PASSWORD,
+  ).toBe("abc#def");
+});

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { parseEnv } from "node:util";
 
 // Environment variable builder
 export type EnvConfig = Record<string, string | undefined>;
@@ -212,23 +213,7 @@ export function isSensitiveKey(key: string): boolean {
 }
 
 export function parseEnvFile(content: string): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eqIndex = trimmed.indexOf("=");
-    if (eqIndex === -1) continue;
-    const key = trimmed.slice(0, eqIndex).trim();
-    let value = trimmed.slice(eqIndex + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    env[key] = value;
-  }
-  return env;
+  return parseEnv(content);
 }
 
 export function updateEnvValue(
@@ -288,4 +273,11 @@ export function parsePortConflict(stderr: string): string | null {
 
 function escapeEnvQuotedValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function generateEncryptionSecrets(existing: EnvConfig): EnvConfig {
+  return {
+    EMAIL_ENCRYPT_SECRET: existing.EMAIL_ENCRYPT_SECRET || generateSecret(32),
+    EMAIL_ENCRYPT_SALT: existing.EMAIL_ENCRYPT_SALT || generateSecret(16),
+  };
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -213,7 +213,17 @@ export function isSensitiveKey(key: string): boolean {
 }
 
 export function parseEnvFile(content: string): Record<string, string> {
-  return parseEnv(content);
+  const env = parseEnv(content);
+  // Compose treats unspaced hashes in unquoted database passwords as literal.
+  const password = [
+    ...content.matchAll(/^[ \t]*POSTGRES_PASSWORD[ \t]*=[ \t]*(.*)$/gm),
+  ]
+    .at(-1)?.[1]
+    ?.trim();
+  if (password && !password.startsWith('"') && !password.startsWith("'")) {
+    env.POSTGRES_PASSWORD = password.replace(/\s+#.*$/, "").trim();
+  }
+  return env;
 }
 
 export function updateEnvValue(

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -216,11 +216,13 @@ export function parseEnvFile(content: string): Record<string, string> {
   const env = parseEnv(content);
   // Compose treats unspaced hashes in unquoted database passwords as literal.
   const password = [
-    ...content.matchAll(/^[ \t]*POSTGRES_PASSWORD[ \t]*=[ \t]*(.*)$/gm),
-  ]
-    .at(-1)?.[1]
-    ?.trim();
-  if (password && !password.startsWith('"') && !password.startsWith("'")) {
+    ...content.matchAll(/^[ \t]*POSTGRES_PASSWORD[ \t]*=(.*)$/gm),
+  ].at(-1)?.[1];
+  if (
+    password &&
+    !password.trim().startsWith('"') &&
+    !password.trim().startsWith("'")
+  ) {
     env.POSTGRES_PASSWORD = password.replace(/\s+#.*$/, "").trim();
   }
   return env;


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-084840_pr-3515_9de1175941b4/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Rerunning local or AWS setup replaced encryption keys while retaining database records encrypted with the old keys. Reuse existing local key material and create AWS encryption parameters without overwriting existing values.

- Parse existing environment files with Node's environment parser so comments do not become part of reused passwords or keys.
- AWS preserves existing parameters atomically and still reports permission failures.
- Validation: 3 regression cases failed before fixes; all 49 focused CLI utility and AWS tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - AWS setup now correctly handles existing parameters without overwriting protected encryption secrets.
  - Setup errors unrelated to an already existing parameter are reported accurately.
  - Environment values containing inline comments are parsed correctly.

- **Improvements**
  - Re-running setup preserves existing database passwords and email encryption secrets.
  - New installations generate secure email encryption secrets and salts automatically.
  - Other AWS secret parameters can be updated when setup is run again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->