### PR TITLE
cli: Use supported Vercel development variable types

### DIFF
--- a/packages/cli/src/setup-vercel.test.ts
+++ b/packages/cli/src/setup-vercel.test.ts
@@ -108,7 +108,7 @@ describe("buildVercelEnvValues", () => {
       ),
     ).toMatchObject({
       createValue: expect.any(Function),
-      sensitive: true,
+      sensitive: false,
     });
   });
 });
@@ -146,4 +146,33 @@ describe("seedLlmPlaceholderCredentials", () => {
       seedLlmPlaceholderCredentials("unknown-provider", {}),
     ).toThrowError("Unsupported LLM provider: unknown-provider");
   });
+});
+
+it("uses supported variable types for each Vercel environment", () => {
+  const values = buildVercelEnvValues({
+    baseUrl: "https://mail.example.com",
+    llmEnv: { LLM_API_KEY: "key" },
+  });
+  for (const key of [
+    "AUTH_SECRET",
+    "EMAIL_ENCRYPT_SECRET",
+    "GOOGLE_CLIENT_SECRET",
+    "LLM_API_KEY",
+  ]) {
+    expect(
+      values.find(
+        (value) => value.key === key && value.environment === "development",
+      )?.sensitive,
+    ).toBe(false);
+    expect(
+      values.find(
+        (value) => value.key === key && value.environment === "production",
+      )?.sensitive,
+    ).toBe(true);
+    expect(
+      values.find(
+        (value) => value.key === key && value.environment === "preview",
+      )?.sensitive,
+    ).toBe(true);
+  }
 });

--- a/packages/cli/src/setup-vercel.ts
+++ b/packages/cli/src/setup-vercel.ts
@@ -83,7 +83,7 @@ export function buildVercelEnvValues(config: {
         key,
         value,
         environment,
-        sensitive: isSensitiveKey(key),
+        sensitive: environment !== "development" && isSensitiveKey(key),
       });
     }
   };


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-085210_pr-3518_b0c9c3b797e0/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Vercel rejects sensitive variables targeting Development, causing setup to abort while seeding credentials. Apply the sensitive flag only to Production and Preview, and use regular encrypted variables for Development as required by [Vercel's documentation](https://vercel.com/docs/environment-variables/sensitive-environment-variables).

- Preserve sensitivity for deployed secrets and placeholders in supported targets.
- Validation: regression failed before the fix; all 6 Vercel setup tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development environment variables are no longer marked as sensitive.
  - Production and preview environment variables continue to receive sensitive handling.
  - Added coverage to verify sensitivity settings for authentication, encryption, provider, and API key variables across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->