### PR TITLE
auth: Restore connected state after Google account linking

### DIFF
--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 import prisma from "@/utils/__mocks__/prisma";
 
 const {
@@ -53,6 +54,9 @@ vi.mock("@/utils/middleware", async () => {
 });
 
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/error-messages", () => ({
+  clearAccountDisconnectedErrorIfResolved: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@/utils/oauth/callback-validation", () => ({
   validateOAuthCallback: mockValidateOAuthCallback,
@@ -171,6 +175,7 @@ describe("google linking callback route", () => {
     expect(prisma.account.update).toHaveBeenCalledWith({
       where: { id: "existing-account-123" },
       data: expect.objectContaining({
+        disconnectedAt: null,
         providerAccountId: "new-provider-account-id",
         access_token: "access-token",
         refresh_token: "refresh-token",
@@ -187,6 +192,10 @@ describe("google linking callback route", () => {
     expect(mockEnsureEmailAccountsWatched).not.toHaveBeenCalled();
 
     await runScheduledAfterCallback();
+    expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalledWith({
+      userId: "user-123",
+      logger: expect.anything(),
+    });
 
     expect(mockEnsureEmailAccountsWatched).toHaveBeenCalledWith({
       userIds: ["user-123"],

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -158,7 +158,14 @@ describe("google linking callback route", () => {
     } as Awaited<ReturnType<typeof prisma.account.update>>);
   });
 
-  it("updates an existing same-user Google account in emulation instead of creating a duplicate", async () => {
+  it.each([
+    false,
+    true,
+  ])("restores an existing same-user account without duplication (watch lookup fails: %s)", async (watchFails) => {
+    if (watchFails)
+      mockEnsureEmailAccountsWatched.mockRejectedValueOnce(
+        new Error("watch lookup failed"),
+      );
     mockHandleAccountLinking.mockResolvedValue({
       type: "continue_create",
     });

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -192,6 +192,12 @@ describe("google linking callback route", () => {
     expect(mockEnsureEmailAccountsWatched).not.toHaveBeenCalled();
 
     await runScheduledAfterCallback();
+    expect(
+      mockEnsureEmailAccountsWatched.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(clearAccountDisconnectedErrorIfResolved).mock
+        .invocationCallOrder[0],
+    );
     expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalledWith({
       userId: "user-123",
       logger: expect.anything(),

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -414,17 +414,21 @@ async function completeGoogleAccountLinking({
   await setOAuthCodeResult(code, { success });
 
   after(() =>
-    Promise.all([
-      clearAccountDisconnectedErrorIfResolved({ userId: targetUserId, logger }),
-      ensureEmailAccountsWatched({ userIds: [targetUserId], logger }),
-    ]).catch((error) => {
-      logger.error(
-        "Failed to re-register email watches after account linking",
-        {
-          error,
-        },
-      );
-    }),
+    ensureEmailAccountsWatched({ userIds: [targetUserId], logger })
+      .then(() =>
+        clearAccountDisconnectedErrorIfResolved({
+          userId: targetUserId,
+          logger,
+        }),
+      )
+      .catch((error) => {
+        logger.error(
+          "Failed to re-register email watches after account linking",
+          {
+            error,
+          },
+        );
+      }),
   );
 
   return createAccountLinkingRedirect({

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -1,4 +1,5 @@
 import { after } from "next/server";
+import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 import { env } from "@/env";
 import { auth } from "@/utils/auth";
 import { hash } from "@/utils/hash";
@@ -413,10 +414,10 @@ async function completeGoogleAccountLinking({
   await setOAuthCodeResult(code, { success });
 
   after(() =>
-    ensureEmailAccountsWatched({
-      userIds: [targetUserId],
-      logger,
-    }).catch((error) => {
+    Promise.all([
+      clearAccountDisconnectedErrorIfResolved({ userId: targetUserId, logger }),
+      ensureEmailAccountsWatched({ userIds: [targetUserId], logger }),
+    ]).catch((error) => {
       logger.error(
         "Failed to re-register email watches after account linking",
         {
@@ -447,6 +448,7 @@ async function updateGoogleAccount({
       ...(providerAccountId && {
         providerAccountId,
       }),
+      disconnectedAt: null,
       access_token: tokens.access_token,
       ...(tokens.refresh_token != null && {
         refresh_token: tokens.refresh_token,

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -415,7 +415,7 @@ async function completeGoogleAccountLinking({
 
   after(() =>
     ensureEmailAccountsWatched({ userIds: [targetUserId], logger })
-      .then(() =>
+      .finally(() =>
         clearAccountDisconnectedErrorIfResolved({
           userId: targetUserId,
           logger,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-090711_pr-3523_d873ab9af86a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Google account linking stored fresh credentials but left previously disconnected accounts ineligible for watch registration. Clear `disconnectedAt` with the replacement credentials and clear resolved disconnection notices when scheduling watch restoration.

- The callback regression fails before the fix; all 4 callback tests now pass. Biome checks pass.
- Adds one background disconnection-state check after linking; token storage remains a single database update.