### PR TITLE
auth: Preserve concurrent mailbox links during account merges

### DIFF
--- a/apps/web/__tests__/db/mailbox-merge.test.ts
+++ b/apps/web/__tests__/db/mailbox-merge.test.ts
@@ -1,0 +1,157 @@
+import { Client } from "pg";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/prisma";
+import { createScopedLogger } from "@/utils/logger";
+import { mergeAccount } from "@/utils/user/merge-account";
+import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
+
+vi.mock("@/utils/user/merge-premium", () => ({
+  transferPremiumDuringMerge: vi.fn(),
+}));
+vi.mock("@/utils/redis/account-validation", () => ({
+  invalidateAccountValidation: vi.fn(),
+}));
+
+const sourceUserId = "mailbox-merge-db-source";
+const targetUserId = "mailbox-merge-db-target";
+const logger = createScopedLogger("mailbox-merge-test");
+
+describe.skipIf(!process.env.RUN_DB_TESTS)(
+  "mailbox merging (real database)",
+  () => {
+    beforeEach(async () => {
+      vi.resetAllMocks();
+      await prisma.user.deleteMany({
+        where: { id: { in: [sourceUserId, targetUserId] } },
+      });
+      await prisma.user.createMany({
+        data: [
+          { id: sourceUserId, email: "merge-source@example.com" },
+          { id: targetUserId, email: "merge-target@example.com" },
+        ],
+      });
+      await createMailbox("original", sourceUserId);
+    });
+
+    afterAll(async () => {
+      await prisma.user.deleteMany({
+        where: { id: { in: [sourceUserId, targetUserId] } },
+      });
+    });
+
+    it("preserves a mailbox linked after the merge reads its source account snapshot", async () => {
+      vi.mocked(transferPremiumDuringMerge).mockImplementationOnce(async () => {
+        await createMailbox("concurrent", sourceUserId);
+      });
+
+      await mergeAccount({
+        sourceUserId,
+        targetUserId,
+        sourceAccountId: "mailbox-merge-original",
+        email: "merge-original@example.com",
+        name: null,
+        logger,
+      }).catch(() => undefined);
+
+      expect(
+        await prisma.emailAccount.findUnique({
+          where: { email: "merge-concurrent@example.com" },
+        }),
+      ).toMatchObject({ userId: sourceUserId });
+      expect(
+        await prisma.user.findUnique({ where: { id: sourceUserId } }),
+      ).not.toBeNull();
+    });
+
+    it("waits for an in-flight mailbox link before checking whether the source can be deleted", async () => {
+      const connection = new Client({
+        connectionString: process.env.DATABASE_URL,
+      });
+      await connection.connect();
+      const { promise: linked, resolve: signalLinked } =
+        Promise.withResolvers<void>();
+      vi.mocked(transferPremiumDuringMerge).mockImplementationOnce(async () => {
+        await connection.query("BEGIN");
+        await connection.query(
+          'INSERT INTO "Account" (id, "userId", provider, "providerAccountId", "updatedAt") VALUES ($1, $2, $3, $1, NOW())',
+          ["mailbox-merge-inflight", sourceUserId, "google"],
+        );
+        await connection.query(
+          'INSERT INTO "EmailAccount" (id, "accountId", "userId", email, "updatedAt") VALUES ($1, $1, $2, $3, NOW())',
+          [
+            "mailbox-merge-inflight",
+            sourceUserId,
+            "merge-inflight@example.com",
+          ],
+        );
+        signalLinked();
+      });
+      const merging = mergeAccount({
+        sourceUserId,
+        targetUserId,
+        sourceAccountId: "mailbox-merge-original",
+        email: "merge-original@example.com",
+        name: null,
+        logger,
+      }).catch((error: unknown) => error);
+      try {
+        await linked;
+        await vi.waitFor(
+          async () => {
+            const result = await connection.query(
+              `SELECT count(*)::int AS count FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type = 'Lock' AND query LIKE '%SELECT id FROM "User"%FOR UPDATE%'`,
+            );
+            expect(result.rows[0].count).toBeGreaterThan(0);
+          },
+          { timeout: 5000 },
+        );
+        await connection.query("COMMIT");
+        expect(await merging).toMatchObject({ code: "P2025" });
+        expect(
+          await prisma.emailAccount.findUnique({
+            where: { email: "merge-inflight@example.com" },
+          }),
+        ).toMatchObject({ userId: sourceUserId });
+      } finally {
+        await connection.query("ROLLBACK");
+        await connection.end();
+        await merging;
+      }
+    });
+
+    it("still merges a source user whose only mailbox is being moved", async () => {
+      await expect(
+        mergeAccount({
+          sourceUserId,
+          targetUserId,
+          sourceAccountId: "mailbox-merge-original",
+          email: "merge-original@example.com",
+          name: null,
+          logger,
+        }),
+      ).resolves.toBe("full_merge");
+      expect(
+        await prisma.user.findUnique({ where: { id: sourceUserId } }),
+      ).toBeNull();
+      expect(
+        await prisma.emailAccount.findUnique({
+          where: { email: "merge-original@example.com" },
+        }),
+      ).toMatchObject({ userId: targetUserId });
+    });
+  },
+);
+
+async function createMailbox(suffix: string, userId: string) {
+  return prisma.account.create({
+    data: {
+      id: `mailbox-merge-${suffix}`,
+      userId,
+      provider: "google",
+      providerAccountId: `mailbox-merge-${suffix}`,
+      emailAccount: {
+        create: { userId, email: `merge-${suffix}@example.com` },
+      },
+    },
+  });
+}

