### PR TITLE
fix: correct historical email processing and test-page rendering

### DIFF
--- a/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from "@playwright/test";
+import { test } from "../playwright-test";
+import { getEmailAccountId } from "../account-test-helpers";
+import { markAutomationOnboardingViewed } from "./automation-tabs-test-helpers";
+
+for (const tier of ["PLUS_MONTHLY", "PROFESSIONAL_MONTHLY"] as const) {
+  test(`explains historical read-email access for ${tier}`, async ({
+    page,
+  }) => {
+    const emailAccountId = await getEmailAccountId(page);
+    await markAutomationOnboardingViewed(page);
+    await page.route("**/api/user/me", async (route) => {
+      const response = await route.fetch();
+      const user = await response.json();
+      await route.fulfill({
+        response,
+        json: {
+          ...user,
+          premium: {
+            ...user.premium,
+            tier,
+            stripeSubscriptionStatus: "active",
+          },
+        },
+      });
+    });
+
+    await page.goto(`/${emailAccountId}/automation`);
+    await page.getByRole("button", { name: "Process Past Emails" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByText("Run your rules on emails already in your inbox."),
+    ).toBeVisible();
+    const includeRead = dialog.getByRole("switch").first();
+
+    if (tier === "PLUS_MONTHLY") {
+      await expect(includeRead).toBeDisabled();
+      await expect(
+        dialog.getByText(
+          "Including read emails is available on the Professional plan.",
+        ),
+      ).toBeVisible();
+    } else {
+      await expect(includeRead).toBeEnabled();
+      await includeRead.click();
+      await expect(includeRead).toBeChecked();
+    }
+  });
+}

--- a/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
@@ -26,8 +26,13 @@ for (const tier of ["PLUS_MONTHLY", "PROFESSIONAL_MONTHLY"] as const) {
     });
 
     await page.goto(`/${emailAccountId}/automation`);
-    await page.getByRole("button", { name: "Process Past Emails" }).click();
-    const dialog = page.getByRole("dialog");
+    const dialog = page.getByRole("dialog", { name: "Bulk Process Emails" });
+    await expect(async () => {
+      if (!(await dialog.isVisible())) {
+        await page.getByRole("button", { name: "Process Past Emails" }).click();
+      }
+      await expect(dialog).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30_000 });
     await expect(
       dialog.getByText("Run your rules on emails already in your inbox."),
     ).toBeVisible();

--- a/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
@@ -3,6 +3,52 @@ import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
 import { markAutomationOnboardingViewed } from "./automation-tabs-test-helpers";
 
