### PR TITLE
ui: Redesign toast notifications

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-thread-actions.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { format } from "date-fns";
 import { toast } from "sonner";
+import { toastUndo } from "@/components/Toast";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import {
   cancelPendingMailMutation,
@@ -181,20 +182,16 @@ export function useThreadActions({
       const batch: UndoableBatch = { action, snapshots, undone: false };
       lastAction.current = batch;
       const failedCount = threadKeys.length - snapshots.length;
-      toast.success(
-        summarise(
+      toastUndo({
+        message: summarise(
           action === "archive" ? "Archived" : "Deleted",
           snapshots.length,
         ),
-        {
-          action: {
-            label: `Undo · ${getShortcutHint("undo")}`,
-            onClick: () => {
-              undoBatch(batch);
-            },
-          },
+        shortcut: getShortcutHint("undo"),
+        onUndo: () => {
+          undoBatch(batch);
         },
-      );
+      });
       if (failedCount) {
         toast.error(
           action === "archive"

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -175,7 +175,7 @@ export default async function RootLayout({
           </Suspense>
           <GlobalProviders>
             {children}
-            <Toaster closeButton richColors theme="light" visibleToasts={9} />
+            <Toaster />
           </GlobalProviders>
         </PostHogProvider>
         <Analytics />

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -76,9 +76,7 @@ export function Toaster() {
         unstyled: true,
         classNames: {
           toast:
-            "relative flex w-full items-center gap-3 overflow-hidden rounded-lg border border-border bg-popover py-3 pl-4 pr-2 text-popover-foreground shadow-lg before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-blue-600 dark:before:bg-blue-400",
-          error: "before:bg-destructive",
-          warning: "before:bg-amber-500",
+            "relative flex w-full items-center gap-3 overflow-hidden rounded-lg border border-border bg-popover py-3 pl-4 pr-2 text-popover-foreground shadow-lg before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-blue-500 data-[type=error]:before:bg-destructive data-[type=warning]:before:bg-amber-500",
           icon: "relative flex size-4 shrink-0 items-center justify-center",
           content: "min-w-0 flex-1",
           title: "text-sm font-medium leading-5",

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -1,19 +1,26 @@
+import { CircleAlert, Loader2, X } from "lucide-react";
 import { Toaster as SonnerToaster, toast } from "sonner";
+import { Kbd } from "@/components/Kbd";
+import { cn } from "@/utils";
+
+// The app's primary token is near-black in light mode and near-white in dark,
+// so links and rails use the mail palette's blue explicitly.
+const ACCENT_TEXT = "text-blue-600 dark:text-blue-400";
 
 export function toastSuccess(options: {
   title?: string;
   description: string;
   id?: string;
 }) {
-  return toast.success(options.title || "Success", {
-    description: options.description,
+  return toast.success(options.title || options.description, {
+    description: options.title ? options.description : undefined,
     id: options.id,
   });
 }
 
 export function toastError(options: { title?: string; description: string }) {
-  return toast.error(options.title || "Error", {
-    description: options.description,
+  return toast.error(options.title || options.description, {
+    description: options.title ? options.description : undefined,
     duration: 10_000,
   });
 }
@@ -29,4 +36,63 @@ export function toastInfo(options: {
   });
 }
 
-export const Toaster = SonnerToaster;
+export function toastUndo(options: {
+  message: string;
+  shortcut?: string;
+  onUndo: () => void;
+}) {
+  return toast.success(options.message, {
+    id: "undo",
+    action: {
+      label: (
+        <>
+          Undo
+          {options.shortcut && (
+            <Kbd className={cn("ml-1.5", ACCENT_TEXT)}>{options.shortcut}</Kbd>
+          )}
+        </>
+      ),
+      onClick: options.onUndo,
+    },
+  });
+}
+
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="bottom-left"
+      closeButton
+      visibleToasts={9}
+      gap={8}
+      icons={{
+        success: null,
+        info: null,
+        warning: <CircleAlert className="size-4 text-amber-500" />,
+        error: <CircleAlert className="size-4 text-destructive" />,
+        loading: <Loader2 className={cn("size-4 animate-spin", ACCENT_TEXT)} />,
+        close: <X className="size-4" />,
+      }}
+      toastOptions={{
+        unstyled: true,
+        classNames: {
+          toast:
+            "relative flex w-full items-center gap-3 overflow-hidden rounded-lg border border-border bg-popover py-3 pl-4 pr-2 text-popover-foreground shadow-lg before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-blue-600 dark:before:bg-blue-400",
+          error: "before:bg-destructive",
+          warning: "before:bg-amber-500",
+          icon: "relative flex size-4 shrink-0 items-center justify-center",
+          content: "min-w-0 flex-1",
+          title: "text-sm font-medium leading-5",
+          description: "mt-0.5 text-sm leading-5 text-muted-foreground",
+          actionButton: cn(
+            "inline-flex shrink-0 items-center rounded px-1.5 py-1 text-sm font-medium hover:bg-blue-600/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            ACCENT_TEXT,
+          ),
+          cancelButton:
+            "inline-flex shrink-0 items-center rounded px-1.5 py-1 text-sm font-medium text-muted-foreground hover:bg-muted",
+          closeButton:
+            "order-last inline-flex shrink-0 items-center rounded p-1.5 text-muted-foreground/70 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
<!-- inbox-zero-pr-qa:start -->
> ✅ **Browser QA passed** · [QA report](https://qa.getinboxzero.com/20260906-152401_pr-3541_3f2b126adf89/report.html)
>
> <sub>Apply `rerun-qa` to rerun.</sub>
<!-- inbox-zero-pr-qa:end -->

Restyles app-wide toast notifications and moves them to the bottom-left.

- Sonner now runs unstyled with our own classes: neutral card, thin colour rail per type (blue for success/info, red for error, amber for warning), no icon on success/info, text-link actions, quiet close button. Dark mode follows the popover tokens.
- Removes `richColors` and the forced light theme from the root toaster. The old action button rendered black on a tinted card.
- `toastSuccess`/`toastError` no longer prepend a generic "Success"/"Error" title when the caller passes only a description, so most notices become a single line.
- New `toastUndo` helper renders Undo with the shortcut as a kbd chip and reuses one toast id, so rapid archives replace the toast instead of stacking. Thread actions use it.
- Verified in the emulated mail view in light and dark mode: archive/undo, single-line and titled errors, info with action, loading, plain success. Lint and the thread actions tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent Undo actions to archive and trash notifications, with optional keyboard shortcut guidance.
  - Improved success and error notifications with clearer titles and no duplicated text.

- **Improvements**
  - Standardized toast placement, styling, icons, controls, and notification limits.
  - Updated notification behavior to use consistent default presentation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->