### PR TITLE
mcp: Clear previous refresh grant when reconnecting

### DIFF
--- a/apps/web/utils/mcp/oauth-grant.test.ts
+++ b/apps/web/utils/mcp/oauth-grant.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  exchangeAuthorization,
+  refreshAuthorization,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import prisma from "@/utils/__mocks__/prisma";
+import { getAuthToken, handleOAuthCallback } from "./oauth";
+
+vi.mock("@/utils/prisma");
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  exchangeAuthorization: vi.fn(),
+  refreshAuthorization: vi.fn(),
+}));
+
+describe("OAuth grant replacement", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    prisma.mcpIntegration.findUnique.mockResolvedValue({
+      id: "integration-1",
+      oauthClientId: "client-id",
+      registeredServerUrl: "https://mcp.notion.com",
+      registeredAuthorizationUrl: "https://mcp.notion.com/authorize",
+      registeredTokenUrl: "https://mcp.notion.com/token",
+    } as never);
+    prisma.mcpIntegration.upsert.mockResolvedValue({
+      id: "integration-1",
+    } as never);
+    let connection: Record<string, unknown> = {
+      id: "connection-1",
+      emailAccountId: "mailbox-1",
+      accessToken: "old-account-access",
+      refreshToken: "old-account-refresh",
+      expiresAt: new Date(0),
+      isActive: true,
+    };
+    prisma.mcpConnection.findFirst.mockImplementation(
+      async () => connection as never,
+    );
+    prisma.mcpConnection.upsert.mockImplementation(async ({ update }) => {
+      for (const [key, value] of Object.entries(update)) {
+        if (value !== undefined) connection[key] = value;
+      }
+      return connection as never;
+    });
+    prisma.mcpConnection.update.mockImplementation(async ({ data }) => {
+      connection = { ...connection, ...data };
+      return connection as never;
+    });
+    vi.mocked(refreshAuthorization).mockResolvedValue({
+      access_token: "refreshed-old-account-access",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+
+  it("does not refresh a new authorization using the previous external account's grant", async () => {
+    vi.mocked(exchangeAuthorization).mockResolvedValue({
+      access_token: "new-account-access",
+      token_type: "Bearer",
+      expires_in: 1,
+    });
+    await handleOAuthCallback({
+      integration: "notion",
+      emailAccountId: "mailbox-1",
+      code: "new-account-code",
+      codeVerifier: "verifier",
+      redirectUri: "https://example.com/oauth/callback",
+    });
+
+    await expect(
+      getAuthToken({ integration: "notion", emailAccountId: "mailbox-1" }),
+    ).rejects.toThrow("no refresh token is available");
+    expect(refreshAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("preserves an omitted refresh token when refreshing the same grant", async () => {
+    await expect(
+      getAuthToken({ integration: "notion", emailAccountId: "mailbox-1" }),
+    ).resolves.toBe("refreshed-old-account-access");
+    expect(prisma.mcpConnection.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ refreshToken: "old-account-refresh" }),
+      }),
+    );
+  });
+});

--- a/apps/web/utils/mcp/oauth.ts
+++ b/apps/web/utils/mcp/oauth.ts
@@ -139,7 +139,7 @@ export async function handleOAuthCallback({
     },
     update: {
       accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token || undefined,
+      refreshToken: tokens.refresh_token || null,
       expiresAt,
       isActive: true,
     },


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-092821_pr-3524_c0efc3d65a6d/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Reauthorizing an existing integration without a new refresh token retained the previous external account's refresh token. After the new access token expired, the connection could silently return to the old account. Replace the complete authorization grant by clearing an omitted refresh token during an authorization-code exchange.

- Refreshes of the same established grant continue preserving an omitted refresh token. A new authorization without a refresh token expires normally; the generic callback has no verified external-account identity that would permit safely reusing an old grant.
- Added a stateful regression that previously refreshed into the old account, plus a same-grant refresh test.
- Validation: 10 focused OAuth and callback tests passed; formatting and diff checks passed.
- No additional runtime database or network calls.