### PR TITLE
rules: Preserve requested action delays from chat

### DIFF
--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -102,6 +102,36 @@ describe("createRuleTool overlap guard", () => {
     ]);
   });
 
+  it.each([
+    "google",
+    "microsoft",
+  ])("preserves requested archive delays for %s", async (provider) => {
+    const result = await createRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider,
+      logger,
+    }).execute({
+      name: "Archive invoices tomorrow",
+      condition: {
+        aiInstructions: "Invoices",
+        static: null,
+        conditionalOperator: null,
+      },
+      actions: [
+        { type: ActionType.ARCHIVE, fields: null, delayInMinutes: 1440 },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(mockCreateRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({
+          actions: [expect.objectContaining({ delayInMinutes: 1440 })],
+        }),
+      }),
+    );
+  });
+
   it("blocks overlapping sender-only rules", async () => {
     const result = await createRuleTool({
       email: "user@example.com",

--- a/apps/web/utils/ai/assistant/tools/rules/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/shared.ts
@@ -64,7 +64,7 @@ export function buildCreateRuleSchemaFromChatToolInput(
       fields: action.fields
         ? buildProviderRuleActionFields({ provider, fields: action.fields })
         : null,
-      delayInMinutes: null,
+      delayInMinutes: action.delayInMinutes ?? null,
     })),
   };
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-091445_pr-3525_ec5e548a8820/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Creating an archive rule from chat accepted a delay but silently persisted it as immediate execution. Preserve each requested delay in the shared creation converter used by both direct creation and confirmed rule creation.

- Added Google and Microsoft regressions that fail before the fix.
- Validation: 55 focused rule-tool, confirmation, and persistence tests passed; formatting and diff checks passed.
- Tool schemas and prompts are unchanged. No additional database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->