### PR TITLE
Assistant: Allow direct chat access before onboarding

### DIFF
--- a/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/chat-test-helpers.ts
@@ -1,18 +1,6 @@
-import type { Page } from "@playwright/test";
 import { Client } from "pg";
 
 export const SEEDED_CHAT_ID = "playwright-manage-chat";
-
-export async function markAssistantOnboardingViewed(page: Page) {
-  await page.goto("/");
-  await page.context().addCookies([
-    {
-      name: "viewed_assistant_onboarding",
-      value: "true",
-      url: new URL(page.url()).origin,
-    },
-  ]);
-}
 
 export async function seedChat(emailAccountId: string) {
   const client = new Client({ connectionString: process.env.DATABASE_URL });

--- a/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from "@playwright/test";
+import { Client } from "pg";
+import { test } from "../playwright-test";
+import { getEmailAccountId } from "../account-test-helpers";
+
+test("opens Assistant without rules or a viewed-onboarding cookie", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  try {
+    const rules = await client.query(
+      'SELECT id FROM "Rule" WHERE "emailAccountId" = $1',
+      [emailAccountId],
+    );
+    expect(rules.rows).toHaveLength(0);
+  } finally {
+    await client.end();
+  }
+  await page.context().clearCookies({ name: "viewed_assistant_onboarding" });
+
+  await page.goto(`/${emailAccountId}/assistant`);
+  await expect(page).toHaveURL(new RegExp(`/${emailAccountId}/assistant$`));
+  await expect(page.getByTestId("chat-input")).toBeVisible();
+
+  await page.goto(`/${emailAccountId}/assistant?onboarding=true`);
+  await expect(page.getByTestId("chat-input")).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
@@ -2,8 +2,9 @@ import { expect } from "@playwright/test";
 import { Client } from "pg";
 import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
+import { markAssistantOnboardingViewed } from "./chat-test-helpers";
 
-test("opens Assistant without rules or a viewed-onboarding cookie", async ({
+test("routes first-time Assistant visitors through onboarding", async ({
   page,
 }) => {
   const emailAccountId = await getEmailAccountId(page);
@@ -21,9 +22,31 @@ test("opens Assistant without rules or a viewed-onboarding cookie", async ({
   await page.context().clearCookies({ name: "viewed_assistant_onboarding" });
 
   await page.goto(`/${emailAccountId}/assistant`);
-  await expect(page).toHaveURL(new RegExp(`/${emailAccountId}/assistant$`));
-  await expect(page.getByTestId("chat-input")).toBeVisible();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === `/${emailAccountId}/onboarding`,
+  );
+  await expect(
+    page.getByRole("heading", { name: "Your inbox, automatically sorted" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("chat-input")).toBeHidden();
 
   await page.goto(`/${emailAccountId}/assistant?onboarding=true`);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === `/${emailAccountId}/onboarding`,
+  );
+  await expect(
+    page.getByRole("heading", { name: "Your inbox, automatically sorted" }),
+  ).toBeVisible();
+});
+
+test("opens Assistant after onboarding has been completed", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await markAssistantOnboardingViewed(page);
+  await page.goto(`/${emailAccountId}/assistant`);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === `/${emailAccountId}/assistant`,
+  );
   await expect(page.getByTestId("chat-input")).toBeVisible();
 });

--- a/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/first-visit.spec.ts
@@ -2,9 +2,8 @@ import { expect } from "@playwright/test";
 import { Client } from "pg";
 import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
-import { markAssistantOnboardingViewed } from "./chat-test-helpers";
 
-test("routes first-time Assistant visitors through onboarding", async ({
+test("opens chat directly without rules or an onboarding cookie", async ({
   page,
 }) => {
   const emailAccountId = await getEmailAccountId(page);
@@ -23,28 +22,11 @@ test("routes first-time Assistant visitors through onboarding", async ({
 
   await page.goto(`/${emailAccountId}/assistant`);
   await expect(page).toHaveURL(
-    (url) => url.pathname === `/${emailAccountId}/onboarding`,
+    (url) => url.pathname === `/${emailAccountId}/assistant`,
   );
-  await expect(
-    page.getByRole("heading", { name: "Your inbox, automatically sorted" }),
-  ).toBeVisible();
-  await expect(page.getByTestId("chat-input")).toBeHidden();
+  await expect(page.getByTestId("chat-input")).toBeVisible();
 
   await page.goto(`/${emailAccountId}/assistant?onboarding=true`);
-  await expect(page).toHaveURL(
-    (url) => url.pathname === `/${emailAccountId}/onboarding`,
-  );
-  await expect(
-    page.getByRole("heading", { name: "Your inbox, automatically sorted" }),
-  ).toBeVisible();
-});
-
-test("opens Assistant after onboarding has been completed", async ({
-  page,
-}) => {
-  const emailAccountId = await getEmailAccountId(page);
-  await markAssistantOnboardingViewed(page);
-  await page.goto(`/${emailAccountId}/assistant`);
   await expect(page).toHaveURL(
     (url) => url.pathname === `/${emailAccountId}/assistant`,
   );

--- a/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/chat/history-management.spec.ts
@@ -1,12 +1,7 @@
 import { expect } from "@playwright/test";
 import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
-import {
-  cleanupSeededChat,
-  getChatState,
-  markAssistantOnboardingViewed,
-  seedChat,
-} from "./chat-test-helpers";
+import { cleanupSeededChat, getChatState, seedChat } from "./chat-test-helpers";
 
 const SERVER_ACTION_TIMEOUT_MS = 120_000;
 
@@ -19,7 +14,6 @@ test("opens, renames, starts fresh from, and deletes persisted chats", async ({
 }) => {
   const emailAccountId = await getEmailAccountId(page);
   await seedChat(emailAccountId);
-  await markAssistantOnboardingViewed(page);
 
   await page.goto(`/${emailAccountId}/assistant`);
   await expect(page).toHaveURL(new RegExp(`/${emailAccountId}/assistant`));

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
@@ -1,19 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import prisma from "@/utils/__mocks__/prisma";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 import AssistantPage from "./page";
 
-vi.mock("@/utils/prisma");
 vi.mock("@/utils/email-account", () => ({
   checkUserOwnsEmailAccount: vi.fn(),
-}));
-vi.mock("next/headers", () => ({
-  cookies: vi.fn().mockResolvedValue({ get: () => undefined }),
-}));
-vi.mock("next/navigation", () => ({
-  redirect: (url: string) => {
-    throw new Error(`redirect:${url}`);
-  },
 }));
 vi.mock("@/app/(app)/[emailAccountId]/PermissionsCheck", () => ({
   PermissionsCheck: () => null,
@@ -25,10 +15,9 @@ describe("AssistantPage access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(checkUserOwnsEmailAccount).mockResolvedValue(undefined);
-    prisma.rule.findFirst.mockResolvedValue(null);
   });
 
-  it("allows the first visit without rules or an onboarding cookie", async () => {
+  it("allows access to a mailbox owned by the user", async () => {
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
@@ -65,7 +65,7 @@ describe("AssistantPage onboarding access", () => {
   });
 
   it("preserves access for an existing account with rules when its cookie is absent", async () => {
-    prisma.rule.findFirst.mockResolvedValue(getRule());
+    prisma.rule.findFirst.mockResolvedValue(getRule("Existing mailbox rule"));
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
@@ -73,15 +73,16 @@ describe("AssistantPage onboarding access", () => {
     ).resolves.toBeDefined();
   });
 
-  it("rejects an unowned mailbox before reading its onboarding state", async () => {
-    vi.mocked(checkUserOwnsEmailAccount).mockRejectedValue(
-      new Error("Not authenticated"),
-    );
+  it.each([
+    "Not authenticated",
+    "redirect:/no-access",
+  ])("propagates %s before reading onboarding state", async (message) => {
+    vi.mocked(checkUserOwnsEmailAccount).mockRejectedValue(new Error(message));
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
       }),
-    ).rejects.toThrow("Not authenticated");
+    ).rejects.toThrow(message);
     expect(prisma.rule.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
@@ -1,7 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRule } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 import AssistantPage from "./page";
 
+const onboarding = vi.hoisted(() => ({
+  cookieValue: undefined as string | undefined,
+}));
+
+vi.mock("@/utils/prisma");
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: () =>
+      onboarding.cookieValue === undefined
+        ? undefined
+        : { value: onboarding.cookieValue },
+  })),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`redirect:${url}`);
+  },
+}));
 vi.mock("@/utils/email-account", () => ({
   checkUserOwnsEmailAccount: vi.fn(),
 }));
@@ -11,32 +31,57 @@ vi.mock("@/app/(app)/[emailAccountId]/PermissionsCheck", () => ({
 vi.mock("@/providers/EmailProvider", () => ({ EmailProvider: () => null }));
 vi.mock("@/components/assistant-chat/chat", () => ({ Chat: () => null }));
 
-describe("AssistantPage access", () => {
+describe("AssistantPage onboarding access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    onboarding.cookieValue = undefined;
+    prisma.rule.findFirst.mockResolvedValue(null);
     vi.mocked(checkUserOwnsEmailAccount).mockResolvedValue(undefined);
   });
 
-  it("allows access to a mailbox owned by the user", async () => {
+  it.each([
+    undefined,
+    "false",
+  ])("sends a new account to onboarding when its cookie is %s", async (cookieValue) => {
+    onboarding.cookieValue = cookieValue;
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
       }),
-    ).resolves.toBeDefined();
+    ).rejects.toThrow("redirect:/account-1/onboarding");
     expect(checkUserOwnsEmailAccount).toHaveBeenCalledWith({
       emailAccountId: "account-1",
     });
   });
 
-  it("still rejects access when the mailbox ownership check fails", async () => {
+  it("allows chat after onboarding even when there are no rules", async () => {
+    onboarding.cookieValue = "true";
+    await expect(
+      AssistantPage({
+        params: Promise.resolve({ emailAccountId: "account-1" }),
+      }),
+    ).resolves.toBeDefined();
+    expect(prisma.rule.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("preserves access for an existing account with rules when its cookie is absent", async () => {
+    prisma.rule.findFirst.mockResolvedValue(getRule());
+    await expect(
+      AssistantPage({
+        params: Promise.resolve({ emailAccountId: "account-1" }),
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects an unowned mailbox before reading its onboarding state", async () => {
     vi.mocked(checkUserOwnsEmailAccount).mockRejectedValue(
       new Error("Not authenticated"),
     );
-
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
       }),
     ).rejects.toThrow("Not authenticated");
+    expect(prisma.rule.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { checkUserOwnsEmailAccount } from "@/utils/email-account";
+import AssistantPage from "./page";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email-account", () => ({
+  checkUserOwnsEmailAccount: vi.fn(),
+}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({ get: () => undefined }),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`redirect:${url}`);
+  },
+}));
+vi.mock("@/app/(app)/[emailAccountId]/PermissionsCheck", () => ({
+  PermissionsCheck: () => null,
+}));
+vi.mock("@/providers/EmailProvider", () => ({ EmailProvider: () => null }));
+vi.mock("@/components/assistant-chat/chat", () => ({ Chat: () => null }));
+
+describe("AssistantPage access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkUserOwnsEmailAccount).mockResolvedValue(undefined);
+    prisma.rule.findFirst.mockResolvedValue(null);
+  });
+
+  it("allows the first visit without rules or an onboarding cookie", async () => {
+    await expect(
+      AssistantPage({
+        params: Promise.resolve({ emailAccountId: "account-1" }),
+      }),
+    ).resolves.toBeDefined();
+    expect(checkUserOwnsEmailAccount).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+    });
+  });
+
+  it("still rejects access when the mailbox ownership check fails", async () => {
+    vi.mocked(checkUserOwnsEmailAccount).mockRejectedValue(
+      new Error("Not authenticated"),
+    );
+
+    await expect(
+      AssistantPage({
+        params: Promise.resolve({ emailAccountId: "account-1" }),
+      }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.test.ts
@@ -1,27 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getRule } from "@/__tests__/helpers";
-import prisma from "@/utils/__mocks__/prisma";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 import AssistantPage from "./page";
 
-const onboarding = vi.hoisted(() => ({
-  cookieValue: undefined as string | undefined,
-}));
-
-vi.mock("@/utils/prisma");
-vi.mock("next/headers", () => ({
-  cookies: vi.fn(async () => ({
-    get: () =>
-      onboarding.cookieValue === undefined
-        ? undefined
-        : { value: onboarding.cookieValue },
-  })),
-}));
-vi.mock("next/navigation", () => ({
-  redirect: (url: string) => {
-    throw new Error(`redirect:${url}`);
-  },
-}));
 vi.mock("@/utils/email-account", () => ({
   checkUserOwnsEmailAccount: vi.fn(),
 }));
@@ -31,58 +11,32 @@ vi.mock("@/app/(app)/[emailAccountId]/PermissionsCheck", () => ({
 vi.mock("@/providers/EmailProvider", () => ({ EmailProvider: () => null }));
 vi.mock("@/components/assistant-chat/chat", () => ({ Chat: () => null }));
 
-describe("AssistantPage onboarding access", () => {
+describe("AssistantPage access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    onboarding.cookieValue = undefined;
-    prisma.rule.findFirst.mockResolvedValue(null);
     vi.mocked(checkUserOwnsEmailAccount).mockResolvedValue(undefined);
   });
 
-  it.each([
-    undefined,
-    "false",
-  ])("sends a new account to onboarding when its cookie is %s", async (cookieValue) => {
-    onboarding.cookieValue = cookieValue;
+  it("allows direct chat for a mailbox owned by the user", async () => {
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
       }),
-    ).rejects.toThrow("redirect:/account-1/onboarding");
+    ).resolves.toBeDefined();
     expect(checkUserOwnsEmailAccount).toHaveBeenCalledWith({
       emailAccountId: "account-1",
     });
   });
 
-  it("allows chat after onboarding even when there are no rules", async () => {
-    onboarding.cookieValue = "true";
-    await expect(
-      AssistantPage({
-        params: Promise.resolve({ emailAccountId: "account-1" }),
-      }),
-    ).resolves.toBeDefined();
-    expect(prisma.rule.findFirst).not.toHaveBeenCalled();
-  });
-
-  it("preserves access for an existing account with rules when its cookie is absent", async () => {
-    prisma.rule.findFirst.mockResolvedValue(getRule("Existing mailbox rule"));
-    await expect(
-      AssistantPage({
-        params: Promise.resolve({ emailAccountId: "account-1" }),
-      }),
-    ).resolves.toBeDefined();
-  });
-
   it.each([
     "Not authenticated",
     "redirect:/no-access",
-  ])("propagates %s before reading onboarding state", async (message) => {
+  ])("preserves the access denial: %s", async (message) => {
     vi.mocked(checkUserOwnsEmailAccount).mockRejectedValue(new Error(message));
     await expect(
       AssistantPage({
         params: Promise.resolve({ emailAccountId: "account-1" }),
       }),
     ).rejects.toThrow(message);
-    expect(prisma.rule.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from "react";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import prisma from "@/utils/prisma";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { EmailProvider } from "@/providers/EmailProvider";
+import { ASSISTANT_ONBOARDING_COOKIE } from "@/utils/cookies";
+import { prefixPath } from "@/utils/path";
 import { Chat } from "@/components/assistant-chat/chat";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 
@@ -13,6 +18,22 @@ export default async function AssistantPage({
 }) {
   const { emailAccountId } = await params;
   await checkUserOwnsEmailAccount({ emailAccountId });
+
+  // onboarding redirect
+  const cookieStore = await cookies();
+  const viewedOnboarding =
+    cookieStore.get(ASSISTANT_ONBOARDING_COOKIE)?.value === "true";
+
+  if (!viewedOnboarding) {
+    const hasRule = await prisma.rule.findFirst({
+      where: { emailAccountId },
+      select: { id: true },
+    });
+
+    if (!hasRule) {
+      redirect(prefixPath(emailAccountId, "/onboarding"));
+    }
+  }
 
   return (
     <EmailProvider>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
@@ -1,11 +1,6 @@
 import { Suspense } from "react";
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-import prisma from "@/utils/prisma";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { EmailProvider } from "@/providers/EmailProvider";
-import { ASSISTANT_ONBOARDING_COOKIE } from "@/utils/cookies";
-import { prefixPath } from "@/utils/path";
 import { Chat } from "@/components/assistant-chat/chat";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 
@@ -18,22 +13,6 @@ export default async function AssistantPage({
 }) {
   const { emailAccountId } = await params;
   await checkUserOwnsEmailAccount({ emailAccountId });
-
-  // onboarding redirect
-  const cookieStore = await cookies();
-  const viewedOnboarding =
-    cookieStore.get(ASSISTANT_ONBOARDING_COOKIE)?.value === "true";
-
-  if (!viewedOnboarding) {
-    const hasRule = await prisma.rule.findFirst({
-      where: { emailAccountId },
-      select: { id: true },
-    });
-
-    if (!hasRule) {
-      redirect(prefixPath(emailAccountId, "/assistant?onboarding=true"));
-    }
-  }
 
   return (
     <EmailProvider>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/page.tsx
@@ -1,11 +1,6 @@
 import { Suspense } from "react";
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-import prisma from "@/utils/prisma";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { EmailProvider } from "@/providers/EmailProvider";
-import { ASSISTANT_ONBOARDING_COOKIE } from "@/utils/cookies";
-import { prefixPath } from "@/utils/path";
 import { Chat } from "@/components/assistant-chat/chat";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
 
@@ -18,22 +13,6 @@ export default async function AssistantPage({
 }) {
   const { emailAccountId } = await params;
   await checkUserOwnsEmailAccount({ emailAccountId });
-
-  // onboarding redirect
-  const cookieStore = await cookies();
-  const viewedOnboarding =
-    cookieStore.get(ASSISTANT_ONBOARDING_COOKIE)?.value === "true";
-
-  if (!viewedOnboarding) {
-    const hasRule = await prisma.rule.findFirst({
-      where: { emailAccountId },
-      select: { id: true },
-    });
-
-    if (!hasRule) {
-      redirect(prefixPath(emailAccountId, "/onboarding"));
-    }
-  }
 
   return (
     <EmailProvider>


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-094125_pr-3529_77df93342b34/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Assistant chat now opens directly for authenticated mailbox owners, including accounts with no rules and no viewed-onboarding cookie. Remove the chat route’s onboarding redirect and its cookie/rule lookup while retaining mailbox ownership and permissions checks.

- Remove the obsolete chat-only onboarding-cookie helper and redundant onboarding test setup. Automation onboarding continues to use its existing shared cookie and flow.
- Cover direct first visits and the old `onboarding=true` URL in Playwright, plus allowed access and authentication/ownership rejection cases in unit tests.
- Validation: direct-access expectations failed against the previous redirect; focused unit tests and emulated chat browser tests pass. Generated screenshots inspected.
- Runtime: removes a cookie read and conditional database query; adds no database or network calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant is now accessible directly at its URL without an onboarding step.
  * The chat input is available on both the standard Assistant URL and the `onboarding=true` variant.

* **Bug Fixes**
  * Assistant access now consistently validates mailbox ownership and surfaces authentication or access errors appropriately.

* **Tests**
  * Updated browser and page tests to verify direct access and chat availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->