### PR TITLE
cli: Configure runtime Bedrock credentials for AWS setup

### DIFF
--- a/packages/cli/src/aws-setup/bedrock-manifest.test.ts
+++ b/packages/cli/src/aws-setup/bedrock-manifest.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:fs", () => ({
 it("passes both Bedrock runtime keys to ECS through SSM references", () => {
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readFileSync).mockReturnValue(
-    "name: app\nsecrets:\n  BEDROCK_REGION: /region\n",
+    "name: app\nsecrets:\n  # BEDROCK_ACCESS_KEY: /placeholder\n  # BEDROCK_SECRET_KEY: /placeholder\n  BEDROCK_REGION: /region\n",
   );
   updateServiceManifestSecrets({
     llmEnvVar: "BEDROCK_REGION",

--- a/packages/cli/src/aws-setup/bedrock-manifest.test.ts
+++ b/packages/cli/src/aws-setup/bedrock-manifest.test.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { expect, it, vi } from "vitest";
+import { updateServiceManifestSecrets } from "../setup-aws";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+it("passes both Bedrock runtime keys to ECS through SSM references", () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(
+    "name: app\nsecrets:\n  BEDROCK_REGION: /region\n",
+  );
+  updateServiceManifestSecrets({
+    llmEnvVar: "BEDROCK_REGION",
+    hasGoogleOAuth: false,
+  });
+  const content = vi.mocked(writeFileSync).mock.calls[0]?.[1]?.toString();
+  expect(content).toMatch(
+    /BEDROCK_ACCESS_KEY: \/copilot\/.*\/secrets\/BEDROCK_ACCESS_KEY/,
+  );
+  expect(content).toMatch(
+    /BEDROCK_SECRET_KEY: \/copilot\/.*\/secrets\/BEDROCK_SECRET_KEY/,
+  );
+});

--- a/packages/cli/src/aws-setup/bedrock-manifest.test.ts
+++ b/packages/cli/src/aws-setup/bedrock-manifest.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
 import { updateServiceManifestSecrets } from "../setup-aws";
 
 vi.mock("node:fs", () => ({
@@ -7,6 +7,8 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
 }));
+
+beforeEach(() => vi.clearAllMocks());
 
 it("passes both Bedrock runtime keys to ECS through SSM references", () => {
   vi.mocked(existsSync).mockReturnValue(true);
@@ -24,4 +26,17 @@ it("passes both Bedrock runtime keys to ECS through SSM references", () => {
   expect(content).toMatch(
     /BEDROCK_SECRET_KEY: \/copilot\/.*\/secrets\/BEDROCK_SECRET_KEY/,
   );
+});
+
+it("removes Bedrock credentials when switching to another provider", () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(
+    "name: app\nsecrets:\n  BEDROCK_ACCESS_KEY: /access\n  BEDROCK_SECRET_KEY: /secret\n  BEDROCK_REGION: /region\n",
+  );
+  updateServiceManifestSecrets({
+    llmEnvVar: "ANTHROPIC_API_KEY",
+    hasGoogleOAuth: false,
+  });
+  const content = vi.mocked(writeFileSync).mock.calls[0]?.[1]?.toString();
+  expect(content).not.toMatch(/BEDROCK_(ACCESS_KEY|SECRET_KEY|REGION):/);
 });

--- a/packages/cli/src/aws-setup/bedrock.test.ts
+++ b/packages/cli/src/aws-setup/bedrock.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { getBedrockCredentials } from "./bedrock";
+
+afterEach(() => vi.unstubAllEnvs());
+
+it("rejects unattended setup without runtime Bedrock credentials", async () => {
+  vi.stubEnv("BEDROCK_ACCESS_KEY", "");
+  vi.stubEnv("BEDROCK_SECRET_KEY", "");
+  await expect(getBedrockCredentials(true)).rejects.toThrow(
+    /BEDROCK_ACCESS_KEY.*BEDROCK_SECRET_KEY/,
+  );
+});
+
+it("uses explicit runtime keys independently of the deployment AWS profile", async () => {
+  vi.stubEnv("BEDROCK_ACCESS_KEY", "runtime-access-key");
+  vi.stubEnv("BEDROCK_SECRET_KEY", "runtime-secret-key");
+  await expect(getBedrockCredentials(true)).resolves.toEqual({
+    BEDROCK_ACCESS_KEY: "runtime-access-key",
+    BEDROCK_SECRET_KEY: "runtime-secret-key",
+  });
+});

--- a/packages/cli/src/aws-setup/bedrock.test.ts
+++ b/packages/cli/src/aws-setup/bedrock.test.ts
@@ -1,7 +1,18 @@
+import * as p from "@clack/prompts";
 import { afterEach, expect, it, vi } from "vitest";
 import { getBedrockCredentials } from "./bedrock";
 
-afterEach(() => vi.unstubAllEnvs());
+vi.mock("@clack/prompts", () => ({
+  log: { info: vi.fn() },
+  group: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
 
 it("rejects unattended setup without runtime Bedrock credentials", async () => {
   vi.stubEnv("BEDROCK_ACCESS_KEY", "");
@@ -18,4 +29,43 @@ it("uses explicit runtime keys independently of the deployment AWS profile", asy
     BEDROCK_ACCESS_KEY: "runtime-access-key",
     BEDROCK_SECRET_KEY: "runtime-secret-key",
   });
+});
+
+it.each([
+  ["present", ""],
+  ["", "present"],
+])("rejects partial unattended credentials (%s, %s)", async (accessKey, secretKey) => {
+  vi.stubEnv("BEDROCK_ACCESS_KEY", accessKey);
+  vi.stubEnv("BEDROCK_SECRET_KEY", secretKey);
+  await expect(getBedrockCredentials(true)).rejects.toThrow(
+    /BEDROCK_ACCESS_KEY.*BEDROCK_SECRET_KEY/,
+  );
+  expect(p.group).not.toHaveBeenCalled();
+});
+
+it("collects runtime credentials interactively", async () => {
+  vi.stubEnv("BEDROCK_ACCESS_KEY", "");
+  vi.stubEnv("BEDROCK_SECRET_KEY", "");
+  vi.mocked(p.group).mockResolvedValue({
+    accessKey: "interactive-access",
+    secretKey: "interactive-secret",
+  });
+  await expect(getBedrockCredentials(false)).resolves.toEqual({
+    BEDROCK_ACCESS_KEY: "interactive-access",
+    BEDROCK_SECRET_KEY: "interactive-secret",
+  });
+});
+
+it("cancels interactive setup without reporting a failure", async () => {
+  vi.stubEnv("BEDROCK_ACCESS_KEY", "");
+  vi.stubEnv("BEDROCK_SECRET_KEY", "");
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit:${code}`);
+  });
+  vi.mocked(p.group).mockImplementation(async (_prompts, options) => {
+    options?.onCancel?.({ results: {} });
+    return {};
+  });
+  await expect(getBedrockCredentials(false)).rejects.toThrow("process.exit:0");
+  expect(p.cancel).toHaveBeenCalledWith("Setup cancelled.");
 });

--- a/packages/cli/src/aws-setup/bedrock.ts
+++ b/packages/cli/src/aws-setup/bedrock.ts
@@ -28,7 +28,8 @@ export async function getBedrockCredentials(nonInteractive: boolean) {
       },
       {
         onCancel: () => {
-          throw new Error("Bedrock setup cancelled");
+          p.cancel("Setup cancelled.");
+          process.exit(0);
         },
       },
     );

--- a/packages/cli/src/aws-setup/bedrock.ts
+++ b/packages/cli/src/aws-setup/bedrock.ts
@@ -1,0 +1,41 @@
+import * as p from "@clack/prompts";
+
+export async function getBedrockCredentials(nonInteractive: boolean) {
+  let accessKey = process.env.BEDROCK_ACCESS_KEY;
+  let secretKey = process.env.BEDROCK_SECRET_KEY;
+  if (nonInteractive && (!accessKey || !secretKey)) {
+    throw new Error(
+      "Set BEDROCK_ACCESS_KEY and BEDROCK_SECRET_KEY for the deployed application's Bedrock access before running unattended AWS setup.",
+    );
+  }
+  if (!accessKey || !secretKey) {
+    p.log.info(
+      "The deployed app requires its own Bedrock credentials. The local AWS deployment profile is not passed to ECS.",
+    );
+    const credentials = await p.group(
+      {
+        accessKey: () =>
+          p.text({
+            message: "Bedrock access key ID",
+            initialValue: accessKey,
+            validate: (value) => (value ? undefined : "Access key is required"),
+          }),
+        secretKey: () =>
+          p.password({
+            message: "Bedrock secret access key",
+            validate: (value) => (value ? undefined : "Secret key is required"),
+          }),
+      },
+      {
+        onCancel: () => {
+          throw new Error("Bedrock setup cancelled");
+        },
+      },
+    );
+    accessKey = credentials.accessKey;
+    secretKey = credentials.secretKey;
+  }
+  if (!accessKey || !secretKey)
+    throw new Error("BEDROCK_ACCESS_KEY and BEDROCK_SECRET_KEY are required");
+  return { BEDROCK_ACCESS_KEY: accessKey, BEDROCK_SECRET_KEY: secretKey };
+}

--- a/packages/cli/src/setup-aws.test.ts
+++ b/packages/cli/src/setup-aws.test.ts
@@ -47,6 +47,16 @@ describe("runAwsSetup", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects unattended setup before AWS calls when runtime Bedrock keys are absent", async () => {
+    vi.stubEnv("BEDROCK_ACCESS_KEY", "");
+    vi.stubEnv("BEDROCK_SECRET_KEY", "");
+    await expect(
+      runAwsSetup({ yes: true, environment: "staging" }),
+    ).rejects.toThrow(/BEDROCK_ACCESS_KEY.*BEDROCK_SECRET_KEY/);
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("rejects invalid --environment values before shelling out", async () => {

--- a/packages/cli/src/setup-aws.ts
+++ b/packages/cli/src/setup-aws.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { putSsmParameterWithTags } from "./aws-setup/aws-cli";
+import { getBedrockCredentials } from "./aws-setup/bedrock";
 import { getWebhookUrl, setupGooglePubSub } from "./aws-setup/google-pubsub";
 import {
   ensureDatabaseUrlParameters,
@@ -107,6 +108,10 @@ export async function runAwsSetup(options: AwsSetupOptions) {
   if (nonInteractive) {
     p.log.info("Running in non-interactive mode with defaults");
   }
+
+  const bedrockCredentials = nonInteractive
+    ? await getBedrockCredentials(true)
+    : undefined;
 
   // Cleanup any leftover files from a previous interrupted run
   cleanupInterruptedRun();
@@ -452,11 +457,11 @@ export async function runAwsSetup(options: AwsSetupOptions) {
   let llmEnvVar = "";
 
   if (nonInteractive) {
-    // Use Bedrock as default since it uses AWS credentials (no API key needed)
+    // Explicit runtime credentials are validated before provisioning.
     llmProvider = "bedrock";
     llmEnvVar = "BEDROCK_REGION";
     llmApiKey = region;
-    p.log.info("LLM provider: AWS Bedrock (uses AWS credentials)");
+    p.log.info("LLM provider: AWS Bedrock");
   } else {
     const llmChoice = await p.select({
       message: "LLM Provider:",
@@ -489,7 +494,7 @@ export async function runAwsSetup(options: AwsSetupOptions) {
     // Get LLM API key
     if (llmProvider === "bedrock") {
       p.log.info(
-        "Bedrock uses AWS credentials. Make sure your IAM user has Bedrock access.",
+        "Configure Bedrock credentials with access to the selected models.",
       );
       llmEnvVar = "BEDROCK_REGION";
       llmApiKey = region;
@@ -612,6 +617,14 @@ export async function runAwsSetup(options: AwsSetupOptions) {
       ? `projects/${googleConfig.projectId}/topics/inbox-zero-emails`
       : "projects/your-project-id/topics/inbox-zero-emails");
   secrets.push({ name: "GOOGLE_PUBSUB_TOPIC_NAME", value: pubsubTopicName });
+
+  if (llmProvider === "bedrock") {
+    const credentials =
+      bedrockCredentials ?? (await getBedrockCredentials(false));
+    for (const [name, value] of Object.entries(credentials)) {
+      secrets.push({ name, value });
+    }
+  }
 
   // Add LLM API key
   if (llmEnvVar && llmApiKey) {
@@ -1306,7 +1319,7 @@ function updateAddonsParameters(config: {
   writeFileSync(paramsFile, content);
 }
 
-function updateServiceManifestSecrets(config: {
+export function updateServiceManifestSecrets(config: {
   llmEnvVar: string;
   hasGoogleOAuth: boolean;
   enableRedis?: boolean;
@@ -1332,6 +1345,9 @@ function updateServiceManifestSecrets(config: {
   ];
   const optionalSecrets = [
     ...(config.llmEnvVar ? [config.llmEnvVar] : []),
+    ...(config.llmEnvVar === "BEDROCK_REGION"
+      ? ["BEDROCK_ACCESS_KEY", "BEDROCK_SECRET_KEY"]
+      : []),
     ...(config.hasGoogleOAuth
       ? ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]
       : []),
@@ -1340,6 +1356,18 @@ function updateServiceManifestSecrets(config: {
 
   for (const secretName of [...baseSecrets, ...optionalSecrets]) {
     content = normalizeSecretReference(content, secretName);
+    if (
+      config.llmEnvVar === "BEDROCK_REGION" &&
+      (secretName === "BEDROCK_ACCESS_KEY" ||
+        secretName === "BEDROCK_SECRET_KEY") &&
+      !content.includes(`${secretName}:`)
+    ) {
+      content = content.replace(
+        /^secrets:.*$/m,
+        (heading) =>
+          `${heading}\n  ${secretName}: ${getSecretReference(secretName)}`,
+      );
+    }
   }
 
   content = removeSecrets(content, [

--- a/packages/cli/src/setup-aws.ts
+++ b/packages/cli/src/setup-aws.ts
@@ -109,7 +109,7 @@ export async function runAwsSetup(options: AwsSetupOptions) {
     p.log.info("Running in non-interactive mode with defaults");
   }
 
-  const bedrockCredentials = nonInteractive
+  let bedrockCredentials = nonInteractive
     ? await getBedrockCredentials(true)
     : undefined;
 
@@ -496,6 +496,7 @@ export async function runAwsSetup(options: AwsSetupOptions) {
       p.log.info(
         "Configure Bedrock credentials with access to the selected models.",
       );
+      bedrockCredentials = await getBedrockCredentials(false);
       llmEnvVar = "BEDROCK_REGION";
       llmApiKey = region;
     } else {
@@ -618,10 +619,8 @@ export async function runAwsSetup(options: AwsSetupOptions) {
       : "projects/your-project-id/topics/inbox-zero-emails");
   secrets.push({ name: "GOOGLE_PUBSUB_TOPIC_NAME", value: pubsubTopicName });
 
-  if (llmProvider === "bedrock") {
-    const credentials =
-      bedrockCredentials ?? (await getBedrockCredentials(false));
-    for (const [name, value] of Object.entries(credentials)) {
+  if (bedrockCredentials) {
+    for (const [name, value] of Object.entries(bedrockCredentials)) {
       secrets.push({ name, value });
     }
   }
@@ -1374,7 +1373,9 @@ export function updateServiceManifestSecrets(config: {
     "UPSTASH_REDIS_URL",
     "UPSTASH_REDIS_TOKEN",
     ...(config.enableRedis ? [] : ["REDIS_URL"]),
-    ...(config.llmEnvVar === "BEDROCK_REGION" ? [] : ["BEDROCK_REGION"]),
+    ...(config.llmEnvVar === "BEDROCK_REGION"
+      ? []
+      : ["BEDROCK_REGION", "BEDROCK_ACCESS_KEY", "BEDROCK_SECRET_KEY"]),
   ]);
 
   // Add LLM provider secret if not already present

--- a/packages/cli/src/setup-aws.ts
+++ b/packages/cli/src/setup-aws.ts
@@ -1360,7 +1360,7 @@ export function updateServiceManifestSecrets(config: {
       config.llmEnvVar === "BEDROCK_REGION" &&
       (secretName === "BEDROCK_ACCESS_KEY" ||
         secretName === "BEDROCK_SECRET_KEY") &&
-      !content.includes(`${secretName}:`)
+      !new RegExp(`^\\s+${secretName}:`, "m").test(content)
     ) {
       content = content.replace(
         /^secrets:.*$/m,


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260905-201535_pr-3528_f29ffdc79ba7/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

AWS setup selected Bedrock but only configured its region, leaving the deployed app without the explicit credentials its current provider requires. Collect runtime Bedrock keys in interactive setup, require them before unattended provisioning, and add their SSM references to the ECS manifest.

- The deployment's local AWS profile is kept separate from application credentials; no production infrastructure was changed.
- Validation: the manifest regression fails against the previous implementation; all 7 focused credential, setup and manifest tests pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->