### PR TITLE
cli: Enable verified TLS for generated RDS URLs

### DIFF
--- a/packages/cli/src/aws-setup/ssm-urls.test.ts
+++ b/packages/cli/src/aws-setup/ssm-urls.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildDatabaseUrl } from "./ssm-urls";
+
+describe("RDS database URL", () => {
+  it("requires verified TLS and preserves escaped credentials", () => {
+    const url = new URL(
+      buildDatabaseUrl({
+        username: "user@example",
+        password: "p@ss:/#",
+        endpoint: "database.example.rds.amazonaws.com",
+        port: 5432,
+        database: "inboxzero",
+      }),
+    );
+    expect(url.searchParams.get("sslmode")).toBe("verify-full");
+    expect(decodeURIComponent(url.username)).toBe("user@example");
+    expect(decodeURIComponent(url.password)).toBe("p@ss:/#");
+  });
+});

--- a/packages/cli/src/aws-setup/ssm-urls.ts
+++ b/packages/cli/src/aws-setup/ssm-urls.ts
@@ -170,7 +170,7 @@ export function buildDatabaseUrl(params: {
 }): string {
   const username = encodeURIComponent(params.username);
   const password = encodeURIComponent(params.password);
-  return `postgresql://${username}:${password}@${params.endpoint}:${params.port}/${params.database}`;
+  return `postgresql://${username}:${password}@${params.endpoint}:${params.port}/${params.database}?sslmode=verify-full`;
 }
 
 export function buildRedisUrl(params: {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-085358_pr-3519_4ff89cf0486b/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Generated RDS connection strings did not enable TLS, while the provisioned PostgreSQL version requires it by default. Add sslmode=verify-full so the app and migrations use verified TLS with the RDS CA bundle already configured by their startup scripts.

- Applies to both DATABASE_URL and DIRECT_URL stored by AWS setup.
- Validation: regression failed before the fix and now passes; the installed pg client resolves the old URL to ssl=false and the corrected URL to enabled TLS with certificate verification.
- [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html) confirms the server-side SSL requirement.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->