### PR TITLE
assistant: Preserve rule actions in optimistic updates

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -602,10 +602,7 @@ describe("RuleForm", () => {
 
   it("optimistically caches reconstructed actions and revalidates failed saves", async () => {
     const mutate = vi.fn();
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
-    mockUpdateRuleAction.mockResolvedValueOnce({ serverError: "Save failed" });
+    mockUpdateRuleAction.mockResolvedValueOnce({});
     const view = render(
       <RuleForm
         alwaysEditMode
@@ -666,7 +663,6 @@ describe("RuleForm", () => {
     expect(optimisticActions[1]).not.toHaveProperty("delayInMinutes");
     expect(mutate.mock.calls[0]?.[1]).toBe(false);
     expect(mutate).toHaveBeenNthCalledWith(2);
-    consoleError.mockRestore();
   });
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -599,6 +599,75 @@ describe("RuleForm", () => {
       ],
     });
   });
+
+  it("optimistically caches reconstructed actions and revalidates failed saves", async () => {
+    const mutate = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockUpdateRuleAction.mockResolvedValueOnce({ serverError: "Save failed" });
+    const view = render(
+      <RuleForm
+        alwaysEditMode
+        mutate={mutate}
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Delayed draft rule",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-draft",
+              type: ActionType.DRAFT_EMAIL,
+              content: { value: "Thanks" },
+              delayInMinutes: 30,
+            },
+            {
+              id: "action-label",
+              type: ActionType.LABEL,
+              labelId: { value: "label-1", name: "Follow up" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      within(view.container).getByRole("button", { name: "Save" }),
+    );
+
+    await waitFor(() => expect(mutate).toHaveBeenCalledTimes(2));
+
+    const optimisticActions = mutate.mock.calls[0]?.[0]?.rule.actions;
+    expect(optimisticActions).toEqual([
+      expect.objectContaining({
+        id: "action-draft",
+        type: ActionType.DRAFT_EMAIL,
+        delayInMinutes: 30,
+      }),
+      expect.objectContaining({
+        id: "action-label",
+        type: ActionType.LABEL,
+      }),
+    ]);
+    expect(optimisticActions[1]).not.toHaveProperty("delayInMinutes");
+    expect(mutate.mock.calls[0]?.[1]).toBe(false);
+    expect(mutate).toHaveBeenNthCalledWith(2);
+    consoleError.mockRestore();
+  });
 });
 
 function createMessagingChannel({

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -85,12 +85,11 @@ import { shouldIncludeDigestAction } from "@/utils/premium/digest";
 import { UpgradeToPlusButton } from "@/components/UpgradeToPlusButton";
 import { useIntegrationActionsEnabled } from "@/hooks/useFeatureFlags";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
-import { sortActionsByPriority } from "@/utils/action-sort";
-import {
-  denormalizeDraftReplyActions,
-  normalizeDraftReplyActions,
-} from "@/app/(app)/[emailAccountId]/assistant/draftReplyActions";
 import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
+import {
+  buildPersistedRuleActions,
+  getRuleFormActionState,
+} from "@/app/(app)/[emailAccountId]/assistant/ruleFormActions";
 
 export function Rule({
   ruleId,
@@ -140,42 +139,20 @@ export function RuleForm({
     tier,
     minimumTier: "PLUS_MONTHLY",
   });
-  const ruleEditorActions = getRuleEditorActions(rule.actions);
+  const ruleFormActionState = getRuleFormActionState({
+    actions: rule.actions,
+    webhookActionsEnabled: env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false,
+  });
 
   const form = useForm<CreateRuleBody>({
     resolver: zodResolver(createRuleBody),
     defaultValues: rule
       ? {
           ...rule,
-          digest: ruleEditorActions.some(
-            (action) => action.type === ActionType.DIGEST,
-          ),
+          digest: ruleFormActionState.digest,
           notifyMessagingChannelId:
-            ruleEditorActions.find(
-              (action) => action.type === ActionType.NOTIFY_MESSAGING_CHANNEL,
-            )?.messagingChannelId ?? null,
-          actions: [
-            ...normalizeDraftReplyActions(
-              sortActionsByPriority(
-                ruleEditorActions
-                  .filter(
-                    (action) =>
-                      action.type !== ActionType.DIGEST &&
-                      action.type !== ActionType.NOTIFY_MESSAGING_CHANNEL,
-                  )
-                  .map((action) => ({
-                    ...action,
-                    delayInMinutes: action.delayInMinutes,
-                    content: {
-                      ...action.content,
-                      setManually: !!action.content?.value,
-                    },
-                    folderName: action.folderName,
-                    folderId: action.folderId,
-                  })),
-              ),
-            ),
-          ],
+            ruleFormActionState.notifyMessagingChannelId,
+          actions: ruleFormActionState.actions,
         }
       : undefined,
   });
@@ -227,22 +204,6 @@ export function RuleForm({
 
   const onSubmit: SubmitHandler<CreateRuleBody> = useCallback(
     async (data) => {
-      // set content to empty string if it's not set manually
-      for (const action of data.actions) {
-        if (isDraftReplyActionType(action.type)) {
-          if (!action.content?.setManually) {
-            action.content = { value: "", ai: false };
-          }
-        }
-      }
-
-      const normalizedActions = denormalizeDraftReplyActions(data.actions);
-
-      const hasDraftAction = normalizedActions.some((action) =>
-        isDraftReplyActionType(action.type),
-      );
-
-      const actionsToSubmit = [...normalizedActions];
       const existingDigestAction = rule.actions.find(
         (action) => action.type === ActionType.DIGEST,
       );
@@ -252,42 +213,23 @@ export function RuleForm({
         wantsDigest: !!data.digest,
         hasExistingDigest: !!existingDigestAction,
       });
-      if (includeDigestAction) {
-        actionsToSubmit.push({
-          id: existingDigestAction?.id,
-          type: ActionType.DIGEST,
-        });
-      }
-
-      // Add NOTIFY_MESSAGING_CHANNEL action if a channel is selected
-      if (data.notifyMessagingChannelId) {
-        const existingNotifyAction = rule.actions.find(
-          (action) => action.type === ActionType.NOTIFY_MESSAGING_CHANNEL,
-        );
-
-        actionsToSubmit.push({
-          id: existingNotifyAction?.id,
-          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-          messagingChannelId: data.notifyMessagingChannelId,
-        });
-      }
+      const actionsToSubmit = buildPersistedRuleActions({
+        formActions: data.actions,
+        originalActions: rule.actions,
+        includeDigestAction,
+        notifyMessagingChannelId: data.notifyMessagingChannelId,
+        webhookActionsEnabled: env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false,
+      });
+      const hasDraftAction = actionsToSubmit.some((action) =>
+        isDraftReplyActionType(action.type),
+      );
 
       if (data.id) {
-        const orderedActionsToSubmit = restorePersistedActionSequence({
-          actions: actionsToSubmit,
-          originalActions: rule.actions,
-        });
-
         if (mutate) {
-          // mutate delayInMinutes optimistically to keep the UI consistent
-          // in case the modal is reopened immediately after saving
           const optimisticData = {
             rule: {
               ...rule,
-              actions: rule.actions.map((action, index) => ({
-                ...action,
-                delayInMinutes: data.actions[index]?.delayInMinutes,
-              })),
+              actions: actionsToSubmit,
             },
           };
           mutate(optimisticData, false);
@@ -295,7 +237,7 @@ export function RuleForm({
 
         const res = await updateRuleAction(emailAccountId, {
           ...data,
-          actions: orderedActionsToSubmit,
+          actions: actionsToSubmit,
           id: data.id,
         });
 
@@ -323,7 +265,7 @@ export function RuleForm({
           if (mutate) mutate();
           posthog.capture("User updated AI rule", {
             conditions: data.conditions.map((condition) => condition.type),
-            actions: orderedActionsToSubmit.map((action) => action.type),
+            actions: actionsToSubmit.map((action) => action.type),
             runOnThreads: data.runOnThreads,
             digest: data.digest,
           });
@@ -413,8 +355,8 @@ export function RuleForm({
   const conditionalOperator = watch("conditionalOperator");
   const terminology = getEmailTerminology(provider);
   const existingActionTypes = useMemo(
-    () => ruleEditorActions.map((action) => action.type),
-    [ruleEditorActions],
+    () => ruleFormActionState.editableActionTypes,
+    [ruleFormActionState.editableActionTypes],
   );
 
   const formErrors = useMemo(
@@ -900,55 +842,6 @@ function allowMultipleConditions(systemType: SystemType | null | undefined) {
     systemType !== SystemType.COLD_EMAIL &&
     !isConversationStatusType(systemType)
   );
-}
-
-function restorePersistedActionSequence({
-  actions,
-  originalActions,
-}: {
-  actions: CreateRuleBody["actions"];
-  originalActions: CreateRuleBody["actions"];
-}) {
-  const originalIndexById = new Map(
-    originalActions.flatMap((action, index) =>
-      action.id ? [[action.id, index] as const] : [],
-    ),
-  );
-
-  if (originalIndexById.size === 0) return actions;
-
-  const existing: CreateRuleBody["actions"] = [];
-  const added: CreateRuleBody["actions"] = [];
-
-  for (const action of actions) {
-    if (action.id && originalIndexById.has(action.id)) {
-      existing.push(action);
-    } else {
-      added.push(action);
-    }
-  }
-
-  if (existing.length === 0) return actions;
-
-  existing.sort(
-    (a, b) =>
-      (originalIndexById.get(a.id ?? "") ?? 0) -
-      (originalIndexById.get(b.id ?? "") ?? 0),
-  );
-
-  return [...existing, ...added];
-}
-
-function getRuleEditorActions(actions: CreateRuleBody["actions"]) {
-  let filteredActions = actions;
-
-  if (env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED === false) {
-    filteredActions = filteredActions.filter(
-      (action) => action.type !== ActionType.CALL_WEBHOOK,
-    );
-  }
-
-  return filteredActions;
 }
 
 type ActionTypeOption = {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
@@ -126,4 +126,49 @@ describe("rule form action conversion", () => {
       ]),
     );
   });
+
+  it("creates newly added draft destinations without duplicating a persisted id", () => {
+    const originalActions = [
+      {
+        id: "action-draft",
+        type: ActionType.DRAFT_EMAIL,
+        content: { value: "Draft response", setManually: true },
+        delayInMinutes: 30,
+      },
+      {
+        id: "action-label",
+        type: ActionType.LABEL,
+        labelId: { value: "label-1", name: "Follow up" },
+      },
+    ];
+
+    const persistedActions = buildPersistedRuleActions({
+      formActions: [
+        originalActions[1],
+        originalActions[0],
+        {
+          ...originalActions[0],
+          type: ActionType.DRAFT_MESSAGING_CHANNEL,
+          messagingChannelId: "cmessagingchannel1234567890123",
+        },
+      ],
+      originalActions,
+      includeDigestAction: false,
+      notifyMessagingChannelId: null,
+      webhookActionsEnabled: true,
+    });
+
+    expect(persistedActions.map((action) => action.id)).toEqual([
+      "action-draft",
+      "action-label",
+      undefined,
+    ]);
+    expect(persistedActions[2]).toEqual(
+      expect.objectContaining({
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "cmessagingchannel1234567890123",
+        delayInMinutes: 30,
+      }),
+    );
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { ActionType } from "@/generated/prisma/enums";
+import {
+  buildPersistedRuleActions,
+  getRuleFormActionState,
+} from "@/app/(app)/[emailAccountId]/assistant/ruleFormActions";
+
+describe("rule form action conversion", () => {
+  it("round-trips reordered action delays by identity", () => {
+    const originalActions = [
+      {
+        id: "action-draft",
+        type: ActionType.DRAFT_EMAIL,
+        content: { value: "Thanks" },
+        delayInMinutes: 30,
+      },
+      {
+        id: "action-label",
+        type: ActionType.LABEL,
+        labelId: { value: "label-1", name: "Follow up" },
+      },
+    ];
+
+    const state = getRuleFormActionState({
+      actions: originalActions,
+      webhookActionsEnabled: true,
+    });
+    expect(state.actions.map((action) => action.id)).toEqual([
+      "action-label",
+      "action-draft",
+    ]);
+
+    const persistedActions = buildPersistedRuleActions({
+      formActions: state.actions,
+      originalActions,
+      includeDigestAction: false,
+      notifyMessagingChannelId: null,
+      webhookActionsEnabled: true,
+    });
+
+    expect(persistedActions).toEqual([
+      expect.objectContaining({
+        id: "action-draft",
+        type: ActionType.DRAFT_EMAIL,
+        delayInMinutes: 30,
+      }),
+      expect.objectContaining({
+        id: "action-label",
+        type: ActionType.LABEL,
+      }),
+    ]);
+    expect(persistedActions[1]).not.toHaveProperty("delayInMinutes");
+  });
+
+  it("preserves special, hidden, and multi-destination actions in persisted order", () => {
+    const originalActions = [
+      {
+        id: "action-telegram",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "cmessagingchannel1234567890456",
+        content: { value: "Draft response" },
+        delayInMinutes: 45,
+      },
+      { id: "action-digest", type: ActionType.DIGEST },
+      {
+        id: "action-email",
+        type: ActionType.DRAFT_EMAIL,
+        content: { value: "Draft response" },
+        subject: { value: "Re: update" },
+        delayInMinutes: 45,
+      },
+      {
+        id: "action-notify",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        messagingChannelId: "cmessagingchannel1234567890123",
+      },
+      {
+        id: "action-slack",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "cmessagingchannel1234567890123",
+        content: { value: "Draft response" },
+        delayInMinutes: 45,
+      },
+      {
+        id: "action-webhook",
+        type: ActionType.CALL_WEBHOOK,
+        url: { value: "https://example.com/hook" },
+      },
+    ];
+
+    const state = getRuleFormActionState({
+      actions: originalActions,
+      webhookActionsEnabled: false,
+    });
+    const persistedActions = buildPersistedRuleActions({
+      formActions: state.actions,
+      originalActions,
+      includeDigestAction: state.digest,
+      notifyMessagingChannelId: state.notifyMessagingChannelId,
+      webhookActionsEnabled: false,
+    });
+
+    expect(state.actions.map((action) => action.id)).toEqual([
+      "action-email",
+      "action-telegram",
+      "action-slack",
+    ]);
+    expect(persistedActions.map((action) => action.id)).toEqual(
+      originalActions.map((action) => action.id),
+    );
+    expect(persistedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "action-telegram",
+          messagingChannelId: "cmessagingchannel1234567890456",
+          delayInMinutes: 45,
+        }),
+        expect.objectContaining({
+          id: "action-notify",
+          messagingChannelId: "cmessagingchannel1234567890123",
+        }),
+        expect.objectContaining({
+          id: "action-webhook",
+          url: { value: "https://example.com/hook" },
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
@@ -171,4 +171,48 @@ describe("rule form action conversion", () => {
       }),
     );
   });
+
+  it("keeps a messaging draft id on its existing destination when adding email", () => {
+    const originalActions = [
+      {
+        id: "action-chat-draft",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "cmessagingchannel1234567890123",
+        content: { value: "Draft response", setManually: true },
+        delayInMinutes: 30,
+      },
+      {
+        id: "action-label",
+        type: ActionType.LABEL,
+        labelId: { value: "label-1", name: "Follow up" },
+      },
+    ];
+
+    const persistedActions = buildPersistedRuleActions({
+      formActions: [
+        originalActions[1],
+        {
+          ...originalActions[0],
+          type: ActionType.DRAFT_EMAIL,
+          messagingChannelId: null,
+        },
+        originalActions[0],
+      ],
+      originalActions,
+      includeDigestAction: false,
+      notifyMessagingChannelId: null,
+      webhookActionsEnabled: true,
+    });
+
+    expect(persistedActions.map((action) => action.id)).toEqual([
+      "action-chat-draft",
+      "action-label",
+      undefined,
+    ]);
+    expect(persistedActions.map((action) => action.type)).toEqual([
+      ActionType.DRAFT_MESSAGING_CHANNEL,
+      ActionType.LABEL,
+      ActionType.DRAFT_EMAIL,
+    ]);
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.test.ts
@@ -128,26 +128,25 @@ describe("rule form action conversion", () => {
   });
 
   it("creates newly added draft destinations without duplicating a persisted id", () => {
-    const originalActions = [
-      {
-        id: "action-draft",
-        type: ActionType.DRAFT_EMAIL,
-        content: { value: "Draft response", setManually: true },
-        delayInMinutes: 30,
-      },
-      {
-        id: "action-label",
-        type: ActionType.LABEL,
-        labelId: { value: "label-1", name: "Follow up" },
-      },
-    ];
+    const draftAction = {
+      id: "action-draft",
+      type: ActionType.DRAFT_EMAIL,
+      content: { value: "Draft response", setManually: true },
+      delayInMinutes: 30,
+    };
+    const labelAction = {
+      id: "action-label",
+      type: ActionType.LABEL,
+      labelId: { value: "label-1", name: "Follow up" },
+    };
+    const originalActions = [draftAction, labelAction];
 
     const persistedActions = buildPersistedRuleActions({
       formActions: [
-        originalActions[1],
-        originalActions[0],
+        labelAction,
+        draftAction,
         {
-          ...originalActions[0],
+          ...draftAction,
           type: ActionType.DRAFT_MESSAGING_CHANNEL,
           messagingChannelId: "cmessagingchannel1234567890123",
         },
@@ -163,7 +162,7 @@ describe("rule form action conversion", () => {
       "action-label",
       undefined,
     ]);
-    expect(persistedActions[2]).toEqual(
+    expect(persistedActions.at(2)).toEqual(
       expect.objectContaining({
         type: ActionType.DRAFT_MESSAGING_CHANNEL,
         messagingChannelId: "cmessagingchannel1234567890123",
@@ -173,30 +172,29 @@ describe("rule form action conversion", () => {
   });
 
   it("keeps a messaging draft id on its existing destination when adding email", () => {
-    const originalActions = [
-      {
-        id: "action-chat-draft",
-        type: ActionType.DRAFT_MESSAGING_CHANNEL,
-        messagingChannelId: "cmessagingchannel1234567890123",
-        content: { value: "Draft response", setManually: true },
-        delayInMinutes: 30,
-      },
-      {
-        id: "action-label",
-        type: ActionType.LABEL,
-        labelId: { value: "label-1", name: "Follow up" },
-      },
-    ];
+    const chatDraftAction = {
+      id: "action-chat-draft",
+      type: ActionType.DRAFT_MESSAGING_CHANNEL,
+      messagingChannelId: "cmessagingchannel1234567890123",
+      content: { value: "Draft response", setManually: true },
+      delayInMinutes: 30,
+    };
+    const labelAction = {
+      id: "action-label",
+      type: ActionType.LABEL,
+      labelId: { value: "label-1", name: "Follow up" },
+    };
+    const originalActions = [chatDraftAction, labelAction];
 
     const persistedActions = buildPersistedRuleActions({
       formActions: [
-        originalActions[1],
+        labelAction,
         {
-          ...originalActions[0],
+          ...chatDraftAction,
           type: ActionType.DRAFT_EMAIL,
           messagingChannelId: null,
         },
-        originalActions[0],
+        chatDraftAction,
       ],
       originalActions,
       includeDigestAction: false,
@@ -206,6 +204,50 @@ describe("rule form action conversion", () => {
 
     expect(persistedActions.map((action) => action.id)).toEqual([
       "action-chat-draft",
+      "action-label",
+      undefined,
+    ]);
+    expect(persistedActions.map((action) => action.type)).toEqual([
+      ActionType.DRAFT_MESSAGING_CHANNEL,
+      ActionType.LABEL,
+      ActionType.DRAFT_EMAIL,
+    ]);
+  });
+
+  it("keeps a legacy channel-targeted draft id on its normalized destination", () => {
+    const legacyChatDraftAction = {
+      id: "action-legacy-chat-draft",
+      type: ActionType.DRAFT_EMAIL,
+      messagingChannelId: "cmessagingchannel1234567890123",
+      content: { value: "Draft response", setManually: true },
+    };
+    const labelAction = {
+      id: "action-label",
+      type: ActionType.LABEL,
+      labelId: { value: "label-1", name: "Follow up" },
+    };
+
+    const persistedActions = buildPersistedRuleActions({
+      formActions: [
+        labelAction,
+        {
+          ...legacyChatDraftAction,
+          type: ActionType.DRAFT_EMAIL,
+          messagingChannelId: null,
+        },
+        {
+          ...legacyChatDraftAction,
+          type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        },
+      ],
+      originalActions: [legacyChatDraftAction, labelAction],
+      includeDigestAction: false,
+      notifyMessagingChannelId: null,
+      webhookActionsEnabled: true,
+    });
+
+    expect(persistedActions.map((action) => action.id)).toEqual([
+      "action-legacy-chat-draft",
       "action-label",
       undefined,
     ]);

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
@@ -61,7 +61,7 @@ export function buildPersistedRuleActions({
   notifyMessagingChannelId: string | null | undefined;
   webhookActionsEnabled: boolean;
 }) {
-  const actions = removeDuplicateActionIds(
+  const actions = preservePersistedActionIds(
     denormalizeDraftReplyActions(
       formActions.map((action) => {
         if (
@@ -74,6 +74,7 @@ export function buildPersistedRuleActions({
         return action;
       }),
     ),
+    originalActions,
   );
 
   if (!webhookActionsEnabled) {
@@ -108,15 +109,38 @@ export function buildPersistedRuleActions({
   return restorePersistedActionSequence({ actions, originalActions });
 }
 
-function removeDuplicateActionIds(actions: RuleFormAction[]) {
-  const seenIds = new Set<string>();
+function preservePersistedActionIds(
+  actions: RuleFormAction[],
+  originalActions: RuleFormAction[],
+) {
+  const preferredIndexById = new Map<string, number>();
 
-  return actions.map((action) => {
+  for (const [index, action] of actions.entries()) {
+    if (!action.id || preferredIndexById.has(action.id)) continue;
+
+    const originalAction = originalActions.find(
+      (original) => original.id === action.id,
+    );
+    const matchingOriginalIndex = originalAction
+      ? actions.findIndex(
+          (candidate) =>
+            candidate.id === originalAction.id &&
+            candidate.type === originalAction.type &&
+            candidate.messagingChannelId === originalAction.messagingChannelId,
+        )
+      : -1;
+
+    preferredIndexById.set(
+      action.id,
+      matchingOriginalIndex === -1 ? index : matchingOriginalIndex,
+    );
+  }
+
+  return actions.map((action, index) => {
     if (!action.id) return action;
-    if (seenIds.has(action.id)) return { ...action, id: undefined };
-
-    seenIds.add(action.id);
-    return action;
+    return preferredIndexById.get(action.id) === index
+      ? action
+      : { ...action, id: undefined };
   });
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
@@ -125,8 +125,7 @@ function preservePersistedActionIds(
       ? actions.findIndex(
           (candidate) =>
             candidate.id === originalAction.id &&
-            candidate.type === originalAction.type &&
-            candidate.messagingChannelId === originalAction.messagingChannelId,
+            hasSamePersistedIdentity(candidate, originalAction),
         )
       : -1;
 
@@ -142,6 +141,22 @@ function preservePersistedActionIds(
       ? action
       : { ...action, id: undefined };
   });
+}
+
+function hasSamePersistedIdentity(
+  action: RuleFormAction,
+  originalAction: RuleFormAction,
+) {
+  const [normalizedAction] = normalizeDraftReplyActions([action]);
+  const [normalizedOriginalAction] = normalizeDraftReplyActions([
+    originalAction,
+  ]);
+
+  return (
+    normalizedAction?.type === normalizedOriginalAction?.type &&
+    normalizedAction?.messagingChannelId ===
+      normalizedOriginalAction?.messagingChannelId
+  );
 }
 
 function restorePersistedActionSequence({

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
@@ -1,0 +1,141 @@
+import { ActionType } from "@/generated/prisma/enums";
+import type { CreateRuleBody } from "@/utils/actions/rule.validation";
+import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
+import { sortActionsByPriority } from "@/utils/action-sort";
+import {
+  denormalizeDraftReplyActions,
+  normalizeDraftReplyActions,
+} from "@/app/(app)/[emailAccountId]/assistant/draftReplyActions";
+
+type RuleFormAction = CreateRuleBody["actions"][number];
+
+export function getRuleFormActionState({
+  actions,
+  webhookActionsEnabled,
+}: {
+  actions: RuleFormAction[];
+  webhookActionsEnabled: boolean;
+}) {
+  const editableActions = actions.filter(
+    (action) =>
+      webhookActionsEnabled || action.type !== ActionType.CALL_WEBHOOK,
+  );
+
+  return {
+    actions: normalizeDraftReplyActions(
+      sortActionsByPriority(
+        editableActions
+          .filter(
+            (action) =>
+              action.type !== ActionType.DIGEST &&
+              action.type !== ActionType.NOTIFY_MESSAGING_CHANNEL,
+          )
+          .map((action) => ({
+            ...action,
+            content: {
+              ...action.content,
+              setManually: !!action.content?.value,
+            },
+          })),
+      ),
+    ),
+    digest: editableActions.some((action) => action.type === ActionType.DIGEST),
+    notifyMessagingChannelId:
+      editableActions.find(
+        (action) => action.type === ActionType.NOTIFY_MESSAGING_CHANNEL,
+      )?.messagingChannelId ?? null,
+    editableActionTypes: editableActions.map((action) => action.type),
+  };
+}
+
+export function buildPersistedRuleActions({
+  formActions,
+  originalActions,
+  includeDigestAction,
+  notifyMessagingChannelId,
+  webhookActionsEnabled,
+}: {
+  formActions: RuleFormAction[];
+  originalActions: RuleFormAction[];
+  includeDigestAction: boolean;
+  notifyMessagingChannelId: string | null | undefined;
+  webhookActionsEnabled: boolean;
+}) {
+  const actions = denormalizeDraftReplyActions(
+    formActions.map((action) => {
+      if (isDraftReplyActionType(action.type) && !action.content?.setManually) {
+        return { ...action, content: { value: "", ai: false } };
+      }
+
+      return action;
+    }),
+  );
+
+  if (!webhookActionsEnabled) {
+    actions.push(
+      ...originalActions.filter(
+        (action) => action.type === ActionType.CALL_WEBHOOK,
+      ),
+    );
+  }
+
+  const existingDigestAction = originalActions.find(
+    (action) => action.type === ActionType.DIGEST,
+  );
+  if (includeDigestAction) {
+    actions.push({
+      id: existingDigestAction?.id,
+      type: ActionType.DIGEST,
+    });
+  }
+
+  if (notifyMessagingChannelId) {
+    const existingNotifyAction = originalActions.find(
+      (action) => action.type === ActionType.NOTIFY_MESSAGING_CHANNEL,
+    );
+    actions.push({
+      id: existingNotifyAction?.id,
+      type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+      messagingChannelId: notifyMessagingChannelId,
+    });
+  }
+
+  return restorePersistedActionSequence({ actions, originalActions });
+}
+
+function restorePersistedActionSequence({
+  actions,
+  originalActions,
+}: {
+  actions: RuleFormAction[];
+  originalActions: RuleFormAction[];
+}) {
+  const originalIndexById = new Map(
+    originalActions.flatMap((action, index) =>
+      action.id ? [[action.id, index] as const] : [],
+    ),
+  );
+
+  if (originalIndexById.size === 0) return actions;
+
+  const existing: RuleFormAction[] = [];
+  const added: RuleFormAction[] = [];
+
+  for (const action of actions) {
+    if (action.id && originalIndexById.has(action.id)) {
+      existing.push(action);
+    } else {
+      added.push(action);
+    }
+  }
+
+  if (existing.length === 0) return actions;
+
+  existing.sort(
+    (a, b) =>
+      (originalIndexById.get(a.id ?? "") ?? 0) -
+      (originalIndexById.get(b.id ?? "") ?? 0),
+  );
+
+  return [...existing, ...added];
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ruleFormActions.ts
@@ -61,14 +61,19 @@ export function buildPersistedRuleActions({
   notifyMessagingChannelId: string | null | undefined;
   webhookActionsEnabled: boolean;
 }) {
-  const actions = denormalizeDraftReplyActions(
-    formActions.map((action) => {
-      if (isDraftReplyActionType(action.type) && !action.content?.setManually) {
-        return { ...action, content: { value: "", ai: false } };
-      }
+  const actions = removeDuplicateActionIds(
+    denormalizeDraftReplyActions(
+      formActions.map((action) => {
+        if (
+          isDraftReplyActionType(action.type) &&
+          !action.content?.setManually
+        ) {
+          return { ...action, content: { value: "", ai: false } };
+        }
 
-      return action;
-    }),
+        return action;
+      }),
+    ),
   );
 
   if (!webhookActionsEnabled) {
@@ -101,6 +106,18 @@ export function buildPersistedRuleActions({
   }
 
   return restorePersistedActionSequence({ actions, originalActions });
+}
+
+function removeDuplicateActionIds(actions: RuleFormAction[]) {
+  const seenIds = new Set<string>();
+
+  return actions.map((action) => {
+    if (!action.id) return action;
+    if (seenIds.has(action.id)) return { ...action, id: undefined };
+
+    seenIds.add(action.id);
+    return action;
+  });
 }
 
 function restorePersistedActionSequence({


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-094950_pr-3535_e70b67107319/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Centralize conversion between persisted rule actions and editor actions so optimistic cache state matches the server payload.

- preserve action IDs, delays, persisted order, special actions, hidden existing webhooks, and multi-destination drafts
- cover reordered delays, failed-save revalidation, conversion round trips, and the emulated manual-rule flow

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rule updates so reordered actions retain their correct settings and delays.
  - Preserved special, hidden, notification, webhook, and multi-destination actions when editing rules.
  - Improved handling of draft replies, digest settings, and messaging notifications during rule saves.
  - Prevented duplicate identifiers when adding new messaging destinations or changing destination types.
  - Failed rule saves now correctly refresh the form state and remove unrelated optimistic changes.
  - Newly added actions are saved alongside existing actions without disrupting their established order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->