### PR TITLE
auth: Preserve reconnected credentials after stale provider failures

### DIFF
--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -36,9 +36,49 @@ describe("cleanupInvalidTokens", () => {
     accountId: "acc_1",
     userId: "user_1",
     user: { email: "owner@example.com" },
-    account: { disconnectedAt: null },
+    account: {
+      disconnectedAt: null,
+      access_token: "access-token",
+      updatedAt: new Date("2026-09-05T12:00:00Z"),
+    },
     watchEmailsExpirationDate: new Date(Date.now() + 1000 * 60 * 60), // Valid expiration
   };
+
+  it("preserves reconnected credentials when an old request fails", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...mockEmailAccount,
+      account: {
+        disconnectedAt: null,
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        updatedAt: new Date("2026-09-05T12:00:00Z"),
+      },
+    } as any);
+    prisma.account.updateMany.mockResolvedValue({ count: 1 });
+
+    await cleanupInvalidTokens({
+      emailAccountId: "ea_1",
+      reason: "invalid_grant",
+      failedAccessToken: "old-access",
+      failedRefreshToken: "old-refresh",
+      logger,
+    });
+
+    expect(prisma.account.updateMany).not.toHaveBeenCalled();
+    expect(sendReconnectionEmail).not.toHaveBeenCalled();
+    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
+  });
+
+  it("preserves credentials when no failed credential snapshot is available", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(mockEmailAccount as any);
+    prisma.account.updateMany.mockResolvedValue({ count: 1 });
+    await cleanupInvalidTokens({
+      emailAccountId: "ea_1",
+      reason: "invalid_grant",
+      logger,
+    });
+    expect(prisma.account.updateMany).not.toHaveBeenCalled();
+  });
 
   it("marks account as disconnected and sends email to the disconnected account on invalid_grant when account is watched", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue(mockEmailAccount as any);
@@ -46,13 +86,18 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "invalid_grant",
       logger,
     });
 
     expect(prisma.account.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "acc_1", disconnectedAt: null },
+        where: {
+          id: "acc_1",
+          updatedAt: mockEmailAccount.account.updatedAt,
+          disconnectedAt: null,
+        },
         data: expect.objectContaining({
           disconnectedAt: expect.any(Date),
         }),
@@ -84,6 +129,7 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "invalid_grant",
       logger,
     });
