### PR TITLE
mail: Preserve reply and forward draft sessions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -377,6 +377,37 @@ test("opens and sends a reply from the reader with Enter", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "reply-sent-in-thread");
 });
 
+test("keeps reply and forward drafts in separate composer sessions", async ({
+  page,
+}) => {
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  const message = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  await expect(message).toBeVisible();
+
+  await message.getByRole("button", { name: "Reply", exact: true }).click();
+  const editor = page.getByRole("textbox", { name: "Email message" });
+  await editor.fill("Reply-only draft text");
+
+  await message.getByRole("button", { name: "Forward", exact: true }).click();
+  await expect(editor).not.toContainText("Reply-only draft text");
+  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue("");
+  await editor.fill("Forward-only draft text");
+
+  await message.getByRole("button", { name: "Reply", exact: true }).click();
+  await expect(editor).toContainText("Reply-only draft text");
+  await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
+  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue(
+    /leslie@example\.com/i,
+  );
+
+  await message.getByRole("button", { name: "Forward", exact: true }).click();
+  await expect(editor).toContainText("Forward-only draft text");
+  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue("");
+});
+
 async function selectEditorText(editor: Locator, text: string) {
   await editor.evaluate((element, selectedText) => {
     const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -161,6 +161,15 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
           messageId: props.draftSessionId,
         }
       : undefined,
+    props.draftMode === "forward" &&
+      props.draftKeyMessageId &&
+      props.replyingToEmail?.threadId
+      ? {
+          emailAccountId: selectedEmailAccountId,
+          threadId: props.replyingToEmail.threadId,
+          messageId: props.draftKeyMessageId,
+        }
+      : undefined,
   );
   return (
     <LoadingContent error={error} loading={isLoading || localDraft.isLoading}>
@@ -1268,7 +1277,14 @@ function ComposeEmailFormContent({
                 try {
                   if ((await onDiscard()) === false) return;
                   await clearLocalDraft();
-                } catch {}
+                } catch (error) {
+                  toastError({
+                    description:
+                      error instanceof Error
+                        ? error.message
+                        : "Could not discard this draft.",
+                  });
+                }
               }}
               size={isComposeWindow ? "iconSm" : "icon"}
               title="Discard draft"

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -161,15 +161,14 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
           messageId: props.draftSessionId,
         }
       : undefined,
-    props.draftMode === "forward" &&
-      props.draftKeyMessageId &&
-      props.replyingToEmail?.threadId
+    props.draftKeyMessageId && props.replyingToEmail?.threadId
       ? {
           emailAccountId: selectedEmailAccountId,
           threadId: props.replyingToEmail.threadId,
           messageId: props.draftKeyMessageId,
         }
       : undefined,
