### PR TITLE
config: Normalize tenant and credit-limit environment values

### DIFF
--- a/apps/web/env.test.ts
+++ b/apps/web/env.test.ts
@@ -52,6 +52,31 @@ describe("env LLM compatibility conversion", () => {
     expect(env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS).toBe(10);
   });
 
+  it.each([
+    undefined,
+    "",
+    "   ",
+  ])("defaults a blank or unset credit limit %j", async (value) => {
+    process.env.DEFAULT_LLMS = "openai:gpt-5.4-mini";
+    if (value === undefined)
+      delete process.env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS;
+    else process.env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS = value;
+    const { env } = await import("./env");
+    expect(env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS).toBe(5);
+  });
+
+  it.each([
+    "-1",
+    "5.5",
+    "abc",
+  ])("rejects an invalid credit limit %j", async (value) => {
+    process.env.DEFAULT_LLMS = "openai:gpt-5.4-mini";
+    process.env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS = value;
+    await expect(import("./env")).rejects.toThrow(
+      "Invalid environment variables",
+    );
+  });
+
   it("converts legacy default model and fallbacks into DEFAULT_LLMS", async () => {
     process.env.DEFAULT_LLM_PROVIDER = "openai";
     process.env.DEFAULT_LLM_MODEL = "gpt-5.4-mini";

--- a/apps/web/env.test.ts
+++ b/apps/web/env.test.ts
@@ -35,6 +35,23 @@ describe("env LLM compatibility conversion", () => {
     Object.assign(process.env, originalEnv);
   });
 
+  it.each([
+    "",
+    "   ",
+  ])("uses the documented default for blank Microsoft tenant %j", async (tenant) => {
+    process.env.DEFAULT_LLMS = "openai:gpt-5.4-mini";
+    process.env.MICROSOFT_TENANT_ID = tenant;
+    const { env } = await import("./env");
+    expect(env.MICROSOFT_TENANT_ID).toBe("common");
+  });
+
+  it("accepts a configured unsubscribe credit limit from the environment", async () => {
+    process.env.DEFAULT_LLMS = "openai:gpt-5.4-mini";
+    process.env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS = "10";
+    const { env } = await import("./env");
+    expect(env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS).toBe(10);
+  });
+
   it("converts legacy default model and fallbacks into DEFAULT_LLMS", async () => {
     process.env.DEFAULT_LLM_PROVIDER = "openai";
     process.env.DEFAULT_LLM_MODEL = "gpt-5.4-mini";

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -87,7 +87,10 @@ const parsedEnv = createEnv({
     MICROSOFT_BASE_URL: z.string().url().optional(),
     MICROSOFT_CLIENT_ID: z.string().optional(),
     MICROSOFT_CLIENT_SECRET: z.string().optional(),
-    MICROSOFT_TENANT_ID: z.string().optional().default("common"),
+    MICROSOFT_TENANT_ID: z.preprocess(
+      optionalEnvValue,
+      z.string().default("common"),
+    ),
     APPLE_CLIENT_ID: z.string().optional(),
     APPLE_TEAM_ID: z.string().optional(),
     APPLE_KEY_ID: z.string().optional(),
@@ -379,7 +382,10 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_BUSINESS_ANNUALLY_VARIANT_ID: z.coerce.number().default(0),
     NEXT_PUBLIC_COPILOT_MONTHLY_VARIANT_ID: z.coerce.number().default(0),
 
-    NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS: z.number().default(5),
+    NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS: z.preprocess(
+      optionalEnvValue,
+      z.coerce.number().int().nonnegative().default(5),
+    ),
     NEXT_PUBLIC_CALL_LINK: z
       .string()
       .default("https://cal.com/team/inbox-zero/feedback"),


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-085724_pr-3521_3c2759fbb4cb/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Following the documented blank Microsoft tenant configuration produced invalid OAuth URLs, and setting the unsubscribe credit limit to an environment string prevented startup. Normalize blank tenants to common and parse credit limits as nonnegative integers, preserving the default when unset or blank.

- Validation: three regression cases failed for the actual incorrect tenant values and rejected numeric string; all 6 environment tests now pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->