+for (const custom of [false, true]) {
+  test(`can test ${custom ? "custom content" : "an email"} after browser translation replaces button text`, async ({
+    page,
+  }) => {
+    const emailAccountId = await getEmailAccountId(page);
+    await markAutomationOnboardingViewed(page);
+    await page.goto(`/${emailAccountId}/automation?tab=test`);
+    if (custom) {
+      await page.getByRole("button", { name: "Custom" }).click();
+      await page
+        .locator("textarea[name=content]")
+        .fill("A routine project update.");
+    }
+    const scope = custom
+      ? page.locator("form").filter({ has: page.locator("textarea") })
+      : page.getByRole("row").filter({ hasText: "Playwright Test Message" });
+    const button = scope.getByRole("button", { name: "Test", exact: true });
+    await expect(button).toBeVisible();
+
+    await button.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const textNodes: Node[] = [];
+      while (walker.nextNode()) textNodes.push(walker.currentNode);
+      for (const node of textNodes) {
+        if (!node.textContent?.trim()) continue;
+        // Translation replaces React's text nodes with its own elements.
+        const translated = document.createElement("font");
+        translated.textContent = node.textContent;
+        node.parentNode?.replaceChild(translated, node);
+      }
+    });
+
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        !!response.request().headers()["next-action"],
+    );
+    await button.click();
+    await actionResponse;
+    await expect(scope).toBeVisible();
+    await expect(
+      scope.getByRole("button", { name: /^(Test|Retest)$/ }),
+    ).toBeEnabled();
+  });
+}
+
 test("preserves search, custom email, and Apply workspace state", async ({
   page,
 }) => {

--- a/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/test-tab.spec.ts
@@ -43,9 +43,15 @@ for (const custom of [false, true]) {
     await button.click();
     await actionResponse;
     await expect(scope).toBeVisible();
-    await expect(
-      scope.getByRole("button", { name: /^(Test|Retest)$/ }),
-    ).toBeEnabled();
+    if (custom) {
+      await expect(
+        page.getByText("Test result", { exact: true }),
+      ).toBeVisible();
+    } else {
+      await expect(
+        scope.getByRole("button", { name: "Retest", exact: true }),
+      ).toBeEnabled();
+    }
   });
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -215,7 +215,7 @@ export function BulkRunRules() {
                 enabled={includeRead}
                 onChange={(enabled) => setIncludeRead(enabled)}
                 disabled={isProcessing || !isBusinessPlusTier}
-                disabledTooltipText={
+                explainText={
                   !isBusinessPlusTier && hasAiAccess
                     ? "Including read emails is available on the Professional plan."
                     : undefined
@@ -309,7 +309,7 @@ export function BulkRunRules() {
                     includeRead,
                     rerun: isRerunEnabled,
                   })}{" "}
-                  found in the selected date range.
+                  found in your inbox in the selected date range.
                 </div>
               )}
             </div>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -341,11 +341,13 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
                 disabled={!hasMore || isValidating}
               >
                 {!isValidating && <ChevronsDownIcon className="mr-2 size-4" />}
-                {isValidating
-                  ? "Loading..."
-                  : hasMore
-                    ? "Load More"
-                    : "No More Messages"}
+                <span>
+                  {isValidating
+                    ? "Loading..."
+                    : hasMore
+                      ? "Load More"
+                      : "No More Messages"}
+                </span>
               </Button>
             </div>
           </Card>
@@ -460,7 +462,7 @@ function ProcessRulesRow({
                 onClick={() => onRun()}
               >
                 {!isRunning && <SparklesIcon className="mr-2 size-4" />}
-                {testMode ? "Test" : "Run"}
+                <span>{testMode ? "Test" : "Run"}</span>
               </Button>
             )}
           </div>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -256,6 +256,13 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
 
   const { setInput } = useChat();
 
