### PR TITLE
llms: Preserve original errors when retries stop

### DIFF
--- a/apps/web/utils/llms/retry.test.ts
+++ b/apps/web/utils/llms/retry.test.ts
@@ -254,9 +254,7 @@ describe("withLLMRetry", () => {
     const authError = createError("Invalid API key", { status: 401 });
     const fn = vi.fn().mockRejectedValue(authError);
 
-    await expect(withLLMRetry(fn, { label: "test" })).rejects.toMatchObject({
-      error: { message: "Invalid API key" },
-    });
+    await expect(withLLMRetry(fn, { label: "test" })).rejects.toBe(authError);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/utils/llms/retry.ts
+++ b/apps/web/utils/llms/retry.ts
@@ -241,21 +241,21 @@ export async function withLLMRetry<T>(
   return pRetry(operation, {
     retries: maxRetries,
     minTimeout: 0,
-    onFailedAttempt: async (error) => {
+    onFailedAttempt: async ({ error, attemptNumber }) => {
       const errorInfo = extractLLMErrorInfo(error);
 
       if (!errorInfo.retryable) {
         throw error;
       }
 
-      const baseDelayMs = 2000 * 2 ** (error.attemptNumber - 1);
+      const baseDelayMs = 2000 * 2 ** (attemptNumber - 1);
       const delayMs = errorInfo.retryAfterMs ?? Math.min(baseDelayMs, 60_000);
       const jitter = Math.random() * 0.1 * delayMs;
       const totalDelayMs = delayMs + jitter;
 
       logger.warn("LLM rate limit error, retrying", {
         label,
-        attemptNumber: error.attemptNumber,
+        attemptNumber,
         maxRetries,
         delayMs: Math.round(totalDelayMs),
         isRateLimit: errorInfo.isRateLimit,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-085026_pr-3517_2737c6a4347f/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

When an LLM call fails with a non-retryable provider error, the retry helper throws p-retry’s callback context instead of the original error. That loses the normal error identity, message and provider metadata expected by callers.

Destructure the callback context so the helper throws the original error and keeps the existing retry/backoff behavior. Tighten the authentication-error regression to assert error identity and a single attempt: it fails before the fix, and all 27 retry tests pass afterward.

Validation: `pnpm test utils/llms/retry.test.ts`, focused Biome checks, and `git diff --check`. No additional requests, database work, or model-facing prompt/tool changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-retryable errors so the original error is preserved and returned as expected.
  * Maintained existing retry behavior, delays, and logging while making retry-attempt reporting more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->