### PR TITLE
mail: Show sender profile beside the reader

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -158,3 +158,84 @@ test("offers to disable auto archive for an enabled sender", async ({
     }),
   ).toHaveCount(0);
 });
+
+test("opens the sender profile beside the reader", async ({
+  page,
+}, testInfo) => {
+  await page.route("**/api/user/public-contact-context/**", (route) =>
+    route.fulfill({
+      json: {
+        status: "found",
+        context: {
+          role: "Head of Product",
+          company: {
+            name: "Example Labs",
+            domain: "example.com",
+            website: "https://example.com",
+            description: "Builds collaboration tools for distributed teams.",
+            industry: "Software",
+            employeeCount: "51-200 employees",
+            funding: "Series A",
+          },
+          sources: ["https://example.com/team", "https://example.com/about"],
+          confidence: "high",
+        },
+      },
+    }),
+  );
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Visual Message",
+  ).click();
+  const subject = page.getByRole("heading", {
+    name: "Re: Reader Visual Message",
+  });
+  await expect(subject).toBeVisible();
+
+  await page
+    .getByRole("button", {
+      exact: true,
+      name: "View public profile for Morgan Example",
+    })
+    .click();
+  const panel = page.getByTestId("sender-context-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText("Head of Product")).toBeVisible();
+  await expect(panel.getByText("Example Labs")).toBeVisible();
+  // Beside the reader, not over it: the email stays readable and nothing dims.
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(subject).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-reader-sender-profile",
+  );
+
+  // Too narrow for a second column, so the same profile slides over instead.
+  await page.setViewportSize({ width: 900, height: 720 });
+  const sheet = page.getByRole("dialog");
+  await expect(sheet).toBeVisible();
+  await expect(sheet.getByText("Head of Product")).toBeVisible();
+  await expect(panel).toHaveCount(0);
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-reader-sender-profile-narrow",
+  );
+
+  await sheet.getByRole("button", { name: "Close" }).click();
+  await expect(sheet).toHaveCount(0);
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page
+    .getByRole("button", {
+      exact: true,
+      name: "View public profile for Morgan Example",
+    })
+    .click();
+  await expect(panel).toBeVisible();
+  await panel.getByRole("button", { name: "Close sender profile" }).click();
+  await expect(panel).toHaveCount(0);
+});

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -214,7 +214,7 @@ test("opens the sender profile beside the reader", async ({
   );
 
   // Too narrow for a second column, so the same profile slides over instead.
-  await page.setViewportSize({ width: 900, height: 720 });
+  await page.setViewportSize({ width: 700, height: 720 });
   const sheet = page.getByRole("dialog");
   await expect(sheet).toBeVisible();
   await expect(sheet.getByText("Head of Product")).toBeVisible();
@@ -238,4 +238,16 @@ test("opens the sender profile beside the reader", async ({
   await expect(panel).toBeVisible();
   await panel.getByRole("button", { name: "Close sender profile" }).click();
   await expect(panel).toHaveCount(0);
+
+  // Escape dismisses the pane without also backing out of the thread.
+  await page
+    .getByRole("button", {
+      exact: true,
+      name: "View public profile for Morgan Example",
+    })
+    .click();
+  await expect(panel).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(panel).toHaveCount(0);
+  await expect(subject).toBeVisible();
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import {
   Building2Icon,
   ExternalLinkIcon,
@@ -51,6 +52,13 @@ export function SenderContextPanel({
   const isResearching =
     isLoading ||
     (data?.status === "unavailable" && data.reason === "research_in_progress");
+  const inlineRef = useRef<HTMLElement>(null);
+
+  // Takes focus like the sheet does, so Escape lands on the pane and can
+  // dismiss it from the keyboard.
+  useEffect(() => {
+    inlineRef.current?.focus();
+  }, []);
 
   const body = (
     <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
@@ -105,8 +113,17 @@ export function SenderContextPanel({
   return (
     <aside
       aria-label="Sender profile"
-      className="flex w-80 shrink-0 flex-col border-border border-l bg-card"
+      className="flex w-80 shrink-0 flex-col border-border border-l bg-card outline-none"
       data-testid="sender-context-panel"
+      onKeyDown={(event) => {
+        if (event.key !== "Escape") return;
+        // Stopped here so the mail shell's Escape shortcut, which listens on
+        // the document, doesn't also close the whole reader.
+        event.stopPropagation();
+        onClose();
+      }}
+      ref={inlineRef}
+      tabIndex={-1}
     >
       <div className="flex items-start gap-2 border-border border-b px-5 py-4">
         {identity}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
@@ -7,80 +7,121 @@ import {
   SparklesIcon,
   UsersIcon,
   WalletCardsIcon,
+  XIcon,
 } from "lucide-react";
 import { usePublicContactContext } from "@/app/(app)/[emailAccountId]/mail/use-public-contact-context";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Sheet,
   SheetContent,
   SheetDescription,
-  SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { PublicContactContextUnavailableReason } from "@/utils/ai/public-contact-context";
 import type { PublicContactContext } from "@/utils/ai/public-contact-context-schema";
 
-export function SenderContextSheet({
-  messageId,
-  senderName,
-  senderEmail,
-  open,
-  onOpenChange,
-}: {
+type SenderContextPanelProps = {
   messageId: string;
   senderName: string;
   senderEmail: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
+  /**
+   * `inline` sits beside the reader as a pane. `sheet` slides over it, for
+   * viewports too narrow to give up a column.
+   */
+  variant: "inline" | "sheet";
+  onClose: () => void;
+};
+
+/** Who a sender is, from public sources: role, company, and where that came from. */
+export function SenderContextPanel({
+  messageId,
+  senderName,
+  senderEmail,
+  variant,
+  onClose,
+}: SenderContextPanelProps) {
   const { data, isLoading, error } = usePublicContactContext({
     messageId,
-    enabled: open,
+    enabled: true,
   });
   const isResearching =
     isLoading ||
     (data?.status === "unavailable" && data.reason === "research_in_progress");
 
-  return (
-    <Sheet onOpenChange={onOpenChange} open={open}>
-      <SheetContent className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-md">
-        <SheetHeader className="border-border border-b px-6 py-5 pr-12">
-          <div className="flex items-center gap-3 text-left">
-            <Avatar className="size-11 border border-border">
-              <AvatarFallback className="font-title font-medium text-sm">
-                {getInitials(senderName || senderEmail)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0">
-              <SheetTitle className="truncate font-title text-foreground">
-                {senderName}
-              </SheetTitle>
-              <SheetDescription className="truncate">
-                {senderEmail}
-              </SheetDescription>
-            </div>
-          </div>
-        </SheetHeader>
+  const body = (
+    <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+      <LoadingContent
+        error={error}
+        errorComponent={<ContextError />}
+        loading={isResearching}
+        loadingComponent={<ContextSkeleton />}
+      >
+        {data?.status === "found" ? (
+          <PublicContext context={data.context} />
+        ) : (
+          <ContextUnavailable reason={data?.reason} />
+        )}
+      </LoadingContent>
+    </div>
+  );
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-          <LoadingContent
-            error={error}
-            errorComponent={<ContextError />}
-            loading={isResearching}
-            loadingComponent={<ContextSkeleton />}
-          >
-            {data?.status === "found" ? (
-              <PublicContext context={data.context} />
-            ) : (
-              <ContextUnavailable reason={data?.reason} />
-            )}
-          </LoadingContent>
+  const identity = (
+    <div className="flex min-w-0 flex-1 items-center gap-3 text-left">
+      <Avatar className="size-10 border border-border">
+        <AvatarFallback className="font-title font-medium text-sm">
+          {getInitials(senderName || senderEmail)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <div className="truncate font-title font-medium text-base text-foreground">
+          {senderName}
         </div>
-      </SheetContent>
-    </Sheet>
+        <div className="truncate text-muted-foreground text-sm">
+          {senderEmail}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (variant === "sheet") {
+    return (
+      <Sheet onOpenChange={(open) => !open && onClose()} open>
+        <SheetContent className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-md">
+          <SheetTitle className="sr-only">{senderName}</SheetTitle>
+          <SheetDescription className="sr-only">{senderEmail}</SheetDescription>
+          <div className="border-border border-b px-5 py-4 pr-12">
+            {identity}
+          </div>
+          {body}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Sender profile"
+      className="flex w-80 shrink-0 flex-col border-border border-l bg-card"
+      data-testid="sender-context-panel"
+    >
+      <div className="flex items-start gap-2 border-border border-b px-5 py-4">
+        {identity}
+        <Button
+          aria-label="Close sender profile"
+          className="-mr-2 -mt-1 size-7 shrink-0 text-muted-foreground"
+          onClick={onClose}
+          size="icon"
+          variant="ghost"
+        >
+          <XIcon className="size-4" />
+        </Button>
+      </div>
+      {body}
+    </aside>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SenderContextPanel.tsx
@@ -115,6 +115,7 @@ export function SenderContextPanel({
           className="-mr-2 -mt-1 size-7 shrink-0 text-muted-foreground"
           onClick={onClose}
           size="icon"
+          type="button"
           variant="ghost"
         >
           <XIcon className="size-4" />

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useState, type ComponentProps, type ReactNode } from "react";
+import {
+  useCallback,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import dynamic from "next/dynamic";
 import { Loader2Icon, MailIcon } from "lucide-react";
 import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
@@ -16,13 +21,19 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 
-const SenderContextSheet = dynamic(
+const SenderContextPanel = dynamic(
   () =>
-    import("@/app/(app)/[emailAccountId]/mail/SenderContextSheet").then(
-      (module) => module.SenderContextSheet,
+    import("@/app/(app)/[emailAccountId]/mail/SenderContextPanel").then(
+      (module) => module.SenderContextPanel,
     ),
   { ssr: false },
 );
+
+/**
+ * Below this the reader would be squeezed too far by a pane beside it, so the
+ * sender profile slides over the reader instead.
+ */
+const INLINE_SENDER_CONTEXT_MIN_WIDTH = 880;
 
 export type ThreadReaderProps = {
   enableMessageNavigation: boolean;
@@ -80,8 +91,8 @@ export function ThreadReader({
     messageId: string;
     senderEmail: string;
     senderName: string;
-    open: boolean;
   } | null>(null);
+  const [readerRef, readerWidth] = useElementWidth();
   const headerMessage = thread?.messages.at(-1) ?? messages.at(-1);
 
   if (error || !headerMessage) {
@@ -133,7 +144,7 @@ export function ThreadReader({
   );
 
   return (
-    <>
+    <div className="flex min-h-0 min-w-0 flex-1" ref={readerRef}>
       {/* White, unlike the list: the reader is its own surface, and it has to
       match `EmailThread` below or the toolbar reads as a separate band. */}
       <div
@@ -166,7 +177,6 @@ export function ThreadReader({
                   senderEmail,
                   senderName:
                     extractNameFromEmail(message.headers.from) || senderEmail,
-                  open: true,
                 });
               }}
               refetch={refetch}
@@ -179,20 +189,36 @@ export function ThreadReader({
       </div>
 
       {senderContext ? (
-        <SenderContextSheet
+        <SenderContextPanel
           messageId={senderContext.messageId}
-          onOpenChange={(open: boolean) =>
-            setSenderContext((current) =>
-              current ? { ...current, open } : current,
-            )
-          }
-          open={senderContext.open}
+          onClose={() => setSenderContext(null)}
           senderEmail={senderContext.senderEmail}
           senderName={senderContext.senderName}
+          variant={
+            readerWidth >= INLINE_SENDER_CONTEXT_MIN_WIDTH ? "inline" : "sheet"
+          }
         />
       ) : null}
-    </>
+    </div>
   );
+}
+
+/**
+ * A callback ref rather than an effect: the reader mounts its measured element
+ * only once a thread is open, after the loading branch has come and gone.
+ */
+function useElementWidth() {
+  const [width, setWidth] = useState(0);
+  const ref = useCallback((element: HTMLElement | null) => {
+    if (!element) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width] as const;
 }
 
 /** A readable measure, centred whenever the reader owns the full width. */

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -6,7 +6,6 @@ import {
   ReplyIcon,
   ChevronsUpDownIcon,
   ChevronsDownUpIcon,
-  UserRoundSearchIcon,
 } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import {
@@ -299,6 +298,30 @@ function MessageHeader({
     open();
   };
 
+  const avatar = (
+    <Avatar aria-hidden className="size-7 shrink-0">
+      <AvatarImage alt="" src={senderImage || undefined} />
+      <AvatarFallback
+        className={cn(
+          "font-semibold text-[10px] tracking-wide",
+          isSent
+            ? "bg-primary/10 text-primary"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {initialsFor(senderName)}
+      </AvatarFallback>
+    </Avatar>
+  );
+  // Fixed widths on the collapsed rows keep the snippet column aligned down
+  // the thread, whichever senders are clickable.
+  const senderNameClassName = cn(
+    "truncate text-sm",
+    expanded
+      ? "max-w-40 shrink font-semibold text-foreground"
+      : "w-24 shrink-0 font-medium text-secondary-foreground sm:w-28",
+  );
+
   return (
     <div
       {...toggleProps}
@@ -307,60 +330,36 @@ function MessageHeader({
         onToggle && "cursor-pointer",
       )}
     >
-      <Avatar aria-hidden className="size-7 shrink-0">
-        <AvatarImage alt="" src={senderImage || undefined} />
-        <AvatarFallback
-          className={cn(
-            "font-semibold text-[10px] tracking-wide",
-            isSent
-              ? "bg-primary/10 text-primary"
-              : "bg-muted text-muted-foreground",
-          )}
-        >
-          {initialsFor(senderName)}
-        </AvatarFallback>
-      </Avatar>
-
       {canResearchSender ? (
-        <Button
-          type="button"
-          aria-label={`View public profile for ${senderName}`}
-          className={cn(
-            "h-7 min-w-0 justify-start gap-1 p-0",
-            expanded ? "max-w-40 shrink" : "w-24 shrink-0 sm:w-28",
-          )}
-          onClick={(event) => {
-            event.stopPropagation();
-            onOpenSenderContext?.(message);
-          }}
-          title="View public profile"
-          variant="ghost"
-        >
-          <span
+        <Tooltip content="View public profile">
+          <button
+            aria-label={`View public profile for ${senderName}`}
             className={cn(
-              "truncate text-sm",
-              expanded
-                ? "font-semibold text-foreground"
-                : "font-medium text-secondary-foreground",
+              "group/sender flex items-center gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              expanded ? "min-w-0" : "shrink-0",
             )}
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenSenderContext?.(message);
+            }}
+            type="button"
           >
-            {senderName}
-          </span>
-          {expanded && (
-            <UserRoundSearchIcon className="hidden size-3.5 shrink-0 text-muted-foreground sm:block" />
-          )}
-        </Button>
+            {avatar}
+            <span
+              className={cn(
+                senderNameClassName,
+                "text-left underline-offset-4 group-hover/sender:underline",
+              )}
+            >
+              {senderName}
+            </span>
+          </button>
+        </Tooltip>
       ) : (
-        <span
-          className={cn(
-            "truncate text-sm",
-            expanded
-              ? "max-w-40 shrink font-semibold text-foreground"
-              : "w-24 shrink-0 font-medium text-secondary-foreground sm:w-28",
-          )}
-        >
-          {senderName}
-        </span>
+        <>
+          {avatar}
+          <span className={senderNameClassName}>{senderName}</span>
+        </>
       )}
 
       {expanded ? (


### PR DESCRIPTION
The public sender profile opened as a slide-over sheet that dimmed and blurred the email behind it, and the header carried an awkward search icon next to the sender name.

- Render the profile as an inline pane beside the open thread, keeping the email readable and undimmed
- Fall back to the sheet only when the reader row is too narrow for a second column (measured with a resize observer)
- Remove the profile icon; the sender avatar and name are now the trigger, with a hover underline and tooltip
- Add an emulated Playwright test covering the inline pane, the narrow-viewport sheet fallback, and closing both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sender profiles now appear in an inline side panel on wider screens.
  * On narrower screens, sender profiles open in a sheet-style view.
  * Added close controls for both profile presentations.
  * Sender avatars and names now provide a clearer “View public profile” action.

* **Bug Fixes**
  * Improved responsive behavior by adapting sender profile presentation to the available reading area.

* **Tests**
  * Added visual coverage for sender profiles across wide and narrow layouts, including close interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->