### PR TITLE
cold-email: Preserve onboarding emails and honor trusted senders

### DIFF
--- a/apps/web/__tests__/eval/cold-email-cases.ts
+++ b/apps/web/__tests__/eval/cold-email-cases.ts
@@ -690,6 +690,105 @@ I teach a small online course on email habits and would like to include two diag
   },
   // Not cold: automated and bulk mail belongs to other rules
   {
+    name: "signup lifecycle: welcome tour with promotional feature descriptions",
+    category: "onboarding",
+    expected: false,
+    email: getEmail({
+      from: "Support <team@notebrook.example>",
+      subject: "Explore your new workspace",
+      content: `Welcome to NoteBrook! Here's a quick tour to help you get started.
+
+Capture ideas anywhere. Your notebook syncs across your phone and computer, so your thoughts are always at hand. Turn notes into tasks and share them with your team. It's all ready in your workspace.
+
+Make it yours: choose a template, invite a teammate, or install the desktop app for quick capture. Open your workspace to try these features today.
+
+Questions? Reply here for help.
+The NoteBrook team`,
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: activation reminder for an email platform",
+    category: "onboarding",
+    expected: false,
+    email: getEmail({
+      from: "MailHarbor <start@mailharbor.example>",
+      subject: "Your workspace is waiting",
+      content: `Thanks for creating your MailHarbor account. You haven't connected an inbox yet. Connect it from your dashboard to activate your complimentary trial and start organizing messages. Need a hand? Reply and our team will help.`,
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: personal onboarding offer from a founder",
+    category: "onboarding",
+    expected: false,
+    email: getEmail({
+      from: "Founder <founder@taskgrove.example>",
+      subject: "Can I help with setup?",
+      content: `Hi, I built TaskGrove and saw you created a workspace yesterday. If you'd like help importing your team's projects, book a short call with me. Your account includes two weeks on the team plan at no charge. I'd love to hear what you're hoping to use it for.`,
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: trial expiry with upgrade call to action",
+    category: "onboarding",
+    expected: false,
+    email: getEmail({
+      from: "ChartNest <accounts@chartnest.example>",
+      subject: "Keep your dashboards running",
+      content:
+        "Your ChartNest trial ends in three days. The dashboards you created will become read-only unless you choose a plan. Upgrade in your workspace to keep scheduled reports and invite more teammates. Your saved reports remain available on the free plan.",
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: Spanish setup follow-up",
+    category: "onboarding",
+    expected: false,
+    email: getEmail({
+      from: "Equipo <hola@reservanube.example>",
+      subject: "Completa tu página de reservas",
+      content:
+        "Gracias por registrarte en ReservaNube. Tu cuenta ya está creada; falta conectar tu calendario y definir tus horarios. Entra en tu panel para terminar la configuración y empezar a recibir reservas durante tu prueba gratuita. Si necesitas ayuda, responde a este correo.",
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: transactional subscription receipt",
+    category: "transactional",
+    expected: false,
+    email: getEmail({
+      from: "FileMeadow billing <receipts@filemeadow.example>",
+      subject: "Your monthly subscription receipt",
+      content:
+        "Payment received for your FileMeadow workspace subscription. Your plan renews next month. Download your invoice or manage billing from your account settings. Thank you for using FileMeadow.",
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: unsolicited free trial pitch",
+    category: "vendor pitch",
+    expected: true,
+    email: getEmail({
+      from: "Sales <sales@pipelinefern.example>",
+      subject: "A trial for your sales team",
+      content:
+        "I found your company in a startup directory and thought PipelineFern could help your sales team find more leads. Would you be open to trying our platform free for two weeks? I can walk you through it on a quick demo call.",
+      date,
+    }),
+  },
+  {
+    name: "signup lifecycle: unsolicited account provisioning disguised as onboarding",
+    category: "vendor pitch",
+    expected: true,
+    email: getEmail({
+      from: "Growth <growth@reachwillow.example>",
+      subject: "Welcome to your new workspace",
+      content: `You don't know us yet. I found your company online and went ahead and created a ReachWillow account for you, loaded with prospects who could buy your product. Activate it today and book a demo so I can show you our paid lead generation plans.`,
+      date,
+    }),
+  },
+  {
     name: "marketing newsletter with unsubscribe",
     category: "automated",
     expected: false,

--- a/apps/web/prisma/migrations/20260906120000_clarify_cold_email_onboarding/migration.sql
+++ b/apps/web/prisma/migrations/20260906120000_clarify_cold_email_onboarding/migration.sql
@@ -1,6 +1,7 @@
 -- Update the stock cold-email prompt; preserve customized instructions.
 UPDATE "Rule"
-SET "instructions" = $q$Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it.
+SET "updatedAt" = CURRENT_TIMESTAMP,
+    "instructions" = $q$Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it.
 
 Signing up for a service establishes a relationship, even before any email exchange. Its onboarding, trial reminders, and account messages are not cold outreach, even with promotional content. An unsolicited trial offer does not establish that relationship.
 

--- a/apps/web/prisma/migrations/20260906120000_clarify_cold_email_onboarding/migration.sql
+++ b/apps/web/prisma/migrations/20260906120000_clarify_cold_email_onboarding/migration.sql
@@ -1,0 +1,57 @@
+-- Update the stock cold-email prompt; preserve customized instructions.
+UPDATE "Rule"
+SET "instructions" = $q$Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it.
+
+Signing up for a service establishes a relationship, even before any email exchange. Its onboarding, trial reminders, and account messages are not cold outreach, even with promotional content. An unsolicited trial offer does not establish that relationship.
+
+Examples of cold emails:
+- Sell a product or service (e.g., agency pitching their services)
+- Request a partnership or collaboration out of the blue
+- Templated outreach that could have been sent to anyone, including "are you open to opportunities" fishing
+
+Unsolicited outreach is NOT a cold email when it is specific to you and worth your attention, such as:
+- A potential customer or partner with a concrete need or opportunity
+- An investor that wants to learn more or invest in the company
+
+Emails that are NOT cold emails include:
+- Email from a friend or colleague
+- Email from someone you met at a conference
+- Intro emails where someone is introducing you to another person
+- Email from a customer
+- Newsletter
+- Password reset
+- Welcome emails
+- Receipts
+- Promotions
+- Alerts
+- Updates
+- Calendar invites
+
+Regular marketing or automated emails are NOT cold emails, even if unwanted.$q$
+WHERE "systemType" = 'COLD_EMAIL'
+  AND "instructions" = $q$Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it. The aim is to recognize outreach that doesn't matter to you while not mistaking outreach that does.
+
+Examples of cold emails:
+- Sell a product or service (e.g., agency pitching their services)
+- Request a partnership or collaboration out of the blue
+- Templated outreach that could have been sent to anyone, including "are you open to opportunities" fishing
+
+Unsolicited outreach is NOT a cold email when it is specific to you and worth your attention, such as:
+- A potential customer or partner with a concrete need or opportunity
+- An investor that wants to learn more or invest in the company
+
+Emails that are NOT cold emails include:
+- Email from a friend or colleague
+- Email from someone you met at a conference
+- Intro emails where someone is introducing you to another person
+- Email from a customer
+- Newsletter
+- Password reset
+- Welcome emails
+- Receipts
+- Promotions
+- Alerts
+- Updates
+- Calendar invites
+
+Regular marketing or automated emails are NOT cold emails, even if unwanted.$q$;

--- a/apps/web/utils/ai/automated-archive-exception.test.ts
+++ b/apps/web/utils/ai/automated-archive-exception.test.ts
@@ -49,4 +49,34 @@ describe("shouldSkipAutomatedArchiveForSender", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    "OR",
+    "or",
+    "Or",
+  ])("honors every explicit sender separated by %s", (separator) => {
+    envMock.WHITELIST_FROM = `first@service.example ${separator} second@service.example`;
+
+    expect(
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.ARCHIVE,
+        from: '"Service team" <SECOND@SERVICE.EXAMPLE>',
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    "invalid whitelist",
+    "service.example",
+    undefined,
+  ])("does not exempt malformed senders with whitelist %s", (whitelist) => {
+    envMock.WHITELIST_FROM = whitelist;
+
+    expect(
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.ARCHIVE,
+        from: "invalid sender",
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/web/utils/ai/automated-archive-exception.ts
+++ b/apps/web/utils/ai/automated-archive-exception.ts
@@ -1,6 +1,6 @@
 import { ActionType } from "@/generated/prisma/enums";
 import { env } from "@/env";
-import { extractEmailAddress } from "@/utils/email";
+import { isWhitelistedSender } from "@/utils/email/whitelist";
 
 export function shouldSkipAutomatedArchiveForSender({
   actionType,
@@ -9,10 +9,8 @@ export function shouldSkipAutomatedArchiveForSender({
   actionType: ActionType;
   from: string;
 }) {
-  if (actionType !== ActionType.ARCHIVE || !env.WHITELIST_FROM) return false;
-
   return (
-    extractEmailAddress(from).toLowerCase() ===
-    extractEmailAddress(env.WHITELIST_FROM).toLowerCase()
+    actionType === ActionType.ARCHIVE &&
+    isWhitelistedSender(from, env.WHITELIST_FROM)
   );
 }

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -10,6 +10,17 @@ import { createGenerateObject } from "@/utils/llms";
 
 vi.mock("@/utils/prisma");
 
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return {
+    ...actual,
+    env: {
+      ...actual.env,
+      WHITELIST_FROM: "welcome@service.example OR service.example",
+    },
+  };
+});
+
 vi.mock("./cold-email-rule", () => ({
   getColdEmailRule: vi.fn(),
 }));
@@ -225,6 +236,71 @@ describe("isColdEmail", () => {
       mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
     ).not.toHaveBeenCalled();
     expect(createGenerateObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "welcome@service.example",
+    '"Service team" <WELCOME@SERVICE.EXAMPLE>',
+  ])("should exempt the whitelisted sender %s even with a learned cold pattern", async (from) => {
+    vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
+      id: "group-item-id",
+      type: GroupItemType.FROM,
+      value: "welcome@service.example",
+      exclude: false,
+      group: { id: "group-id", name: "Cold Email" },
+    } as any);
+
+    const result = await isColdEmail({
+      email: {
+        id: "msg-onboarding",
+        from,
+        to: "user@customer.test",
+        subject: "Finish setting up your account",
+        content: "Your workspace is ready to configure.",
+        date: new Date(),
+      },
+      emailAccount: getEmailAccount({ email: "user@customer.test" }),
+      provider: mockProvider as never,
+      coldEmailRule: { instructions: "test instructions", groupId: "group-id" },
+    });
+
+    expect(result).toEqual({ isColdEmail: false, reason: "applicationSender" });
+    expect(prisma.groupItem.findFirst).not.toHaveBeenCalled();
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).not.toHaveBeenCalled();
+    expect(createGenerateObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "other@service.example",
+    "welcome@service.example.attacker.test",
+    '"welcome@service.example" <sender@attacker.test>',
+  ])("should not extend the whitelist to %s", async (from) => {
+    vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
+      id: "group-item-id",
+      type: GroupItemType.FROM,
+      value: extractEmailAddress(from),
+      exclude: false,
+      group: { id: "group-id", name: "Cold Email" },
+    } as any);
+
+    const result = await isColdEmail({
+      email: {
+        id: "msg-untrusted",
+        from,
+        to: "user@customer.test",
+        subject: "Hello",
+        content: "Can we schedule a sales call?",
+        date: new Date(),
+      },
+      emailAccount: getEmailAccount({ email: "user@customer.test" }),
+      provider: mockProvider as never,
+      coldEmailRule: { instructions: "test instructions", groupId: "group-id" },
+    });
+
+    expect(result.isColdEmail).toBe(true);
+    expect(result.reason).toBe("ai-already-labeled");
   });
 
   // Blocking a sender we could not verify is worse than missing a cold email.

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -14,10 +14,7 @@ vi.mock("@/env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/env")>();
   return {
     ...actual,
-    env: {
-      ...actual.env,
-      WHITELIST_FROM: "welcome@service.example OR service.example",
-    },
+    env: { ...actual.env },
   };
 });
 
@@ -44,6 +41,7 @@ const mockProvider = {
 describe("isColdEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    env.WHITELIST_FROM = "welcome@service.example OR service.example";
   });
 
   it("should recognize a known cold email sender even when from field format differs", async () => {
@@ -241,7 +239,10 @@ describe("isColdEmail", () => {
   it.each([
     "welcome@service.example",
     '"Service team" <WELCOME@SERVICE.EXAMPLE>',
+    "updates@another.example",
   ])("should exempt the whitelisted sender %s even with a learned cold pattern", async (from) => {
+    env.WHITELIST_FROM =
+      "welcome@service.example OR service.example OR updates@another.example";
     vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
       id: "group-item-id",
       type: GroupItemType.FROM,
@@ -273,10 +274,26 @@ describe("isColdEmail", () => {
   });
 
   it.each([
-    "other@service.example",
-    "welcome@service.example.attacker.test",
-    '"welcome@service.example" <sender@attacker.test>',
-  ])("should not extend the whitelist to %s", async (from) => {
+    {
+      from: "other@service.example",
+      whitelist: "welcome@service.example OR service.example",
+    },
+    {
+      from: "welcome@service.example.attacker.test",
+      whitelist: "welcome@service.example",
+    },
+    {
+      from: '"welcome@service.example" <sender@attacker.test>',
+      whitelist: "welcome@service.example",
+    },
+    { from: "invalid sender", whitelist: "invalid whitelist" },
+    { from: "invalid sender", whitelist: "service.example" },
+    { from: "welcome@service.example", whitelist: undefined },
+  ])("should not exempt $from with whitelist $whitelist", async ({
+    from,
+    whitelist,
+  }) => {
+    env.WHITELIST_FROM = whitelist;
     vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
       id: "group-item-id",
       type: GroupItemType.FROM,

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -59,8 +59,11 @@ export async function isColdEmail({
 
   logger.info("Checking is cold email");
 
-  if (isSameEmailAddress(email.from, env.RESEND_FROM_EMAIL)) {
-    logger.info("Sender is the application notification sender");
+  if (
+    isSameEmailAddress(email.from, env.RESEND_FROM_EMAIL) ||
+    (env.WHITELIST_FROM && isSameEmailAddress(email.from, env.WHITELIST_FROM))
+  ) {
+    logger.info("Sender is an application sender");
     return { isColdEmail: false, reason: "applicationSender" };
   }
 
@@ -152,26 +155,11 @@ async function aiIsColdEmail(
   coldEmailPrompt: string,
   modelType?: ModelType,
 ) {
-  const system = `You are an assistant that decides if an email is a cold email or not.
+  const system = `Decide whether the email is cold outreach. Give a concise reason.
 
 <instructions>
 ${coldEmailPrompt || DEFAULT_COLD_EMAIL_PROMPT}
-</instructions>
-
-<output_format>
-Return a JSON object with a "reason" and "coldEmail" field.
-The "reason" should be a concise explanation that explains why the email is or isn't considered a cold email.
-The "coldEmail" should be a boolean that is true if the email is a cold email and false otherwise.
-</output_format>
-
-<example_response>
-{
-  "reason": "This is someone trying to sell you services.",
-  "coldEmail": true
-}
-</example_response>
-
-Determine if the email is a cold email or not.`;
+</instructions>`;
 
   const prompt = `<email>
 ${stringifyEmail(email, 500)}

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -59,9 +59,15 @@ export async function isColdEmail({
 
   logger.info("Checking is cold email");
 
+  const applicationSenders = [
+    env.RESEND_FROM_EMAIL,
+    ...(env.WHITELIST_FROM?.split(/\s+OR\s+/) || []),
+  ];
   if (
-    isSameEmailAddress(email.from, env.RESEND_FROM_EMAIL) ||
-    (env.WHITELIST_FROM && isSameEmailAddress(email.from, env.WHITELIST_FROM))
+    applicationSenders.some((sender) => {
+      const address = extractEmailAddress(sender);
+      return !!address && isSameEmailAddress(email.from, address);
+    })
   ) {
     logger.info("Sender is an application sender");
     return { isColdEmail: false, reason: "applicationSender" };

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -11,11 +11,8 @@ import type { EmailForLLM } from "@/utils/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { getModel, type ModelType } from "@/utils/llms/model";
 import { createGenerateObject } from "@/utils/llms";
-import {
-  extractEmailAddress,
-  isSameEmailAddress,
-  isSameOrganization,
-} from "@/utils/email";
+import { extractEmailAddress, isSameOrganization } from "@/utils/email";
+import { isWhitelistedSender } from "@/utils/email/whitelist";
 import { hasPriorContactOrAssumeYes } from "@/utils/cold-email/has-prior-contact";
 
 export const COLD_EMAIL_FOLDER_NAME = "Cold Emails";
@@ -59,15 +56,9 @@ export async function isColdEmail({
 
   logger.info("Checking is cold email");
 
-  const applicationSenders = [
-    env.RESEND_FROM_EMAIL,
-    ...(env.WHITELIST_FROM?.split(/\s+OR\s+/) || []),
-  ];
   if (
-    applicationSenders.some((sender) => {
-      const address = extractEmailAddress(sender);
-      return !!address && isSameEmailAddress(email.from, address);
-    })
+    isWhitelistedSender(email.from, env.RESEND_FROM_EMAIL) ||
+    isWhitelistedSender(email.from, env.WHITELIST_FROM)
   ) {
     logger.info("Sender is an application sender");
     return { isColdEmail: false, reason: "applicationSender" };

--- a/apps/web/utils/cold-email/prompt.ts
+++ b/apps/web/utils/cold-email/prompt.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_COLD_EMAIL_PROMPT = `Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it. The aim is to recognize outreach that doesn't matter to you while not mistaking outreach that does.
+export const DEFAULT_COLD_EMAIL_PROMPT = `Cold emails are unsolicited outreach from someone you have no existing relationship with, sent to get something from you rather than because you need it.
+
+Signing up for a service establishes a relationship, even before any email exchange. Its onboarding, trial reminders, and account messages are not cold outreach, even with promotional content. An unsolicited trial offer does not establish that relationship.
 
 Examples of cold emails:
 - Sell a product or service (e.g., agency pitching their services)

--- a/apps/web/utils/email/whitelist.ts
+++ b/apps/web/utils/email/whitelist.ts
@@ -11,7 +11,7 @@ export function isWhitelistedSender(
   return (
     whitelist?.split(/\s+OR\s+/i).some((entry) => {
       const whitelistedAddress = extractEmailAddress(entry).toLowerCase();
-      return !!whitelistedAddress && address === whitelistedAddress;
+      return address === whitelistedAddress;
     }) ?? false
   );
 }

--- a/apps/web/utils/email/whitelist.ts
+++ b/apps/web/utils/email/whitelist.ts
@@ -1,0 +1,17 @@
+import { extractEmailAddress } from "@/utils/email";
+
+export function isWhitelistedSender(
+  from: string,
+  whitelist: string | undefined,
+) {
+  const address = extractEmailAddress(from).toLowerCase();
+  if (!address) return false;
+
+  // Application exemptions are mailbox-specific; domain terms are only for the Gmail filter.
+  return (
+    whitelist?.split(/\s+OR\s+/i).some((entry) => {
+      const whitelistedAddress = extractEmailAddress(entry).toLowerCase();
+      return !!whitelistedAddress && address === whitelistedAddress;
+    }) ?? false
+  );
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-101406_pr-3537_2557caea7690/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Onboarding and account emails can be misclassified as cold outreach, and the cold-email detector does not consult the configured sender whitelist. Share explicit sender whitelist matching across cold-email detection and archive exemptions, honor it before learned patterns and AI classification, and clarify the signup relationship in a shorter classifier prompt.

- Add generic onboarding, transactional, and unsolicited-trial eval coverage plus whitelist regression tests.
- Migrate only the exact previous stock prompt; preserve customized instructions. Verified that the migration replacement matches the runtime default.
- Validation: 151 focused unit tests passed; all 55 scored cases passed with the updated prompt in the full cold-email eval; Biome and diff checks passed.

The runtime change adds no database or network calls. Whitelisted messages bypass classification, and redundant model-facing instructions are removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cold-email detection to distinguish legitimate onboarding, trial reminders, account messages, and receipts from unsolicited sales outreach.
  - Added support for multiple explicitly whitelisted senders with case-insensitive matching.
  - Extended sender whitelist coverage to configured application and alternate sender addresses.

- **Bug Fixes**
  - Improved handling of sender names, alternate domains, malformed whitelist entries, and missing whitelist settings.
  - Prevented lookalike or spoofed addresses from incorrectly bypassing cold-email classification.
  - Improved automated archive exceptions for valid whitelisted senders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->