### PR TITLE
assistant: Centralize confirmation reservations

### DIFF
--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -905,140 +905,76 @@ async function reservePendingAssistantEmailAction({
   persistenceWaitMs?: number;
   logger: Logger;
 }) {
-  const matchEmailParts = (parts: unknown) =>
-    !!findPendingAssistantEmailPart({ parts, toolCallId, actionType });
   const waitForPersistenceMs = waitForPersistence
     ? (persistenceWaitMs ?? PENDING_ACTION_PERSIST_WAIT_MS)
     : undefined;
 
-  const chatMessage = await findChatMessageForPendingAction({
+  const reservation = await reservePendingAssistantPart({
     chatId,
     chatMessageId,
     emailAccountId,
     logger,
-    matchParts: matchEmailParts,
+    findPart: (parts) =>
+      findPendingAssistantEmailPart({ parts, toolCallId, actionType }),
+    getConfirmed: (lookup) =>
+      lookup.output.confirmationState === "confirmed" &&
+      lookup.output.confirmationResult
+        ? lookup.output.confirmationResult
+        : null,
+    validateLookup: (lookup) => {
+      if (lookup.output.emailAccountId !== emailAccountId) {
+        throw new SafeError(
+          "The sending mailbox for this draft could not be verified. Prepare the draft again in the account you want to send from.",
+        );
+      }
+    },
     logPrefix: "Assistant email confirmation",
     waitForPersistenceMs,
+    inProgressError: CONFIRMATION_IN_PROGRESS_ERROR,
+    onMessageNotFound: () =>
+      warnAndThrowAssistantEmailConfirmationError({
+        logger,
+        logMessage:
+          "Assistant email confirmation failed: chat message not found",
+        safeMessage: "Chat message not found",
+        chatMessageId,
+        toolCallId,
+        actionType,
+      }),
+    onPartNotFound: (resolvedChatMessageId) =>
+      warnAndThrowAssistantEmailConfirmationError({
+        logger,
+        logMessage:
+          "Assistant email confirmation failed: pending assistant action not found",
+        safeMessage: "Pending assistant action not found",
+        chatMessageId: resolvedChatMessageId,
+        toolCallId,
+        actionType,
+      }),
+    onRaceMessageNotFound: (resolvedChatMessageId) =>
+      warnAndThrowAssistantEmailConfirmationError({
+        logger,
+        logMessage:
+          "Assistant email confirmation failed after reservation race: chat message not found",
+        safeMessage: "Chat message not found",
+        chatMessageId: resolvedChatMessageId,
+        toolCallId,
+        actionType,
+      }),
   });
 
-  if (!chatMessage) {
-    warnAndThrowAssistantEmailConfirmationError({
-      logger,
-      logMessage: "Assistant email confirmation failed: chat message not found",
-      safeMessage: "Chat message not found",
-      chatMessageId,
-      toolCallId,
-      actionType,
-    });
-  }
-
-  const lookup = findPendingAssistantEmailPart({
-    parts: chatMessage.parts,
-    toolCallId,
-    actionType,
-  });
-  if (!lookup) {
-    warnAndThrowAssistantEmailConfirmationError({
-      logger,
-      logMessage:
-        "Assistant email confirmation failed: pending assistant action not found",
-      safeMessage: "Pending assistant action not found",
-      chatMessageId: chatMessage.id,
-      toolCallId,
-      actionType,
-    });
-  }
-
-  if (
-    lookup.output.confirmationState === "confirmed" &&
-    lookup.output.confirmationResult
-  ) {
+  if (reservation.status === "confirmed") {
     return {
       status: "confirmed" as const,
-      confirmationResult: lookup.output.confirmationResult,
+      confirmationResult: reservation.value,
     };
   }
 
-  if (lookup.output.emailAccountId !== emailAccountId) {
-    throw new SafeError(
-      "The sending mailbox for this draft could not be verified. Prepare the draft again in the account you want to send from.",
-    );
-  }
-
-  if (
-    lookup.output.confirmationState === "processing" &&
-    !hasProcessingLeaseExpired(lookup.output.confirmationProcessingAt)
-  ) {
-    throw new SafeError(CONFIRMATION_IN_PROGRESS_ERROR);
-  }
-
-  const processingAt = new Date().toISOString();
-  const processingParts = updateAssistantEmailPartWithProcessing({
-    parts: lookup.parts,
-    partIndex: lookup.index,
-    processingAt,
-  });
-
-  const claim = await prisma.chatMessage.updateMany({
-    where: {
-      id: chatMessage.id,
-      chatId: chatMessage.chatId,
-      updatedAt: chatMessage.updatedAt,
-    },
-    data: {
-      parts: processingParts as Prisma.InputJsonValue,
-    },
-  });
-
-  if (claim.count === 1) {
-    return {
-      status: "reserved" as const,
-      chatMessageId: chatMessage.id,
-      output: lookup.output,
-      parts: processingParts,
-      partIndex: lookup.index,
-    };
-  }
-
-  const latestMessage = await findChatMessageForPendingAction({
-    chatId,
-    chatMessageId,
-    emailAccountId,
-    logger,
-    matchParts: matchEmailParts,
-    logPrefix: "Assistant email confirmation",
-    waitForPersistenceMs,
-  });
-
-  if (!latestMessage) {
-    warnAndThrowAssistantEmailConfirmationError({
-      logger,
-      logMessage:
-        "Assistant email confirmation failed after reservation race: chat message not found",
-      safeMessage: "Chat message not found",
-      chatMessageId: chatMessage.id,
-      toolCallId,
-      actionType,
-    });
-  }
-
-  const latestLookup = findPendingAssistantEmailPart({
-    parts: latestMessage.parts,
-    toolCallId,
-    actionType,
-  });
-
-  if (
-    latestLookup?.output.confirmationState === "confirmed" &&
-    latestLookup.output.confirmationResult
-  ) {
-    return {
-      status: "confirmed" as const,
-      confirmationResult: latestLookup.output.confirmationResult,
-    };
-  }
-
-  throw new SafeError(CONFIRMATION_IN_PROGRESS_ERROR);
+  return {
+    status: "reserved" as const,
+    chatMessageId: reservation.chatMessageId,
+    output: reservation.lookup.output,
+  };
 }
 
 async function clearPendingPartProcessing({
@@ -1328,121 +1264,61 @@ async function reservePendingAssistantSaveMemory({
   waitForPersistence?: boolean;
   logger: Logger;
 }) {
-  const matchSaveMemoryParts = (parts: unknown) =>
-    !!findPendingAssistantSaveMemoryPart({ parts, toolCallId });
   const waitForPersistenceMs = waitForPersistence
     ? PENDING_ACTION_PERSIST_WAIT_MS
     : undefined;
 
-  const chatMessage = await findChatMessageForPendingAction({
+  const reservation = await reservePendingAssistantPart({
     chatId,
     chatMessageId,
     emailAccountId,
     logger,
-    matchParts: matchSaveMemoryParts,
+    findPart: (parts) =>
+      findPendingAssistantSaveMemoryPart({ parts, toolCallId }),
+    getConfirmed: (lookup) =>
+      lookup.output.confirmationState === "confirmed" &&
+      lookup.output.confirmationResult
+        ? lookup.output.confirmationResult
+        : null,
     logPrefix: "Assistant save memory confirmation",
     waitForPersistenceMs,
-  });
-
-  if (!chatMessage) {
-    logger.warn("Assistant save memory confirmation: chat message not found", {
-      chatMessageId,
-      toolCallId,
-    });
-    throw new SafeError("Chat message not found");
-  }
-
-  const lookup = findPendingAssistantSaveMemoryPart({
-    parts: chatMessage.parts,
-    toolCallId,
-  });
-
-  if (!lookup) {
-    logger.warn("Assistant save memory confirmation: pending not found", {
-      chatMessageId: chatMessage.id,
-      toolCallId,
-    });
-    throw new SafeError("Pending memory save not found");
-  }
-
-  if (
-    lookup.output.confirmationState === "confirmed" &&
-    lookup.output.confirmationResult
-  ) {
-    return {
-      status: "confirmed" as const,
-      content: lookup.output.confirmationResult.content,
-      confirmationResult: lookup.output.confirmationResult,
-    };
-  }
-
-  if (
-    lookup.output.confirmationState === "processing" &&
-    !hasProcessingLeaseExpired(lookup.output.confirmationProcessingAt)
-  ) {
-    throw new SafeError(SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR);
-  }
-
-  const processingAt = new Date().toISOString();
-  const processingParts = updateAssistantEmailPartWithProcessing({
-    parts: lookup.parts,
-    partIndex: lookup.index,
-    processingAt,
-  });
-
-  const claim = await prisma.chatMessage.updateMany({
-    where: {
-      id: chatMessage.id,
-      chatId: chatMessage.chatId,
-      updatedAt: chatMessage.updatedAt,
+    inProgressError: SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR,
+    onMessageNotFound: () => {
+      logger.warn(
+        "Assistant save memory confirmation: chat message not found",
+        {
+          chatMessageId,
+          toolCallId,
+        },
+      );
+      throw new SafeError("Chat message not found");
     },
-    data: {
-      parts: processingParts as Prisma.InputJsonValue,
+    onPartNotFound: (resolvedChatMessageId) => {
+      logger.warn("Assistant save memory confirmation: pending not found", {
+        chatMessageId: resolvedChatMessageId,
+        toolCallId,
+      });
+      throw new SafeError("Pending memory save not found");
+    },
+    onRaceMessageNotFound: () => {
+      throw new SafeError("Chat message not found");
     },
   });
 
-  if (claim.count === 1) {
-    return {
-      status: "reserved" as const,
-      chatMessageId: chatMessage.id,
-      output: lookup.output,
-      parts: processingParts,
-      partIndex: lookup.index,
-      toolInput: lookup.toolInput,
-    };
-  }
-
-  const latestMessage = await findChatMessageForPendingAction({
-    chatId,
-    chatMessageId,
-    emailAccountId,
-    logger,
-    matchParts: matchSaveMemoryParts,
-    logPrefix: "Assistant save memory confirmation",
-    waitForPersistenceMs,
-  });
-
-  if (!latestMessage) {
-    throw new SafeError("Chat message not found");
-  }
-
-  const latestLookup = findPendingAssistantSaveMemoryPart({
-    parts: latestMessage.parts,
-    toolCallId,
-  });
-
-  if (
-    latestLookup?.output.confirmationState === "confirmed" &&
-    latestLookup.output.confirmationResult
-  ) {
+  if (reservation.status === "confirmed") {
     return {
       status: "confirmed" as const,
-      content: latestLookup.output.confirmationResult.content,
-      confirmationResult: latestLookup.output.confirmationResult,
+      content: reservation.value.content,
+      confirmationResult: reservation.value,
     };
   }
 
-  throw new SafeError(SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR);
+  return {
+    status: "reserved" as const,
+    chatMessageId: reservation.chatMessageId,
+    output: reservation.lookup.output,
+    toolInput: reservation.lookup.toolInput,
+  };
 }
 
 async function reservePendingAssistantCreateRule({
@@ -1460,62 +1336,138 @@ async function reservePendingAssistantCreateRule({
   waitForPersistence?: boolean;
   logger: Logger;
 }) {
-  const matchCreateRuleParts = (parts: unknown) =>
-    !!findPendingAssistantCreateRulePart({ parts, toolCallId });
   const waitForPersistenceMs = waitForPersistence
     ? PENDING_ACTION_PERSIST_WAIT_MS
     : undefined;
 
-  const chatMessage = await findChatMessageForPendingAction({
+  const reservation = await reservePendingAssistantPart({
     chatId,
     chatMessageId,
     emailAccountId,
     logger,
-    matchParts: matchCreateRuleParts,
+    findPart: (parts) =>
+      findPendingAssistantCreateRulePart({ parts, toolCallId }),
+    getConfirmed: (lookup) =>
+      lookup.output.confirmationState === "confirmed" && lookup.output.ruleId
+        ? lookup.output.ruleId
+        : null,
     logPrefix: "Assistant create rule confirmation",
     waitForPersistenceMs,
+    inProgressError: CONFIRMATION_IN_PROGRESS_ERROR,
+    onMessageNotFound: () => {
+      logger.warn(
+        "Assistant create rule confirmation: chat message not found",
+        {
+          chatMessageId,
+          toolCallId,
+        },
+      );
+      throw new SafeError("Chat message not found");
+    },
+    onPartNotFound: (resolvedChatMessageId) => {
+      logger.warn("Assistant create rule confirmation: pending not found", {
+        chatMessageId: resolvedChatMessageId,
+        toolCallId,
+      });
+      throw new SafeError("Pending rule creation not found");
+    },
+    onRaceMessageNotFound: () => {
+      throw new SafeError("Chat message not found");
+    },
   });
 
-  if (!chatMessage) {
-    logger.warn("Assistant create rule confirmation: chat message not found", {
-      chatMessageId,
-      toolCallId,
-    });
-    throw new SafeError("Chat message not found");
-  }
-
-  const lookup = findPendingAssistantCreateRulePart({
-    parts: chatMessage.parts,
-    toolCallId,
-  });
-
-  if (!lookup) {
-    logger.warn("Assistant create rule confirmation: pending not found", {
-      chatMessageId: chatMessage.id,
-      toolCallId,
-    });
-    throw new SafeError("Pending rule creation not found");
-  }
-
-  if (lookup.output.confirmationState === "confirmed" && lookup.output.ruleId) {
+  if (reservation.status === "confirmed") {
     return {
       status: "confirmed" as const,
-      ruleId: lookup.output.ruleId,
+      ruleId: reservation.value,
     };
   }
+
+  return {
+    status: "reserved" as const,
+    chatMessageId: reservation.chatMessageId,
+    output: reservation.lookup.output,
+    toolInput: reservation.lookup.toolInput,
+  };
+}
+
+async function reservePendingAssistantPart<
+  TLookup extends {
+    index: number;
+    parts: unknown[];
+    output: {
+      confirmationState: string;
+      confirmationProcessingAt?: string | null;
+    };
+  },
+  TConfirmed,
+>({
+  chatId,
+  chatMessageId,
+  emailAccountId,
+  logger,
+  findPart,
+  getConfirmed,
+  validateLookup,
+  logPrefix,
+  waitForPersistenceMs,
+  inProgressError,
+  onMessageNotFound,
+  onPartNotFound,
+  onRaceMessageNotFound,
+}: {
+  chatId: string;
+  chatMessageId?: string;
+  emailAccountId: string;
+  logger: Logger;
+  findPart: (parts: unknown) => TLookup | null;
+  getConfirmed: (lookup: TLookup) => TConfirmed | null;
+  validateLookup?: (lookup: TLookup) => void;
+  logPrefix: string;
+  waitForPersistenceMs?: number;
+  inProgressError: string;
+  onMessageNotFound: () => never;
+  onPartNotFound: (chatMessageId: string) => never;
+  onRaceMessageNotFound: (chatMessageId: string) => never;
+}): Promise<
+  | { status: "confirmed"; value: TConfirmed }
+  | { status: "reserved"; chatMessageId: string; lookup: TLookup }
+> {
+  const findMessage = () =>
+    findChatMessageForPendingAction({
+      chatId,
+      chatMessageId,
+      emailAccountId,
+      logger,
+      matchParts: (parts) => !!findPart(parts),
+      logPrefix,
+      waitForPersistenceMs,
+    });
+
+  const chatMessage = await findMessage();
+  if (!chatMessage) return onMessageNotFound();
+
+  const lookup = findPart(chatMessage.parts);
+  if (!lookup) return onPartNotFound(chatMessage.id);
+
+  const confirmed = getConfirmed(lookup);
+  if (confirmed !== null) {
+    return { status: "confirmed", value: confirmed };
+  }
+
+  validateLookup?.(lookup);
 
   if (
     lookup.output.confirmationState === "processing" &&
     !hasProcessingLeaseExpired(lookup.output.confirmationProcessingAt)
   ) {
-    throw new SafeError(CONFIRMATION_IN_PROGRESS_ERROR);
+    throw new SafeError(inProgressError);
   }
 
-  const processingAt = new Date().toISOString();
   const processingParts = updateAssistantEmailPartWithProcessing({
     parts: lookup.parts,
     partIndex: lookup.index,
-    processingAt,
+    processingAt: new Date().toISOString(),
   });
 
   const claim = await prisma.chatMessage.updateMany({
@@ -1531,45 +1483,24 @@ async function reservePendingAssistantCreateRule({
 
   if (claim.count === 1) {
     return {
-      status: "reserved" as const,
+      status: "reserved",
       chatMessageId: chatMessage.id,
-      output: lookup.output,
-      parts: processingParts,
-      partIndex: lookup.index,
-      toolInput: lookup.toolInput,
+      lookup,
     };
   }
 
-  const latestMessage = await findChatMessageForPendingAction({
-    chatId,
-    chatMessageId,
-    emailAccountId,
-    logger,
-    matchParts: matchCreateRuleParts,
-    logPrefix: "Assistant create rule confirmation",
-    waitForPersistenceMs,
-  });
+  const latestMessage = await findMessage();
+  if (!latestMessage) return onRaceMessageNotFound(chatMessage.id);
 
-  if (!latestMessage) {
-    throw new SafeError("Chat message not found");
+  const latestLookup = findPart(latestMessage.parts);
+  if (latestLookup) {
+    const latestConfirmed = getConfirmed(latestLookup);
+    if (latestConfirmed !== null) {
+      return { status: "confirmed", value: latestConfirmed };
+    }
   }
 
-  const latestLookup = findPendingAssistantCreateRulePart({
-    parts: latestMessage.parts,
-    toolCallId,
-  });
-
-  if (
-    latestLookup?.output.confirmationState === "confirmed" &&
-    latestLookup.output.ruleId
-  ) {
-    return {
-      status: "confirmed" as const,
-      ruleId: latestLookup.output.ruleId,
-    };
-  }
-
-  throw new SafeError(CONFIRMATION_IN_PROGRESS_ERROR);
+  throw new SafeError(inProgressError);
 }
 
 async function persistConfirmedAssistantCreateRulePart({

--- a/apps/web/utils/actions/assistant-chat-create-rule.test.ts
+++ b/apps/web/utils/actions/assistant-chat-create-rule.test.ts
@@ -371,6 +371,7 @@ describe("confirmAssistantCreateRule", () => {
       confirmationState: "confirmed",
       ruleId: "rule-created-by-other-request",
     });
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(1);
     expect(createRuleMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/assistant-chat-create-rule.test.ts
+++ b/apps/web/utils/actions/assistant-chat-create-rule.test.ts
@@ -330,4 +330,47 @@ describe("confirmAssistantCreateRule", () => {
         .output.confirmationState,
     ).toBe("confirmed");
   });
+
+  it("returns the confirmed rule when another request wins the reservation race", async () => {
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce({
+        id: "cm-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [buildPendingCreateRulePart()],
+      } as never)
+      .mockResolvedValueOnce({
+        id: "cm-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+        parts: [
+          buildPendingCreateRulePart({
+            output: {
+              confirmationState: "confirmed",
+              ruleId: "rule-created-by-other-request",
+              confirmationResult: {
+                ruleId: "rule-created-by-other-request",
+                confirmedAt: "2026-02-23T00:01:00.000Z",
+              },
+            },
+          }),
+        ],
+      } as never);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    const result = await confirmAssistantCreateRuleForAccount({
+      chatId: "chat-1",
+      chatMessageId: "cm-1",
+      toolCallId: "tool-cr-1",
+      emailAccountId: "ea_1",
+      provider: "google",
+      logger: createTestLogger(),
+    });
+
+    expect(result).toMatchObject({
+      confirmationState: "confirmed",
+      ruleId: "rule-created-by-other-request",
+    });
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -1561,6 +1561,7 @@ describe("confirmAssistantSaveMemory", () => {
       confirmationState: "confirmed",
       confirmationResult,
     });
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(1);
     expect(prisma.chatMemory.findFirst).not.toHaveBeenCalled();
     expect(prisma.chatMemory.create).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -1518,6 +1518,52 @@ describe("confirmAssistantSaveMemory", () => {
     expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
     expect(prisma.chatMemory.create).not.toHaveBeenCalled();
   });
+
+  it("returns the confirmed memory when another request wins the reservation race", async () => {
+    const confirmationResult = {
+      content: "Prefer formal replies with the standard confidential footer.",
+      confirmedAt: "2026-02-23T00:01:00.000Z",
+    };
+
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce({
+        id: "chat-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [buildPendingSaveMemoryPart()],
+      } as any)
+      .mockResolvedValueOnce({
+        id: "chat-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+        parts: [
+          {
+            ...buildPendingSaveMemoryPart(),
+            output: {
+              ...buildPendingSaveMemoryPart().output,
+              confirmationState: "confirmed",
+              confirmationResult,
+            },
+          },
+        ],
+      } as any);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 0 } as any);
+
+    const result = await confirmAssistantSaveMemoryForAccount({
+      chatId: "chat-1",
+      chatMessageId: "chat-message-1",
+      toolCallId: "tool-1",
+      emailAccountId: "ea_1",
+      logger: createTestLogger(),
+    });
+
+    expect(result).toMatchObject({
+      confirmationState: "confirmed",
+      confirmationResult,
+    });
+    expect(prisma.chatMemory.findFirst).not.toHaveBeenCalled();
+    expect(prisma.chatMemory.create).not.toHaveBeenCalled();
+  });
 });
 
 function buildPendingSendPart() {


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-093011_pr-3533_59826226bf71/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Centralizes the shared assistant confirmation reservation lifecycle while preserving action-specific results and validation.

- share persisted-message lookup, processing lease checks, optimistic claims, and race re-reads across email, memory, and rule confirmations
- keep mailbox binding, persistence waits, action errors, and execution effects in their existing action-specific paths
- add race-winner regressions for memory and rule confirmations; verify the focused suites and repository lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for assistant confirmations when multiple requests are processed simultaneously.
  - Confirmed email, memory, and rule actions now consistently return the completed result instead of triggering duplicate operations.
  - Added validation to prevent confirmation attempts when required information is missing or invalid.

- **Tests**
  - Added coverage for concurrent confirmation scenarios involving saved memories and created rules.
  - Verified that duplicate operations are avoided when another request completes the action first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->