### PR TITLE
mail: Preserve document styles in email previews

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -28,6 +28,9 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
     "rgb(244, 233, 218)",
   );
   await expect(
+    emailFrame.getByText("The current reply stays concise and easy to scan."),
+  ).toHaveCSS("margin-bottom", "16px");
+  await expect(
     emailFrame.getByText(
       "This earlier quoted message is hidden until expanded.",
     ),

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -19,6 +19,14 @@ test("captures the rich message reader states", async ({ page }, testInfo) => {
   await expect(
     emailFrame.getByText("The current reply stays concise and easy to scan."),
   ).toBeVisible();
+  await expect(emailFrame.locator("body")).toHaveCSS(
+    "background-color",
+    "rgb(35, 35, 38)",
+  );
+  await expect(emailFrame.locator("body")).toHaveCSS(
+    "color",
+    "rgb(244, 233, 218)",
+  );
   await expect(
     emailFrame.getByText(
       "This earlier quoted message is hidden until expanded.",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -216,10 +216,13 @@ function writeEmulateSeed({ baseURL, playwrightTestEmail, runId }) {
 function createReaderVisualMessage({ attachment, recipient }) {
   const boundary = "playwright-reader-visual-boundary";
   const html = [
+    '<!doctype html><html lang="en"><head><style>p { margin: 0 0 16px; }</style></head>',
+    '<body style="margin: 0; padding: 16px; background: #232326; color: #f4e9da; font-family: Arial, sans-serif">',
     "<div><p>The current reply stays concise and easy to scan.</p>",
     "<p>The attached image should appear as a preview below.</p></div>",
     '<div id="divRplyFwdMsg"><hr><div><b>From:</b> Previous sender</div></div>',
     "<div><p>This earlier quoted message is hidden until expanded.</p></div>",
+    "</body></html>",
   ].join("");
   const mime = [
     "From: Morgan Example <morgan@example.com>",

--- a/apps/web/utils/email/prepare-html.client.test.ts
+++ b/apps/web/utils/email/prepare-html.client.test.ts
@@ -24,12 +24,16 @@ describe("sanitizeEmailHtml", () => {
       </html>
     `);
 
-    const document = new DOMParser().parseFromString(sanitized, "text/html");
+    const parsedDocument = new DOMParser().parseFromString(
+      sanitized,
+      "text/html",
+    );
 
-    expect(document.body.getAttribute("style")).toBe(
+    expect(sanitized).toMatch(/^<!doctype html>/i);
+    expect(parsedDocument.body.getAttribute("style")).toBe(
       "background: #222; color: #eee",
     );
-    expect(document.head.querySelector("style")?.textContent).toContain(
+    expect(parsedDocument.head.querySelector("style")?.textContent).toContain(
       "p { margin: 0; }",
     );
   });
@@ -44,10 +48,15 @@ describe("sanitizeEmailHtml", () => {
       </html>
     `);
 
-    const document = new DOMParser().parseFromString(sanitized, "text/html");
+    const parsedDocument = new DOMParser().parseFromString(
+      sanitized,
+      "text/html",
+    );
 
-    expect(document.querySelector("script")).toBeNull();
-    expect(document.body.hasAttribute("onload")).toBe(false);
-    expect(document.querySelector("img")?.hasAttribute("onerror")).toBe(false);
+    expect(parsedDocument.querySelector("script")).toBeNull();
+    expect(parsedDocument.body.hasAttribute("onload")).toBe(false);
+    expect(parsedDocument.querySelector("img")?.hasAttribute("onerror")).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/utils/email/prepare-html.client.test.ts
+++ b/apps/web/utils/email/prepare-html.client.test.ts
@@ -13,6 +13,19 @@ vi.mock("@/env", () => ({
 import { sanitizeEmailHtml } from "./prepare-html.client";
 
 describe("sanitizeEmailHtml", () => {
+  it("wraps and sanitizes email fragments as complete documents", () => {
+    const sanitized = sanitizeEmailHtml(
+      "<div onclick=\"alert('unsafe')\">Readable content</div>",
+    );
+    const parsedDocument = new DOMParser().parseFromString(
+      sanitized,
+      "text/html",
+    );
+
+    expect(sanitized).toMatch(/^<!doctype html><html><head><\/head><body>/i);
+    expect(parsedDocument.body.innerHTML).toBe("<div>Readable content</div>");
+  });
+
   it("preserves document-level styles used by email content", () => {
     const sanitized = sanitizeEmailHtml(`
       <!doctype html>

--- a/apps/web/utils/email/prepare-html.client.test.ts
+++ b/apps/web/utils/email/prepare-html.client.test.ts
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: "https://app.example.com",
+    NEXT_PUBLIC_IMAGE_PROXY_BASE_URL: "https://img.example.com/proxy",
+    NEXT_PUBLIC_IMAGE_PROXY_USE_APP_ROUTE: true,
+  },
+}));
+
+import { sanitizeEmailHtml } from "./prepare-html.client";
+
+describe("sanitizeEmailHtml", () => {
+  it("preserves document-level styles used by email content", () => {
+    const sanitized = sanitizeEmailHtml(`
+      <!doctype html>
+      <html lang="en">
+        <head><style>p { margin: 0; }</style></head>
+        <body style="background: #222; color: #eee">
+          <div>Readable content</div>
+        </body>
+      </html>
+    `);
+
+    const document = new DOMParser().parseFromString(sanitized, "text/html");
+
+    expect(document.body.getAttribute("style")).toBe(
+      "background: #222; color: #eee",
+    );
+    expect(document.head.querySelector("style")?.textContent).toContain(
+      "p { margin: 0; }",
+    );
+  });
+
+  it("removes executable content from complete email documents", () => {
+    const sanitized = sanitizeEmailHtml(`
+      <html>
+        <body onload="alert('unsafe')">
+          <script>alert("unsafe")</script>
+          <img src="https://example.com/image.png" onerror="alert('unsafe')">
+        </body>
+      </html>
+    `);
+
+    const document = new DOMParser().parseFromString(sanitized, "text/html");
+
+    expect(document.querySelector("script")).toBeNull();
+    expect(document.body.hasAttribute("onload")).toBe(false);
+    expect(document.querySelector("img")?.hasAttribute("onerror")).toBe(false);
+  });
+});

--- a/apps/web/utils/email/prepare-html.client.ts
+++ b/apps/web/utils/email/prepare-html.client.ts
@@ -24,10 +24,10 @@ const inFlightPreparation = new Map<
 >();
 
 export function sanitizeEmailHtml(html: string) {
-  return DOMPurify.sanitize(html, {
+  return `<!doctype html>${DOMPurify.sanitize(html, {
     USE_PROFILES: { html: true },
     WHOLE_DOCUMENT: true,
-  });
+  })}`;
 }
 
 export function getPreparedEmailHtml({

--- a/apps/web/utils/email/prepare-html.client.ts
+++ b/apps/web/utils/email/prepare-html.client.ts
@@ -24,7 +24,10 @@ const inFlightPreparation = new Map<
 >();
 
 export function sanitizeEmailHtml(html: string) {
-  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    WHOLE_DOCUMENT: true,
+  });
 }
 
 export function getPreparedEmailHtml({

--- a/apps/web/utils/email/split-email-content.client.test.ts
+++ b/apps/web/utils/email/split-email-content.client.test.ts
@@ -49,6 +49,18 @@ describe("splitEmailContent", () => {
     expect(parsedDocument.body.textContent).toBe("Current reply");
   });
 
+  it("preserves legacy doctype identifiers when collapsing quoted content", () => {
+    const legacyDoctype =
+      '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">';
+    const result = splitEmailContent(
+      `${legacyDoctype}<html><body><p>Current reply</p><div class="gmail_quote">Earlier message</div></body></html>`,
+    );
+
+    expect(result.mainContent).toMatch(
+      /^<!DOCTYPE html PUBLIC "-\/\/W3C\/\/DTD HTML 4\.01 Transitional\/\/EN" "http:\/\/www\.w3\.org\/TR\/html4\/loose\.dtd">/,
+    );
+  });
+
   it("collapses a provider-prefixed Outlook reply header and all later content", () => {
     const result = splitEmailContent(
       [

--- a/apps/web/utils/email/split-email-content.client.test.ts
+++ b/apps/web/utils/email/split-email-content.client.test.ts
@@ -29,6 +29,25 @@ describe("splitEmailContent", () => {
     });
   });
 
+  it("preserves document-level styles when collapsing quoted content", () => {
+    const result = splitEmailContent(
+      '<html><head><style>p { margin: 0; }</style></head><body style="background: #222; color: #eee"><p>Current reply</p><div class="gmail_quote">Earlier message</div></body></html>',
+    );
+    const document = new DOMParser().parseFromString(
+      result.mainContent,
+      "text/html",
+    );
+
+    expect(result.hasQuotedContent).toBe(true);
+    expect(document.body.getAttribute("style")).toBe(
+      "background: #222; color: #eee",
+    );
+    expect(document.head.querySelector("style")?.textContent).toContain(
+      "p { margin: 0; }",
+    );
+    expect(document.body.textContent).toBe("Current reply");
+  });
+
   it("collapses a provider-prefixed Outlook reply header and all later content", () => {
     const result = splitEmailContent(
       [

--- a/apps/web/utils/email/split-email-content.client.test.ts
+++ b/apps/web/utils/email/split-email-content.client.test.ts
@@ -31,21 +31,22 @@ describe("splitEmailContent", () => {
 
   it("preserves document-level styles when collapsing quoted content", () => {
     const result = splitEmailContent(
-      '<html><head><style>p { margin: 0; }</style></head><body style="background: #222; color: #eee"><p>Current reply</p><div class="gmail_quote">Earlier message</div></body></html>',
+      '<!doctype html><html><head><style>p { margin: 0; }</style></head><body style="background: #222; color: #eee"><p>Current reply</p><div class="gmail_quote">Earlier message</div></body></html>',
     );
-    const document = new DOMParser().parseFromString(
+    const parsedDocument = new DOMParser().parseFromString(
       result.mainContent,
       "text/html",
     );
 
     expect(result.hasQuotedContent).toBe(true);
-    expect(document.body.getAttribute("style")).toBe(
+    expect(result.mainContent).toMatch(/^<!doctype html>/i);
+    expect(parsedDocument.body.getAttribute("style")).toBe(
       "background: #222; color: #eee",
     );
-    expect(document.head.querySelector("style")?.textContent).toContain(
+    expect(parsedDocument.head.querySelector("style")?.textContent).toContain(
       "p { margin: 0; }",
     );
-    expect(document.body.textContent).toBe("Current reply");
+    expect(parsedDocument.body.textContent).toBe("Current reply");
   });
 
   it("collapses a provider-prefixed Outlook reply header and all later content", () => {

--- a/apps/web/utils/email/split-email-content.client.ts
+++ b/apps/web/utils/email/split-email-content.client.ts
@@ -13,6 +13,7 @@ export function splitEmailContent(html: string): {
   mainContent: string;
   hasQuotedContent: boolean;
 } {
+  const hasDocumentStructure = /<(?:html|body)(?:\s|>)/i.test(html);
   const doc = new DOMParser().parseFromString(html, "text/html");
   const quoteBoundary = findQuoteBoundary(doc);
 
@@ -24,7 +25,9 @@ export function splitEmailContent(html: string): {
   trimQuoteSpacing(doc.body);
 
   return {
-    mainContent: doc.body.innerHTML,
+    mainContent: hasDocumentStructure
+      ? doc.documentElement.outerHTML
+      : doc.body.innerHTML,
     hasQuotedContent: true,
   };
 }

--- a/apps/web/utils/email/split-email-content.client.ts
+++ b/apps/web/utils/email/split-email-content.client.ts
@@ -8,12 +8,13 @@ const QUOTED_CONTENT_SELECTOR = [
   ".moz-cite-prefix",
   'blockquote[type="cite"]',
 ].join(", ");
+const DOCUMENT_STRUCTURE_PATTERN = /<(?:html|body)(?:\s|>)/i;
 
 export function splitEmailContent(html: string): {
   mainContent: string;
   hasQuotedContent: boolean;
 } {
-  const hasDocumentStructure = /<(?:html|body)(?:\s|>)/i.test(html);
+  const hasDocumentStructure = DOCUMENT_STRUCTURE_PATTERN.test(html);
   const doc = new DOMParser().parseFromString(html, "text/html");
   const quoteBoundary = findQuoteBoundary(doc);
 
@@ -24,10 +25,14 @@ export function splitEmailContent(html: string): {
   removeBoundaryAndFollowingContent(quoteBoundary, doc.body);
   trimQuoteSpacing(doc.body);
 
+  let mainContent = doc.body.innerHTML;
+  if (hasDocumentStructure) {
+    const documentType = doc.doctype ? `<!doctype ${doc.doctype.name}>` : "";
+    mainContent = `${documentType}${doc.documentElement.outerHTML}`;
+  }
+
   return {
-    mainContent: hasDocumentStructure
-      ? doc.documentElement.outerHTML
-      : doc.body.innerHTML,
+    mainContent,
     hasQuotedContent: true,
   };
 }

--- a/apps/web/utils/email/split-email-content.client.ts
+++ b/apps/web/utils/email/split-email-content.client.ts
@@ -27,7 +27,9 @@ export function splitEmailContent(html: string): {
 
   let mainContent = doc.body.innerHTML;
   if (hasDocumentStructure) {
-    const documentType = doc.doctype ? `<!doctype ${doc.doctype.name}>` : "";
+    const documentType = doc.doctype
+      ? new XMLSerializer().serializeToString(doc.doctype)
+      : "";
     mainContent = `${documentType}${doc.documentElement.outerHTML}`;
   }
 


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ⚪ **Browser QA skipped** · [QA report](https://qa.getinboxzero.com/20260906-142932_pr-3538_b327c6c6184a/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Preserves sanitized email document wrappers so body-level and head-level styles render inside previews.

- Retains document structure while collapsing quoted content.
- Adds sanitizer safety coverage and a deterministic reader visual assertion.
- Validated with focused unit/component tests, emulated Playwright, and lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Email previews now preserve document-level styling, including backgrounds, text colors, spacing, and fonts.
  - Collapsing quoted content preserves remaining message styling and complete document declarations.
  - Email previews retain standards-compliant formatting for more consistent rendering.
  - Executable content remains removed while safe presentation styles are preserved.
  - Improved dark-mode rendering with readable backgrounds and text colors.
- **Tests**
  - Added coverage for styling preservation, secure content removal, quoted-content handling, document declarations, and dark-mode display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->