@@ -106,6 +152,7 @@ describe("cleanupInvalidTokens", () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...mockEmailAccount,
       account: {
+        updatedAt: mockEmailAccount.account.updatedAt,
         disconnectedAt: new Date(),
         access_token: "access-token",
         refresh_token: "refresh-token",
@@ -116,12 +163,17 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "invalid_grant",
       logger,
     });
 
     expect(prisma.account.updateMany).toHaveBeenCalledWith({
-      where: { id: "acc_1", disconnectedAt: { not: null } },
+      where: {
+        id: "acc_1",
+        updatedAt: mockEmailAccount.account.updatedAt,
+        disconnectedAt: { not: null },
+      },
       data: {
         access_token: null,
         refresh_token: null,
@@ -137,6 +189,7 @@ describe("cleanupInvalidTokens", () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...mockEmailAccount,
       account: {
+        updatedAt: mockEmailAccount.account.updatedAt,
         disconnectedAt: new Date(),
         access_token: null,
         refresh_token: null,
@@ -146,6 +199,7 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "invalid_grant",
       logger,
     });
@@ -159,6 +213,7 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "insufficient_permissions",
       logger,
     });
@@ -183,6 +238,7 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
+      failedAccessToken: "access-token",
       reason: "policy_enforced",
       logger,
     });

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -199,7 +199,7 @@ describe("cleanupInvalidTokens", () => {
 
     await cleanupInvalidTokens({
       emailAccountId: "ea_1",
-      failedAccessToken: "access-token",
+      failedAccessToken: null,
       reason: "invalid_grant",
       logger,
     });

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -26,9 +26,13 @@ const clearedCredentials = {
 export async function cleanupInvalidTokens({
   emailAccountId,
   reason,
+  failedAccessToken,
+  failedRefreshToken,
   logger,
 }: {
   emailAccountId: string;
+  failedAccessToken?: string | null;
+  failedRefreshToken?: string | null;
   reason:
     | "invalid_grant"
     | "insufficient_permissions"
@@ -36,6 +40,12 @@ export async function cleanupInvalidTokens({
     | "mail_service_not_enabled";
   logger: Logger;
 }) {
+  if (failedAccessToken === undefined && failedRefreshToken === undefined) {
+    logger.info(
+      "Skipping credential cleanup without a failed credential snapshot",
+    );
+    return;
+  }
   logger.info("Cleaning up invalid tokens", { reason });
 
   const emailAccount = await prisma.emailAccount.findUnique({
@@ -53,6 +63,7 @@ export async function cleanupInvalidTokens({
       },
       account: {
         select: {
+          updatedAt: true,
           disconnectedAt: true,
           access_token: true,
           refresh_token: true,
@@ -68,6 +79,16 @@ export async function cleanupInvalidTokens({
   }
 
   const account = emailAccount.account;
+  if (
+    !account ||
+    (failedAccessToken !== undefined &&
+      account.access_token !== failedAccessToken) ||
+    (failedRefreshToken !== undefined &&
+      account.refresh_token !== failedRefreshToken)
+  ) {
+    logger.info("Skipping cleanup of superseded credentials");
+    return;
+  }
 
   if (account?.disconnectedAt) {
     const hasStaleCredentials =
@@ -75,7 +96,11 @@ export async function cleanupInvalidTokens({
 
     if (hasStaleCredentials) {
       await prisma.account.updateMany({
-        where: { id: emailAccount.accountId, disconnectedAt: { not: null } },
+        where: {
+          id: emailAccount.accountId,
+          updatedAt: account.updatedAt,
+          disconnectedAt: { not: null },
+        },
         data: clearedCredentials,
       });
     }
@@ -85,7 +110,11 @@ export async function cleanupInvalidTokens({
   }
 
   const updated = await prisma.account.updateMany({
-    where: { id: emailAccount.accountId, disconnectedAt: null },
+    where: {
+      id: emailAccount.accountId,
+      updatedAt: account.updatedAt,
+      disconnectedAt: null,
+    },
     data: { ...clearedCredentials, disconnectedAt: new Date() },
   });
 

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -44,7 +44,7 @@ export async function cleanupInvalidTokens({
     logger.info(
       "Skipping credential cleanup without a failed credential snapshot",
     );
-    return;
+    return { status: "skipped" as const };
   }
   logger.info("Cleaning up invalid tokens", { reason });
 
@@ -75,7 +75,7 @@ export async function cleanupInvalidTokens({
 
   if (!emailAccount) {
     logger.warn("Email account not found");
-    return;
+    return { status: "skipped" as const };
   }
 
   const account = emailAccount.account;
@@ -87,7 +87,7 @@ export async function cleanupInvalidTokens({
       account.refresh_token !== failedRefreshToken)
   ) {
     logger.info("Skipping cleanup of superseded credentials");
-    return;
+    return { status: "skipped" as const };
   }
 
   if (account?.disconnectedAt) {
@@ -119,10 +119,8 @@ export async function cleanupInvalidTokens({
   });
 
   if (updated.count === 0) {
-    logger.info(
-      "Account already marked as disconnected (via concurrent update)",
-    );
-    return;
+    logger.info("Account changed before credential cleanup");
+    return { status: "skipped" as const };
   }
 
   const errorMessage = getAccountActionRequiredMessage(

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -29,6 +29,24 @@ describe("provider health", () => {
     );
   });
 
+  it("releases cleanup deduplication when the failed credentials have been superseded", async () => {
+    vi.mocked(cleanupInvalidTokens).mockResolvedValueOnce({
+      status: "skipped",
+    });
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("invalid_grant"),
+      failedAccessToken: "old-token",
+      operation: "getMessage",
+      logger: createMockLogger(),
+    });
+    expect(releaseProviderIssueCleanupClaimInRedis).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
+  });
+
   it("records missing refresh token failures as reconnect-required issues", async () => {
     const logger = createMockLogger();
 

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -55,12 +55,19 @@ export async function recordEmailAccountProviderIssue({
   if (!shouldRecord) return;
 
   try {
-    await cleanupInvalidTokens({
+    const result = await cleanupInvalidTokens({
       emailAccountId,
       reason: issue.reason,
       failedAccessToken,
       logger,
     });
+    if (result?.status === "skipped") {
+      await releaseProviderIssueCleanupClaim({
+        emailAccountId,
+        reason: issue.reason,
+        logger,
+      });
+    }
   } catch (error) {
     logger.warn("Failed to clean up provider account issue", {
       error,

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -26,12 +26,14 @@ export async function recordEmailAccountProviderIssue({
   error,
   logger,
   operation,
+  failedAccessToken,
 }: {
   emailAccountId: string;
   provider: "google" | "microsoft";
   error: unknown;
   logger: Logger;
   operation: string;
+  failedAccessToken?: string;
 }) {
   const issue = classifyEmailAccountProviderIssue({ error, provider });
   if (!issue) return;
@@ -56,6 +58,7 @@ export async function recordEmailAccountProviderIssue({
     await cleanupInvalidTokens({
       emailAccountId,
       reason: issue.reason,
+      failedAccessToken,
       logger,
     });
   } catch (error) {

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -5,10 +5,12 @@ import { getGmailClientForEmail } from "@/utils/email-account-client";
 import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
 import { recordEmailAccountProviderIssue } from "@/utils/email/provider-health";
 
-const { gmailGetMessageMock, gmailSearchMessagesMock } = vi.hoisted(() => ({
-  gmailGetMessageMock: vi.fn(),
-  gmailSearchMessagesMock: vi.fn(),
-}));
+const { gmailGetMessageMock, gmailSearchMessagesMock, providerToken } =
+  vi.hoisted(() => ({
+    providerToken: { value: "access-token" },
+    gmailGetMessageMock: vi.fn(),
+    gmailSearchMessagesMock: vi.fn(),
+  }));
 
 vi.mock("@/utils/email-account-client", () => ({
   getGmailClientForEmail: vi.fn(),
@@ -32,7 +34,7 @@ vi.mock("@/utils/email/google", () => ({
     readonly name = "google";
 
     getAccessToken() {
-      return "access-token";
+      return providerToken.value;
     }
 
     searchMessages(...args: unknown[]) {
@@ -54,12 +56,32 @@ vi.mock("@/utils/email/microsoft", () => ({
 describe("createEmailProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    providerToken.value = "access-token";
     vi.mocked(assertProviderNotRateLimited).mockResolvedValue(undefined);
     vi.mocked(getGmailClientForEmail).mockResolvedValue({} as any);
     vi.mocked(flushLoggerSafely).mockResolvedValue(undefined);
     vi.mocked(recordEmailAccountProviderIssue).mockResolvedValue(undefined);
     gmailGetMessageMock.mockResolvedValue({});
     gmailSearchMessagesMock.mockResolvedValue({ messages: [] });
+  });
+
+  it("records the token used before an operation even if the client token changes", async () => {
+    const logger = createMockLogger();
+    gmailSearchMessagesMock.mockImplementationOnce(async () => {
+      providerToken.value = "new-access-token";
+      throw new Error("invalid_grant");
+    });
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+    await expect(
+      provider.searchMessages({ query: "in:inbox" }),
+    ).rejects.toThrow("invalid_grant");
+    expect(recordEmailAccountProviderIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAccessToken: "access-token" }),
+    );
   });
 
   it("logs and flushes provider creation failures", async () => {
@@ -176,6 +198,7 @@ describe("createEmailProvider", () => {
       error: expect.any(Error),
       logger,
       operation: "searchMessages",
+      failedAccessToken: "access-token",
     });
   });
 

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -7,7 +7,7 @@ import { recordEmailAccountProviderIssue } from "@/utils/email/provider-health";
 
 const { gmailGetMessageMock, gmailSearchMessagesMock, providerToken } =
   vi.hoisted(() => ({
-    providerToken: { value: "access-token" },
+    providerToken: { value: "access-token", error: null as Error | null },
     gmailGetMessageMock: vi.fn(),
     gmailSearchMessagesMock: vi.fn(),
   }));
@@ -34,6 +34,7 @@ vi.mock("@/utils/email/google", () => ({
     readonly name = "google";
 
     getAccessToken() {
+      if (providerToken.error) throw providerToken.error;
       return providerToken.value;
     }
 
@@ -57,12 +58,27 @@ describe("createEmailProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     providerToken.value = "access-token";
+    providerToken.error = null;
     vi.mocked(assertProviderNotRateLimited).mockResolvedValue(undefined);
     vi.mocked(getGmailClientForEmail).mockResolvedValue({} as any);
     vi.mocked(flushLoggerSafely).mockResolvedValue(undefined);
     vi.mocked(recordEmailAccountProviderIssue).mockResolvedValue(undefined);
     gmailGetMessageMock.mockResolvedValue({});
     gmailSearchMessagesMock.mockResolvedValue({ messages: [] });
+  });
+
+  it("allows provider requests to proceed when a cached access token is unavailable", async () => {
+    const logger = createMockLogger();
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+    providerToken.error = new Error("No access token");
+    await expect(
+      provider.searchMessages({ query: "in:inbox" }),
+    ).resolves.toEqual({ messages: [] });
+    expect(gmailSearchMessagesMock).toHaveBeenCalledOnce();
   });
 
   it("records the token used before an operation even if the client token changes", async () => {

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -94,6 +94,10 @@ function withProviderFailureLogging(
         let failedAccessToken: string | undefined;
         try {
           failedAccessToken = target.getAccessToken();
+        } catch {
+          // The operation may still refresh a missing cached access token.
+        }
+        try {
           const result = value.apply(target, args);
           if (!isPromiseLike(result)) return result;
 

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -91,13 +91,16 @@ function withProviderFailureLogging(
       if (typeof value !== "function") return value;
 
       return (...args: unknown[]) => {
+        let failedAccessToken: string | undefined;
         try {
+          failedAccessToken = target.getAccessToken();
           const result = value.apply(target, args);
           if (!isPromiseLike(result)) return result;
 
           return result.catch(async (error: unknown) => {
             await logProviderOperationFailureSafely({
               error,
+              failedAccessToken,
               emailAccountId,
               provider,
               logger,
@@ -108,6 +111,7 @@ function withProviderFailureLogging(
         } catch (error) {
           logProviderOperationFailureSafely({
             error,
+            failedAccessToken,
             emailAccountId,
             provider,
             operation: String(property),
@@ -141,12 +145,14 @@ async function logProviderOperationFailure({
   provider,
   logger,
   operation,
+  failedAccessToken,
 }: {
   error: unknown;
   emailAccountId: string;
   provider: "google" | "microsoft";
   logger: Logger;
   operation: string;
+  failedAccessToken?: string;
 }) {
   logger.warn("Email provider operation failed", {
     error,
@@ -160,6 +166,7 @@ async function logProviderOperationFailure({
     error,
     logger,
     operation,
+    failedAccessToken,
   });
   await flushLoggerSafely(logger, {
     action: "emailProvider",
@@ -175,6 +182,7 @@ async function recordProviderIssueSafely({
   error,
   logger,
   operation,
+  failedAccessToken,
 }: ProviderOperationFailureLogInput) {
   await recordEmailAccountProviderIssue({
     emailAccountId,
@@ -182,6 +190,7 @@ async function recordProviderIssueSafely({
     error,
     logger,
     operation,
+    failedAccessToken,
   }).catch((recordError) => {
     logger.warn("Failed to record provider issue", {
       error: recordError,
@@ -198,6 +207,7 @@ type ProviderOperationFailureLogInput = {
   provider: "google" | "microsoft";
   logger: Logger;
   operation: string;
+  failedAccessToken?: string;
 };
 
 function isPromiseLike(value: unknown): value is Promise<unknown> {

--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -43,6 +43,7 @@ const logger = createTestLogger();
 describe("ensureEmailAccountsWatched", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(cleanupInvalidTokens).mockResolvedValue(undefined);
   });
 
   it("cleans up invalid tokens when watch setup reports a detailed invalid_grant error", async () => {

--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -69,6 +69,7 @@ describe("ensureEmailAccountsWatched", () => {
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       name: "google",
+      getAccessToken: () => "access-token",
       watchEmails: vi
         .fn()
         .mockRejectedValue(
@@ -108,6 +109,7 @@ describe("ensureEmailAccountsWatched", () => {
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       name: "google",
+      getAccessToken: () => "access-token",
       watchEmails: vi.fn().mockResolvedValue({
         expirationDate: new Date(Date.now() + 3_600_000),
       }),
@@ -141,6 +143,7 @@ describe("ensureEmailAccountsWatched", () => {
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       name: "google",
+      getAccessToken: () => "access-token",
       watchEmails: vi.fn().mockResolvedValue({
         expirationDate: new Date(Date.now() + 3_600_000),
       }),

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -241,6 +241,7 @@ async function watchEmails({
   { success: true; expirationDate: Date } | { success: false; error: unknown }
 > {
   logger.info("Watching emails");
+  const failedAccessToken = provider.getAccessToken();
 
   try {
     if (isMicrosoftProvider(provider.name)) {
@@ -280,6 +281,7 @@ async function watchEmails({
       await cleanupInvalidTokens({
         emailAccountId,
         reason: isInvalidGrant ? "invalid_grant" : "insufficient_permissions",
+        failedAccessToken,
         logger,
       });
     } else {

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -241,9 +241,14 @@ async function watchEmails({
   { success: true; expirationDate: Date } | { success: false; error: unknown }
 > {
   logger.info("Watching emails");
-  const failedAccessToken = provider.getAccessToken();
+  let failedAccessToken: string | undefined;
 
   try {
+    try {
+      failedAccessToken = provider.getAccessToken();
+    } catch {
+      // The watch request may still refresh a missing cached access token.
+    }
     if (isMicrosoftProvider(provider.name)) {
       const result = await createManagedOutlookSubscription({
         emailAccountId,
@@ -283,7 +288,11 @@ async function watchEmails({
         reason: isInvalidGrant ? "invalid_grant" : "insufficient_permissions",
         failedAccessToken,
         logger,
-      });
+      }).catch((cleanupError) =>
+        logger.warn("Failed to clean up watch authentication failure", {
+          cleanupError,
+        }),
+      );
     } else {
       captureException(error, { emailAccountId });
     }

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -221,6 +221,8 @@ describe("gmail oauth client configuration", () => {
     expect(cleanupInvalidTokens).toHaveBeenCalledWith({
       emailAccountId: "email-account-id",
       reason: "invalid_grant",
+      failedAccessToken: "stale-access-token",
+      failedRefreshToken: "refresh-token",
       logger,
     });
     expect(saveTokens).not.toHaveBeenCalled();

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -58,6 +58,27 @@ vi.mock("@googleapis/people", () => ({
 }));
 
 describe("gmail oauth client configuration", () => {
+  it("records missing refresh tokens using the failed credential snapshot", async () => {
+    const logger = createTestLogger();
+    vi.mocked(cleanupInvalidTokens).mockResolvedValueOnce(undefined);
+    await expect(
+      getGmailClientWithRefresh({
+        accessToken: "access-token",
+        refreshToken: null,
+        expiresAt: null,
+        emailAccountId: "email-account-id",
+        logger,
+      }),
+    ).rejects.toThrow("No refresh token");
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      reason: "invalid_grant",
+      failedAccessToken: "access-token",
+      failedRefreshToken: null,
+      logger,
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -226,6 +247,25 @@ describe("gmail oauth client configuration", () => {
       logger,
     });
     expect(saveTokens).not.toHaveBeenCalled();
+  });
+
+  it("matches only the refresh token when forced permission recovery omits the access token", async () => {
+    refreshAccessToken.mockRejectedValueOnce(new Error("invalid_grant"));
+    await expect(
+      getGmailClientWithRefresh({
+        accessToken: null,
+        refreshToken: "refresh-token",
+        expiresAt: null,
+        emailAccountId: "email-account-id",
+        logger,
+      }),
+    ).rejects.toThrow("invalid_grant");
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        failedAccessToken: undefined,
+        failedRefreshToken: "refresh-token",
+      }),
+    );
   });
 
   it("preserves the original refresh error when invalid token cleanup fails", async () => {

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -65,6 +65,15 @@ export const getGmailClientWithRefresh = async ({
   if (!refreshToken) {
     // expected for disconnected accounts
     logger.warn("No refresh token", { emailAccountId });
+    await cleanupInvalidTokens({
+      emailAccountId,
+      reason: "invalid_grant",
+      failedAccessToken: accessToken ?? undefined,
+      failedRefreshToken: null,
+      logger,
+    }).catch((error) =>
+      logger.warn("Failed to record missing refresh token", { error }),
+    );
     throw new SafeError("No refresh token");
   }
 
@@ -111,7 +120,7 @@ export const getGmailClientWithRefresh = async ({
         await cleanupInvalidTokens({
           emailAccountId,
           reason: "invalid_grant",
-          failedAccessToken: accessToken,
+          failedAccessToken: accessToken ?? undefined,
           failedRefreshToken: refreshToken,
           logger,
         });

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -111,6 +111,8 @@ export const getGmailClientWithRefresh = async ({
         await cleanupInvalidTokens({
           emailAccountId,
           reason: "invalid_grant",
+          failedAccessToken: accessToken,
+          failedRefreshToken: refreshToken,
           logger,
         });
       } catch (cleanupError) {

--- a/apps/web/utils/outlook/client.test.ts
+++ b/apps/web/utils/outlook/client.test.ts
@@ -1,3 +1,4 @@
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Client,
@@ -67,6 +68,27 @@ vi.mock("@/env", () => ({
 }));
 
 describe("outlook client emulator configuration", () => {
+  it("records missing refresh tokens using the failed credential snapshot", async () => {
+    const logger = createTestLogger();
+    vi.mocked(cleanupInvalidTokens).mockResolvedValueOnce(undefined);
+    await expect(
+      getOutlookClientWithRefresh({
+        accessToken: "access-token",
+        refreshToken: null,
+        expiresAt: null,
+        emailAccountId: "email-account-id",
+        logger,
+      }),
+    ).rejects.toThrow("No refresh token");
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      reason: "invalid_grant",
+      failedAccessToken: "access-token",
+      failedRefreshToken: null,
+      logger,
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -175,6 +175,15 @@ export const getOutlookClientWithRefresh = async ({
   if (!refreshToken) {
     // expected for disconnected accounts
     logger.warn("No refresh token", { emailAccountId });
+    await cleanupInvalidTokens({
+      emailAccountId,
+      reason: "invalid_grant",
+      failedAccessToken: accessToken ?? undefined,
+      failedRefreshToken: null,
+      logger,
+    }).catch((error) =>
+      logger.warn("Failed to record missing refresh token", { error }),
+    );
     throw new SafeError("No refresh token");
   }
 
@@ -257,10 +266,14 @@ export const getOutlookClientWithRefresh = async ({
         await cleanupInvalidTokens({
           emailAccountId,
           reason: "invalid_grant",
-          failedAccessToken: accessToken,
+          failedAccessToken: accessToken ?? undefined,
           failedRefreshToken: refreshToken,
           logger,
-        });
+        }).catch((cleanupError) =>
+          logger.warn("Failed to clean up invalid Outlook tokens", {
+            cleanupError,
+          }),
+        );
 
         throw new SafeError(
           "Your Microsoft authorization has expired. Please sign out and log in again to reconnect your account.",

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -257,6 +257,8 @@ export const getOutlookClientWithRefresh = async ({
         await cleanupInvalidTokens({
           emailAccountId,
           reason: "invalid_grant",
+          failedAccessToken: accessToken,
+          failedRefreshToken: refreshToken,
           logger,
         });
 

--- a/apps/web/utils/webhook/error-handler.test.ts
+++ b/apps/web/utils/webhook/error-handler.test.ts
@@ -34,7 +34,7 @@ describe("handleWebhookError", () => {
   const mockCleanupInvalidTokens = vi.mocked(cleanupInvalidTokens);
 
   describe("Gmail errors", () => {
-    it("leaves invalid-grant cleanup to the provider with the failed credential snapshot", async () => {
+    it("does not clean up invalid grants without a credential snapshot", async () => {
       const error = new Error("invalid_grant");
 
       await handleWebhookError(error, baseOptions);

--- a/apps/web/utils/webhook/error-handler.test.ts
+++ b/apps/web/utils/webhook/error-handler.test.ts
@@ -34,16 +34,12 @@ describe("handleWebhookError", () => {
   const mockCleanupInvalidTokens = vi.mocked(cleanupInvalidTokens);
 
   describe("Gmail errors", () => {
-    it("cleans up invalid grants without reporting an unhandled webhook error", async () => {
+    it("leaves invalid-grant cleanup to the provider with the failed credential snapshot", async () => {
       const error = new Error("invalid_grant");
 
       await handleWebhookError(error, baseOptions);
 
-      expect(mockCleanupInvalidTokens).toHaveBeenCalledWith({
-        emailAccountId: "acc-123",
-        reason: "invalid_grant",
-        logger,
-      });
+      expect(mockCleanupInvalidTokens).not.toHaveBeenCalled();
       expect(trackError).not.toHaveBeenCalled();
       expect(mockRecordRateLimitFromApiError).not.toHaveBeenCalled();
     });

--- a/apps/web/utils/webhook/error-handler.ts
+++ b/apps/web/utils/webhook/error-handler.ts
@@ -2,7 +2,6 @@ import { checkCommonErrors, isInvalidGrantError } from "@/utils/error";
 import { trackError } from "@/utils/posthog";
 import type { Logger } from "@/utils/logger";
 import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
-import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 
 /**
  * Handles errors from async webhook processing in the same way as withError middleware
@@ -22,14 +21,8 @@ export async function handleWebhookError(
   if (isInvalidGrantError(error)) {
     logger.warn("Invalid grant while processing webhook", { emailAccountId });
 
-    if (emailAccountId !== "unknown") {
-      await cleanupInvalidTokens({
-        emailAccountId,
-        reason: "invalid_grant",
-        logger,
-      });
-    }
-
+    // Provider clients handle credential cleanup using the tokens that failed.
+    // This outer handler has no credential snapshot and must not clear newer tokens.
     return;
   }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-085540_pr-3520_d4bf3dbe6b46/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

An in-flight request using old OAuth credentials could fail after reconnection and clear the replacement credentials. Match cleanup to the failed access or refresh token and condition the database write on the account timestamp read with those credentials.

- Capture provider access tokens before operations and carry refresh credentials into failure cleanup. Preserve credentials when no failed-token snapshot is available.
- Two cleanup regression tests fail before the fix; all 59 focused auth, provider, Gmail, Outlook, watch, and webhook tests pass. Biome checks pass.
- No added network requests or schema changes. Cleanup reads one additional timestamp and uses it in the existing conditional database update.