### PR TITLE
mcp: Retry OAuth registration after transient failures

### DIFF
--- a/apps/web/utils/mcp/oauth.test.ts
+++ b/apps/web/utils/mcp/oauth.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  registerClient,
+  startAuthorization,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import prisma from "@/utils/__mocks__/prisma";
+import { generateOAuthUrl } from "./oauth";
+
+vi.mock("@/utils/prisma");
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  discoverAuthorizationServerMetadata: vi.fn(),
+  discoverOAuthProtectedResourceMetadata: vi.fn(),
+  registerClient: vi.fn(),
+  startAuthorization: vi.fn(),
+  exchangeAuthorization: vi.fn(),
+  refreshAuthorization: vi.fn(),
+}));
+
+describe("OAuth registration recovery", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    let integration: Record<string, unknown> = {
+      id: "integration-1",
+      name: "notion",
+    };
+    prisma.mcpIntegration.findUnique.mockImplementation(
+      async () => integration as never,
+    );
+    prisma.mcpIntegration.upsert.mockImplementation(async ({ update }) => {
+      integration = { ...integration, ...update };
+      return integration as never;
+    });
+    vi.mocked(discoverOAuthProtectedResourceMetadata).mockResolvedValue(
+      undefined,
+    );
+    vi.mocked(discoverAuthorizationServerMetadata).mockResolvedValue({
+      issuer: "https://mcp.notion.com",
+      authorization_endpoint: "https://mcp.notion.com/authorize",
+      token_endpoint: "https://mcp.notion.com/token",
+      registration_endpoint: "https://mcp.notion.com/register",
+      response_types_supported: ["code"],
+    });
+    vi.mocked(registerClient).mockResolvedValue({
+      client_id: "registered-client",
+    });
+    vi.mocked(startAuthorization).mockResolvedValue({
+      authorizationUrl: new URL(
+        "https://mcp.notion.com/authorize?client_id=registered-client",
+      ),
+      codeVerifier: "verifier",
+    });
+  });
+
+  it("retries registration after transient failure despite cached discovery", async () => {
+    vi.mocked(registerClient).mockRejectedValueOnce(
+      new Error("Registration temporarily unavailable"),
+    );
+
+    await expect(startOAuth()).rejects.toThrow(
+      "Registration temporarily unavailable",
+    );
+    await expect(startOAuth()).resolves.toMatchObject({
+      codeVerifier: "verifier",
+    });
+    expect(registerClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries registration when saving registered credentials fails", async () => {
+    const persistIntegration =
+      prisma.mcpIntegration.upsert.getMockImplementation()!;
+    prisma.mcpIntegration.upsert.mockImplementation(async (args) => {
+      if (args.update.oauthClientId) {
+        prisma.mcpIntegration.upsert.mockImplementation(persistIntegration);
+        throw new Error("Credential storage temporarily unavailable");
+      }
+      return persistIntegration(args);
+    });
+
+    await expect(startOAuth()).rejects.toThrow(
+      "Credential storage temporarily unavailable",
+    );
+    await expect(startOAuth()).resolves.toMatchObject({
+      codeVerifier: "verifier",
+    });
+    expect(registerClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses discovery and credentials after successful registration", async () => {
+    await startOAuth();
+    await startOAuth();
+    expect(registerClient).toHaveBeenCalledTimes(1);
+    expect(discoverAuthorizationServerMetadata).toHaveBeenCalledTimes(1);
+  });
+});
+
+function startOAuth() {
+  return generateOAuthUrl({
+    integration: "notion",
+    redirectUri: "https://example.com/oauth/callback",
+    state: "oauth-state",
+  });
+}

--- a/apps/web/utils/mcp/oauth.test.ts
+++ b/apps/web/utils/mcp/oauth.test.ts
@@ -65,11 +65,14 @@ describe("OAuth registration recovery", () => {
       codeVerifier: "verifier",
     });
     expect(registerClient).toHaveBeenCalledTimes(2);
+    expect(discoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
   });
 
   it("retries registration when saving registered credentials fails", async () => {
     const persistIntegration =
-      prisma.mcpIntegration.upsert.getMockImplementation()!;
+      prisma.mcpIntegration.upsert.getMockImplementation();
+    if (!persistIntegration)
+      throw new Error("Integration persistence mock missing");
     prisma.mcpIntegration.upsert.mockImplementation(async (args) => {
       if (args.update.oauthClientId) {
         prisma.mcpIntegration.upsert.mockImplementation(persistIntegration);
@@ -85,6 +88,7 @@ describe("OAuth registration recovery", () => {
       codeVerifier: "verifier",
     });
     expect(registerClient).toHaveBeenCalledTimes(2);
+    expect(discoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
   });
 
   it("reuses discovery and credentials after successful registration", async () => {

--- a/apps/web/utils/mcp/oauth.ts
+++ b/apps/web/utils/mcp/oauth.ts
@@ -364,15 +364,17 @@ async function discoverMetadata(
   const stored = await prisma.mcpIntegration.findUnique({
     where: { name: integration },
     select: {
+      oauthClientId: true,
       registeredAuthorizationUrl: true,
       registeredTokenUrl: true,
       registeredServerUrl: true,
     },
   });
 
-  // Use cached endpoints if we have them AND they match the current serverUrl
+  // Cached endpoints omit registration metadata, so only reuse them after registration succeeds.
   if (
-    stored?.registeredAuthorizationUrl &&
+    stored?.oauthClientId &&
+    stored.registeredAuthorizationUrl &&
     stored?.registeredTokenUrl &&
     stored.registeredServerUrl === serverUrl
   ) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260905-191435_pr-3516_da04565e7068/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

A transient OAuth client registration or credential-save failure cached discovery endpoints without registration metadata, causing every subsequent connection attempt to fail. Rediscover endpoints while client credentials are absent so registration remains retryable.

- Existing registered clients keep the same cached discovery path.
- Added regressions for registration and credential-storage failures, plus successful cache reuse; the two recovery tests fail before the fix.
- Validation: 11 focused OAuth and callback tests passed; formatting and diff checks passed.
- Recovery attempts rediscover metadata; successful connections add no database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth connection recovery when registration or credential storage temporarily fails.
  - Ensured cached OAuth details are reused only after successful client registration, reducing connection failures caused by incomplete cached information.

- **Tests**
  - Added coverage for OAuth registration retries, recovery scenarios, and reuse of previously discovered connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->