### PR TITLE
mail: Add manual Gmail conversation labeling

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
@@ -144,3 +144,51 @@ test("L labels the open conversation after it leaves the unread list", async ({
     expect.arrayContaining(["INBOX", "Label_project"]),
   );
 });
+
+test("keeps conversations available to retry after an interrupted labeling request", async ({
+  page,
+}) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Keyboard Navigation Message",
+  );
+  await conversation.getByRole("checkbox").click();
+  await page.keyboard.press("l");
+  const picker = page.getByRole("dialog", { name: "Label conversations" });
+  const labelOption = picker.getByRole("option", {
+    name: "Project Alpha",
+    exact: true,
+  });
+  await expect(labelOption).toBeVisible();
+  await page.route("**/mail**", async (route) => {
+    if (route.request().method() === "POST") await route.abort("failed");
+    else await route.continue();
+  });
+  await labelOption.click();
+  await expect(
+    page.getByText("Couldn't label 1 conversation. Select a label to retry.", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(picker).toBeVisible();
+  await expect(labelOption).toBeEnabled();
+  await page.unroute("**/mail**");
+  await labelOption.click();
+  await expect(picker).toBeHidden();
+  await expect(
+    conversation.getByText("Project Alpha", { exact: true }),
+  ).toBeVisible();
+  const response = await page.request.get(
+    "/api/threads/thr_playwright_keyboard",
+    {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    },
+  );
+  expect(response.ok()).toBeTruthy();
+  const { thread } = await response.json();
+  expect(thread.messages[0].labelIds).toEqual(
+    expect.arrayContaining(["INBOX", "Label_project"]),
+  );
+});

