### PR TITLE
docs: Refine pull request workflow

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -118,8 +118,9 @@ from an older commit.
 
 ## 5. Wait before every observation
 
-Run the full wait in the foreground. If the execution tool yields, poll that
-same process in slices no longer than 60 seconds until it exits.
+Before waiting, stop if the PR is no longer open. Run the full wait in the
+foreground. If the execution tool yields, poll that same process in slices no
+longer than 60 seconds until it exits.
 
 ```bash
 sleep <wait-seconds>
@@ -172,7 +173,8 @@ For each failure, open its logs or linked report. Use
 `gh run view <run-id> --log-failed` for GitHub Actions when available. Fix and
 validate failures caused by the PR. If a failure is unrelated or inaccessible,
 record the evidence and report the blocker without claiming the PR is clean.
-Do not rerun, approve, dismiss, or mutate an external check unless authorized.
+Do not start comparison runs, rerun CI, or sync the base branch solely to make
+an unrelated failure pass.
 
 ## 8. Address review comments
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -173,8 +173,8 @@ For each failure, open its logs or linked report. Use
 `gh run view <run-id> --log-failed` for GitHub Actions when available. Fix and
 validate failures caused by the PR. If a failure is unrelated or inaccessible,
 record the evidence and report the blocker without claiming the PR is clean.
-Do not start comparison runs, rerun CI, or sync the base branch solely to make
-an unrelated failure pass.
+Do not start comparison runs or sync the base solely to make an unrelated
+failure pass. Do not mutate external checks unless authorized.
 
 ## 8. Address review comments
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -118,9 +118,9 @@ from an older commit.
 
 ## 5. Wait before every observation
 
-Before waiting, stop if the PR is no longer open. Run the full wait in the
-foreground. If the execution tool yields, poll that same process in slices no
-longer than 60 seconds until it exits.
+Before and after waiting, stop if the PR is no longer open. Run the full wait
+in the foreground. If the execution tool yields, poll that same process in
+slices no longer than 60 seconds until it exits.
 
 ```bash
 sleep <wait-seconds>


### PR DESCRIPTION
Clarify pull request monitoring behavior for terminal and unrelated states.

- stop monitoring closed pull requests
- avoid unnecessary CI restarts for unrelated failures
- validated the skill definition

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pull request monitoring guidance to verify that a PR remains open before and after each wait, exiting if it closes during the wait.
  * Clarified failure-handling guidance to avoid unnecessary comparison runs or base synchronization, and to modify external checks only when authorized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->