--- a/apps/web/__tests__/db/mailbox-merge.test.ts
+++ b/apps/web/__tests__/db/mailbox-merge.test.ts
@@ -3,10 +3,10 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import { mergeAccount } from "@/utils/user/merge-account";
-import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
+import { getPremiumTransferOperations } from "@/utils/user/merge-premium";
 
 vi.mock("@/utils/user/merge-premium", () => ({
-  transferPremiumDuringMerge: vi.fn(),
+  getPremiumTransferOperations: vi.fn(),
 }));
 vi.mock("@/utils/redis/account-validation", () => ({
   invalidateAccountValidation: vi.fn(),
@@ -14,6 +14,10 @@ vi.mock("@/utils/redis/account-validation", () => ({
 
 const sourceUserId = "mailbox-merge-db-source";
 const targetUserId = "mailbox-merge-db-target";
+const premiumId = "mailbox-merge-db-premium";
+const actualPremium = await vi.importActual<
+  typeof import("@/utils/user/merge-premium")
+>("@/utils/user/merge-premium");
 const logger = createScopedLogger("mailbox-merge-test");
 
 describe.skipIf(!process.env.RUN_DB_TESTS)(
@@ -21,9 +25,11 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
   () => {
     beforeEach(async () => {
       vi.resetAllMocks();
+      vi.mocked(getPremiumTransferOperations).mockResolvedValue([]);
       await prisma.user.deleteMany({
         where: { id: { in: [sourceUserId, targetUserId] } },
       });
+      await prisma.premium.deleteMany({ where: { id: premiumId } });
       await prisma.user.createMany({
         data: [
           { id: sourceUserId, email: "merge-source@example.com" },
@@ -37,12 +43,16 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
       await prisma.user.deleteMany({
         where: { id: { in: [sourceUserId, targetUserId] } },
       });
+      await prisma.premium.deleteMany({ where: { id: premiumId } });
     });
 
     it("preserves a mailbox linked after the merge reads its source account snapshot", async () => {
-      vi.mocked(transferPremiumDuringMerge).mockImplementationOnce(async () => {
-        await createMailbox("concurrent", sourceUserId);
-      });
+      vi.mocked(getPremiumTransferOperations).mockImplementationOnce(
+        async () => {
+          await createMailbox("concurrent", sourceUserId);
+          return [];
+        },
+      );
 
       await mergeAccount({
         sourceUserId,
@@ -82,22 +92,25 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
       await connection.connect();
       const { promise: linked, resolve: signalLinked } =
         Promise.withResolvers<void>();
-      vi.mocked(transferPremiumDuringMerge).mockImplementationOnce(async () => {
-        await connection.query("BEGIN");
-        await connection.query(
-          'INSERT INTO "Account" (id, "userId", provider, "providerAccountId", "updatedAt") VALUES ($1, $2, $3, $1, NOW())',
-          ["mailbox-merge-inflight", sourceUserId, "google"],
-        );
-        await connection.query(
-          'INSERT INTO "EmailAccount" (id, "accountId", "userId", email, "updatedAt") VALUES ($1, $1, $2, $3, NOW())',
-          [
-            "mailbox-merge-inflight",
-            sourceUserId,
-            "merge-inflight@example.com",
-          ],
-        );
-        signalLinked();
-      });
+      vi.mocked(getPremiumTransferOperations).mockImplementationOnce(
+        async () => {
+          await connection.query("BEGIN");
+          await connection.query(
+            'INSERT INTO "Account" (id, "userId", provider, "providerAccountId", "updatedAt") VALUES ($1, $2, $3, $1, NOW())',
+            ["mailbox-merge-inflight", sourceUserId, "google"],
+          );
+          await connection.query(
+            'INSERT INTO "EmailAccount" (id, "accountId", "userId", email, "updatedAt") VALUES ($1, $1, $2, $3, NOW())',
+            [
+              "mailbox-merge-inflight",
+              sourceUserId,
+              "merge-inflight@example.com",
+            ],
+          );
+          signalLinked();
+          return [];
+        },
+      );
       const merging = mergeAccount({
         sourceUserId,
         targetUserId,
@@ -132,7 +145,57 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
       }
     });
 
-    it("still merges a source user whose only mailbox is being moved", async () => {
+    it("rolls back premium membership and admin access when a concurrent mailbox aborts the merge", async () => {
+      await prisma.premium.create({
+        data: {
+          id: premiumId,
+          users: { connect: { id: sourceUserId } },
+          admins: { connect: { id: sourceUserId } },
+        },
+      });
+      vi.mocked(getPremiumTransferOperations).mockImplementationOnce(
+        async (options) => {
+          const operations =
+            await actualPremium.getPremiumTransferOperations(options);
+          await createMailbox("concurrent", sourceUserId);
+          return operations;
+        },
+      );
+      await expect(
+        mergeAccount({
+          sourceUserId,
+          targetUserId,
+          sourceAccountId: "mailbox-merge-original",
+          email: "merge-original@example.com",
+          name: null,
+          logger,
+        }),
+      ).rejects.toMatchObject({ code: "P2025" });
+      expect(
+        await prisma.user.findUnique({ where: { id: targetUserId } }),
+      ).toMatchObject({
+        premiumId: null,
+        premiumAdminId: null,
+      });
+      expect(
+        await prisma.user.findUnique({ where: { id: sourceUserId } }),
+      ).toMatchObject({
+        premiumId,
+        premiumAdminId: premiumId,
+      });
+    });
+
+    it("still merges the only mailbox together with premium membership and admin access", async () => {
+      await prisma.premium.create({
+        data: {
+          id: premiumId,
+          users: { connect: { id: sourceUserId } },
+          admins: { connect: { id: sourceUserId } },
+        },
+      });
+      vi.mocked(getPremiumTransferOperations).mockImplementationOnce(
+        actualPremium.getPremiumTransferOperations,
+      );
       await expect(
         mergeAccount({
           sourceUserId,
@@ -146,6 +209,9 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
       expect(
         await prisma.user.findUnique({ where: { id: sourceUserId } }),
       ).toBeNull();
+      expect(
+        await prisma.user.findUnique({ where: { id: targetUserId } }),
+      ).toMatchObject({ premiumId, premiumAdminId: premiumId });
       expect(
         await prisma.emailAccount.findUnique({
           where: { email: "merge-original@example.com" },

--- a/apps/web/__tests__/db/mailbox-merge.test.ts
+++ b/apps/web/__tests__/db/mailbox-merge.test.ts
@@ -59,11 +59,23 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
         }),
       ).toMatchObject({ userId: sourceUserId });
       expect(
+        await prisma.account.findUnique({
+          where: { id: "mailbox-merge-original" },
+        }),
+      ).toMatchObject({ userId: sourceUserId });
+      expect(
+        await prisma.emailAccount.findUnique({
+          where: { email: "merge-original@example.com" },
+        }),
+      ).toMatchObject({ userId: sourceUserId });
+      expect(
         await prisma.user.findUnique({ where: { id: sourceUserId } }),
       ).not.toBeNull();
     });
 
-    it("waits for an in-flight mailbox link before checking whether the source can be deleted", async () => {
+    it("waits for an in-flight mailbox link before checking whether the source can be deleted", {
+      timeout: 15_000,
+    }, async () => {
       const connection = new Client({
         connectionString: process.env.DATABASE_URL,
       });
@@ -98,6 +110,7 @@ describe.skipIf(!process.env.RUN_DB_TESTS)(
         await linked;
         await vi.waitFor(
           async () => {
+            await connection.query("SELECT pg_stat_clear_snapshot()");
             const result = await connection.query(
               `SELECT count(*)::int AS count FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type = 'Lock' AND query LIKE '%SELECT id FROM "User"%FOR UPDATE%'`,
             );

--- a/apps/web/utils/user/merge-account.test.ts
+++ b/apps/web/utils/user/merge-account.test.ts
@@ -4,7 +4,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import { getMockUserSelect, createTestLogger } from "@/__tests__/helpers";
 import { getEmailAccount } from "@/utils/redis/account-validation";
 import { redis } from "@/utils/redis";
-import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
+import { getPremiumTransferOperations } from "@/utils/user/merge-premium";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/user/merge-premium");
@@ -215,7 +215,7 @@ describe("mergeAccount", () => {
       prisma.user.delete.mockResolvedValue({} as any);
       prisma.$transaction.mockImplementation((ops) => Promise.resolve(ops));
 
-      vi.mocked(transferPremiumDuringMerge).mockResolvedValue();
+      vi.mocked(getPremiumTransferOperations).mockResolvedValue([]);
 
       const result = await mergeAccount({
         sourceAccountId: accountId,
@@ -227,7 +227,7 @@ describe("mergeAccount", () => {
       });
 
       expect(result).toBe("full_merge");
-      expect(transferPremiumDuringMerge).toHaveBeenCalledWith({
+      expect(getPremiumTransferOperations).toHaveBeenCalledWith({
         sourceUserId,
         targetUserId,
         logger,
@@ -277,7 +277,7 @@ describe("mergeAccount", () => {
       prisma.user.delete.mockResolvedValue({} as any);
       prisma.$transaction.mockImplementation((ops) => Promise.resolve(ops));
 
-      vi.mocked(transferPremiumDuringMerge).mockResolvedValue();
+      vi.mocked(getPremiumTransferOperations).mockResolvedValue([]);
 
       await expect(
         getEmailAccount({ userId: sourceUserId, emailAccountId }),

--- a/apps/web/utils/user/merge-account.test.ts
+++ b/apps/web/utils/user/merge-account.test.ts
@@ -245,7 +245,11 @@ describe("mergeAccount", () => {
         },
       });
       expect(prisma.user.delete).toHaveBeenCalledWith({
-        where: { id: sourceUserId },
+        where: {
+          id: sourceUserId,
+          accounts: { none: {} },
+          emailAccounts: { none: {} },
+        },
       });
     });
 

--- a/apps/web/utils/user/merge-account.ts
+++ b/apps/web/utils/user/merge-account.ts
@@ -97,6 +97,9 @@ export async function mergeAccount({
   });
 
   await prisma.$transaction([
+    // Foreign-key checks for new links must finish before the deletion check,
+    // or wait until this transaction has committed.
+    prisma.$queryRaw`SELECT id FROM "User" WHERE id = ${sourceUserId} FOR UPDATE`,
     prisma.account.update({
       where: { id: sourceAccountId },
       data: { userId: targetUserId },
@@ -110,7 +113,11 @@ export async function mergeAccount({
       },
     }),
     prisma.user.delete({
-      where: { id: sourceUserId },
+      where: {
+        id: sourceUserId,
+        accounts: { none: {} },
+        emailAccounts: { none: {} },
+      },
     }),
   ]);
 

--- a/apps/web/utils/user/merge-account.ts
+++ b/apps/web/utils/user/merge-account.ts
@@ -1,5 +1,5 @@
 import prisma from "@/utils/prisma";
-import { transferPremiumDuringMerge } from "@/utils/user/merge-premium";
+import { getPremiumTransferOperations } from "@/utils/user/merge-premium";
 import type { Logger } from "@/utils/logger";
 import { invalidateAccountValidation } from "@/utils/redis/account-validation";
 
@@ -90,7 +90,7 @@ export async function mergeAccount({
     return "partial_reassign";
   }
 
-  await transferPremiumDuringMerge({
+  const premiumOperations = await getPremiumTransferOperations({
     sourceUserId,
     targetUserId,
     logger,
@@ -100,6 +100,7 @@ export async function mergeAccount({
     // Foreign-key checks for new links must finish before the deletion check,
     // or wait until this transaction has committed.
     prisma.$queryRaw`SELECT id FROM "User" WHERE id = ${sourceUserId} FOR UPDATE`,
+    ...premiumOperations,
     prisma.account.update({
       where: { id: sourceAccountId },
       data: { userId: targetUserId },

--- a/apps/web/utils/user/merge-premium.test.ts
+++ b/apps/web/utils/user/merge-premium.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PremiumTier } from "@/generated/prisma/enums";
-import { transferPremiumDuringMerge } from "./merge-premium";
+import { getPremiumTransferOperations } from "./merge-premium";
 import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 
@@ -8,7 +8,7 @@ const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
 
-describe("transferPremiumDuringMerge", () => {
+describe("getPremiumTransferOperations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -48,7 +48,11 @@ describe("transferPremiumDuringMerge", () => {
 
       prisma.user.update.mockResolvedValue({} as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not call premium.update since we use atomic user.update
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -92,7 +96,11 @@ describe("transferPremiumDuringMerge", () => {
           },
         } as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not make any premium updates since target has higher tier
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -133,7 +141,11 @@ describe("transferPremiumDuringMerge", () => {
 
       prisma.user.update.mockResolvedValue({} as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not call premium.update since we use atomic user.update
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -179,7 +191,11 @@ describe("transferPremiumDuringMerge", () => {
           },
         } as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not make any updates since they share the same premium
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -217,7 +233,11 @@ describe("transferPremiumDuringMerge", () => {
 
       prisma.user.update.mockResolvedValue({} as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should update target user to use source's premium
       expect(prisma.user.update).toHaveBeenCalledWith({
@@ -253,7 +273,11 @@ describe("transferPremiumDuringMerge", () => {
           },
         } as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not make any updates since target already has premium
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -283,7 +307,11 @@ describe("transferPremiumDuringMerge", () => {
           premium: null,
         } as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not make any updates since neither has premium
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -321,7 +349,11 @@ describe("transferPremiumDuringMerge", () => {
       prisma.premium.update.mockResolvedValue({} as any);
       prisma.user.update.mockResolvedValue({} as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should connect target user as admin
       expect(prisma.premium.update).toHaveBeenCalledWith({
@@ -369,7 +401,11 @@ describe("transferPremiumDuringMerge", () => {
 
       prisma.premium.update.mockResolvedValue({} as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should connect target user as admin
       expect(prisma.premium.update).toHaveBeenCalledWith({
@@ -399,7 +435,11 @@ describe("transferPremiumDuringMerge", () => {
         premium: null,
       } as any);
 
-      await transferPremiumDuringMerge({ sourceUserId, targetUserId, logger });
+      await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
 
       // Should not make any updates when source user is not found
       expect(prisma.premium.update).not.toHaveBeenCalled();
@@ -423,15 +463,15 @@ describe("transferPremiumDuringMerge", () => {
 
       // Should not throw an error, but should complete gracefully
       await expect(
-        transferPremiumDuringMerge({ sourceUserId, targetUserId, logger }),
-      ).resolves.toBeUndefined();
+        getPremiumTransferOperations({ sourceUserId, targetUserId, logger }),
+      ).resolves.toEqual([]);
 
       // Should not make any updates when target user is not found
       expect(prisma.premium.update).not.toHaveBeenCalled();
       expect(prisma.user.update).not.toHaveBeenCalled();
     });
 
-    it("should handle database errors gracefully", async () => {
+    it("returns mutation failures for the merge transaction to handle", async () => {
       const sourceUserId = "source-user-id";
       const targetUserId = "target-user-id";
       const sourcePremiumId = "source-premium-id";
@@ -463,10 +503,14 @@ describe("transferPremiumDuringMerge", () => {
         new Error("Database connection failed"),
       );
 
-      // Should not throw an error, but should complete gracefully
-      await expect(
-        transferPremiumDuringMerge({ sourceUserId, targetUserId, logger }),
-      ).resolves.toBeUndefined();
+      const operations = await getPremiumTransferOperations({
+        sourceUserId,
+        targetUserId,
+        logger,
+      });
+      await expect(Promise.all(operations)).rejects.toThrow(
+        "Database connection failed",
+      );
     });
   });
 });

--- a/apps/web/utils/user/merge-premium.ts
+++ b/apps/web/utils/user/merge-premium.ts
@@ -1,12 +1,12 @@
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { isOnHigherTier } from "@/utils/premium";
 
 /**
- * Transfer premium subscription from source user to target user during account merge
- * This ensures premium subscriptions are preserved when accounts are merged
+ * Prepare premium mutations to execute atomically with the account merge
  */
-export async function transferPremiumDuringMerge({
+export async function getPremiumTransferOperations({
   sourceUserId,
   targetUserId,
   logger,
@@ -15,7 +15,7 @@ export async function transferPremiumDuringMerge({
   targetUserId: string;
   logger: Logger;
 }) {
-  logger.info("Starting premium transfer during user merge", {
+  logger.info("Preparing premium transfer during user merge", {
     sourceUserId,
     targetUserId,
   });
@@ -48,7 +48,7 @@ export async function transferPremiumDuringMerge({
 
     if (!sourceUser) {
       logger.warn("Source user not found", { sourceUserId });
-      return;
+      return [];
     }
 
     const targetUser = await prisma.user.findUnique({
@@ -72,7 +72,7 @@ export async function transferPremiumDuringMerge({
       throw new Error(`Target user ${targetUserId} not found`);
     }
 
-    const operations: Promise<unknown>[] = [];
+    const operations: Prisma.PrismaPromise<unknown>[] = [];
 
     // Handle premium subscription scenarios
     if (sourceUser.premiumId && targetUser.premiumId) {
@@ -190,29 +190,14 @@ export async function transferPremiumDuringMerge({
       }
     }
 
-    // Execute all premium transfer operations
-    if (operations.length > 0) {
-      logger.info("Executing premium transfer operations", {
-        operationCount: operations.length,
-        sourceUserId,
-        targetUserId,
-      });
-
-      await Promise.all(operations);
-
-      logger.info("Premium transfer completed successfully", {
-        sourceUserId,
-        targetUserId,
-      });
-    } else {
-      logger.info("No premium to transfer", { sourceUserId, targetUserId });
-    }
+    return operations;
   } catch (error) {
-    logger.error("Failed to transfer premium during user merge", {
+    logger.error("Failed to prepare premium transfer during user merge", {
       sourceUserId,
       targetUserId,
       error,
     });
-    // Don't rethrow - we want the merge to continue even if premium transfer fails
+    // Keep the existing best-effort behavior for unavailable premium metadata.
+    return [];
   }
 }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260905-201834_pr-3527_ac69309eb6d3/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

A mailbox linked after an account merge read its source mailbox list could be deleted by the source user cascade. Lock the source user within the merge transaction and delete it only when no accounts or mailboxes remain; a stale merge now rolls back so the newly linked mailbox survives. Premium membership and admin transfers execute in the same static Prisma transaction, so a failed merge cannot leave premium access behind.

- Reproduced both cascading mailbox deletion and premium changes surviving an aborted merge with real PostgreSQL regressions before their fixes.
- All 4 focused database tests pass, covering a link committed after the snapshot, an in-flight link blocking the merge, premium rollback, and a successful premium/mailbox merge. All 17 merge and premium unit tests and Biome checks pass.
- Adds one row-lock query to full merges. Concurrent linking may briefly wait or cause the stale merge to fail safely and require retry. Premium mutation failures also abort the merge. There is no schema change or dynamic Prisma transaction.