--- a/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
@@ -53,6 +53,7 @@ test("creates and applies a label to selected conversations with L", async ({
   page,
 }, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
+  const labelName = `Manual Projects ${testInfo.retry}`;
   const first = conversationWithSubject(
     page,
     conversations,
@@ -68,27 +69,23 @@ test("creates and applies a label to selected conversations with L", async ({
   await page.keyboard.press("l");
   const picker = page.getByRole("dialog", { name: "Label conversations" });
   await expect(picker).toBeVisible();
-  await picker.getByRole("combobox").fill("Manual Projects");
+  await picker.getByRole("combobox").fill(labelName);
   await expect(
-    picker.getByRole("option", { name: "Create and apply “Manual Projects”" }),
+    picker.getByRole("option", { name: `Create and apply “${labelName}”` }),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "create-label-picker");
   await picker
-    .getByRole("option", { name: "Create and apply “Manual Projects”" })
+    .getByRole("option", { name: `Create and apply “${labelName}”` })
     .click();
   await expect(picker).toBeHidden();
-  await expect(
-    first.getByText("Manual Projects", { exact: true }),
-  ).toBeVisible();
-  await expect(
-    second.getByText("Manual Projects", { exact: true }),
-  ).toBeVisible();
+  await expect(first.getByText(labelName, { exact: true })).toBeVisible();
+  await expect(second.getByText(labelName, { exact: true })).toBeVisible();
   const labelsResponse = await page.request.get("/api/labels", {
     headers: { "X-Email-Account-ID": emailAccountId },
   });
   const { labels } = await labelsResponse.json();
   const label = labels.find(
-    (label: { name: string }) => label.name === "Manual Projects",
+    (label: { name: string }) => label.name === labelName,
   );
   expect(label).toBeTruthy();
   for (const threadId of ["thr_playwright_1", "thr_playwright_2"]) {

--- a/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
@@ -1,0 +1,149 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("applies an existing label from the reader menu and keeps the conversation in inbox", async ({
+  page,
+}, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Navigation Message",
+  );
+  await conversation.click();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await page.getByRole("menuitem", { name: /^Label/ }).click();
+  const picker = page.getByRole("dialog", { name: "Label conversations" });
+  await picker.getByRole("combobox").fill("Project");
+  await expect(
+    picker.getByRole("option", { name: "Project Alpha", exact: true }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "search-label-picker");
+  await picker
+    .getByRole("option", { name: "Project Alpha", exact: true })
+    .click();
+  await expect(picker).toBeHidden();
+  await expect(
+    page.getByRole("link", { name: "Project Alpha", exact: true }).last(),
+  ).toBeVisible();
+  const response = await page.request.get(
+    "/api/threads/thr_playwright_reader",
+    { headers: { "X-Email-Account-ID": emailAccountId } },
+  );
+  expect(response.ok()).toBeTruthy();
+  const { thread } = await response.json();
+  expect(thread.messages).toHaveLength(2);
+  for (const message of thread.messages) {
+    expect(message.labelIds).toEqual(
+      expect.arrayContaining(["INBOX", "Label_project"]),
+    );
+  }
+  await page
+    .getByRole("button", { name: "Back to inbox", exact: true })
+    .click();
+  await expect(conversation).toBeVisible();
+  await expect(
+    conversation.getByText("Project Alpha", { exact: true }),
+  ).toBeVisible();
+});
+
+test("creates and applies a label to selected conversations with L", async ({
+  page,
+}, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const first = conversationWithSubject(
+    page,
+    conversations,
+    "Playwright Test Message",
+  );
+  const second = conversationWithSubject(
+    page,
+    conversations,
+    "Read Command Message",
+  );
+  await first.getByRole("checkbox").click();
+  await second.getByRole("checkbox").click();
+  await page.keyboard.press("l");
+  const picker = page.getByRole("dialog", { name: "Label conversations" });
+  await expect(picker).toBeVisible();
+  await picker.getByRole("combobox").fill("Manual Projects");
+  await expect(
+    picker.getByRole("option", { name: "Create and apply “Manual Projects”" }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "create-label-picker");
+  await picker
+    .getByRole("option", { name: "Create and apply “Manual Projects”" })
+    .click();
+  await expect(picker).toBeHidden();
+  await expect(
+    first.getByText("Manual Projects", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    second.getByText("Manual Projects", { exact: true }),
+  ).toBeVisible();
+  const labelsResponse = await page.request.get("/api/labels", {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  const { labels } = await labelsResponse.json();
+  const label = labels.find(
+    (label: { name: string }) => label.name === "Manual Projects",
+  );
+  expect(label).toBeTruthy();
+  for (const threadId of ["thr_playwright_1", "thr_playwright_2"]) {
+    const response = await page.request.get(`/api/threads/${threadId}`, {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    });
+    const { thread } = await response.json();
+    for (const message of thread.messages) {
+      expect(message.labelIds).toEqual(
+        expect.arrayContaining(["INBOX", label.id]),
+      );
+    }
+  }
+  await page.getByRole("button", { name: "Label", exact: true }).click();
+  await expect(picker).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(picker).toBeHidden();
+  await expect(page.getByText("2 selected", { exact: true })).toBeVisible();
+});
+
+test("L labels the open conversation after it leaves the unread list", async ({
+  page,
+}) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  await page.getByRole("button", { name: "Unread", exact: true }).click();
+  const conversation = conversationWithSubject(
+    page,
+    conversations,
+    "Second Unread Command Message",
+  );
+  await conversation.click();
+  const heading = page.getByRole("heading", {
+    name: "Second Unread Command Message",
+  });
+  await expect(heading).toBeVisible();
+  await expect(conversation).toHaveCount(0);
+  await page.keyboard.press("l");
+  const picker = page.getByRole("dialog", { name: "Label conversations" });
+  await expect(picker).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(picker).toBeHidden();
+  await expect(heading).toBeVisible();
+  await page.keyboard.press("l");
+  await picker.getByRole("combobox").fill("Project Alpha");
+  await expect(
+    picker.getByRole("option", { name: "Project Alpha", exact: true }),
+  ).toBeVisible();
+  await page.keyboard.press("Enter");
+  await expect(picker).toBeHidden();
+  await expect(heading).toBeVisible();
+  const response = await page.request.get("/api/threads/thr_playwright_3", {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  const { thread } = await response.json();
+  expect(thread.messages[0].labelIds).toEqual(
+    expect.arrayContaining(["INBOX", "Label_project"]),
+  );
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
@@ -24,6 +24,7 @@ import { useLabels } from "@/hooks/useLabels";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { createLabelAction } from "@/utils/actions/mail";
 import { applyThreadLabelsAction } from "@/utils/actions/mail-label";
+import { applyThreadLabelsInBatches } from "@/utils/label/apply-thread-labels";
 import { getActionErrorMessage } from "@/utils/error";
 
 export function LabelPickerDialog({
@@ -69,15 +70,19 @@ export function LabelPickerDialog({
             throw new Error(getActionErrorMessage(result ?? {}));
           id = result.data.id;
           createdLabel.current = { name, id };
-          await mutate();
+          mutate().catch(() => {});
         }
       }
-      const result = await applyLabel({
-        threadIds: remainingThreadIds,
-        labelId: id,
-      });
-      if (!result?.data) throw new Error(getActionErrorMessage(result ?? {}));
-      const { succeededThreadIds, failedThreadIds } = result.data;
+      const { succeededThreadIds, failedThreadIds, error } =
+        await applyThreadLabelsInBatches({
+          threadIds: remainingThreadIds,
+          applyBatch: async (threadIds) => {
+            const result = await applyLabel({ threadIds, labelId: id });
+            if (!result?.data)
+              throw new Error(getActionErrorMessage(result ?? {}));
+            return result.data;
+          },
+        });
       if (succeededThreadIds.length) {
         onApplied(succeededThreadIds, id);
         toast.success(
@@ -87,6 +92,7 @@ export function LabelPickerDialog({
         );
       }
       setRemainingThreadIds(failedThreadIds);
+      if (error) throw error;
       if (failedThreadIds.length) {
         toast.error(
           `Couldn't label ${failedThreadIds.length} conversations. Select a label to retry.`,

--- a/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { useAction } from "next-safe-action/hooks";
 import { PlusIcon, TagIcon } from "lucide-react";
 import { toast } from "sonner";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -43,12 +42,6 @@ export function LabelPickerDialog({
   const pending = useRef(false);
   const [remainingThreadIds, setRemainingThreadIds] = useState(threadIds);
   const createdLabel = useRef<{ name: string; id: string } | null>(null);
-  const { executeAsync: createLabel } = useAction(
-    createLabelAction.bind(null, emailAccountId),
-  );
-  const { executeAsync: applyLabel } = useAction(
-    applyThreadLabelsAction.bind(null, emailAccountId),
-  );
   const name = search.trim();
   const canCreate =
     name.length > 0 &&
@@ -65,7 +58,7 @@ export function LabelPickerDialog({
       if (!id) {
         if (createdLabel.current?.name === name) id = createdLabel.current.id;
         else {
-          const result = await createLabel({ name });
+          const result = await createLabelAction(emailAccountId, { name });
           if (!result?.data?.id)
             throw new Error(getActionErrorMessage(result ?? {}));
           id = result.data.id;
@@ -77,7 +70,10 @@ export function LabelPickerDialog({
         await applyThreadLabelsInBatches({
           threadIds: remainingThreadIds,
           applyBatch: async (threadIds) => {
-            const result = await applyLabel({ threadIds, labelId: id });
+            const result = await applyThreadLabelsAction(emailAccountId, {
+              threadIds,
+              labelId: id,
+            });
             if (!result?.data)
               throw new Error(getActionErrorMessage(result ?? {}));
             return result.data;
@@ -92,10 +88,10 @@ export function LabelPickerDialog({
         );
       }
       setRemainingThreadIds(failedThreadIds);
-      if (error) throw error;
       if (failedThreadIds.length) {
         toast.error(
-          `Couldn't label ${failedThreadIds.length} conversations. Select a label to retry.`,
+          `Couldn't label ${failedThreadIds.length} conversation${failedThreadIds.length === 1 ? "" : "s"}. Select a label to retry.`,
+          { description: error instanceof Error ? error.message : undefined },
         );
       } else onClose();
     } catch (error) {

--- a/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/LabelPickerDialog.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useAction } from "next-safe-action/hooks";
+import { PlusIcon, TagIcon } from "lucide-react";
+import { toast } from "sonner";
+import { LoadingContent } from "@/components/LoadingContent";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useLabels } from "@/hooks/useLabels";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { createLabelAction } from "@/utils/actions/mail";
+import { applyThreadLabelsAction } from "@/utils/actions/mail-label";
+import { getActionErrorMessage } from "@/utils/error";
+
+export function LabelPickerDialog({
+  threadIds,
+  onClose,
+  onApplied,
+}: {
+  threadIds: string[];
+  onClose: () => void;
+  onApplied: (threadIds: string[], labelId: string) => void;
+}) {
+  const { emailAccountId } = useAccount();
+  const { userLabels, isLoading, error, mutate } = useLabels(emailAccountId);
+  const [search, setSearch] = useState("");
+  const [isPending, setIsPending] = useState(false);
+  const pending = useRef(false);
+  const [remainingThreadIds, setRemainingThreadIds] = useState(threadIds);
+  const createdLabel = useRef<{ name: string; id: string } | null>(null);
+  const { executeAsync: createLabel } = useAction(
+    createLabelAction.bind(null, emailAccountId),
+  );
+  const { executeAsync: applyLabel } = useAction(
+    applyThreadLabelsAction.bind(null, emailAccountId),
+  );
+  const name = search.trim();
+  const canCreate =
+    name.length > 0 &&
+    !userLabels.some(
+      (label) => label.name.toLowerCase() === name.toLowerCase(),
+    );
+
+  async function apply(labelId?: string) {
+    if (pending.current) return;
+    pending.current = true;
+    setIsPending(true);
+    try {
+      let id = labelId;
+      if (!id) {
+        if (createdLabel.current?.name === name) id = createdLabel.current.id;
+        else {
+          const result = await createLabel({ name });
+          if (!result?.data?.id)
+            throw new Error(getActionErrorMessage(result ?? {}));
+          id = result.data.id;
+          createdLabel.current = { name, id };
+          await mutate();
+        }
+      }
+      const result = await applyLabel({
+        threadIds: remainingThreadIds,
+        labelId: id,
+      });
+      if (!result?.data) throw new Error(getActionErrorMessage(result ?? {}));
+      const { succeededThreadIds, failedThreadIds } = result.data;
+      if (succeededThreadIds.length) {
+        onApplied(succeededThreadIds, id);
+        toast.success(
+          succeededThreadIds.length === 1
+            ? "Label applied"
+            : `Label applied to ${succeededThreadIds.length} conversations`,
+        );
+      }
+      setRemainingThreadIds(failedThreadIds);
+      if (failedThreadIds.length) {
+        toast.error(
+          `Couldn't label ${failedThreadIds.length} conversations. Select a label to retry.`,
+        );
+      } else onClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Couldn't apply label. Please try again.",
+      );
+    } finally {
+      pending.current = false;
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !pending.current) onClose();
+      }}
+    >
+      <DialogContent
+        className="gap-0 overflow-hidden p-0 sm:max-w-md"
+        onEscapeKeyDown={(event) => event.stopPropagation()}
+      >
+        <DialogHeader className="px-4 pt-4 pb-3">
+          <DialogTitle>Label conversations</DialogTitle>
+          <DialogDescription>
+            {remainingThreadIds.length === 1
+              ? "Apply a label to this conversation."
+              : `Apply a label to ${remainingThreadIds.length} conversations.`}{" "}
+            Conversations stay where they are.
+          </DialogDescription>
+        </DialogHeader>
+        <Command>
+          <CommandInput
+            aria-label="Search labels"
+            placeholder="Search or create a label…"
+            value={search}
+            onValueChange={setSearch}
+            disabled={isPending}
+          />
+          <LoadingContent loading={isLoading} error={error}>
+            <CommandList aria-busy={isPending}>
+              <CommandEmpty>No matching labels.</CommandEmpty>
+              <CommandGroup>
+                {userLabels.map((label) => (
+                  <CommandItem
+                    key={label.id}
+                    value={label.id}
+                    keywords={[label.name]}
+                    onSelect={() => apply(label.id)}
+                    disabled={isPending}
+                  >
+                    <TagIcon className="mr-2 size-4 shrink-0" />
+                    <span className="break-all">{label.name}</span>
+                  </CommandItem>
+                ))}
+                {canCreate && (
+                  <CommandItem
+                    value={`create:${name}`}
+                    onSelect={() => apply()}
+                    disabled={isPending}
+                  >
+                    <PlusIcon className="mr-2 size-4 shrink-0" />
+                    <span className="break-all">Create and apply “{name}”</span>
+                  </CommandItem>
+                )}
+              </CommandGroup>
+            </CommandList>
+          </LoadingContent>
+        </Command>
+        {isPending && (
+          <p className="px-4 py-2 text-muted-foreground text-sm" role="status">
+            Applying label…
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -33,6 +33,7 @@ import type {
   NewSplitDraft,
   NewSplitOption,
 } from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
+import { LabelPickerDialog } from "@/app/(app)/[emailAccountId]/mail/LabelPickerDialog";
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
 import {
@@ -52,6 +53,7 @@ import { useMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-mail-threa
 import { useCombinedMailThreads } from "@/app/(app)/[emailAccountId]/mail/use-combined-mail-threads";
 import { useAdjacentThreadPrefetch } from "@/app/(app)/[emailAccountId]/mail/use-adjacent-thread-prefetch";
 import { useThreadPrefetchCoordinator } from "@/app/(app)/[emailAccountId]/mail/thread-prefetch-coordinator";
+import { requestMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbox-sync";
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
@@ -167,6 +169,9 @@ export function MailShell() {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [labelTargets, setLabelTargets] = useState<ThreadSelection[] | null>(
+    null,
+  );
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
   const pendingReplyThreadKey = useRef<string | null>(null);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
@@ -632,6 +637,42 @@ export function MailShell() {
     (until: Date) => runOn((ids) => snooze(ids, until), true),
     [runOn, snooze],
   );
+  const labelTargetKeys = (() => {
+    if (selection.hasSelection) return [...selection.selectedIds];
+    if (openThreadKey) return [openThreadKey];
+    return focusedThread ? [getListThreadKey(focusedThread)] : [];
+  })();
+  const currentLabelTargets = labelTargetKeys.flatMap((key) => {
+    const thread = threads.find((thread) => getListThreadKey(thread) === key);
+    if (thread) return [getListThreadSelection(thread, emailAccountId)];
+    return key === openThreadKey && openThreadSelection
+      ? [openThreadSelection]
+      : [];
+  });
+  const labelAccountId = currentLabelTargets[0]?.emailAccountId;
+  const labelAccount =
+    labelAccountId === emailAccountId
+      ? emailAccount
+      : accountsData?.emailAccounts.find(
+          (account) => account.id === labelAccountId,
+        );
+  const canLabel =
+    currentLabelTargets.length > 0 &&
+    currentLabelTargets.length === labelTargetKeys.length &&
+    isGoogleProvider(labelAccount?.account.provider) &&
+    currentLabelTargets.every(
+      (target) => target.emailAccountId === labelAccountId,
+    );
+  const openLabelPicker = () => {
+    if (canLabel) setLabelTargets(currentLabelTargets);
+  };
+  const pickerAccount =
+    labelTargets?.[0]?.emailAccountId === emailAccountId
+      ? emailAccount
+      : accountsData?.emailAccounts.find(
+          (account) => account.id === labelTargets?.[0]?.emailAccountId,
+        );
+
   const commandTargetIds = useMemo(
     () =>
       selection.targetIds(
@@ -678,7 +719,10 @@ export function MailShell() {
     return () => setMailCommandContext(null);
   }, [mailCommandContext, setMailCommandContext]);
   const isMailOverlayOpen =
-    isHelpOpen || isPaletteOpen || (isMenuOpen && Boolean(openThreadId));
+    isHelpOpen ||
+    isPaletteOpen ||
+    Boolean(labelTargets) ||
+    (isMenuOpen && Boolean(openThreadId));
 
   const closeReader = () => {
     setOpenThread(null);
@@ -687,7 +731,7 @@ export function MailShell() {
   // Not memoised: `useShortcuts` keeps handlers in a ref and only re-registers
   // when the set of handled ids changes, so a stable identity buys nothing.
   const handlers: ShortcutHandlers = (() => {
-    if (sidePanelThreadId) return {};
+    if (sidePanelThreadId || labelTargets) return {};
     return {
       next: (event) => {
         if (openThreadId && event?.key === "ArrowDown") return;
@@ -717,6 +761,7 @@ export function MailShell() {
       // re-extends from the same row and the range never grows.
       extendSelectionDown: () => extendSelection(1),
       extendSelectionUp: () => extendSelection(-1),
+      label: canLabel ? openLabelPicker : undefined,
       archive: archiveTargets,
       delete: trashTargets,
       reply: () => {
@@ -1109,6 +1154,7 @@ export function MailShell() {
                 onSelectRangeTo={selection.selectRangeTo}
                 onArchiveSelected={archiveTargets}
                 onDeleteSelected={trashTargets}
+                onLabelSelected={canLabel ? openLabelPicker : undefined}
                 onClearSelection={selection.clear}
                 showLoadMore={hasMore}
                 isLoadingMore={isLoadingMore}
@@ -1154,6 +1200,7 @@ export function MailShell() {
                   isUnread={isOpenThreadUnread}
                   onMarkSpam={markSpamTargets}
                   onDelete={trashTargets}
+                  onLabel={canLabel ? openLabelPicker : undefined}
                   onToggleRead={() => {
                     if (!openThreadKey) return;
                     setReadState([openThreadKey], isOpenThreadUnread);
@@ -1187,6 +1234,41 @@ export function MailShell() {
         variant="compact"
       />
 
+      {labelTargets && pickerAccount && (
+        <EmailAccountScopeProvider emailAccount={pickerAccount}>
+          <LabelPickerDialog
+            threadIds={labelTargets.map((target) => target.threadId)}
+            onClose={() => setLabelTargets(null)}
+            onApplied={(threadIds, labelId) => {
+              const keys = threadIds.map((threadId) =>
+                isAllAccounts ? `${pickerAccount.id}:${threadId}` : threadId,
+              );
+              const updater = <
+                T extends { messages: { labelIds?: string[] }[] },
+              >(
+                thread: T,
+              ): T => ({
+                ...thread,
+                messages: thread.messages.map((message) => ({
+                  ...message,
+                  labelIds: [
+                    ...new Set([...(message.labelIds ?? []), labelId]),
+                  ],
+                })),
+              });
+              const update = isAllAccounts
+                ? combinedThreadState.optimisticallyUpdateThreads(keys, updater)
+                : accountThreadState.optimisticallyUpdateThreads(keys, updater);
+              for (const key of keys) update.commit(key);
+              requestMailboxSync(pickerAccount.id);
+              refetchOpenThread();
+              if (isAllAccounts) combinedThreadState.refetch();
+              mutateLabels();
+              mutateCounts();
+            }}
+          />
+        </EmailAccountScopeProvider>
+      )}
       <ShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
     </div>
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
@@ -13,6 +13,7 @@ export type SelectionBarProps = {
   onArchive: () => void;
   onDelete: () => void;
   onClear: () => void;
+  onLabel?: () => void;
 };
 
 /** The band above the list. Rendered only while the selection is non-empty. */
@@ -21,6 +22,7 @@ export function SelectionBar({
   onArchive,
   onDelete,
   onClear,
+  onLabel,
 }: SelectionBarProps) {
   if (selectedCount === 0) return null;
 
@@ -54,6 +56,16 @@ export function SelectionBar({
         </TooltipTrigger>
         <TooltipContent>Delete ({getShortcutHint("delete")})</TooltipContent>
       </Tooltip>
+      {onLabel && (
+        <Button
+          onClick={onLabel}
+          size="xs-2"
+          variant="outline"
+          title={`Label (${getShortcutHint("label")})`}
+        >
+          Label
+        </Button>
+      )}
       <Button onClick={onClear} size="xs-2" variant="ghost">
         Clear
       </Button>

--- a/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SelectionBar.tsx
@@ -57,14 +57,14 @@ export function SelectionBar({
         <TooltipContent>Delete ({getShortcutHint("delete")})</TooltipContent>
       </Tooltip>
       {onLabel && (
-        <Button
-          onClick={onLabel}
-          size="xs-2"
-          variant="outline"
-          title={`Label (${getShortcutHint("label")})`}
-        >
-          Label
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button onClick={onLabel} size="xs-2" variant="outline">
+              Label
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Label ({getShortcutHint("label")})</TooltipContent>
+        </Tooltip>
       )}
       <Button onClick={onClear} size="xs-2" variant="ghost">
         Clear

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -11,6 +11,7 @@ import {
   ShieldAlertIcon,
   SparklesIcon,
   Trash2Icon,
+  TagIcon,
 } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
@@ -58,6 +59,7 @@ export type ThreadActionsMenuProps = {
   onMarkSpam: () => void;
   onDelete: () => void;
   onToggleRead: () => void;
+  onLabel?: () => void;
   /** Chat remains scoped to the route account, so cross-account rows hide it. */
   showFixWithChat?: boolean;
   open?: boolean;
@@ -76,6 +78,7 @@ export function ThreadActionsMenu({
   onMarkSpam,
   onDelete,
   onToggleRead,
+  onLabel,
   showFixWithChat = true,
   open,
   onOpenChange,
@@ -143,6 +146,16 @@ export function ThreadActionsMenu({
           ) : null}
 
           {plans.length > 0 ? <DropdownMenuSeparator /> : null}
+
+          {onLabel && (
+            <DropdownMenuItem onSelect={onLabel}>
+              <TagIcon className="mr-2 size-4" />
+              Label
+              <DropdownMenuShortcut>
+                {getShortcutHint("label")}
+              </DropdownMenuShortcut>
+            </DropdownMenuItem>
+          )}
 
           <DropdownMenuItem onSelect={onToggleRead}>
             <ReadIcon className="mr-2 size-4" />

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -34,6 +34,7 @@ export type ThreadListProps = {
   onSelectRangeTo: (index: number) => void;
   onArchiveSelected: () => void;
   onDeleteSelected: () => void;
+  onLabelSelected?: () => void;
   onClearSelection: () => void;
   showLoadMore: boolean;
   isLoadingMore: boolean;
@@ -57,6 +58,7 @@ export function ThreadList({
   onSelectRangeTo,
   onArchiveSelected,
   onDeleteSelected,
+  onLabelSelected,
   onClearSelection,
   showLoadMore,
   isLoadingMore,
@@ -129,6 +131,7 @@ export function ThreadList({
           onArchive={onArchiveSelected}
           onClear={onClearSelection}
           onDelete={onDeleteSelected}
+          onLabel={onLabelSelected}
           selectedCount={selectedCount}
         />
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -642,6 +642,7 @@ export function useCombinedMailThreads({
     isLoadingMore: isLoadingMore || isLoadingMoreLocally,
     failedAccountIds,
     labelsByAccount,
+    refetch: mutate,
     removeThreads,
     restoreThreads,
     optimisticallyUpdateThreads,

--- a/apps/web/hooks/useLabels.test.ts
+++ b/apps/web/hooks/useLabels.test.ts
@@ -63,6 +63,19 @@ describe("useLabels", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("scopes label requests to the conversation's account", async () => {
+    mockUseAccount.mockReturnValue({
+      emailAccount: { id: "account-2" },
+      isLoading: false,
+      providerRateLimit: null,
+    });
+    const { useLabels } = await import("./useLabels");
+    renderHook(() => useLabels("account-2"));
+    expect(mockUseSWR).toHaveBeenCalledWith(["/api/labels", "account-2"], {
+      shouldRetryOnError: false,
+    });
+  });
+
   it("fetches labels once the selected account is clear", async () => {
     mockUseAccount.mockReturnValue({
       emailAccount: { id: "account-1" },

--- a/apps/web/hooks/useLabels.test.ts
+++ b/apps/web/hooks/useLabels.test.ts
@@ -65,7 +65,7 @@ describe("useLabels", () => {
 
   it("scopes label requests to the conversation's account", async () => {
     mockUseAccount.mockReturnValue({
-      emailAccount: { id: "account-2" },
+      emailAccount: { id: "account-1" },
       isLoading: false,
       providerRateLimit: null,
     });

--- a/apps/web/hooks/useLabels.ts
+++ b/apps/web/hooks/useLabels.ts
@@ -30,16 +30,17 @@ function isHidden(label: EmailLabel): boolean {
   return label.labelListVisibility === "labelHide";
 }
 
-function useLabelsResponse() {
+function useLabelsResponse(explicitEmailAccountId?: string) {
   const {
     emailAccount,
     isLoading: isLoadingEmailAccount,
     providerRateLimit,
   } = useAccount();
+  const key = explicitEmailAccountId
+    ? ["/api/labels", explicitEmailAccountId]
+    : "/api/labels";
   const swr = useSWR<LabelsResponse>(
-    !isLoadingEmailAccount && emailAccount && !providerRateLimit
-      ? "/api/labels"
-      : null,
+    !isLoadingEmailAccount && emailAccount && !providerRateLimit ? key : null,
     { shouldRetryOnError: false },
   );
 
@@ -69,8 +70,8 @@ export function useAllLabels() {
   };
 }
 
-export function useLabels() {
-  const { data, isLoading, error, mutate } = useLabelsResponse();
+export function useLabels(emailAccountId?: string) {
+  const { data, isLoading, error, mutate } = useLabelsResponse(emailAccountId);
 
   const userLabels: EmailLabel[] = useMemo(() => {
     if (!data?.labels) return [];

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -160,6 +160,13 @@ const SHORTCUT_DEFINITIONS = [
     },
   },
   {
+    id: "label",
+    keys: ["l"],
+    scope: "mail",
+    group: "Triage",
+    label: "Label",
+  },
+  {
     id: "snooze",
     keys: ["h"],
     scope: "mail",

--- a/apps/web/utils/actions/mail-label.test.ts
+++ b/apps/web/utils/actions/mail-label.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { applyThreadLabelsAction } from "@/utils/actions/mail-label";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+const { modify, getLabel } = vi.hoisted(() => ({
+  modify: vi.fn(),
+  getLabel: vi.fn(),
+}));
+vi.mock("@/utils/email-account-client", () => ({
+  getGmailClientForEmail: vi.fn(async () => ({
+    users: { threads: { modify }, labels: { get: getLabel } },
+  })),
+}));
+
+describe("manual thread labels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        email: "user@example.com",
+        userId: "user-1",
+        provider: "google",
+      }),
+    );
+    getLabel.mockResolvedValue({
+      data: { id: "label-1", name: "Projects", type: "user" },
+    });
+    modify.mockResolvedValue({ data: {} });
+  });
+
+  it("adds a label to each whole conversation without removing inbox or other labels", async () => {
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1", "thread-2", "thread-1"],
+      labelId: "label-1",
+    });
+    expect(result?.data).toEqual({
+      succeededThreadIds: ["thread-1", "thread-2"],
+      failedThreadIds: [],
+    });
+    expect(modify).toHaveBeenCalledTimes(2);
+    for (const id of ["thread-1", "thread-2"]) {
+      expect(modify).toHaveBeenCalledWith({
+        userId: "me",
+        id,
+        requestBody: { addLabelIds: ["label-1"], removeLabelIds: undefined },
+      });
+    }
+  });
+
+  it("reports partial failures so successful conversations are not retried", async () => {
+    modify.mockRejectedValueOnce(new Error("Invalid request"));
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1", "thread-2"],
+      labelId: "label-1",
+    });
+    expect(result?.data).toEqual({
+      succeededThreadIds: ["thread-2"],
+      failedThreadIds: ["thread-1"],
+    });
+  });
+
+  it("rejects system labels before modifying conversations", async () => {
+    getLabel.mockResolvedValue({ data: { id: "TRASH", type: "system" } });
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1"],
+      labelId: "TRASH",
+    });
+    expect(result?.serverError).toBe("Select a user-created Gmail label.");
+    expect(modify).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported accounts", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        email: "user@example.com",
+        userId: "user-1",
+        provider: "microsoft",
+      }),
+    );
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1"],
+      labelId: "label-1",
+    });
+    expect(result?.serverError).toBe(
+      "Manual labeling is available for Gmail accounts.",
+    );
+    expect(modify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/mail-label.test.ts
+++ b/apps/web/utils/actions/mail-label.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
+import { redis } from "@/utils/redis";
 import { applyThreadLabelsAction } from "@/utils/actions/mail-label";
 
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/redis", () => ({
+  redis: { get: vi.fn(), set: vi.fn(), del: vi.fn() },
+}));
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({
     user: { id: "user-1", email: "user@example.com" },
@@ -21,7 +25,8 @@ vi.mock("@/utils/email-account-client", () => ({
 
 describe("manual thread labels", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    vi.mocked(redis.get).mockResolvedValue(null);
     prisma.emailAccount.findUnique.mockResolvedValue(
       getMockEmailAccountWithAccount({
         email: "user@example.com",
@@ -34,6 +39,8 @@ describe("manual thread labels", () => {
     });
     modify.mockResolvedValue({ data: {} });
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it("adds a label to each whole conversation without removing inbox or other labels", async () => {
     const result = await applyThreadLabelsAction("account-1", {
@@ -63,6 +70,67 @@ describe("manual thread labels", () => {
     expect(result?.data).toEqual({
       succeededThreadIds: ["thread-2"],
       failedThreadIds: ["thread-1"],
+    });
+  });
+
+  it("retries a transient label lookup failure", async () => {
+    vi.useFakeTimers();
+    getLabel.mockRejectedValueOnce(
+      Object.assign(new Error("Unavailable"), { status: 503 }),
+    );
+    const pendingResult = applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1"],
+      labelId: "label-1",
+    });
+    await vi.runAllTimersAsync();
+    const result = await pendingResult;
+    expect(getLabel).toHaveBeenCalledTimes(2);
+    expect(result?.data?.succeededThreadIds).toEqual(["thread-1"]);
+  });
+
+  it("does not call Gmail while the account is rate limited", async () => {
+    vi.mocked(redis.get).mockResolvedValue(
+      JSON.stringify({
+        provider: "google",
+        retryAt: new Date(Date.now() + 120_000).toISOString(),
+        detectedAt: new Date().toISOString(),
+      }),
+    );
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: ["thread-1"],
+      labelId: "label-1",
+    });
+    expect(result?.serverError).toBeTruthy();
+    expect(getLabel).not.toHaveBeenCalled();
+    expect(modify).not.toHaveBeenCalled();
+  });
+
+  it("records throttling and skips later writes while preserving partial success", async () => {
+    let rateLimitState: string | null = null;
+    vi.mocked(redis.get).mockImplementation(async () => rateLimitState);
+    vi.mocked(redis.set).mockImplementation(async (_key, value) => {
+      rateLimitState = String(value);
+      return "OK";
+    });
+    modify.mockRejectedValueOnce(
+      Object.assign(new Error("Rate limit exceeded"), {
+        status: 429,
+        response: { headers: { "retry-after": "120" } },
+      }),
+    );
+    const result = await applyThreadLabelsAction("account-1", {
+      threadIds: Array.from({ length: 6 }, (_, index) => `thread-${index + 1}`),
+      labelId: "label-1",
+    });
+    expect(redis.set).toHaveBeenCalledWith(
+      "email-provider-rate-limit:account-1",
+      expect.any(String),
+      expect.objectContaining({ ex: expect.any(Number) }),
+    );
+    expect(modify).toHaveBeenCalledTimes(5);
+    expect(result?.data).toEqual({
+      succeededThreadIds: ["thread-2", "thread-3", "thread-4", "thread-5"],
+      failedThreadIds: ["thread-1", "thread-6"],
     });
   });
 

--- a/apps/web/utils/actions/mail-label.ts
+++ b/apps/web/utils/actions/mail-label.ts
@@ -36,7 +36,7 @@ export const applyThreadLabelsAction = actionClient
       });
       const succeededThreadIds: string[] = [];
       const failedThreadIds: string[] = [];
-      results.forEach(({ item: threadId, result }) => {
+      for (const { item: threadId, result } of results) {
         if (result.status === "fulfilled") succeededThreadIds.push(threadId);
         else {
           failedThreadIds.push(threadId);
@@ -44,7 +44,7 @@ export const applyThreadLabelsAction = actionClient
             error: result.reason,
           });
         }
-      });
+      }
       return { succeededThreadIds, failedThreadIds };
     },
   );

--- a/apps/web/utils/actions/mail-label.ts
+++ b/apps/web/utils/actions/mail-label.ts
@@ -6,7 +6,11 @@ import { applyThreadLabelsBody } from "@/utils/actions/mail-label.validation";
 import { getGmailClientForEmail } from "@/utils/email-account-client";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { SafeError } from "@/utils/error";
-import { labelThread } from "@/utils/gmail/label";
+import {
+  assertProviderNotRateLimited,
+  withRateLimitRecording,
+} from "@/utils/email/rate-limit";
+import { getLabelById, labelThread } from "@/utils/gmail/label";
 
 export const applyThreadLabelsAction = actionClient
   .metadata({ name: "applyThreadLabels" })
@@ -19,11 +23,17 @@ export const applyThreadLabelsAction = actionClient
       if (!isGoogleProvider(provider)) {
         throw new SafeError("Manual labeling is available for Gmail accounts.");
       }
+      const rateLimitContext = {
+        emailAccountId,
+        provider,
+        logger,
+        source: "apply-thread-labels",
+      };
+      await assertProviderNotRateLimited(rateLimitContext);
       const gmail = await getGmailClientForEmail({ emailAccountId, logger });
-      const { data: label } = await gmail.users.labels.get({
-        userId: "me",
-        id: labelId,
-      });
+      const label = await withRateLimitRecording(rateLimitContext, () =>
+        getLabelById({ gmail, id: labelId }),
+      );
       if (label.type !== "user") {
         throw new SafeError("Select a user-created Gmail label.");
       }
@@ -31,8 +41,12 @@ export const applyThreadLabelsAction = actionClient
       const results = await runWithBoundedConcurrency({
         items: targets,
         concurrency: 5,
-        run: (threadId) =>
-          labelThread({ gmail, threadId, addLabelIds: [labelId] }),
+        run: async (threadId) => {
+          await assertProviderNotRateLimited(rateLimitContext);
+          return withRateLimitRecording(rateLimitContext, () =>
+            labelThread({ gmail, threadId, addLabelIds: [labelId] }),
+          );
+        },
       });
       const succeededThreadIds: string[] = [];
       const failedThreadIds: string[] = [];

--- a/apps/web/utils/actions/mail-label.ts
+++ b/apps/web/utils/actions/mail-label.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { runWithBoundedConcurrency } from "@/utils/async";
+import { actionClient } from "@/utils/actions/safe-action";
+import { applyThreadLabelsBody } from "@/utils/actions/mail-label.validation";
+import { getGmailClientForEmail } from "@/utils/email-account-client";
+import { isGoogleProvider } from "@/utils/email/provider-types";
+import { SafeError } from "@/utils/error";
+import { labelThread } from "@/utils/gmail/label";
+
+export const applyThreadLabelsAction = actionClient
+  .metadata({ name: "applyThreadLabels" })
+  .inputSchema(applyThreadLabelsBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, provider, logger },
+      parsedInput: { threadIds, labelId },
+    }) => {
+      if (!isGoogleProvider(provider)) {
+        throw new SafeError("Manual labeling is available for Gmail accounts.");
+      }
+      const gmail = await getGmailClientForEmail({ emailAccountId, logger });
+      const { data: label } = await gmail.users.labels.get({
+        userId: "me",
+        id: labelId,
+      });
+      if (label.type !== "user") {
+        throw new SafeError("Select a user-created Gmail label.");
+      }
+      const targets = [...new Set(threadIds)];
+      const results = await runWithBoundedConcurrency({
+        items: targets,
+        concurrency: 5,
+        run: (threadId) =>
+          labelThread({ gmail, threadId, addLabelIds: [labelId] }),
+      });
+      const succeededThreadIds: string[] = [];
+      const failedThreadIds: string[] = [];
+      results.forEach(({ item: threadId, result }) => {
+        if (result.status === "fulfilled") succeededThreadIds.push(threadId);
+        else {
+          failedThreadIds.push(threadId);
+          logger.error("Failed to apply thread label", {
+            error: result.reason,
+          });
+        }
+      });
+      return { succeededThreadIds, failedThreadIds };
+    },
+  );

--- a/apps/web/utils/actions/mail-label.validation.ts
+++ b/apps/web/utils/actions/mail-label.validation.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const applyThreadLabelsBody = z.object({
+  threadIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(500, "Select up to 500 conversations at a time."),
+  labelId: z.string().min(1),
+});

--- a/apps/web/utils/actions/mail-label.validation.ts
+++ b/apps/web/utils/actions/mail-label.validation.ts
@@ -5,6 +5,9 @@ export const applyThreadLabelsBody = z.object({
   threadIds: z
     .array(z.string().min(1))
     .min(1)
-    .max(MAX_LABEL_THREADS_PER_ACTION),
+    .max(
+      MAX_LABEL_THREADS_PER_ACTION,
+      "Couldn’t process this selection. Please try again.",
+    ),
   labelId: z.string().min(1),
 });

--- a/apps/web/utils/actions/mail-label.validation.ts
+++ b/apps/web/utils/actions/mail-label.validation.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
+import { MAX_LABEL_THREADS_PER_ACTION } from "@/utils/label/apply-thread-labels";
 
 export const applyThreadLabelsBody = z.object({
   threadIds: z
     .array(z.string().min(1))
     .min(1)
-    .max(500, "Select up to 500 conversations at a time."),
+    .max(MAX_LABEL_THREADS_PER_ACTION),
   labelId: z.string().min(1),
 });

--- a/apps/web/utils/label/apply-thread-labels.test.ts
+++ b/apps/web/utils/label/apply-thread-labels.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyThreadLabelsInBatches,
+  MAX_LABEL_THREADS_PER_ACTION,
+} from "./apply-thread-labels";
+
+describe("batched manual labels", () => {
+  const targets = Array.from(
+    { length: MAX_LABEL_THREADS_PER_ACTION * 2 + 1 },
+    (_, i) => `thread-${i}`,
+  );
+  it("splits large selections and keeps per-conversation failures", async () => {
+    const applyBatch = vi.fn(async (threadIds: string[]) => ({
+      succeededThreadIds: threadIds.slice(1),
+      failedThreadIds: threadIds.slice(0, 1),
+    }));
+    const result = await applyThreadLabelsInBatches({
+      threadIds: [...targets, targets[0]],
+      applyBatch,
+    });
+    expect(applyBatch.mock.calls.map(([ids]) => ids.length)).toEqual([
+      25, 25, 1,
+    ]);
+    expect(result.failedThreadIds).toEqual([
+      targets[0],
+      targets[25],
+      targets[50],
+    ]);
+    expect(result.succeededThreadIds).toHaveLength(48);
+    expect(result.error).toBeUndefined();
+  });
+  it("retains failed and unattempted conversations after a request fails", async () => {
+    const error = new Error("Connection interrupted");
+    const applyBatch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        succeededThreadIds: targets.slice(1, 25),
+        failedThreadIds: [targets[0]],
+      })
+      .mockRejectedValueOnce(error);
+    const result = await applyThreadLabelsInBatches({
+      threadIds: targets,
+      applyBatch,
+    });
+    expect(applyBatch).toHaveBeenCalledTimes(2);
+    expect(result.succeededThreadIds).toEqual(targets.slice(1, 25));
+    expect(result.failedThreadIds).toEqual([targets[0], ...targets.slice(25)]);
+    expect(result.error).toBe(error);
+  });
+});

--- a/apps/web/utils/label/apply-thread-labels.ts
+++ b/apps/web/utils/label/apply-thread-labels.ts
@@ -1,0 +1,35 @@
+export const MAX_LABEL_THREADS_PER_ACTION = 25;
+
+export async function applyThreadLabelsInBatches({
+  threadIds,
+  applyBatch,
+}: {
+  threadIds: string[];
+  applyBatch: (threadIds: string[]) => Promise<{
+    succeededThreadIds: string[];
+    failedThreadIds: string[];
+  }>;
+}) {
+  const targets = [...new Set(threadIds)];
+  const succeededThreadIds: string[] = [];
+  const failedThreadIds: string[] = [];
+  for (
+    let index = 0;
+    index < targets.length;
+    index += MAX_LABEL_THREADS_PER_ACTION
+  ) {
+    const batch = targets.slice(index, index + MAX_LABEL_THREADS_PER_ACTION);
+    try {
+      const result = await applyBatch(batch);
+      succeededThreadIds.push(...result.succeededThreadIds);
+      failedThreadIds.push(...result.failedThreadIds);
+    } catch (error) {
+      return {
+        succeededThreadIds,
+        failedThreadIds: [...failedThreadIds, ...targets.slice(index)],
+        error,
+      };
+    }
+  }
+  return { succeededThreadIds, failedThreadIds, error: undefined };
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260906-071154_pr-3531_b84b02c49464/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Depends on #3509 (merge first)

Adds a searchable label picker to `/mail` so users can apply existing Gmail labels or create and apply a label without moving conversations.

- Open with `L`, the reader's Label menu item, or the bulk selection Label button; bulk targets stay within one Gmail account.
- Preserve current conversation targeting, refresh visible labels and mailbox data, and batch large selections and retain failed targets for retry.
- Validated with 34 unit tests, four emulated browser flows plus sign-in setup, formatting checks, and screenshot inspection.