### PR TITLE
assistant: Bind pending email confirmations to their sending mailbox

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1939,6 +1939,7 @@ describe("aiProcessAssistantChat", () => {
 
     expect(result).toEqual({
       actionType: "send_email",
+      emailAccountId: "email-account-id",
       confirmationState: "pending",
       pendingAction: {
         to: "recipient@example.test",
@@ -1956,7 +1957,10 @@ describe("aiProcessAssistantChat", () => {
     expect(sendEmailWithHtml).not.toHaveBeenCalled();
   });
 
-  it("rejects unsupported from field in chat send params", async () => {
+  it.each([
+    "from",
+    "emailAccountId",
+  ])("rejects caller-supplied %s in chat send params", async (field) => {
     const tools = await captureToolSet(true, "google");
     mockCreateEmailProvider.mockResolvedValue({
       sendEmailWithHtml: vi.fn(),
@@ -1965,13 +1969,13 @@ describe("aiProcessAssistantChat", () => {
 
     const result = await tools.sendEmail.execute({
       to: "recipient@example.test",
-      from: "sender.alias@example.test",
+      [field]: "untrusted-mailbox",
       subject: "Subject line",
       messageHtml: "<p>Hello</p>",
     } as any);
 
     expect(result).toEqual({
-      error: 'Invalid sendEmail input: unsupported field "from"',
+      error: `Invalid sendEmail input: unsupported field "${field}"`,
     });
     expect(mockCreateEmailProvider).toHaveBeenCalledTimes(providerCallsBefore);
   });
@@ -2014,6 +2018,7 @@ describe("aiProcessAssistantChat", () => {
 
     expect(result).toEqual({
       actionType: "send_email",
+      emailAccountId: "email-account-id",
       confirmationState: "pending",
       pendingAction: {
         to: "recipient@example.test",
@@ -2051,6 +2056,7 @@ describe("aiProcessAssistantChat", () => {
 
     expect(result).toEqual({
       actionType: "forward_email",
+      emailAccountId: "email-account-id",
       confirmationState: "pending",
       pendingAction: {
         messageId: "message-1",

--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -959,6 +959,12 @@ async function reservePendingAssistantEmailAction({
     };
   }
 
+  if (lookup.output.emailAccountId !== emailAccountId) {
+    throw new SafeError(
+      "The sending mailbox for this draft could not be verified. Prepare the draft again in the account you want to send from.",
+    );
+  }
+
   if (
     lookup.output.confirmationState === "processing" &&
     !hasProcessingLeaseExpired(lookup.output.confirmationProcessingAt)

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -26,6 +26,71 @@ describe("confirmAssistantEmailAction", () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    ["send_email", buildPendingSendPart],
+    ["reply_email", buildPendingReplyPart],
+    ["forward_email", buildPendingForwardPart],
+  ] as const)("rejects %s prepared under another mailbox before creating a provider", async (actionType, buildPart) => {
+    const part = buildPart();
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date(),
+      parts: [
+        {
+          ...part,
+          output: { ...part.output, emailAccountId: "original-mailbox" },
+        },
+      ],
+    } as never);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      confirmAssistantEmailActionForAccount({
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: part.toolCallId,
+        actionType,
+        emailAccountId: "switched-mailbox",
+        provider: "microsoft",
+        logger: createTestLogger(),
+      }),
+    ).rejects.toThrow("Prepare the draft again");
+    expect(createEmailProvider).not.toHaveBeenCalled();
+    expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects old drafts without a mailbox binding before creating a provider", async () => {
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date(),
+      parts: [
+        {
+          ...buildPendingSendPart(),
+          output: {
+            ...buildPendingSendPart().output,
+            emailAccountId: undefined,
+          },
+        },
+      ],
+    } as never);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      confirmAssistantEmailActionForAccount({
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "send_email",
+        emailAccountId: "ea_1",
+        provider: "microsoft",
+        logger: createTestLogger(),
+      }),
+    ).rejects.toThrow("Prepare the draft again");
+    expect(createEmailProvider).not.toHaveBeenCalled();
+  });
+
   it("sends a pending prepared email and persists confirmed output", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
@@ -1465,6 +1530,7 @@ function buildPendingSendPart() {
       actionType: "send_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "ea_1",
       pendingAction: {
         to: "recipient@example.com",
         cc: null,
@@ -1544,6 +1610,7 @@ function buildPendingReplyPart() {
       actionType: "reply_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "ea_1",
       pendingAction: {
         messageId: "source-message-1",
         content: "Thanks!",
@@ -1568,6 +1635,7 @@ function buildPendingForwardPart() {
       actionType: "forward_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "ea_1",
       pendingAction: {
         messageId: "source-message-1",
         to: "recipient@example.com",

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -33,6 +33,7 @@ export const pendingSendEmailToolOutputSchema = z.object({
   requiresConfirmation: z.literal(true),
   confirmationState: z.enum(["pending", "processing", "confirmed"]),
   confirmationProcessingAt: z.string().optional(),
+  emailAccountId: z.string().min(1).optional(),
   provider: z.string().optional(),
   pendingAction: z.object({
     to: z.string().trim().min(1),
@@ -54,6 +55,7 @@ export const pendingReplyEmailToolOutputSchema = z.object({
   requiresConfirmation: z.literal(true),
   confirmationState: z.enum(["pending", "processing", "confirmed"]),
   confirmationProcessingAt: z.string().optional(),
+  emailAccountId: z.string().min(1).optional(),
   pendingAction: z.object({
     messageId: z.string().trim().min(1),
     content: z.string().trim().min(1),
@@ -78,6 +80,7 @@ export const pendingForwardEmailToolOutputSchema = z.object({
   requiresConfirmation: z.literal(true),
   confirmationState: z.enum(["pending", "processing", "confirmed"]),
   confirmationProcessingAt: z.string().optional(),
+  emailAccountId: z.string().min(1).optional(),
   pendingAction: z.object({
     messageId: z.string().trim().min(1),
     to: z.string().trim().min(1),

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -104,6 +104,7 @@ describe("chat inbox tools", () => {
       actionType: "send_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "email-account-1",
       pendingAction: {
         to: "recipient@example.com",
         subject: "Hello",
@@ -182,6 +183,7 @@ describe("chat inbox tools", () => {
       actionType: "reply_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "email-account-1",
       pendingAction: {
         messageId: "message-1",
         content: "Thanks for the update.",
@@ -243,6 +245,7 @@ describe("chat inbox tools", () => {
       actionType: "forward_email",
       requiresConfirmation: true,
       confirmationState: "pending",
+      emailAccountId: "email-account-1",
       pendingAction: {
         messageId: "message-1",
         to: "recipient@example.com",

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -1265,6 +1265,7 @@ export const sendEmailTool = ({
           parsedInput.data,
           from || null,
           provider,
+          emailAccountId,
         );
       } catch (error) {
         logger.error("Failed to prepare email from chat", { error });
@@ -1308,7 +1309,11 @@ export const replyEmailTool = ({
           parsedInput.data.messageId,
         );
 
-        return createPendingReplyEmailOutput(parsedInput.data, message);
+        return createPendingReplyEmailOutput(
+          parsedInput.data,
+          message,
+          emailAccountId,
+        );
       } catch (error) {
         logger.error("Failed to prepare reply from chat", { error });
         return { error: "Failed to prepare reply" };
@@ -1350,7 +1355,11 @@ export const forwardEmailTool = ({
         const message = await emailProvider.getMessage(
           parsedInput.data.messageId,
         );
-        return createPendingForwardEmailOutput(parsedInput.data, message);
+        return createPendingForwardEmailOutput(
+          parsedInput.data,
+          message,
+          emailAccountId,
+        );
       } catch (error) {
         logger.error("Failed to prepare email forward from chat", { error });
         return { error: "Failed to prepare email forward" };
@@ -1402,9 +1411,11 @@ function createPendingSendEmailOutput(
   input: z.infer<typeof sendEmailToolInputSchema>,
   from: string | null,
   provider: string,
+  emailAccountId: string,
 ) {
   return {
     success: true,
+    emailAccountId,
     actionType: "send_email" as PendingEmailActionType,
     requiresConfirmation: true,
     confirmationState: "pending" as const,
@@ -1423,9 +1434,11 @@ function createPendingSendEmailOutput(
 function createPendingReplyEmailOutput(
   input: z.infer<typeof replyEmailToolInputSchema>,
   message: ParsedMessage,
+  emailAccountId: string,
 ) {
   return {
     success: true,
+    emailAccountId,
     actionType: "reply_email" as PendingEmailActionType,
     requiresConfirmation: true,
     confirmationState: "pending" as const,
@@ -1445,9 +1458,11 @@ function createPendingReplyEmailOutput(
 function createPendingForwardEmailOutput(
   input: z.infer<typeof forwardEmailToolInputSchema>,
   message: ParsedMessage,
+  emailAccountId: string,
 ) {
   return {
     success: true,
+    emailAccountId,
     actionType: "forward_email" as PendingEmailActionType,
     requiresConfirmation: true,
     confirmationState: "pending" as const,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-090057_pr-3522_cc6538a8dea2/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Switching messaging accounts changed the mailbox used to confirm an already prepared email. Bind pending send, reply, and forward results to their originating mailbox and reject mismatched or unbound drafts before claiming the action or creating an email provider.

- Tool outputs now include the server-selected mailbox ID; tool inputs and prompts are unchanged. Confirmation reads persisted output, and callers cannot replace the mailbox binding.
- Existing unbound pending drafts must be prepared again. Already confirmed actions remain idempotent.
- Added four failing-before-fix regressions for mismatched send/reply/forward drafts and unbound drafts; 112 focused tests passed.
- No additional database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->