+  let loadMoreLabel = "No More Messages";
+  if (isValidating) {
+    loadMoreLabel = "Loading...";
+  } else if (hasMore) {
+    loadMoreLabel = "Load More";
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between gap-2 pb-6">
@@ -341,13 +348,7 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
                 disabled={!hasMore || isValidating}
               >
                 {!isValidating && <ChevronsDownIcon className="mr-2 size-4" />}
-                <span>
-                  {isValidating
-                    ? "Loading..."
-                    : hasMore
-                      ? "Load More"
-                      : "No More Messages"}
-                </span>
+                <span>{loadMoreLabel}</span>
               </Button>
             </div>
           </Card>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/TestCustomEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/TestCustomEmailForm.tsx
@@ -58,7 +58,7 @@ export const TestCustomEmailForm = () => {
         />
         <Button type="submit" loading={isSubmitting} size="sm">
           <SparklesIcon className="mr-2 size-4" />
-          Test
+          <span>Test</span>
         </Button>
       </form>
       {testResults && (

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
@@ -26,12 +26,17 @@ describe("bulk processing", () => {
     );
     await vi.waitFor(() => expect(complete).toHaveBeenCalledWith("success", 0));
 
-    const query = new URL(
-      vi.mocked(fetchWithAccount).mock.calls[0][0].url,
-      "https://example.com",
-    ).searchParams;
-    expect(new Date(query.get("after")!)).toEqual(date);
-    expect(new Date(query.get("before")!)).toEqual(new Date(2025, 3, 11));
+    const request = vi.mocked(fetchWithAccount).mock.calls.at(0)?.at(0);
+    expect(request).toBeDefined();
+    if (!request) throw new Error("Expected a thread request");
+    const query = new URL(request.url, "https://example.com").searchParams;
+    const after = query.get("after");
+    const before = query.get("before");
+    expect(after).toBeTruthy();
+    expect(before).toBeTruthy();
+    if (!after || !before) throw new Error("Expected both date bounds");
+    expect(new Date(after)).toEqual(date);
+    expect(new Date(before)).toEqual(new Date(2025, 3, 11));
     expect(date).toEqual(new Date(2025, 3, 10));
   });
 
@@ -65,7 +70,7 @@ describe("bulk processing", () => {
       expect(query.get("isUnread")).toBe(includeRead ? null : "true");
       expect(query.get("before")).toBeNull();
     }
-    expect(queries[1].get("nextPageToken")).toBe("next-page");
+    expect(queries.at(1)?.get("nextPageToken")).toBe("next-page");
     expect(runAiRules).toHaveBeenCalledWith(
       "account-id",
       [thread],

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { onRun } from "./bulk-run";
+import { fetchWithAccount } from "@/utils/fetch";
+import { runAiRules } from "@/utils/queue/email-actions";
+
+vi.mock("@/utils/fetch", () => ({ fetchWithAccount: vi.fn() }));
+vi.mock("@/utils/queue/email-actions", () => ({ runAiRules: vi.fn() }));
+vi.mock("@/components/Toast", () => ({ toastError: vi.fn() }));
+vi.mock("@/utils/error", () => ({ captureException: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(fetchWithAccount).mockResolvedValue(Response.json({ threads: [] }));
+});
+
+describe("bulk processing", () => {
+  it("includes the entire selected end date, including a same-day range", async () => {
+    const date = new Date(2025, 3, 10);
+    const complete = vi.fn();
+
+    await onRun(
+      "account-id",
+      { startDate: date, endDate: date },
+      vi.fn(),
+      complete,
+    );
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledWith("success", 0));
+
+    const query = new URL(
+      vi.mocked(fetchWithAccount).mock.calls[0][0].url,
+      "https://example.com",
+    ).searchParams;
+    expect(new Date(query.get("after")!)).toEqual(date);
+    expect(new Date(query.get("before")!)).toEqual(new Date(2025, 3, 11));
+    expect(date).toEqual(new Date(2025, 3, 10));
+  });
+
+  it.each([
+    true,
+    false,
+  ])("preserves the read-email filter across pages (includeRead: %s)", async (includeRead) => {
+    const thread = { id: "thread-id", messages: [{ id: "message-id" }] };
+    vi.mocked(fetchWithAccount)
+      .mockResolvedValueOnce(
+        Response.json({ threads: [thread], nextPageToken: "next-page" }),
+      )
+      .mockResolvedValueOnce(Response.json({ threads: [] }));
+    const complete = vi.fn();
+
+    await onRun(
+      "account-id",
+      { startDate: new Date(2025, 3, 1), includeRead },
+      vi.fn(),
+      complete,
+    );
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledWith("success", 1));
+
+    const queries = vi
+      .mocked(fetchWithAccount)
+      .mock.calls.map(
+        ([request]) => new URL(request.url, "https://example.com").searchParams,
+      );
+    expect(queries).toHaveLength(2);
+    for (const query of queries) {
+      expect(query.get("isUnread")).toBe(includeRead ? null : "true");
+      expect(query.get("before")).toBeNull();
+    }
+    expect(queries[1].get("nextPageToken")).toBe("next-page");
+    expect(runAiRules).toHaveBeenCalledWith(
+      "account-id",
+      [thread],
+      false,
+      expect.any(AbortSignal),
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
@@ -1,3 +1,5 @@
+import { addDays } from "date-fns/addDays";
+import { startOfDay } from "date-fns/startOfDay";
 import type { ThreadsResponse } from "@/app/api/threads/route";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { runAiRules } from "@/utils/queue/email-actions";
@@ -34,6 +36,8 @@ export async function onRun(
   let totalProcessed = 0;
   let aborted = false;
   const abortController = new AbortController();
+  // Provider "before" filters are exclusive; the selected calendar day is inclusive.
+  const before = endDate ? startOfDay(addDays(endDate, 1)) : undefined;
 
   function abort() {
     aborted = true;
@@ -48,7 +52,7 @@ export async function onRun(
         type: "inbox",
         limit: BATCH_SIZE,
         after: startDate,
-        ...(endDate ? { before: endDate } : {}),
+        ...(before ? { before } : {}),
         ...(!includeRead ? { isUnread: true } : {}),
         ...(nextPageToken ? { nextPageToken } : {}),
       };

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -395,6 +395,25 @@ describe("OutlookProvider.getSentMessageIds", () => {
 });
 
 describe("OutlookProvider.getThreadsWithQuery", () => {
+  it.each([
+    true,
+    undefined,
+  ])("puts date filters before folder and read filters for historical inbox queries (unread: %s)", async (isUnread) => {
+    const client = createMockOutlookClient([]);
+    const provider = new OutlookProvider(client);
+    const after = new Date("2025-04-01T00:00:00.000Z");
+    const before = new Date("2025-05-01T00:00:00.000Z");
+
+    await provider.getThreadsWithQuery({
+      query: { type: "inbox", after, before, isUnread },
+    });
+
+    // Graph rejects sorted message queries when non-sort fields precede the date filter.
+    expect(client.getRequestLog()[0]?.filter).toBe(
+      `receivedDateTime gt ${after.toISOString()} and receivedDateTime lt ${before.toISOString()} and parentFolderId eq 'inbox-folder-id'${isUnread ? " and isRead eq false" : ""}`,
+    );
+  });
+
   it("omits message bodies from metadata list requests", async () => {
     const client = createMockOutlookClient([
       createMessage({ id: "message-1", conversationId: "thread-1" }),

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -409,7 +409,7 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     });
 
     // Graph rejects sorted message queries when non-sort fields precede the date filter.
-    expect(client.getRequestLog()[0]?.filter).toBe(
+    expect(client.getRequestLog().at(0)?.filter).toBe(
       `receivedDateTime gt ${after.toISOString()} and receivedDateTime lt ${before.toISOString()} and parentFolderId eq 'inbox-folder-id'${isUnread ? " and isRead eq false" : ""}`,
     );
   });

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1672,6 +1672,15 @@ export class OutlookProvider implements EmailProvider {
       let endpoint = "/me/messages";
       const filters: string[] = [];
 
+      // Graph requires the orderby field's filters before all other fields.
+      if (after) {
+        filters.push(`receivedDateTime gt ${after.toISOString()}`);
+      }
+
+      if (before) {
+        filters.push(`receivedDateTime lt ${before.toISOString()}`);
+      }
+
       // Route to appropriate endpoint based on type
       // parentFolderId on messages is a GUID, not a well-known name — always resolve
       if (folderId) {
@@ -1701,14 +1710,6 @@ export class OutlookProvider implements EmailProvider {
       if (fromEmail) {
         const escapedEmail = escapeODataString(fromEmail);
         filters.push(`from/emailAddress/address eq '${escapedEmail}'`);
-      }
-
-      if (after) {
-        filters.push(`receivedDateTime gt ${after.toISOString()}`);
-      }
-
-      if (before) {
-        filters.push(`receivedDateTime lt ${before.toISOString()}`);
       }
 
       if (isUnread) {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260905-210404_pr-3530_82f4169ac157/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Historical processing now includes the entire selected end date and orders Outlook date filters correctly for Microsoft Graph queries.

- Prevent translation-related DOM crashes when testing emails and custom content.
- Show the Professional requirement for read-email bulk processing without hovering and clarify that processing searches the inbox.
- Validated with 49 focused unit tests, the full automation browser suite, inspected screenshots, and formatting checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical email processing now includes the selected end date, including same-day ranges.
  * Read-email filtering is preserved when loading additional pages.
  * Microsoft email searches apply date filters consistently for more reliable historical results.
  * Improved messaging clarifies when date-range searches return no emails and when read-email processing requires an upgrade.
  * Automation test controls remain usable when browser translation is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->