+    props.draftMode,
   );
   return (
     <LoadingContent error={error} loading={isLoading || localDraft.isLoading}>

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -64,6 +64,7 @@ import { env } from "@/env";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
 import { useModifierKey } from "@/hooks/useModifierKey";
+import { useReplyDraftPersistence } from "@/hooks/useReplyDraftPersistence";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { sendEmailAction } from "@/utils/actions/mail";
@@ -74,9 +75,9 @@ import {
   splitRecipientList,
 } from "@/utils/email";
 import type { StoredReplyDraft } from "@/utils/email-cache/database";
-import {
-  createReplyDraftWriter,
-  type ReplyDraftContent,
+import type {
+  ReplyDraftContent,
+  ReplyDraftMode,
 } from "@/utils/email-cache/reply-drafts";
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
@@ -120,11 +121,13 @@ type ComposeEmailFormProps = {
   fromAccounts?: GetEmailAccountsResponse["emailAccounts"];
   layout?: "default" | "window";
   draftKeyMessageId?: string;
+  draftMode?: ReplyDraftMode;
+  draftSessionId?: string;
   replyingToEmail?: ReplyingToEmail;
   refetch?: () => void;
   onSuccess?: (messageId: string, threadId: string) => void;
   onClose?: () => void;
-  onDiscard?: () => void;
+  onDiscard?: () => boolean | Promise<boolean>;
 };
 
 type ComposeAttachment = EmailComposerAttachment & {
@@ -151,11 +154,11 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
       ?.account.provider ?? provider;
 
   const localDraft = useLocalReplyDraft(
-    props.draftKeyMessageId && props.replyingToEmail?.threadId
+    props.draftSessionId && props.replyingToEmail?.threadId
       ? {
           emailAccountId: selectedEmailAccountId,
           threadId: props.replyingToEmail.threadId,
-          messageId: props.draftKeyMessageId,
+          messageId: props.draftSessionId,
         }
       : undefined,
   );
@@ -168,7 +171,7 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
           draftLoadError={localDraft.error}
           accountProvider={selectedAccountProvider}
           accountSignatureHtml={emailAccount.signature ?? ""}
-          key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftKeyMessageId ?? ""}`}
+          key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftSessionId ?? ""}`}
           onSelectEmailAccount={setSelectedEmailAccountId}
           selectedEmailAccountId={selectedEmailAccountId}
         />
@@ -180,6 +183,8 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
 function ComposeEmailFormContent({
   layout = "default",
   draftKeyMessageId,
+  draftMode,
+  draftSessionId,
   storedDraft,
   draftLoadError,
   replyingToEmail,
@@ -211,36 +216,11 @@ function ComposeEmailFormContent({
     () => storedDraft?.content?.requestId ?? randomUuid(),
   );
   const deliveryPath = useRef(storedDraft?.content?.deliveryPath);
-  const [draftSaveError, setDraftSaveError] = useState(
-    draftLoadError?.message ?? "",
-  );
   const [submissionError, setSubmissionError] = useState(() => {
     const times = parseDeliveryTimes(sendAt, remindAt);
     return times.valid ? "" : times.error;
   });
-  const [draftWriter] = useState(() =>
-    isInlineReply
-      ? createReplyDraftWriter(
-          {
-            emailAccountId: selectedEmailAccountId,
-            threadId: replyingToEmail!.threadId!,
-            messageId: draftKeyMessageId!,
-          },
-          storedDraft?.revision,
-        )
-      : undefined,
-  );
-  const draftStopped = useRef(false);
-  const draftTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-  const latestDraft = useRef<ReplyDraftContent | undefined>(undefined);
-  const saveDraftRef = useRef<
-    (options?: { sendAt?: string; remindAt?: string }) => void
-  >(() => {});
   const editorInitialized = useRef(false);
-  const lastSavedSnapshot = useRef<string | undefined>(undefined);
-  const latestDraftSnapshot = useRef<string | undefined>(undefined);
 
   const [restoredAttachments] = useState<ComposeAttachment[]>(() =>
     (storedDraft?.content?.attachments ?? []).map((attachment) => ({
@@ -346,34 +326,11 @@ function ComposeEmailFormContent({
     },
   });
 
-  const persistDraft = useCallback(() => {
-    clearTimeout(draftTimer.current);
-    const content = latestDraft.current;
-    if (!content || !draftWriter || draftStopped.current) return;
-    const snapshot = latestDraftSnapshot.current;
-    if (snapshot === lastSavedSnapshot.current) return;
-    draftWriter.save(content).then(
-      () => {
-        lastSavedSnapshot.current = snapshot;
-        if (
-          isMountedRef.current &&
-          !draftStopped.current &&
-          latestDraftSnapshot.current === snapshot
-        )
-          setDraftSaveError("");
-      },
-      (error) => {
-        if (isMountedRef.current)
-          setDraftSaveError(
-            error instanceof Error
-              ? error.message
-              : "Could not save draft on this device.",
-          );
-      },
-    );
-  }, [draftWriter]);
-  saveDraftRef.current = (options) => {
-    if (!draftWriter || draftStopped.current || !editorRef.current) return;
+  const getDraftContent = (options?: {
+    sendAt?: string;
+    remindAt?: string;
+  }): ReplyDraftContent | undefined => {
+    if (!editorRef.current) return;
     const value = editorRef.current.getValue();
     const values = { ...getValues() };
     for (const field of ["to", "cc", "bcc"] as const) {
@@ -381,7 +338,8 @@ function ComposeEmailFormContent({
       if (pending)
         values[field] = [values[field], pending].filter(Boolean).join(", ");
     }
-    const content: ReplyDraftContent = {
+    return {
+      composeMode: draftMode,
       requestId,
       deliveryPath: deliveryPath.current,
       values,
@@ -399,45 +357,38 @@ function ComposeEmailFormContent({
       sendAt: options?.sendAt ?? sendAt,
       remindAt: options?.remindAt ?? remindAt,
     };
-    const snapshot = getReplyDraftSnapshot(content);
-    if (snapshot === latestDraftSnapshot.current) return;
-    latestDraftSnapshot.current = snapshot;
-    latestDraft.current = content;
-    clearTimeout(draftTimer.current);
-    draftTimer.current = setTimeout(persistDraft, 300);
   };
+  const {
+    capture: captureDraft,
+    clear: clearLocalDraft,
+    flush: flushDraft,
+    saveError: draftSaveError,
+  } = useReplyDraftPersistence({
+    identity:
+      isInlineReply && draftSessionId
+        ? {
+            emailAccountId: selectedEmailAccountId,
+            threadId: replyingToEmail!.threadId!,
+            messageId: draftSessionId,
+          }
+        : undefined,
+    initialRevision: storedDraft?.revision,
+    loadError: draftLoadError,
+    getContent: getDraftContent,
+  });
   useEffect(() => {
-    const subscription = watch(() => saveDraftRef.current());
+    const subscription = watch(() => captureDraft());
     return () => subscription.unsubscribe();
-  }, [watch]);
-  useEffect(
-    () => () => {
-      persistDraft();
-    },
-    [persistDraft],
-  );
-  useEffect(() => {
-    const flushWhenHidden = () => {
-      if (document.visibilityState === "hidden") persistDraft();
-    };
-    window.addEventListener("pagehide", persistDraft);
-    document.addEventListener("visibilitychange", flushWhenHidden);
-    return () => {
-      window.removeEventListener("pagehide", persistDraft);
-      document.removeEventListener("visibilitychange", flushWhenHidden);
-    };
-  }, [persistDraft]);
-  const clearLocalDraft = useCallback(async () => {
-    draftStopped.current = true;
-    clearTimeout(draftTimer.current);
-    await draftWriter?.clear();
-  }, [draftWriter]);
+  }, [captureDraft, watch]);
 
-  const updateAttachments = useCallback((next: ComposeAttachment[]) => {
-    attachmentsRef.current = next;
-    setAttachments(next);
-    saveDraftRef.current();
-  }, []);
+  const updateAttachments = useCallback(
+    (next: ComposeAttachment[]) => {
+      attachmentsRef.current = next;
+      setAttachments(next);
+      captureDraft();
+    },
+    [captureDraft],
+  );
 
   const removeUnusedInlineAttachments = useCallback(
     (contentIds: string[]) => {
@@ -469,9 +420,9 @@ function ComposeEmailFormContent({
         });
         return;
       }
-      saveDraftRef.current();
+      captureDraft();
     },
-    [removeUnusedInlineAttachments],
+    [captureDraft, removeUnusedInlineAttachments],
   );
 
   const addFiles = useCallback(
@@ -671,11 +622,8 @@ function ComposeEmailFormContent({
           }
           deliveryPath.current ??= sendAt || remindAt ? "scheduled" : "outbox";
         }
-        if (draftWriter) {
-          saveDraftRef.current();
-          clearTimeout(draftTimer.current);
-          if (latestDraft.current) await draftWriter.save(latestDraft.current);
-        }
+        captureDraft();
+        await flushDraft();
         if (isInlineReply && deliveryPath.current === "scheduled") {
           const result = await scheduleEmailAction(selectedEmailAccountId, {
             clientMutationId: requestId,
@@ -802,8 +750,9 @@ function ComposeEmailFormContent({
       remindAt,
       requestId,
       draftKeyMessageId,
-      draftWriter,
+      captureDraft,
       clearLocalDraft,
+      flushDraft,
       mutate,
       onClose,
       onSuccess,
@@ -850,10 +799,10 @@ function ComposeEmailFormContent({
     (field: ComposeRecipientField, query: string) => {
       pendingRecipientsRef.current[field] = query;
       queueMicrotask(() => {
-        if (isMountedRef.current) saveDraftRef.current();
+        if (isMountedRef.current) captureDraft();
       });
     },
-    [],
+    [captureDraft],
   );
 
   const recipientFieldProps = {
@@ -899,12 +848,12 @@ function ComposeEmailFormContent({
     setSubmissionError("");
     setSendAt(value);
     setRemindAt(nextRemindAt);
-    saveDraftRef.current({ sendAt: value, remindAt: nextRemindAt });
+    captureDraft({ sendAt: value, remindAt: nextRemindAt });
   };
   const handleRemindAtChange = (value: string) => {
     setSubmissionError("");
     setRemindAt(value);
-    saveDraftRef.current({ remindAt: value });
+    captureDraft({ remindAt: value });
   };
 
   return (
@@ -919,7 +868,7 @@ function ComposeEmailFormContent({
             } as CSSProperties)
           : undefined
       }
-      onInput={() => saveDraftRef.current()}
+      onInput={() => captureDraft()}
       onSubmit={handleSubmit(onSubmit)}
       className={cn(
         isComposeWindow
@@ -1317,16 +1266,9 @@ function ComposeEmailFormContent({
               disabled={isSubmitting}
               onClick={async () => {
                 try {
+                  if ((await onDiscard()) === false) return;
                   await clearLocalDraft();
-                  onDiscard();
-                } catch (error) {
-                  draftStopped.current = false;
-                  setDraftSaveError(
-                    error instanceof Error
-                      ? error.message
-                      : "Could not discard this draft.",
-                  );
-                }
+                } catch {}
               }}
               size={isComposeWindow ? "iconSm" : "icon"}
               title="Discard draft"
@@ -1658,13 +1600,4 @@ function getQueuedEmailDescription(
     return "Email queued. Reconnect this account to send it.";
   }
   return "Email queued and will keep sending in the background.";
-}
-
-function getReplyDraftSnapshot(content: ReplyDraftContent) {
-  return JSON.stringify({
-    ...content,
-    attachments: content.attachments.map(
-      ({ contentBase64: _content, ...metadata }) => metadata,
-    ),
-  });
 }

--- a/apps/web/components/email-list/EmailMessage.test.tsx
+++ b/apps/web/components/email-list/EmailMessage.test.tsx
@@ -85,7 +85,7 @@ describe("EmailMessage draft recovery", () => {
 
     render(
       <EmailMessage
-        defaultShowReply
+        defaultComposeMode="reply"
         draftMessage={createMessage("draft-1")}
         expanded
         message={createMessage("message-1")}

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -38,12 +38,18 @@ import { env } from "@/env";
 import type { ContactsResponse } from "@/app/api/user/contacts/route";
 import { toastError } from "@/components/Toast";
 import { getActionErrorMessage } from "@/utils/error";
+import {
+  getReplyDraftSessionId,
+  type ReplyDraftMode,
+} from "@/utils/email-cache/reply-drafts";
+
+type ComposeSession = { id: number; mode: ReplyDraftMode };
 
 export function EmailMessage({
   message,
   refetch,
   showReplyButton,
-  defaultShowReply,
+  defaultComposeMode,
   draftMessage,
   expanded,
   onToggle,
@@ -58,7 +64,7 @@ export function EmailMessage({
   draftMessage?: ThreadMessage;
   refetch: () => void;
   showReplyButton: boolean;
-  defaultShowReply?: boolean;
+  defaultComposeMode?: ReplyDraftMode;
   expanded: boolean;
   /** Absent when the thread has a single message, which never collapses. */
   onToggle?: () => void;
@@ -70,45 +76,44 @@ export function EmailMessage({
   onNavigateMessage?: (direction: -1 | 1) => void;
 }) {
   const { emailAccountId } = useAccount();
-  // `null` follows `defaultShowReply`, which the reader's Reply button flips
+  // `null` follows `defaultComposeMode`, which the reader's Reply button flips
   // long after this message mounted.
-  const [replyOverride, setReplyOverride] = useState<boolean | null>(null);
-  const showReply = replyOverride ?? Boolean(defaultShowReply);
+  const [composeOverride, setComposeOverride] = useState<
+    ReplyDraftMode | "closed" | null
+  >(null);
+  const composeMode = resolveComposeMode(composeOverride, defaultComposeMode);
 
   const [showDetails, setShowDetails] = useState(false);
-  const [showForward, setShowForward] = useState(false);
   const composeSessionRef = useRef(0);
 
   const onReply = useCallback(() => {
     composeSessionRef.current += 1;
-    setReplyOverride(true);
-    setShowForward(false);
+    setComposeOverride("reply");
   }, []);
   const onForward = useCallback(() => {
     composeSessionRef.current += 1;
-    setReplyOverride(false);
-    setShowForward(true);
+    setComposeOverride("forward");
   }, []);
 
   const onCloseCompose = useCallback(() => {
-    setReplyOverride(false);
-    setShowForward(false);
+    setComposeOverride("closed");
   }, []);
 
-  const onStartDiscard = useCallback(() => {
-    const composeSession = composeSessionRef.current;
+  const onStartDiscard = useCallback((): ComposeSession | undefined => {
+    if (!composeMode) return;
+    const composeSession = {
+      id: composeSessionRef.current,
+      mode: composeMode,
+    };
     onCloseCompose();
     return composeSession;
-  }, [onCloseCompose]);
+  }, [composeMode, onCloseCompose]);
 
-  const onRestoreCompose = useCallback(
-    (composeSession: number) => {
-      if (composeSessionRef.current !== composeSession) return;
-      if (showReply) onReply();
-      else onForward();
-    },
-    [onForward, onReply, showReply],
-  );
+  const onRestoreCompose = useCallback((composeSession: ComposeSession) => {
+    if (composeSessionRef.current !== composeSession.id) return;
+    composeSessionRef.current += 1;
+    setComposeOverride(composeSession.mode);
+  }, []);
 
   const toggleDetails = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -180,9 +185,9 @@ export function EmailMessage({
 
           {message.attachments && <EmailAttachments message={message} />}
 
-          {(showReply || showForward) && (
+          {composeMode && (
             <ReplyPanel
-              defaultShowReply={defaultShowReply}
+              defaultComposeMode={defaultComposeMode}
               draftMessage={draftMessage}
               message={message}
               onCloseCompose={onCloseCompose}
@@ -190,7 +195,7 @@ export function EmailMessage({
               onSendSuccess={onSendSuccess}
               onStartDiscard={onStartDiscard}
               refetch={refetch}
-              showReply={showReply}
+              composeMode={composeMode}
             />
           )}
         </div>
@@ -434,18 +439,18 @@ function ReplyPanel({
   onCloseCompose,
   onRestoreCompose,
   onStartDiscard,
-  defaultShowReply,
-  showReply,
+  defaultComposeMode,
+  composeMode,
   draftMessage,
 }: {
   message: ParsedMessage;
   refetch: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
   onCloseCompose: () => void;
-  onRestoreCompose: (composeSession: number) => void;
-  onStartDiscard: () => number;
-  defaultShowReply?: boolean;
-  showReply: boolean;
+  onRestoreCompose: (composeSession: ComposeSession) => void;
+  onStartDiscard: () => ComposeSession | undefined;
+  defaultComposeMode?: ReplyDraftMode;
+  composeMode: ReplyDraftMode;
   draftMessage?: ThreadMessage;
 }) {
   const { emailAccountId } = useAccount();
@@ -454,7 +459,7 @@ function ReplyPanel({
 
   // scroll to the reply panel when it first opens
   useEffect(() => {
-    if (!defaultShowReply || !replyRef.current) return;
+    if (!defaultComposeMode || !replyRef.current) return;
 
     // Wait for the reply panel layout before scrolling.
     const scrollTimeout = setTimeout(() => {
@@ -462,29 +467,30 @@ function ReplyPanel({
     }, 500);
 
     return () => clearTimeout(scrollTimeout);
-  }, [defaultShowReply]);
+  }, [defaultComposeMode]);
 
   const replyingToEmail: ReplyingToEmail = useMemo(() => {
-    if (showReply) {
+    if (composeMode === "reply") {
       if (draftMessage) return prepareDraftReplyEmail(draftMessage);
 
       return prepareReplyingToEmail(message);
     }
     return prepareForwardingEmail(message);
-  }, [showReply, message, draftMessage]);
+  }, [composeMode, message, draftMessage]);
 
   const { executeAsync: discardDraft } = useAction(
     deleteDraftAction.bind(null, emailAccountId),
   );
 
   const onDiscard = useCallback(async () => {
-    if (!draftMessage) {
+    if (composeMode === "forward" || !draftMessage) {
       onCloseCompose();
-      return;
+      return true;
     }
 
     const discardPromise = discardDraft({ draftMessageId: draftMessage.id });
     const composeSession = onStartDiscard();
+    if (!composeSession) return false;
 
     try {
       const result = await discardPromise;
@@ -495,14 +501,18 @@ function ReplyPanel({
           }),
         });
         onRestoreCompose(composeSession);
+        return false;
       }
     } catch {
       toastError({ description: "Failed to discard draft" });
       onRestoreCompose(composeSession);
+      return false;
     } finally {
       refetch();
     }
+    return true;
   }, [
+    composeMode,
     draftMessage,
     discardDraft,
     onCloseCompose,
@@ -515,6 +525,8 @@ function ReplyPanel({
     <div className="mt-5" ref={replyRef}>
       <ComposeEmailFormLazy
         draftKeyMessageId={message.id}
+        draftMode={composeMode}
+        draftSessionId={getReplyDraftSessionId(message.id, composeMode)}
         onClose={onCloseCompose}
         onDiscard={onDiscard}
         onSuccess={(messageId: string, threadId: string) => {
@@ -534,6 +546,15 @@ function initialsFor(name: string) {
   if (words.length === 0) return "?";
   if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
   return `${words[0][0]}${words[words.length - 1][0]}`.toUpperCase();
+}
+
+function resolveComposeMode(
+  override: ReplyDraftMode | "closed" | null,
+  defaultComposeMode: ReplyDraftMode | undefined,
+) {
+  if (override === "closed") return;
+  if (override) return override;
+  return defaultComposeMode;
 }
 
 /** "to me", "to Dana", "to me and 3 others" — who a message went out to. */

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -289,6 +289,7 @@ function getLocalDraftMode(drafts: StoredReplyDraft[], messageId: string) {
   const latest = drafts
     .filter(
       (draft) =>
+        draft.messageId === messageId ||
         draft.messageId === getReplyDraftSessionId(messageId, "reply") ||
         draft.messageId === getReplyDraftSessionId(messageId, "forward"),
     )

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -10,6 +10,7 @@ import { useReplyDrafts } from "@/hooks/useReplyDrafts";
 import { ThreadDeliveryStatus } from "@/components/email-list/ThreadDeliveryStatus";
 import { Button } from "@/components/ui/button";
 import {
+  getReplyDraftMode,
   getReplyDraftSessionId,
   type ReplyDraftMode,
 } from "@/utils/email-cache/reply-drafts";
@@ -295,7 +296,7 @@ function getLocalDraftMode(drafts: StoredReplyDraft[], messageId: string) {
   if (!latest) return;
   return latest.messageId === getReplyDraftSessionId(messageId, "forward")
     ? ("forward" as const)
-    : ("reply" as const);
+    : getReplyDraftMode(latest);
 }
 
 function getDefaultComposeMode({

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -9,6 +9,11 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { useReplyDrafts } from "@/hooks/useReplyDrafts";
 import { ThreadDeliveryStatus } from "@/components/email-list/ThreadDeliveryStatus";
 import { Button } from "@/components/ui/button";
+import {
+  getReplyDraftSessionId,
+  type ReplyDraftMode,
+} from "@/utils/email-cache/reply-drafts";
+import type { StoredReplyDraft } from "@/utils/email-cache/database";
 
 export function EmailThread({
   messages,
@@ -72,6 +77,7 @@ export function EmailThread({
   >(() => new Map());
   const [recoveredReply, setRecoveredReply] = useState<{
     messageId: string;
+    mode: ReplyDraftMode;
     version: number;
   }>();
   useEffect(() => {
@@ -83,7 +89,7 @@ export function EmailThread({
   const expanded = (id: string, hasDraft: boolean) =>
     expansionOverrides.get(id) ?? (id === lastMessageId || hasDraft);
   const hasLocalDraft = (id: string) =>
-    localDrafts.some((draft) => draft.messageId === id);
+    Boolean(getLocalDraftMode(localDrafts, id));
   const allExpanded = organizedMessages.every(({ message, draftMessage }) =>
     expanded(
       message.id,
@@ -198,11 +204,15 @@ export function EmailThread({
 
       <ul className="pt-1">
         {organizedMessages.map(({ message, draftMessage }) => {
-          const defaultShowReply =
-            autoOpenReplyForMessageId === message.id ||
-            recoveredReply?.messageId === message.id ||
-            Boolean(draftMessage) ||
-            hasLocalDraft(message.id);
+          const defaultComposeMode = getDefaultComposeMode({
+            autoOpen: autoOpenReplyForMessageId === message.id,
+            draftMessage: Boolean(draftMessage),
+            localDraftMode: getLocalDraftMode(localDrafts, message.id),
+            recoveredReply:
+              recoveredReply?.messageId === message.id
+                ? recoveredReply
+                : undefined,
+          });
           return (
             <EmailMessage
               onNavigateMessage={
@@ -218,9 +228,9 @@ export function EmailThread({
                   ? () => setSelectedMessageId(message.id)
                   : undefined
               }
-              defaultShowReply={defaultShowReply}
+              defaultComposeMode={defaultComposeMode}
               draftMessage={draftMessage}
-              expanded={expanded(message.id, defaultShowReply)}
+              expanded={expanded(message.id, Boolean(defaultComposeMode))}
               hasDraft={Boolean(draftMessage) || hasLocalDraft(message.id)}
               key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
@@ -240,7 +250,7 @@ export function EmailThread({
                       setExpansionOverrides((prev) =>
                         new Map(prev).set(
                           message.id,
-                          !expanded(message.id, defaultShowReply),
+                          !expanded(message.id, Boolean(defaultComposeMode)),
                         ),
                       );
                     }
@@ -258,12 +268,13 @@ export function EmailThread({
           threadId={threadId}
           messageIds={messages.map((message) => message.id)}
           refetch={refetch}
-          onEditReply={(messageId) => {
+          onEditReply={(messageId, mode) => {
             setExpansionOverrides((previous) =>
               new Map(previous).set(messageId, true),
             );
             setRecoveredReply((previous) => ({
               messageId,
+              mode,
               version: (previous?.version ?? 0) + 1,
             }));
           }}
@@ -271,4 +282,34 @@ export function EmailThread({
       )}
     </div>
   );
+}
+
+function getLocalDraftMode(drafts: StoredReplyDraft[], messageId: string) {
+  const latest = drafts
+    .filter(
+      (draft) =>
+        draft.messageId === getReplyDraftSessionId(messageId, "reply") ||
+        draft.messageId === getReplyDraftSessionId(messageId, "forward"),
+    )
+    .sort((left, right) => right.updatedAt - left.updatedAt)[0];
+  if (!latest) return;
+  return latest.messageId === getReplyDraftSessionId(messageId, "forward")
+    ? ("forward" as const)
+    : ("reply" as const);
+}
+
+function getDefaultComposeMode({
+  autoOpen,
+  draftMessage,
+  localDraftMode,
+  recoveredReply,
+}: {
+  autoOpen: boolean;
+  draftMessage: boolean;
+  localDraftMode?: ReplyDraftMode;
+  recoveredReply?: { mode: ReplyDraftMode };
+}) {
+  if (recoveredReply) return recoveredReply.mode;
+  if (autoOpen || draftMessage) return "reply" as const;
+  return localDraftMode;
 }

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import useSWR from "swr";
 import { restoreReplyFromOutbox } from "@/utils/email-cache/reply-drafts";
+import type { ReplyDraftMode } from "@/utils/email-cache/reply-drafts";
 import { Button } from "@/components/ui/button";
 import {
   getEmailCacheDatabase,
@@ -36,7 +37,7 @@ export function ThreadDeliveryStatus({
   emailAccountId: string;
   threadId: string;
   messageIds: string[];
-  onEditReply: (messageId: string) => void;
+  onEditReply: (messageId: string, mode: ReplyDraftMode) => void;
   refetch: () => void;
   canEditReply: boolean;
 }) {
@@ -192,8 +193,11 @@ export function ThreadDeliveryStatus({
                 size="sm"
                 onClick={() =>
                   act(async () => {
-                    await restoreReplyFromOutbox(row.id, emailAccountId);
-                    onEditReply(row.messageIds[0]);
+                    const restored = await restoreReplyFromOutbox(
+                      row.id,
+                      emailAccountId,
+                    );
+                    onEditReply(restored.messageId, restored.mode);
                   })
                 }
               >

--- a/apps/web/hooks/useLocalReplyDraft.ts
+++ b/apps/web/hooks/useLocalReplyDraft.ts
@@ -2,13 +2,16 @@
 
 import { useEffect, useState } from "react";
 import {
-  getReplyDraft,
+  getReplyDraftForSession,
   type ReplyDraftIdentity,
 } from "@/utils/email-cache/reply-drafts";
 import type { StoredReplyDraft } from "@/utils/email-cache/database";
 
-export function useLocalReplyDraft(identity: ReplyDraftIdentity | undefined) {
-  const key = identity ? JSON.stringify(identity) : "";
+export function useLocalReplyDraft(
+  identity: ReplyDraftIdentity | undefined,
+  legacyIdentity?: ReplyDraftIdentity,
+) {
+  const key = identity ? JSON.stringify({ identity, legacyIdentity }) : "";
   const [loaded, setLoaded] = useState<{
     key: string;
     draft?: StoredReplyDraft;
@@ -17,7 +20,14 @@ export function useLocalReplyDraft(identity: ReplyDraftIdentity | undefined) {
   useEffect(() => {
     if (!key) return;
     let cancelled = false;
-    getReplyDraft(JSON.parse(key)).then(
+    const identities = JSON.parse(key) as {
+      identity: ReplyDraftIdentity;
+      legacyIdentity?: ReplyDraftIdentity;
+    };
+    getReplyDraftForSession(
+      identities.identity,
+      identities.legacyIdentity,
+    ).then(
       (draft) => {
         if (!cancelled) setLoaded({ key, draft });
       },

--- a/apps/web/hooks/useLocalReplyDraft.ts
+++ b/apps/web/hooks/useLocalReplyDraft.ts
@@ -10,8 +10,11 @@ import type { StoredReplyDraft } from "@/utils/email-cache/database";
 export function useLocalReplyDraft(
   identity: ReplyDraftIdentity | undefined,
   legacyIdentity?: ReplyDraftIdentity,
+  mode?: "reply" | "forward",
 ) {
-  const key = identity ? JSON.stringify({ identity, legacyIdentity }) : "";
+  const key = identity
+    ? JSON.stringify({ identity, legacyIdentity, mode })
+    : "";
   const [loaded, setLoaded] = useState<{
     key: string;
     draft?: StoredReplyDraft;
@@ -23,10 +26,12 @@ export function useLocalReplyDraft(
     const identities = JSON.parse(key) as {
       identity: ReplyDraftIdentity;
       legacyIdentity?: ReplyDraftIdentity;
+      mode?: "reply" | "forward";
     };
     getReplyDraftForSession(
       identities.identity,
       identities.legacyIdentity,
+      identities.mode,
     ).then(
       (draft) => {
         if (!cancelled) setLoaded({ key, draft });

--- a/apps/web/hooks/useReplyDraftPersistence.test.ts
+++ b/apps/web/hooks/useReplyDraftPersistence.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useReplyDraftPersistence } from "./useReplyDraftPersistence";
+import type { ReplyDraftContent } from "@/utils/email-cache/reply-drafts";
+
+const { save, clear } = vi.hoisted(() => ({
+  save: vi.fn(),
+  clear: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/reply-drafts", async (importOriginal) => ({
+  ...(await importOriginal()),
+  createReplyDraftWriter: () => ({ save, clear }),
+}));
+
+const content: ReplyDraftContent = {
+  values: { to: "person@example.com", subject: "Reply" },
+  draft: {
+    editableHtml: "<p>Keep this draft</p>",
+    mode: "rich",
+    quotedHtml: "",
+    signatureHtml: "",
+    unsupported: [],
+  },
+  preservedBlocks: [],
+  attachments: [],
+};
+
+describe("useReplyDraftPersistence", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("retries an unchanged snapshot after a save failure", async () => {
+    vi.useFakeTimers();
+    save
+      .mockRejectedValueOnce(new Error("Storage failed"))
+      .mockResolvedValue({});
+    const { result } = renderHook(() =>
+      useReplyDraftPersistence({
+        identity: {
+          emailAccountId: "account",
+          threadId: "thread",
+          messageId: "message",
+        },
+        getContent: () => content,
+      }),
+    );
+
+    act(() => result.current.capture());
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(save).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.capture());
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/hooks/useReplyDraftPersistence.test.ts
+++ b/apps/web/hooks/useReplyDraftPersistence.test.ts
@@ -11,7 +11,9 @@ const { save, clear } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/utils/email-cache/reply-drafts", async (importOriginal) => ({
-  ...(await importOriginal()),
+  ...(await importOriginal<
+    typeof import("@/utils/email-cache/reply-drafts")
+  >()),
   createReplyDraftWriter: () => ({ save, clear }),
 }));
 

--- a/apps/web/hooks/useReplyDraftPersistence.ts
+++ b/apps/web/hooks/useReplyDraftPersistence.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createReplyDraftWriter,
+  type ReplyDraftContent,
+  type ReplyDraftIdentity,
+} from "@/utils/email-cache/reply-drafts";
+
+type DraftDeliveryTimes = { sendAt?: string; remindAt?: string };
+
+export function useReplyDraftPersistence({
+  identity,
+  initialRevision,
+  loadError,
+  getContent,
+}: {
+  identity?: ReplyDraftIdentity;
+  initialRevision?: number;
+  loadError?: Error;
+  getContent: (
+    deliveryTimes?: DraftDeliveryTimes,
+  ) => ReplyDraftContent | undefined;
+}) {
+  const [saveError, setSaveError] = useState(loadError?.message ?? "");
+  const [writer] = useState(() =>
+    identity ? createReplyDraftWriter(identity, initialRevision) : undefined,
+  );
+  const stopped = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const latest = useRef<ReplyDraftContent | undefined>(undefined);
+  const latestSnapshot = useRef<string | undefined>(undefined);
+  const queuedSnapshot = useRef<string | undefined>(undefined);
+  const mounted = useRef(true);
+  const getContentRef = useRef(getContent);
+  getContentRef.current = getContent;
+
+  const flush = useCallback(async () => {
+    clearTimeout(timer.current);
+    const content = latest.current;
+    const snapshot = latestSnapshot.current;
+    if (!content || !snapshot || !writer || stopped.current) return;
+    if (snapshot === queuedSnapshot.current) return;
+
+    queuedSnapshot.current = snapshot;
+    try {
+      await writer.save(content);
+      if (
+        mounted.current &&
+        !stopped.current &&
+        latestSnapshot.current === snapshot
+      ) {
+        setSaveError("");
+      }
+    } catch (error) {
+      if (queuedSnapshot.current === snapshot)
+        queuedSnapshot.current = undefined;
+      if (mounted.current) {
+        setSaveError(
+          error instanceof Error
+            ? error.message
+            : "Could not save draft on this device.",
+        );
+      }
+    }
+  }, [writer]);
+
+  const capture = useCallback(
+    (deliveryTimes?: DraftDeliveryTimes) => {
+      if (!writer || stopped.current) return;
+      const content = getContentRef.current(deliveryTimes);
+      if (!content) return;
+      const snapshot = getReplyDraftSnapshot(content);
+      if (snapshot === latestSnapshot.current) return;
+
+      latest.current = content;
+      latestSnapshot.current = snapshot;
+      clearTimeout(timer.current);
+      timer.current = setTimeout(() => flush().catch(() => {}), 300);
+    },
+    [flush, writer],
+  );
+
+  const clear = useCallback(async () => {
+    stopped.current = true;
+    clearTimeout(timer.current);
+    try {
+      await writer?.clear();
+    } catch (error) {
+      stopped.current = false;
+      if (mounted.current) {
+        setSaveError(
+          error instanceof Error
+            ? error.message
+            : "Could not discard this draft.",
+        );
+      }
+      throw error;
+    }
+  }, [writer]);
+
+  useEffect(() => {
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") flush().catch(() => {});
+    };
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", flushWhenHidden);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", flushWhenHidden);
+      flush().catch(() => {});
+    };
+  }, [flush]);
+
+  useEffect(
+    () => () => {
+      mounted.current = false;
+    },
+    [],
+  );
+
+  return { capture, clear, flush, saveError };
+}
+
+function getReplyDraftSnapshot(content: ReplyDraftContent) {
+  return JSON.stringify({
+    ...content,
+    attachments: content.attachments.map(
+      ({ contentBase64: _content, ...metadata }) => metadata,
+    ),
+  });
+}

--- a/apps/web/hooks/useReplyDraftPersistence.ts
+++ b/apps/web/hooks/useReplyDraftPersistence.ts
@@ -71,7 +71,11 @@ export function useReplyDraftPersistence({
       const content = getContentRef.current(deliveryTimes);
       if (!content) return;
       const snapshot = getReplyDraftSnapshot(content);
-      if (snapshot === latestSnapshot.current) return;
+      if (
+        snapshot === latestSnapshot.current &&
+        snapshot === queuedSnapshot.current
+      )
+        return;
 
       latest.current = content;
       latestSnapshot.current = snapshot;

--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -130,7 +130,10 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
                 fromAccounts={accountsData?.emailAccounts}
                 layout="window"
                 onClose={closeCompose}
-                onDiscard={closeCompose}
+                onDiscard={() => {
+                  closeCompose();
+                  return true;
+                }}
                 onSuccess={closeCompose}
               />
             </div>

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -149,6 +149,17 @@ describe("local reply drafts", () => {
     await assertions;
   });
 
+  it("does not migrate a legacy draft while account cleanup is running", async () => {
+    await createReplyDraftWriter(identity).save(content);
+    const migration = getReplyDraftForSession(replyIdentity, identity, "reply");
+    const assertion = expect(migration).rejects.toThrow("cleared");
+    await clearEmailCacheForAccount(identity.emailAccountId);
+    await assertion;
+    expect(
+      await getReplyDrafts(identity.emailAccountId, identity.threadId),
+    ).toEqual([]);
+  });
+
   it("does not recreate an outbox draft when recovery overlaps account cleanup", async () => {
     const queued = await enqueueMailMutation({
       ...identity,

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -12,6 +12,7 @@ import {
   restoreReplyFromOutbox,
   createReplyDraftWriter,
   getReplyDraft,
+  getReplyDraftForSession,
   getReplyDrafts,
   getReplyDraftSessionId,
   type ReplyDraftContent,
@@ -87,6 +88,19 @@ describe("local reply drafts", () => {
     expect(
       (await getReplyDraft(forwardIdentity))?.content?.draft.editableHtml,
     ).toBe("<p>Forward text</p>");
+  });
+  it("migrates a legacy forward draft to its separate session", async () => {
+    const forwardIdentity = {
+      ...identity,
+      messageId: getReplyDraftSessionId(identity.messageId, "forward"),
+    };
+    await createReplyDraftWriter(identity).save(content);
+
+    const migrated = await getReplyDraftForSession(forwardIdentity, identity);
+
+    expect(migrated?.content).toMatchObject({ composeMode: "forward" });
+    expect(migrated?.content?.draft.editableHtml).toBe("<p>My reply</p>");
+    expect((await getReplyDraft(identity))?.content).toBeNull();
   });
   it("does not hydrate drafts from reads overlapping account cleanup", async () => {
     await createReplyDraftWriter(identity).save(content);

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -127,6 +127,14 @@ describe("local reply drafts", () => {
     );
 
     expect(migrated?.content).toMatchObject({ composeMode: "reply" });
+    expect(migrated?.content?.draft.editableHtml).toBe("<p>My reply</p>");
+    expect(migrated?.content?.values).toMatchObject({
+      to: "someone@example.com",
+      replyToEmail: {
+        threadId: identity.threadId,
+        headerMessageId: "header-message-id",
+      },
+    });
     expect((await getReplyDraft(identity))?.content).toBeNull();
   });
   it("does not hydrate drafts from reads overlapping account cleanup", async () => {

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -89,16 +89,22 @@ describe("local reply drafts", () => {
       (await getReplyDraft(forwardIdentity))?.content?.draft.editableHtml,
     ).toBe("<p>Forward text</p>");
   });
-  it("migrates a legacy forward draft to its separate session", async () => {
+  it("migrates a legacy forward draft across concurrent readers", async () => {
     const forwardIdentity = {
       ...identity,
       messageId: getReplyDraftSessionId(identity.messageId, "forward"),
     };
     await createReplyDraftWriter(identity).save(content);
 
-    const migrated = await getReplyDraftForSession(forwardIdentity, identity);
+    const [migrated, concurrentMigration] = await Promise.all([
+      getReplyDraftForSession(forwardIdentity, identity),
+      getReplyDraftForSession(forwardIdentity, identity),
+    ]);
 
     expect(migrated?.content).toMatchObject({ composeMode: "forward" });
+    expect(concurrentMigration?.content).toMatchObject({
+      composeMode: "forward",
+    });
     expect(migrated?.content?.draft.editableHtml).toBe("<p>My reply</p>");
     expect((await getReplyDraft(identity))?.content).toBeNull();
   });

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -97,8 +97,8 @@ describe("local reply drafts", () => {
     await createReplyDraftWriter(identity).save(content);
 
     const [migrated, concurrentMigration] = await Promise.all([
-      getReplyDraftForSession(forwardIdentity, identity),
-      getReplyDraftForSession(forwardIdentity, identity),
+      getReplyDraftForSession(forwardIdentity, identity, "forward"),
+      getReplyDraftForSession(forwardIdentity, identity, "forward"),
     ]);
 
     expect(migrated?.content).toMatchObject({ composeMode: "forward" });
@@ -106,6 +106,27 @@ describe("local reply drafts", () => {
       composeMode: "forward",
     });
     expect(migrated?.content?.draft.editableHtml).toBe("<p>My reply</p>");
+    expect((await getReplyDraft(identity))?.content).toBeNull();
+  });
+  it("migrates a legacy reply draft to its separate session", async () => {
+    await createReplyDraftWriter(identity).save({
+      ...content,
+      values: {
+        ...content.values,
+        replyToEmail: {
+          threadId: identity.threadId,
+          headerMessageId: "header-message-id",
+        },
+      },
+    });
+
+    const migrated = await getReplyDraftForSession(
+      replyIdentity,
+      identity,
+      "reply",
+    );
+
+    expect(migrated?.content).toMatchObject({ composeMode: "reply" });
     expect((await getReplyDraft(identity))?.content).toBeNull();
   });
   it("does not hydrate drafts from reads overlapping account cleanup", async () => {

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -13,6 +13,7 @@ import {
   createReplyDraftWriter,
   getReplyDraft,
   getReplyDrafts,
+  getReplyDraftSessionId,
   type ReplyDraftContent,
 } from "./reply-drafts";
 
@@ -20,6 +21,10 @@ const identity = {
   emailAccountId: "account",
   threadId: "thread",
   messageId: "parent",
+};
+const replyIdentity = {
+  ...identity,
+  messageId: getReplyDraftSessionId(identity.messageId, "reply"),
 };
 const content: ReplyDraftContent = {
   values: {
@@ -64,6 +69,25 @@ describe("local reply drafts", () => {
       "private@example.com",
     );
   });
+  it("keeps reply and forward sessions isolated for the same message", async () => {
+    const forwardIdentity = {
+      ...identity,
+      messageId: getReplyDraftSessionId(identity.messageId, "forward"),
+    };
+    await createReplyDraftWriter(replyIdentity).save(content);
+    await createReplyDraftWriter(forwardIdentity).save({
+      ...content,
+      values: { ...content.values, to: "" },
+      draft: { ...content.draft, editableHtml: "<p>Forward text</p>" },
+    });
+
+    expect(
+      (await getReplyDraft(replyIdentity))?.content?.draft.editableHtml,
+    ).toBe("<p>My reply</p>");
+    expect(
+      (await getReplyDraft(forwardIdentity))?.content?.draft.editableHtml,
+    ).toBe("<p>Forward text</p>");
+  });
   it("does not hydrate drafts from reads overlapping account cleanup", async () => {
     await createReplyDraftWriter(identity).save(content);
     const read = getReplyDraft(identity);
@@ -82,6 +106,10 @@ describe("local reply drafts", () => {
       messageIds: [identity.messageId],
       kind: "reply",
       email: {
+        replyToEmail: {
+          threadId: identity.threadId,
+          headerMessageId: "header-message-id",
+        },
         to: "person@example.com",
         subject: "Reply",
         messageHtml: "<p>Private draft</p>",
@@ -109,12 +137,23 @@ describe("local reply drafts", () => {
     await expect(stale.save(content)).rejects.toThrow("another tab");
     expect(await getReplyDrafts("account", "thread")).toEqual([]);
   });
+  it("does not leave a writer closed when clearing fails", async () => {
+    const stale = createReplyDraftWriter(identity);
+    await createReplyDraftWriter(identity).save(content);
+
+    await expect(stale.clear()).rejects.toThrow("another tab");
+    await expect(stale.save(content)).rejects.toThrow("another tab");
+  });
   it("restores a queued reply for editing atomically without losing its body", async () => {
     const queued = await enqueueMailMutation({
       ...identity,
       messageIds: [identity.messageId],
       kind: "reply",
       email: {
+        replyToEmail: {
+          threadId: identity.threadId,
+          headerMessageId: "header-message-id",
+        },
         to: "person@example.com",
         subject: "Reply",
         messageHtml: "<p>Keep this text</p>",
@@ -126,12 +165,42 @@ describe("local reply drafts", () => {
     await restoreReplyFromOutbox(queued.id, identity.emailAccountId);
     expect(await getMailMutation(queued.id)).toBeUndefined();
     expect(
-      (await getReplyDraft(identity))?.content?.draft.editableHtml,
+      (await getReplyDraft(replyIdentity))?.content?.draft.editableHtml,
     ).toContain("Keep this text");
     const attachments =
-      (await getReplyDraft(identity))?.content?.attachments ?? [];
+      (await getReplyDraft(replyIdentity))?.content?.attachments ?? [];
     expect(attachments).toHaveLength(1);
     expect(validateEmailAttachments(attachments).valid).toBe(true);
+  });
+  it("restores a queued forward into its forward session", async () => {
+    const queued = await enqueueMailMutation({
+      ...identity,
+      messageIds: [identity.messageId],
+      kind: "reply",
+      email: {
+        to: "person@example.com",
+        subject: "Fwd: Reply",
+        messageHtml: "<p>Forward this text</p>",
+      },
+    });
+
+    const restored = await restoreReplyFromOutbox(
+      queued.id,
+      identity.emailAccountId,
+    );
+
+    expect(restored).toEqual({
+      messageId: identity.messageId,
+      mode: "forward",
+    });
+    expect(
+      (
+        await getReplyDraft({
+          ...identity,
+          messageId: getReplyDraftSessionId(identity.messageId, "forward"),
+        })
+      )?.content,
+    ).toMatchObject({ composeMode: "forward" });
   });
   it("does not restore a reply already claimed for sending", async () => {
     const queued = await enqueueMailMutation({

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -86,34 +86,90 @@ export async function getReplyDraftForSession(
   legacyIdentity?: ReplyDraftIdentity,
   mode?: ReplyDraftMode,
 ) {
+  const epoch = captureEmailCacheEpoch(identity.emailAccountId);
   const draft = await getReplyDraft(identity);
   if (draft || !legacyIdentity || !mode) return draft;
 
-  const legacyDraft = await getReplyDraft(legacyIdentity);
-  if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== mode) return;
-
   try {
-    await createReplyDraftWriter(identity).save({
-      ...legacyDraft.content,
-      composeMode: mode,
+    await pendingWrites
+      .get(getReplyDraftIdentityKey(legacyIdentity))
+      ?.catch(() => {});
+    const database = await getEmailCacheDatabase();
+    if (!database)
+      throw new Error("Draft storage is unavailable on this device.");
+    if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+      throw new Error("This account’s local draft storage was cleared.");
+
+    const transaction = database.transaction("replyDrafts", "readwrite");
+    const store = transaction.store;
+    const currentDraft = await store.get([
+      identity.emailAccountId,
+      identity.threadId,
+      identity.messageId,
+    ]);
+    if (currentDraft) {
+      await transaction.done;
+      if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+        throw new Error("This account’s local draft storage was cleared.");
+      return currentDraft;
+    }
+
+    const legacyDraft = await store.get([
+      legacyIdentity.emailAccountId,
+      legacyIdentity.threadId,
+      legacyIdentity.messageId,
+    ]);
+    if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== mode) {
+      await transaction.done;
+      if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+        throw new Error("This account’s local draft storage was cleared.");
+      return;
+    }
+
+    const migratedDraft: StoredReplyDraft = {
+      ...identity,
+      content: { ...legacyDraft.content, composeMode: mode },
+      revision: 1,
+      updatedAt: Date.now(),
+    };
+    await store.put(migratedDraft);
+    await store.put({
+      ...legacyDraft,
+      content: null,
+      revision: legacyDraft.revision + 1,
+      updatedAt: Date.now(),
     });
-  } catch {
+    await transaction.done;
+    if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+      throw new Error("This account’s local draft storage was cleared.");
+    notifyReplyDraftChange(identity);
+    notifyReplyDraftChange(legacyIdentity);
+    return migratedDraft;
+  } catch (error) {
+    if (!isEmailCacheEpochCurrent(identity.emailAccountId, epoch))
+      throw new Error("This account’s local draft storage was cleared.");
     const concurrentDraft = await getReplyDraft(identity).catch(
       () => undefined,
     );
-    return (
-      concurrentDraft ?? {
+    if (concurrentDraft) return concurrentDraft;
+
+    const legacyDraft = await getReplyDraft(legacyIdentity).catch(
+      () => undefined,
+    );
+    if (
+      legacyDraft?.content &&
+      getReplyDraftMode(legacyDraft) === mode &&
+      isEmailCacheEpochCurrent(identity.emailAccountId, epoch)
+    ) {
+      return {
         ...legacyDraft,
         messageId: identity.messageId,
         revision: 0,
         content: { ...legacyDraft.content, composeMode: mode },
-      }
-    );
+      };
+    }
+    throw error;
   }
-  await createReplyDraftWriter(legacyIdentity, legacyDraft.revision)
-    .clear()
-    .catch(() => {});
-  return getReplyDraft(identity);
 }
 
 export function getReplyDraftMode(draft: StoredReplyDraft) {
@@ -178,8 +234,7 @@ export function createReplyDraftWriter(
         await transaction.done;
         revision += 1;
         if (Boolean(previous?.content) !== Boolean(content)) {
-          for (const listener of listeners) listener(identity);
-          channel?.postMessage(identity);
+          notifyReplyDraftChange(identity);
         }
       });
     pending = operation;
@@ -221,6 +276,11 @@ function getReplyDraftIdentityKey(identity: ReplyDraftIdentity) {
 function clearPendingWrite(identityKey: string, operation: Promise<unknown>) {
   if (pendingWrites.get(identityKey) === operation)
     pendingWrites.delete(identityKey);
+}
+
+function notifyReplyDraftChange(scope: ReplyDraftScope) {
+  for (const listener of listeners) listener(scope);
+  channel?.postMessage(scope);
 }
 
 export async function restoreReplyFromOutbox(

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -196,7 +196,7 @@ export async function restoreReplyFromOutbox(
   if (row?.kind !== "reply" || row.emailAccountId !== emailAccountId)
     throw new Error("Queued reply was not found.");
   const email = sendEmailBody.parse((row.payload as { email: unknown }).email);
-  const composeMode = email.replyToEmail ? "reply" : "forward";
+  const composeMode: ReplyDraftMode = email.replyToEmail ? "reply" : "forward";
   const draft = prepareEmailDraft({ html: email.messageHtml });
   const { attachments, messageHtml: _messageHtml, ...values } = email;
   const content: ReplyDraftContent = {

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -92,10 +92,24 @@ export async function getReplyDraftForSession(
   if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== "forward")
     return;
 
-  await createReplyDraftWriter(identity).save({
-    ...legacyDraft.content,
-    composeMode: "forward",
-  });
+  try {
+    await createReplyDraftWriter(identity).save({
+      ...legacyDraft.content,
+      composeMode: "forward",
+    });
+  } catch {
+    const concurrentDraft = await getReplyDraft(identity).catch(
+      () => undefined,
+    );
+    return (
+      concurrentDraft ?? {
+        ...legacyDraft,
+        messageId: identity.messageId,
+        revision: 0,
+        content: { ...legacyDraft.content, composeMode: "forward" },
+      }
+    );
+  }
   await createReplyDraftWriter(legacyIdentity, legacyDraft.revision)
     .clear()
     .catch(() => {});

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -16,6 +16,7 @@ import {
 } from "./database";
 
 export type ReplyDraftContent = {
+  composeMode?: ReplyDraftMode;
   requestId?: string;
   deliveryPath?: "scheduled" | "outbox";
   values: Omit<SendEmailBody, "attachments" | "messageHtml">;
@@ -30,12 +31,21 @@ export type ReplyDraftIdentity = Pick<
   StoredReplyDraft,
   "emailAccountId" | "threadId" | "messageId"
 >;
+export type ReplyDraftMode = "reply" | "forward";
 type ReplyDraftScope = Pick<ReplyDraftIdentity, "emailAccountId" | "threadId">;
 const listeners = new Set<(scope: ReplyDraftScope) => void>();
+const pendingWrites = new Map<string, Promise<unknown>>();
 const channel =
   typeof window !== "undefined" && typeof BroadcastChannel !== "undefined"
     ? new BroadcastChannel("inbox-zero-reply-drafts")
     : null;
+
+export function getReplyDraftSessionId(
+  messageId: string,
+  mode: ReplyDraftMode,
+) {
+  return mode === "reply" ? messageId : `${messageId}:forward`;
+}
 channel?.addEventListener("message", (event) => {
   const scope = event.data;
   if (
@@ -57,6 +67,7 @@ export function subscribeToReplyDrafts(
 
 export async function getReplyDraft(identity: ReplyDraftIdentity) {
   const epoch = captureEmailCacheEpoch(identity.emailAccountId);
+  await pendingWrites.get(getReplyDraftIdentityKey(identity))?.catch(() => {});
   const database = await getEmailCacheDatabase();
   if (!database)
     throw new Error("Draft storage is unavailable on this device.");
@@ -131,6 +142,12 @@ export function createReplyDraftWriter(
         }
       });
     pending = operation;
+    const identityKey = getReplyDraftIdentityKey(identity);
+    pendingWrites.set(identityKey, operation);
+    operation.then(
+      () => clearPendingWrite(identityKey, operation),
+      () => clearPendingWrite(identityKey, operation),
+    );
     return operation;
   };
   return {
@@ -144,9 +161,25 @@ export function createReplyDraftWriter(
     clear() {
       stopped = true;
       // Keep a revision tombstone so an older tab cannot resurrect a sent draft.
-      return write(null);
+      return write(null).catch((error) => {
+        stopped = false;
+        throw error;
+      });
     },
   };
+}
+
+function getReplyDraftIdentityKey(identity: ReplyDraftIdentity) {
+  return JSON.stringify([
+    identity.emailAccountId,
+    identity.threadId,
+    identity.messageId,
+  ]);
+}
+
+function clearPendingWrite(identityKey: string, operation: Promise<unknown>) {
+  if (pendingWrites.get(identityKey) === operation)
+    pendingWrites.delete(identityKey);
 }
 
 export async function restoreReplyFromOutbox(
@@ -163,9 +196,11 @@ export async function restoreReplyFromOutbox(
   if (row?.kind !== "reply" || row.emailAccountId !== emailAccountId)
     throw new Error("Queued reply was not found.");
   const email = sendEmailBody.parse((row.payload as { email: unknown }).email);
+  const composeMode = email.replyToEmail ? "reply" : "forward";
   const draft = prepareEmailDraft({ html: email.messageHtml });
   const { attachments, messageHtml: _messageHtml, ...values } = email;
   const content: ReplyDraftContent = {
+    composeMode,
     values,
     draft,
     preservedBlocks: createPreservedEmailBlocks(draft),
@@ -179,13 +214,14 @@ export async function restoreReplyFromOutbox(
       contentId: file.contentId,
     })),
   };
+  const originalMessageId = row.messageIds[0];
+  if (!originalMessageId)
+    throw new Error("The reply's original message is unavailable.");
   const identity = {
     emailAccountId: row.emailAccountId,
     threadId: row.threadId,
-    messageId: row.messageIds[0],
+    messageId: getReplyDraftSessionId(originalMessageId, composeMode),
   };
-  if (!identity.messageId)
-    throw new Error("The reply's original message is unavailable.");
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch))
     throw new Error("This account’s local draft storage was cleared.");
   const transaction = database.transaction(
@@ -226,4 +262,5 @@ export async function restoreReplyFromOutbox(
   for (const listener of listeners) listener(identity);
   channel?.postMessage(identity);
   notifyMailMutationChange();
+  return { messageId: originalMessageId, mode: composeMode };
 }

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -81,6 +81,33 @@ export async function getReplyDraft(identity: ReplyDraftIdentity) {
   return draft;
 }
 
+export async function getReplyDraftForSession(
+  identity: ReplyDraftIdentity,
+  legacyIdentity?: ReplyDraftIdentity,
+) {
+  const draft = await getReplyDraft(identity);
+  if (draft || !legacyIdentity) return draft;
+
+  const legacyDraft = await getReplyDraft(legacyIdentity);
+  if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== "forward")
+    return;
+
+  await createReplyDraftWriter(identity).save({
+    ...legacyDraft.content,
+    composeMode: "forward",
+  });
+  await createReplyDraftWriter(legacyIdentity, legacyDraft.revision)
+    .clear()
+    .catch(() => {});
+  return getReplyDraft(identity);
+}
+
+export function getReplyDraftMode(draft: StoredReplyDraft) {
+  if (!draft.content) return;
+  if (draft.content.composeMode) return draft.content.composeMode;
+  return draft.content.values.replyToEmail ? "reply" : "forward";
+}
+
 export async function getReplyDrafts(emailAccountId: string, threadId: string) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
   const database = await getEmailCacheDatabase();

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -44,7 +44,7 @@ export function getReplyDraftSessionId(
   messageId: string,
   mode: ReplyDraftMode,
 ) {
-  return mode === "reply" ? messageId : `${messageId}:forward`;
+  return `${messageId}:${mode}`;
 }
 channel?.addEventListener("message", (event) => {
   const scope = event.data;
@@ -84,18 +84,18 @@ export async function getReplyDraft(identity: ReplyDraftIdentity) {
 export async function getReplyDraftForSession(
   identity: ReplyDraftIdentity,
   legacyIdentity?: ReplyDraftIdentity,
+  mode?: ReplyDraftMode,
 ) {
   const draft = await getReplyDraft(identity);
-  if (draft || !legacyIdentity) return draft;
+  if (draft || !legacyIdentity || !mode) return draft;
 
   const legacyDraft = await getReplyDraft(legacyIdentity);
-  if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== "forward")
-    return;
+  if (!legacyDraft?.content || getReplyDraftMode(legacyDraft) !== mode) return;
 
   try {
     await createReplyDraftWriter(identity).save({
       ...legacyDraft.content,
-      composeMode: "forward",
+      composeMode: mode,
     });
   } catch {
     const concurrentDraft = await getReplyDraft(identity).catch(
@@ -106,7 +106,7 @@ export async function getReplyDraftForSession(
         ...legacyDraft,
         messageId: identity.messageId,
         revision: 0,
-        content: { ...legacyDraft.content, composeMode: "forward" },
+        content: { ...legacyDraft.content, composeMode: mode },
       }
     );
   }


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-143555_pr-3536_583514ae9402/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

## Summary

- centralize inline composer persistence behind one hook while preserving revision-ordered IndexedDB writes
- give reply and forward composers separate sessions so mode switches remount cleanly without losing either draft
- restore scheduled/outbox retries into the correct composer mode and keep local work when discard fails

## Validation

- `pnpm lint`
- `pnpm test utils/email-cache/reply-drafts.test.ts components/email-list/EmailMessage.test.tsx`
- `pnpm -F inbox-zero-ai test:playwright:emulated mail/compose-and-reply.spec.ts`
- `pnpm -F inbox-zero-ai test:playwright:emulated mail/thread-states.spec.ts mail/scheduled-replies.spec.ts mail/offline-outbox.spec.ts` (thread and scheduled passed; offline OAuth setup timed out before tests)
- `pnpm -F inbox-zero-ai test:playwright:emulated mail/offline-outbox.spec.ts` (rerun passed)

Browser screenshots for restored drafts and durable offline replies were inspected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reply and forward drafts now remain separate when switching composer modes.
  - Draft content, recipients, attachments, and delivery options are preserved more reliably.
  - Restored drafts reopen in the correct reply or forward mode.
  - Failed draft saves can retry, and discard failures are reported to users.

- **Tests**
  - Added coverage confirming independent preservation of reply and forward drafts when switching between composers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->