### PR TITLE
mail: Tighten reader top spacing on desktop

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -10,6 +10,7 @@ import {
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 type ReaderToolbarProps = {
   subject: string;
@@ -23,6 +24,8 @@ type ReaderToolbarProps = {
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
+  /** Sits beside the back arrow when the reader owns the full width. */
+  showSidebarToggle?: boolean;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
   messageExpansion?: {
@@ -42,21 +45,31 @@ export function ReaderToolbar({
   onRemoveLabel,
   onBackToInbox,
   onArchive,
+  showSidebarToggle = false,
   menu,
   messageExpansion,
 }: ReaderToolbarProps) {
   return (
     <div className="flex flex-wrap items-start gap-x-4 gap-y-3 pb-3">
-      <Button
-        aria-label="Back to inbox"
-        className="h-7 w-7"
-        onClick={onBackToInbox}
-        size="icon"
-        title="Back to inbox"
-        variant="ghost"
-      >
-        <ArrowLeftIcon className="size-3.5" />
-      </Button>
+      <div className="flex items-center gap-1">
+        {showSidebarToggle ? (
+          <SidebarTrigger
+            className="hidden lg:inline-flex"
+            name="left-sidebar"
+          />
+        ) : null}
+
+        <Button
+          aria-label="Back to inbox"
+          className="h-7 w-7"
+          onClick={onBackToInbox}
+          size="icon"
+          title="Back to inbox"
+          variant="ghost"
+        >
+          <ArrowLeftIcon className="size-3.5" />
+        </Button>
+      </div>
 
       <div className="min-w-56 flex-1">
         <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -12,7 +12,6 @@ import { EmailThread } from "@/components/email-list/EmailThread";
 import type { ThreadMessage } from "@/components/email-list/types";
 import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
 import { LoadingContent } from "@/components/LoadingContent";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 
@@ -117,6 +116,9 @@ export function ThreadReader({
       userLabels,
     }) ?? [];
 
+  /** No list column beside us, so the reader carries the sidebar toggle. */
+  const ownsFullWidth = layout === "list" && showSidebarToggle;
+
   const renderToolbar = (
     messageExpansion?: ComponentProps<typeof ReaderToolbar>["messageExpansion"],
   ) => (
@@ -128,6 +130,7 @@ export function ThreadReader({
       onArchive={onArchive}
       onBackToInbox={onBackToInbox}
       onRemoveLabel={onRemoveLabel}
+      showSidebarToggle={ownsFullWidth}
       subject={headerMessage.headers.subject}
     />
   );
@@ -141,16 +144,10 @@ export function ThreadReader({
         data-detail-selection-settled={detailSelectionSettled}
         data-testid="thread-reader"
       >
-        {layout === "list" && showSidebarToggle ? (
-          <div
-            className="hidden px-3 py-3 lg:flex"
-            data-desktop-mac-titlebar-spacer
-          >
-            <SidebarTrigger name="left-sidebar" />
-          </div>
-        ) : null}
-
-        <div className={readerMeasure({ layout })}>
+        <div
+          className={readerMeasure({ layout })}
+          data-desktop-mac-titlebar-spacer={ownsFullWidth || undefined}
+        >
           {messages.length > 0 ? (
             <EmailThread
               renderToolbar={renderToolbar}


### PR DESCRIPTION
On the desktop app the thread reader gave the sidebar toggle a row of its own above the thread, which stacked on top of the Mac title-bar spacer and pushed the subject well down the window.

- Move the sidebar toggle beside the reader's back arrow so it no longer costs a row
- Apply the title-bar spacer to the reader content instead of the removed row, keeping the header clear of the traffic lights
- Verified in the emulated browser environment with the Mac desktop attribute set: the subject now sits directly below the traffic lights

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional sidebar toggle to the mail reader toolbar on desktop.
  * Grouped the sidebar toggle with the back-to-inbox control for easier navigation.

* **Bug Fixes**
  * Improved reader layout handling when the sidebar toggle is enabled, preventing redundant spacing above message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->