### PR TITLE
Compose: add keyboard shortcuts

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -242,6 +242,36 @@ test("does not add a line break for the send shortcut", async ({
   );
 });
 
+test("attaches files and discards a compose draft with shortcuts", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const editor = dialog.locator("[contenteditable='true']");
+  const attachButton = dialog.getByRole("button", { name: "Attach files" });
+  await attachButton.hover();
+  await expect(page.getByRole("tooltip")).toContainText("Attach files");
+  await expect(page.getByRole("tooltip").locator("kbd")).toHaveText("⌘⇧U");
+  await capturePlaywrightCheckpoint(page, testInfo, "composer-shortcut-hint");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await editor.press("ControlOrMeta+Shift+u");
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "notes.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("Attachment contents"),
+  });
+  await expect(dialog.getByRole("list", { name: "Attachments" })).toContainText(
+    "notes.txt",
+  );
+
+  await editor.press("ControlOrMeta+Shift+,");
+  await expect(dialog).toBeHidden();
+});
+
 test("composes, sends, and reads a new message from Sent", async ({
   page,
 }, testInfo) => {
@@ -367,8 +397,20 @@ test("opens and sends a reply from the reader with Enter", async ({
   await expect(replyEditor).toContainText(replyBody);
   const sendButton = page.getByRole("button", { name: "Send", exact: true });
   await expect(sendButton).toHaveText("Send");
+
+  await replyEditor.press("ControlOrMeta+Shift+l");
+  await expect(page.getByRole("dialog", { name: "Send later" })).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "send-later-shortcut");
+  await page.keyboard.press("Escape");
+
+  await replyEditor.press("ControlOrMeta+Shift+h");
+  await expect(page.getByRole("dialog", { name: "Remind me" })).toBeVisible();
+  await page.keyboard.press("Escape");
+
   await sendButton.hover();
-  await expect(page.getByRole("tooltip")).toHaveText(/(?:⌘|Ctrl)\+Enter/);
+  const sendTooltip = page.getByRole("tooltip");
+  await expect(sendTooltip).toContainText("Send and mark done");
+  await expect(sendTooltip.locator("kbd")).toHaveText(["⌘↵", "⌘⇧↵"]);
   await capturePlaywrightCheckpoint(page, testInfo, "protected-quoted-reply");
   await sendButton.click();
 

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -401,10 +401,17 @@ test("opens and sends a reply from the reader with Enter", async ({
   await replyEditor.press("ControlOrMeta+Shift+l");
   await expect(page.getByRole("dialog", { name: "Send later" })).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "send-later-shortcut");
+
+  await page.getByRole("button", { name: "Choose date and time" }).click();
+  await page
+    .getByLabel("Send later date and time")
+    .press("ControlOrMeta+Shift+h");
+  await expect(page.getByRole("dialog", { name: "Remind me" })).toBeVisible();
   await page.keyboard.press("Escape");
 
-  await replyEditor.press("ControlOrMeta+Shift+h");
-  await expect(page.getByRole("dialog", { name: "Remind me" })).toBeVisible();
+  await replyEditor.press("ControlOrMeta+Shift+l");
+  await expect(page.getByRole("dialog", { name: "Send later" })).toBeVisible();
+  await expect(page.getByLabel("Send later date and time")).toBeHidden();
   await page.keyboard.press("Escape");
 
   await sendButton.hover();

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -38,7 +38,6 @@ import {
   useState,
 } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
-import { useHotkeys } from "react-hotkeys-hook";
 import useSWR, { useSWRConfig } from "swr";
 import type {
   ContactsErrorResponse,
@@ -63,8 +62,10 @@ import {
 import { env } from "@/env";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
-import { useModifierKey } from "@/hooks/useModifierKey";
 import { useReplyDraftPersistence } from "@/hooks/useReplyDraftPersistence";
+import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
+import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { sendEmailAction } from "@/utils/actions/mail";
@@ -95,7 +96,8 @@ import {
   resolveComposeRecipients,
   resolveRecipientSelection,
 } from "./compose-recipients";
-import { DeliveryOptions } from "./DeliveryOptions";
+import { ComposeShortcutTooltipContent } from "./ComposeShortcutTooltipContent";
+import { DeliveryOptions, type DeliveryOptionsHandle } from "./DeliveryOptions";
 import {
   getReminderAfterSendTimeChange,
   parseDeliveryTimes,
@@ -126,6 +128,7 @@ type ComposeEmailFormProps = {
   replyingToEmail?: ReplyingToEmail;
   refetch?: () => void;
   onSuccess?: (messageId: string, threadId: string) => void;
+  onMarkDone?: () => void;
   onClose?: () => void;
   onDiscard?: () => boolean | Promise<boolean>;
 };
@@ -173,16 +176,18 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
   return (
     <LoadingContent error={error} loading={isLoading || localDraft.isLoading}>
       {emailAccount && (
-        <ComposeEmailFormContent
-          {...props}
-          storedDraft={localDraft.draft}
-          draftLoadError={localDraft.error}
-          accountProvider={selectedAccountProvider}
-          accountSignatureHtml={emailAccount.signature ?? ""}
-          key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftSessionId ?? ""}`}
-          onSelectEmailAccount={setSelectedEmailAccountId}
-          selectedEmailAccountId={selectedEmailAccountId}
-        />
+        <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
+          <ComposeEmailFormContent
+            {...props}
+            storedDraft={localDraft.draft}
+            draftLoadError={localDraft.error}
+            accountProvider={selectedAccountProvider}
+            accountSignatureHtml={emailAccount.signature ?? ""}
+            key={`${selectedEmailAccountId}:${props.replyingToEmail?.threadId ?? ""}:${props.draftSessionId ?? ""}`}
+            onSelectEmailAccount={setSelectedEmailAccountId}
+            selectedEmailAccountId={selectedEmailAccountId}
+          />
+        </ShortcutsProvider>
       )}
     </LoadingContent>
   );
@@ -203,6 +208,7 @@ function ComposeEmailFormContent({
   onSelectEmailAccount,
   refetch,
   onSuccess,
+  onMarkDone,
   onClose,
   onDiscard,
 }: ComposeEmailFormProps & {
@@ -316,7 +322,8 @@ function ComposeEmailFormContent({
   const hideCcBccButtonRef = useRef<HTMLButtonElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const inlineImageInputRef = useRef<HTMLInputElement>(null);
-  const { symbol } = useModifierKey();
+  const sendAndMarkDoneButtonRef = useRef<HTMLButtonElement>(null);
+  const deliveryOptionsRef = useRef<DeliveryOptionsHandle>(null);
   const {
     register,
     getValues,
@@ -545,7 +552,10 @@ function ComposeEmailFormContent({
   }, []);
 
   const onSubmit: SubmitHandler<ComposeFormValues> = useCallback(
-    async (data) => {
+    async (data, event) => {
+      const submitter = (event?.nativeEvent as SubmitEvent | undefined)
+        ?.submitter;
+      const markDoneAfterSend = submitter === sendAndMarkDoneButtonRef.current;
       const recipients = resolveComposeRecipientFields({
         selectedRecipients: {
           to: data.to,
@@ -657,6 +667,7 @@ function ComposeEmailFormContent({
                 "Reply scheduled, but its local draft copy could not be cleared.",
             });
           }
+          if (markDoneAfterSend) onMarkDone?.();
           await mutate([
             `/api/user/scheduled-emails?threadId=${encodeURIComponent(replyingToEmail!.threadId!)}`,
             selectedEmailAccountId,
@@ -705,6 +716,7 @@ function ComposeEmailFormContent({
           }
           if (outcome.status === "sent") {
             if (!isInlineReply) toastSuccess({ description: "Email sent!" });
+            if (markDoneAfterSend) onMarkDone?.();
             onSuccess?.(outcome.messageId, outcome.threadId);
             refetch?.();
           } else if (outcome.status === "queued") {
@@ -712,6 +724,7 @@ function ComposeEmailFormContent({
               toastSuccess({
                 description: getQueuedEmailDescription(outcome.reason),
               });
+            if (markDoneAfterSend) onMarkDone?.();
             onClose?.();
           } else if (outcome.status === "uncertain") {
             if (outcome.ownsNotification) {
@@ -733,6 +746,7 @@ function ComposeEmailFormContent({
         );
         if (result?.data) {
           toastSuccess({ description: "Email sent!" });
+          if (markDoneAfterSend) onMarkDone?.();
           onSuccess?.(result.data.messageId ?? "", result.data.threadId ?? "");
         } else {
           toastError({
@@ -763,26 +777,13 @@ function ComposeEmailFormContent({
       flushDraft,
       mutate,
       onClose,
+      onMarkDone,
       onSuccess,
       preservedBlocks,
       refetch,
       replyingToEmail,
       selectedEmailAccountId,
     ],
-  );
-
-  useHotkeys(
-    "mod+enter",
-    (event) => {
-      event.preventDefault();
-      if (!isSubmitting) formRef.current?.requestSubmit();
-    },
-    {
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-      eventListenerOptions: { capture: true },
-      preventDefault: true,
-    },
   );
 
   const reconnectContacts = async () => {
@@ -863,6 +864,58 @@ function ComposeEmailFormContent({
     setRemindAt(value);
     captureDraft({ remindAt: value });
   };
+  const handleDiscard = useCallback(async () => {
+    if (!onDiscard || isSubmitting) return;
+    try {
+      if ((await onDiscard()) === false) return;
+      await clearLocalDraft();
+    } catch (error) {
+      toastError({
+        description:
+          error instanceof Error
+            ? error.message
+            : "Could not discard this draft.",
+      });
+    }
+  }, [clearLocalDraft, isSubmitting, onDiscard]);
+
+  useShortcuts({
+    send: (event) => {
+      if (!isShortcutForForm(event, formRef.current) || isSubmitting) return;
+      formRef.current?.requestSubmit();
+    },
+    sendAndMarkDone: onMarkDone
+      ? (event) => {
+          if (!isShortcutForForm(event, formRef.current) || isSubmitting)
+            return;
+          const submitter = sendAndMarkDoneButtonRef.current;
+          if (submitter) formRef.current?.requestSubmit(submitter);
+        }
+      : undefined,
+    sendLater:
+      isInlineReply && !isSubmitting
+        ? (event) => {
+            if (isShortcutForForm(event, formRef.current))
+              deliveryOptionsRef.current?.open("sendLater");
+          }
+        : undefined,
+    remindMe:
+      isInlineReply && !isSubmitting
+        ? (event) => {
+            if (isShortcutForForm(event, formRef.current))
+              deliveryOptionsRef.current?.open("remindMe");
+          }
+        : undefined,
+    attachFiles: (event) => {
+      if (isShortcutForForm(event, formRef.current))
+        attachmentInputRef.current?.click();
+    },
+    discardDraft: onDiscard
+      ? (event) => {
+          if (isShortcutForForm(event, formRef.current)) handleDiscard();
+        }
+      : undefined,
+  });
 
   return (
     <form
@@ -1200,26 +1253,36 @@ function ComposeEmailFormContent({
         )}
       >
         <div className="flex flex-wrap items-center gap-1">
-          {isComposeWindow ? (
+          <Tooltip
+            contentComponent={
+              <ComposeShortcutTooltipContent
+                shortcuts={onMarkDone ? ["send", "sendAndMarkDone"] : ["send"]}
+              />
+            }
+          >
             <Button
-              className="h-9 px-0 font-semibold text-foreground hover:bg-transparent hover:text-foreground"
+              className={cn(
+                isComposeWindow &&
+                  "h-9 px-0 font-semibold text-foreground hover:bg-transparent hover:text-foreground",
+              )}
               disabled={isSubmitting}
               type="submit"
-              variant="ghost"
+              variant={isComposeWindow ? "ghost" : "gradient"}
             >
               {isSubmitting && <ButtonLoader />}
               Send
             </Button>
-          ) : (
-            <Tooltip content={`${symbol}+Enter`}>
-              <Button disabled={isSubmitting} type="submit" variant="gradient">
-                {isSubmitting && <ButtonLoader />}
-                Send
-              </Button>
-            </Tooltip>
-          )}
+          </Tooltip>
+          <button
+            aria-hidden
+            hidden
+            ref={sendAndMarkDoneButtonRef}
+            tabIndex={-1}
+            type="submit"
+          />
           {isInlineReply && (
             <DeliveryOptions
+              ref={deliveryOptionsRef}
               sendAt={sendAt}
               remindAt={remindAt}
               disabled={isSubmitting}
@@ -1238,16 +1301,22 @@ function ComposeEmailFormContent({
             ref={attachmentInputRef}
             type="file"
           />
-          <Button
-            aria-label="Attach files"
-            className="text-muted-foreground hover:bg-transparent hover:text-foreground"
-            onClick={() => attachmentInputRef.current?.click()}
-            size={isComposeWindow ? "iconSm" : "icon"}
-            type="button"
-            variant="ghost"
+          <Tooltip
+            contentComponent={
+              <ComposeShortcutTooltipContent shortcuts={["attachFiles"]} />
+            }
           >
-            <PaperclipIcon className="size-4" />
-          </Button>
+            <Button
+              aria-label="Attach files"
+              className="text-muted-foreground hover:bg-transparent hover:text-foreground"
+              onClick={() => attachmentInputRef.current?.click()}
+              size={isComposeWindow ? "iconSm" : "icon"}
+              type="button"
+              variant="ghost"
+            >
+              <PaperclipIcon className="size-4" />
+            </Button>
+          </Tooltip>
           <input
             accept={EMAIL_INLINE_IMAGE_MIME_TYPES.join(",")}
             className="hidden"
@@ -1268,30 +1337,23 @@ function ComposeEmailFormContent({
             <ImageIcon className="size-4" />
           </Button>
           {onDiscard && (
-            <Button
-              aria-label="Discard draft"
-              className="text-muted-foreground hover:bg-transparent hover:text-foreground"
-              disabled={isSubmitting}
-              onClick={async () => {
-                try {
-                  if ((await onDiscard()) === false) return;
-                  await clearLocalDraft();
-                } catch (error) {
-                  toastError({
-                    description:
-                      error instanceof Error
-                        ? error.message
-                        : "Could not discard this draft.",
-                  });
-                }
-              }}
-              size={isComposeWindow ? "iconSm" : "icon"}
-              title="Discard draft"
-              type="button"
-              variant="ghost"
+            <Tooltip
+              contentComponent={
+                <ComposeShortcutTooltipContent shortcuts={["discardDraft"]} />
+              }
             >
-              <TrashIcon className="size-4" />
-            </Button>
+              <Button
+                aria-label="Discard draft"
+                className="text-muted-foreground hover:bg-transparent hover:text-foreground"
+                disabled={isSubmitting}
+                onClick={handleDiscard}
+                size={isComposeWindow ? "iconSm" : "icon"}
+                type="button"
+                variant="ghost"
+              >
+                <TrashIcon className="size-4" />
+              </Button>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -1615,4 +1677,11 @@ function getQueuedEmailDescription(
     return "Email queued. Reconnect this account to send it.";
   }
   return "Email queued and will keep sending in the background.";
+}
+
+function isShortcutForForm(
+  event: KeyboardEvent | undefined,
+  form: HTMLFormElement | null,
+) {
+  return event?.target instanceof Node && Boolean(form?.contains(event.target));
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -34,6 +34,7 @@ import {
   type CSSProperties,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -324,6 +325,7 @@ function ComposeEmailFormContent({
   const inlineImageInputRef = useRef<HTMLInputElement>(null);
   const sendAndMarkDoneButtonRef = useRef<HTMLButtonElement>(null);
   const deliveryOptionsRef = useRef<DeliveryOptionsHandle>(null);
+  const shortcutOwnerId = useId();
   const {
     register,
     getValues,
@@ -881,12 +883,19 @@ function ComposeEmailFormContent({
 
   useShortcuts({
     send: (event) => {
-      if (!isShortcutForForm(event, formRef.current) || isSubmitting) return;
+      if (
+        !isShortcutForForm(event, formRef.current, shortcutOwnerId) ||
+        isSubmitting
+      )
+        return;
       formRef.current?.requestSubmit();
     },
     sendAndMarkDone: onMarkDone
       ? (event) => {
-          if (!isShortcutForForm(event, formRef.current) || isSubmitting)
+          if (
+            !isShortcutForForm(event, formRef.current, shortcutOwnerId) ||
+            isSubmitting
+          )
             return;
           const submitter = sendAndMarkDoneButtonRef.current;
           if (submitter) formRef.current?.requestSubmit(submitter);
@@ -895,24 +904,29 @@ function ComposeEmailFormContent({
     sendLater:
       isInlineReply && !isSubmitting
         ? (event) => {
-            if (isShortcutForForm(event, formRef.current))
+            if (isShortcutForForm(event, formRef.current, shortcutOwnerId))
               deliveryOptionsRef.current?.open("sendLater");
           }
         : undefined,
     remindMe:
       isInlineReply && !isSubmitting
         ? (event) => {
-            if (isShortcutForForm(event, formRef.current))
+            if (isShortcutForForm(event, formRef.current, shortcutOwnerId))
               deliveryOptionsRef.current?.open("remindMe");
           }
         : undefined,
     attachFiles: (event) => {
-      if (isShortcutForForm(event, formRef.current))
-        attachmentInputRef.current?.click();
+      if (
+        !isShortcutForForm(event, formRef.current, shortcutOwnerId) ||
+        isSubmitting
+      )
+        return;
+      attachmentInputRef.current?.click();
     },
     discardDraft: onDiscard
       ? (event) => {
-          if (isShortcutForForm(event, formRef.current)) handleDiscard();
+          if (isShortcutForForm(event, formRef.current, shortcutOwnerId))
+            handleDiscard();
         }
       : undefined,
   });
@@ -1288,6 +1302,7 @@ function ComposeEmailFormContent({
               disabled={isSubmitting}
               onSendAtChange={handleSendAtChange}
               onRemindAtChange={handleRemindAtChange}
+              shortcutOwnerId={shortcutOwnerId}
             />
           )}
         </div>
@@ -1682,6 +1697,15 @@ function getQueuedEmailDescription(
 function isShortcutForForm(
   event: KeyboardEvent | undefined,
   form: HTMLFormElement | null,
+  shortcutOwnerId: string,
 ) {
-  return event?.target instanceof Node && Boolean(form?.contains(event.target));
+  if (!(event?.target instanceof Node)) return false;
+  if (form?.contains(event.target)) return true;
+  if (!(event.target instanceof Element)) return false;
+
+  return (
+    event.target
+      .closest("[data-compose-shortcut-owner]")
+      ?.getAttribute("data-compose-shortcut-owner") === shortcutOwnerId
+  );
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeShortcutTooltipContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeShortcutTooltipContent.tsx
@@ -1,0 +1,23 @@
+import { Kbd } from "@/components/Kbd";
+import {
+  getShortcut,
+  getShortcutHint,
+  type ShortcutId,
+} from "@/lib/shortcuts/registry";
+
+export function ComposeShortcutTooltipContent({
+  shortcuts,
+}: {
+  shortcuts: readonly ShortcutId[];
+}) {
+  return (
+    <div className="space-y-1.5">
+      {shortcuts.map((shortcut) => (
+        <div className="flex items-center justify-between gap-4" key={shortcut}>
+          <span>{getShortcut(shortcut).label}</span>
+          <Kbd variant="onColor">{getShortcutHint(shortcut)}</Kbd>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import {
   CalendarDaysIcon,
   ChevronLeftIcon,
@@ -13,20 +13,35 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ComposeShortcutTooltipContent } from "./ComposeShortcutTooltipContent";
 
-export function DeliveryOptions({
-  sendAt,
-  remindAt,
-  disabled,
-  onSendAtChange,
-  onRemindAtChange,
-}: {
-  sendAt: string;
-  remindAt: string;
-  disabled: boolean;
-  onSendAtChange: (value: string) => void;
-  onRemindAtChange: (value: string) => void;
-}) {
+export type DeliveryOptionsHandle = {
+  open: (option: "sendLater" | "remindMe") => void;
+};
+
+export const DeliveryOptions = forwardRef<
+  DeliveryOptionsHandle,
+  {
+    sendAt: string;
+    remindAt: string;
+    disabled: boolean;
+    onSendAtChange: (value: string) => void;
+    onRemindAtChange: (value: string) => void;
+  }
+>(function DeliveryOptions(
+  { sendAt, remindAt, disabled, onSendAtChange, onRemindAtChange },
+  ref,
+) {
+  const [openOption, setOpenOption] = useState<"sendLater" | "remindMe" | null>(
+    null,
+  );
+  useImperativeHandle(ref, () => ({ open: setOpenOption }), []);
+
   return (
     <>
       <DeliveryTimePicker
@@ -34,6 +49,9 @@ export function DeliveryOptions({
         value={sendAt}
         onChange={onSendAtChange}
         disabled={disabled}
+        open={openOption === "sendLater"}
+        onOpenChange={(open) => setOpenOption(open ? "sendLater" : null)}
+        shortcut="sendLater"
       />
       <DeliveryTimePicker
         label="Remind me"
@@ -41,10 +59,13 @@ export function DeliveryOptions({
         onChange={onRemindAtChange}
         disabled={disabled}
         after={sendAt}
+        open={openOption === "remindMe"}
+        onOpenChange={(open) => setOpenOption(open ? "remindMe" : null)}
+        shortcut="remindMe"
       />
     </>
   );
-}
+});
 
 function DeliveryTimePicker({
   label,
@@ -52,14 +73,19 @@ function DeliveryTimePicker({
   onChange,
   disabled,
   after,
+  open,
+  onOpenChange,
+  shortcut,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   disabled: boolean;
   after?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  shortcut: "sendLater" | "remindMe";
 }) {
-  const [open, setOpen] = useState(false);
   const [custom, setCustom] = useState("");
   const [showCustom, setShowCustom] = useState(false);
   const isReminder = label === "Remind me";
@@ -67,35 +93,42 @@ function DeliveryTimePicker({
   const choose = (date: Date) => {
     onChange(date.toISOString());
     setShowCustom(false);
-    setOpen(false);
+    onOpenChange(false);
   };
   return (
     <Popover
       open={open}
       onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
+        onOpenChange(nextOpen);
         if (!nextOpen) setShowCustom(false);
       }}
     >
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={disabled}
-          className="px-2 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
-          aria-label={label}
-        >
-          {value
-            ? new Date(value).toLocaleString(undefined, {
-                month: "short",
-                day: "numeric",
-                hour: "numeric",
-                minute: "2-digit",
-              })
-            : label}
-        </Button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              className="px-2 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
+              aria-label={label}
+            >
+              {value
+                ? new Date(value).toLocaleString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })
+                : label}
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <ComposeShortcutTooltipContent shortcuts={[shortcut]} />
+        </TooltipContent>
+      </Tooltip>
       <PopoverContent
         className="w-72 p-1"
         align="start"
@@ -186,7 +219,7 @@ function DeliveryTimePicker({
                 className="h-9 w-full justify-start gap-2 px-2 text-xs font-normal text-muted-foreground"
                 onClick={() => {
                   onChange("");
-                  setOpen(false);
+                  onOpenChange(false);
                 }}
               >
                 <XIcon className="size-3.5" />

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -32,9 +32,17 @@ export const DeliveryOptions = forwardRef<
     disabled: boolean;
     onSendAtChange: (value: string) => void;
     onRemindAtChange: (value: string) => void;
+    shortcutOwnerId: string;
   }
 >(function DeliveryOptions(
-  { sendAt, remindAt, disabled, onSendAtChange, onRemindAtChange },
+  {
+    sendAt,
+    remindAt,
+    disabled,
+    onSendAtChange,
+    onRemindAtChange,
+    shortcutOwnerId,
+  },
   ref,
 ) {
   const [openOption, setOpenOption] = useState<"sendLater" | "remindMe" | null>(
@@ -52,6 +60,7 @@ export const DeliveryOptions = forwardRef<
         open={openOption === "sendLater"}
         onOpenChange={(open) => setOpenOption(open ? "sendLater" : null)}
         shortcut="sendLater"
+        shortcutOwnerId={shortcutOwnerId}
       />
       <DeliveryTimePicker
         label="Remind me"
@@ -62,6 +71,7 @@ export const DeliveryOptions = forwardRef<
         open={openOption === "remindMe"}
         onOpenChange={(open) => setOpenOption(open ? "remindMe" : null)}
         shortcut="remindMe"
+        shortcutOwnerId={shortcutOwnerId}
       />
     </>
   );
@@ -76,6 +86,7 @@ function DeliveryTimePicker({
   open,
   onOpenChange,
   shortcut,
+  shortcutOwnerId,
 }: {
   label: string;
   value: string;
@@ -85,6 +96,7 @@ function DeliveryTimePicker({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   shortcut: "sendLater" | "remindMe";
+  shortcutOwnerId: string;
 }) {
   const [custom, setCustom] = useState("");
   const [showCustom, setShowCustom] = useState(false);
@@ -138,6 +150,7 @@ function DeliveryTimePicker({
       <PopoverContent
         className="w-72 p-1"
         align="start"
+        data-compose-shortcut-owner={shortcutOwnerId}
         role="dialog"
         aria-label={label}
       >

--- a/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/DeliveryOptions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import {
   CalendarDaysIcon,
   ChevronLeftIcon,
@@ -90,6 +90,12 @@ function DeliveryTimePicker({
   const [showCustom, setShowCustom] = useState(false);
   const isReminder = label === "Remind me";
   const earliest = Math.max(Date.now(), after ? new Date(after).getTime() : 0);
+  useEffect(() => {
+    if (!open) {
+      setCustom("");
+      setShowCustom(false);
+    }
+  }, [open]);
   const choose = (date: Date) => {
     onChange(date.toISOString());
     setShowCustom(false);

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -158,6 +158,7 @@ export function ThreadReader({
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
               key={threadId}
               messages={messages}
+              onMarkDone={onArchive}
               onOpenSenderContext={(message) => {
                 const senderEmail = extractEmailAddress(message.headers.from);
                 setSenderContext({

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -54,6 +54,7 @@ export function EmailMessage({
   expanded,
   onToggle,
   onSendSuccess,
+  onMarkDone,
   onOpenSenderContext,
   hasDraft = false,
   selected,
@@ -69,6 +70,7 @@ export function EmailMessage({
   /** Absent when the thread has a single message, which never collapses. */
   onToggle?: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
+  onMarkDone?: () => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   hasDraft?: boolean;
   selected?: boolean;
@@ -193,6 +195,7 @@ export function EmailMessage({
               onCloseCompose={onCloseCompose}
               onRestoreCompose={onRestoreCompose}
               onSendSuccess={onSendSuccess}
+              onMarkDone={onMarkDone}
               onStartDiscard={onStartDiscard}
               refetch={refetch}
               composeMode={composeMode}
@@ -436,6 +439,7 @@ function ReplyPanel({
   message,
   refetch,
   onSendSuccess,
+  onMarkDone,
   onCloseCompose,
   onRestoreCompose,
   onStartDiscard,
@@ -446,6 +450,7 @@ function ReplyPanel({
   message: ParsedMessage;
   refetch: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
+  onMarkDone?: () => void;
   onCloseCompose: () => void;
   onRestoreCompose: (composeSession: ComposeSession) => void;
   onStartDiscard: () => ComposeSession | undefined;
@@ -529,6 +534,7 @@ function ReplyPanel({
         draftSessionId={getReplyDraftSessionId(message.id, composeMode)}
         onClose={onCloseCompose}
         onDiscard={onDiscard}
+        onMarkDone={onMarkDone}
         onSuccess={(messageId: string, threadId: string) => {
           onSendSuccess(messageId, threadId);
           onCloseCompose();

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -23,6 +23,7 @@ export function EmailThread({
   autoOpenReplyForMessageId,
   topRightComponent,
   onSendSuccess,
+  onMarkDone,
   onOpenSenderContext,
   withHeader,
   renderToolbar,
@@ -34,6 +35,7 @@ export function EmailThread({
   autoOpenReplyForMessageId?: string;
   topRightComponent?: React.ReactNode;
   onSendSuccess?: (messageId: string, threadId: string) => void;
+  onMarkDone?: () => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   withHeader?: boolean;
   enableMessageNavigation?: boolean;
@@ -236,6 +238,7 @@ export function EmailThread({
               key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
               onOpenSenderContext={onOpenSenderContext}
+              onMarkDone={onMarkDone}
               onSendSuccess={(messageId) => {
                 setExpansionOverrides((prev) =>
                   new Map(prev).set(messageId, true),

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -45,6 +45,11 @@ describe("shortcut registry", () => {
     expect(formatShortcutKeys(getShortcut("commandPalette"))).toBe("⌘K");
     expect(formatShortcutKeys(getShortcut("selectAll"))).toBe("⌘A");
     expect(formatShortcutKeys(getShortcut("send"))).toBe("⌘↵");
+    expect(formatShortcutKeys(getShortcut("sendAndMarkDone"))).toBe("⌘⇧↵");
+    expect(formatShortcutKeys(getShortcut("sendLater"))).toBe("⌘⇧L");
+    expect(formatShortcutKeys(getShortcut("remindMe"))).toBe("⌘⇧H");
+    expect(formatShortcutKeys(getShortcut("attachFiles"))).toBe("⌘⇧U");
+    expect(formatShortcutKeys(getShortcut("discardDraft"))).toBe("⌘⇧,");
     expect(formatShortcutKeys(getShortcut("backToApp"))).toBe("G A");
     expect(formatShortcutKeys(getShortcut("delete"))).toBe("#");
   });

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -22,6 +22,7 @@ export const SHORTCUT_GROUPS = [
   "Navigate",
   "Triage",
   "View",
+  "Compose",
   "Assistant & rules",
 ] as const;
 
@@ -59,6 +60,8 @@ export type ShortcutEntry = {
   display?: readonly string[];
   /** Fires even while typing. Only for modifier combos and Escape. */
   allowWhileTyping?: boolean;
+  /** Handles the key before rich text editors can consume it. */
+  capture?: boolean;
   /** Present means the entry shows in ⌘K once a handler is registered. */
   palette?: ShortcutPalette;
   /** Fallback when no handler is injected at the call site. */
@@ -229,7 +232,7 @@ const SHORTCUT_DEFINITIONS = [
     id: "compose",
     keys: ["c"],
     scope: "global",
-    group: "Assistant & rules",
+    group: "Compose",
     label: "New message",
     palette: {
       section: "actions",
@@ -242,9 +245,56 @@ const SHORTCUT_DEFINITIONS = [
     id: "send",
     keys: ["mod+enter"],
     scope: "mail",
-    group: "Assistant & rules",
-    label: "Send reply",
+    group: "Compose",
+    label: "Send",
     allowWhileTyping: true,
+    capture: true,
+  },
+  {
+    id: "sendAndMarkDone",
+    keys: ["mod+shift+enter"],
+    scope: "mail",
+    group: "Compose",
+    label: "Send and mark done",
+    allowWhileTyping: true,
+    capture: true,
+  },
+  {
+    id: "sendLater",
+    keys: ["mod+shift+l"],
+    scope: "mail",
+    group: "Compose",
+    label: "Send later",
+    allowWhileTyping: true,
+    capture: true,
+  },
+  {
+    id: "remindMe",
+    keys: ["mod+shift+h"],
+    scope: "mail",
+    group: "Compose",
+    label: "Remind me",
+    allowWhileTyping: true,
+    capture: true,
+  },
+  {
+    id: "attachFiles",
+    keys: ["mod+shift+u"],
+    scope: "mail",
+    group: "Compose",
+    label: "Attach files",
+    allowWhileTyping: true,
+    capture: true,
+  },
+  {
+    id: "discardDraft",
+    keys: ["mod+shift+,", "mod+shift+<"],
+    display: ["mod+shift+,"],
+    scope: "mail",
+    group: "Compose",
+    label: "Discard draft",
+    allowWhileTyping: true,
+    capture: true,
   },
 ] as const satisfies readonly ShortcutEntry[];
 

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -54,6 +54,37 @@ describe("useShortcuts", () => {
     expect(send).toHaveBeenCalledOnce();
   });
 
+  it("runs compose modifier shortcuts while the user is typing", () => {
+    const sendAndMarkDone = vi.fn();
+    const sendLater = vi.fn();
+    const remindMe = vi.fn();
+    const attachFiles = vi.fn();
+    const discardDraft = vi.fn();
+    renderShortcuts({
+      sendAndMarkDone,
+      sendLater,
+      remindMe,
+      attachFiles,
+      discardDraft,
+    });
+    const textbox = screen.getByRole("textbox");
+
+    press(
+      { key: "Enter", code: "Enter", ctrlKey: true, shiftKey: true },
+      textbox,
+    );
+    press({ key: "l", code: "KeyL", ctrlKey: true, shiftKey: true }, textbox);
+    press({ key: "h", code: "KeyH", ctrlKey: true, shiftKey: true }, textbox);
+    press({ key: "u", code: "KeyU", ctrlKey: true, shiftKey: true }, textbox);
+    press({ key: "<", code: "Comma", ctrlKey: true, shiftKey: true }, textbox);
+
+    expect(sendAndMarkDone).toHaveBeenCalledOnce();
+    expect(sendLater).toHaveBeenCalledOnce();
+    expect(remindMe).toHaveBeenCalledOnce();
+    expect(attachFiles).toHaveBeenCalledOnce();
+    expect(discardDraft).toHaveBeenCalledOnce();
+  });
+
   it("leaves Mod-K to an email editor's link control", () => {
     const commandPalette = vi.fn();
     renderShortcuts({ commandPalette }, MAIL_SCOPES, true);

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -97,10 +97,11 @@ describe("useShortcuts", () => {
     expect(commandPalette).not.toHaveBeenCalled();
   });
 
-  it("leaves Tab and Enter navigation inside dialogs to the browser", () => {
+  it("leaves dialog navigation keys to the browser", () => {
+    const backToList = vi.fn();
     const open = vi.fn();
     const nextSplit = vi.fn();
-    renderShortcuts({ nextSplit, open });
+    renderShortcuts({ backToList, nextSplit, open });
 
     const mailEvent = press({ key: "Tab", code: "Tab" });
     const mailOpenEvent = press({ key: "Enter", code: "Enter" });
@@ -112,13 +113,19 @@ describe("useShortcuts", () => {
       { key: "Enter", code: "Enter" },
       screen.getByRole("button", { name: "Dialog action" }),
     );
+    const dialogEscapeEvent = press(
+      { key: "Escape", code: "Escape" },
+      screen.getByRole("button", { name: "Dialog action" }),
+    );
 
     expect(nextSplit).toHaveBeenCalledOnce();
     expect(open).toHaveBeenCalledOnce();
+    expect(backToList).not.toHaveBeenCalled();
     expect(mailEvent.defaultPrevented).toBe(true);
     expect(mailOpenEvent.defaultPrevented).toBe(true);
     expect(dialogTabEvent.defaultPrevented).toBe(false);
     expect(dialogOpenEvent.defaultPrevented).toBe(false);
+    expect(dialogEscapeEvent.defaultPrevented).toBe(false);
   });
 
   it("ignores modified presses of a plain shortcut", () => {

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -192,7 +192,7 @@ function resolveTarget(
   }
   if (
     target?.type === "entry" &&
-    (target.entry.id === "open" || target.entry.id === "nextSplit") &&
+    ["backToList", "open", "nextSplit"].includes(target.entry.id) &&
     event.target instanceof Element &&
     event.target.closest('[role="dialog"]')
   ) {

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -18,6 +18,8 @@ type HotkeysEvent = Parameters<HotkeyCallback>[1];
 
 type SequenceTracker = ReturnType<typeof createSequencePrefixTracker>;
 
+const HOTKEYS_DELIMITER = "|";
+
 type ShortcutTarget =
   | { type: "entry"; entry: ShortcutEntry }
   | { type: "prefix"; key: string };
@@ -25,21 +27,27 @@ type ShortcutTarget =
 type ShortcutBucket = {
   scope: ShortcutScope;
   allowWhileTyping: boolean;
-  /** Comma separated hotkeys, the shape react-hotkeys-hook expects. */
-  keys: string;
+  capture: boolean;
+  /** Kept as entries so the comma key is distinct from the list delimiter. */
+  keys: string[];
   targets: Map<string, ShortcutTarget>;
 };
 
 // react-hotkeys-hook takes scope and typing behaviour per hook, so bindings are
 // registered as one hook per combination rather than one hook per shortcut.
 const BUCKET_SPECS = [
-  { scope: "global", allowWhileTyping: false },
-  { scope: "global", allowWhileTyping: true },
-  { scope: "mail", allowWhileTyping: false },
-  { scope: "mail", allowWhileTyping: true },
+  { scope: "global", allowWhileTyping: false, capture: false },
+  { scope: "global", allowWhileTyping: false, capture: true },
+  { scope: "global", allowWhileTyping: true, capture: false },
+  { scope: "global", allowWhileTyping: true, capture: true },
+  { scope: "mail", allowWhileTyping: false, capture: false },
+  { scope: "mail", allowWhileTyping: false, capture: true },
+  { scope: "mail", allowWhileTyping: true, capture: false },
+  { scope: "mail", allowWhileTyping: true, capture: true },
 ] as const satisfies readonly {
   scope: ShortcutScope;
   allowWhileTyping: boolean;
+  capture: boolean;
 }[];
 
 /**
@@ -59,6 +67,10 @@ export function useShortcuts(handlers: ShortcutHandlers): void {
   useShortcutBucket(buckets[1], handlersRef, sequence);
   useShortcutBucket(buckets[2], handlersRef, sequence);
   useShortcutBucket(buckets[3], handlersRef, sequence);
+  useShortcutBucket(buckets[4], handlersRef, sequence);
+  useShortcutBucket(buckets[5], handlersRef, sequence);
+  useShortcutBucket(buckets[6], handlersRef, sequence);
+  useShortcutBucket(buckets[7], handlersRef, sequence);
 }
 
 function useShortcutBucket(
@@ -111,12 +123,15 @@ function useShortcutBucket(
   );
 
   useHotkeys(bucket.keys, onHotkey, {
+    enabled: bucket.keys.length > 0,
     scopes: [bucket.scope],
     // Hotkeys are matched on the typed character so they survive keyboard
     // layouts that move `#` or `?`.
     useKey: true,
     enableOnFormTags: bucket.allowWhileTyping,
     enableOnContentEditable: bucket.allowWhileTyping,
+    delimiter: HOTKEYS_DELIMITER,
+    eventListenerOptions: bucket.capture ? { capture: true } : undefined,
     sequenceTimeoutMs: SEQUENCE_TIMEOUT_MS,
     preventDefault,
   });
@@ -138,6 +153,7 @@ function buildBuckets(signature: string): ShortcutBucket[] {
       if (!activeIds.has(entry.id)) continue;
       if (entry.scope !== spec.scope) continue;
       if (!!entry.allowWhileTyping !== spec.allowWhileTyping) continue;
+      if (!!entry.capture !== spec.capture) continue;
 
       for (const key of entry.keys) {
         targets.set(key, { type: "entry", entry });
@@ -152,7 +168,8 @@ function buildBuckets(signature: string): ShortcutBucket[] {
     return {
       scope: spec.scope,
       allowWhileTyping: spec.allowWhileTyping,
-      keys: [...targets.keys()].join(","),
+      capture: spec.capture,
+      keys: [...targets.keys()],
       targets,
     };
   });


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ❌ **Browser QA failed** · [QA report](https://qa.getinboxzero.com/20260906-144819_pr-3540_f55afe0cec87/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Adds keyboard shortcuts for common compose and reply actions.

- centralizes compose bindings and shortcut hints
- supports send, scheduling, reminders, attachments, and draft actions
- adds focused unit and browser coverage
- validates with focused tests and lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for sending, sending and marking done, scheduling, reminders, attaching files, and discarding drafts.
  - Added shortcut guidance to compose, attachment, discard, send-later, and reminder controls.
  - Shortcuts now work while typing in the message editor.
  - “Send and mark done” archives the conversation after sending.
  - Reply and forward drafts remain separate and restore the correct compose mode.

- **Bug Fixes**
  - Improved handling of compose shortcuts, including comma-based shortcuts and shortcut-triggered dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->