### PR TITLE
Mail: expand command shortcuts

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -10,7 +10,11 @@ import { Client } from "pg";
 import { getEmailAccountId } from "../account-test-helpers";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
-import { readLatestMailMutation } from "./mail-test-helpers";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
 const SIDE_PANEL_ARCHIVE_MESSAGE_ID = "msg_playwright_archive";
@@ -125,6 +129,14 @@ test("Command K acts on highlighted and selected conversations", async ({
     palette.getByRole("option", { name: "Mark as read" }),
   ).toBeVisible();
   await expect(palette.getByRole("option", { name: "Snooze H" })).toBeVisible();
+  await expect(palette.getByRole("option", { name: "Label L" })).toBeVisible();
+  await expect(palette.getByRole("option", { name: "Move V" })).toBeVisible();
+  await expect(
+    palette.getByRole("option", { name: "Mark as spam !" }),
+  ).toBeVisible();
+  await expect(palette.getByText("navigate", { exact: true })).toHaveCount(0);
+  await expect(palette.getByText("select", { exact: true })).toHaveCount(0);
+  await expect(palette.getByText("close", { exact: true })).toHaveCount(0);
   await expect(palette).not.toContainText("Applies to");
   await attachScreenshotForChangedTest(
     testInfo,
@@ -226,6 +238,44 @@ test("Command K acts on highlighted and selected conversations", async ({
   await palette.getByRole("option", { name: "Snooze 2 conversations" }).click();
   await palette.getByRole("option", { name: "In 3 hours" }).click();
   await expect(options).toHaveCount(initialConversationCount - 2);
+});
+
+test("the open reader exposes its actions in Command K and forwards with F", async ({
+  page,
+}) => {
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Visual Message",
+  ).click();
+  await expect(
+    page.getByRole("heading", { name: "Re: Reader Visual Message" }),
+  ).toBeVisible();
+
+  await page.keyboard.press(`${commandModifier}+KeyK`);
+  const palette = page.getByRole("dialog");
+  await expect(
+    palette.getByRole("option", { name: "Forward F" }),
+  ).toBeVisible();
+  await expect(palette.getByRole("option", { name: "Label L" })).toBeVisible();
+  await expect(palette.getByRole("option", { name: "Move V" })).toBeVisible();
+  await expect(
+    palette.getByRole("option", { name: "Mark as spam !" }),
+  ).toBeVisible();
+  await expect(
+    palette.getByRole("option", { name: "Unsubscribe from sender" }),
+  ).toBeVisible();
+  await expect(
+    palette.getByRole("option", { name: /auto archive/i }),
+  ).toBeVisible();
+  await expect(
+    palette.getByRole("option", { name: "Open in Gmail G G" }),
+  ).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("KeyF");
+  await expect(page.getByRole("textbox", { name: "To" })).toBeVisible();
 });
 
 async function ensureReadState(

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -126,6 +126,9 @@ test("Command K acts on highlighted and selected conversations", async ({
     palette.getByRole("option", { name: "Archive conversation E" }),
   ).toBeVisible();
   await expect(
+    palette.getByRole("option", { name: "Forward F" }),
+  ).toBeVisible();
+  await expect(
     palette.getByRole("option", { name: "Mark as read" }),
   ).toBeVisible();
   await expect(palette.getByRole("option", { name: "Snooze H" })).toBeVisible();
@@ -274,6 +277,7 @@ test("the open reader exposes its actions in Command K and forwards with F", asy
   ).toBeVisible();
 
   await page.keyboard.press("Escape");
+  await expect(palette).toBeHidden();
   await page.keyboard.press("KeyF");
   await expect(page.getByRole("textbox", { name: "To" })).toBeVisible();
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -179,7 +179,10 @@ export function MailShell() {
   } | null>(null);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
   const [forwardToMessageId, setForwardToMessageId] = useState<string>();
-  const pendingReplyThreadKey = useRef<string | null>(null);
+  const pendingComposeRequest = useRef<{
+    mode: "reply" | "forward";
+    threadKey: string;
+  } | null>(null);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   useEffect(() => {
@@ -493,32 +496,49 @@ export function MailShell() {
   const requestReaderReply = useCallback(() => {
     const messageId = openMessages.at(-1)?.id;
     if (messageId) {
-      pendingReplyThreadKey.current = null;
+      pendingComposeRequest.current = null;
       setReplyToMessageId(messageId);
       return;
     }
 
-    pendingReplyThreadKey.current = openReaderThreadKey;
+    if (openReaderThreadKey) {
+      pendingComposeRequest.current = {
+        mode: "reply",
+        threadKey: openReaderThreadKey,
+      };
+    }
   }, [openMessages, openReaderThreadKey]);
 
   const requestReaderForward = useCallback(() => {
     const messageId = openMessages.at(-1)?.id;
-    if (messageId) setForwardToMessageId(messageId);
-  }, [openMessages]);
+    if (messageId) {
+      pendingComposeRequest.current = null;
+      setForwardToMessageId(messageId);
+      return;
+    }
+
+    if (openReaderThreadKey) {
+      pendingComposeRequest.current = {
+        mode: "forward",
+        threadKey: openReaderThreadKey,
+      };
+    }
+  }, [openMessages, openReaderThreadKey]);
 
   useEffect(() => {
-    const pendingThreadKey = pendingReplyThreadKey.current;
-    if (!pendingThreadKey) return;
-    if (pendingThreadKey !== openReaderThreadKey) {
-      pendingReplyThreadKey.current = null;
+    const pendingRequest = pendingComposeRequest.current;
+    if (!pendingRequest) return;
+    if (pendingRequest.threadKey !== openReaderThreadKey) {
+      pendingComposeRequest.current = null;
       return;
     }
 
     const messageId = openMessages.at(-1)?.id;
     if (!readerSelectionSettled || !messageId) return;
 
-    pendingReplyThreadKey.current = null;
-    setReplyToMessageId(messageId);
+    pendingComposeRequest.current = null;
+    if (pendingRequest.mode === "reply") setReplyToMessageId(messageId);
+    else setForwardToMessageId(messageId);
   }, [openMessages, openReaderThreadKey, readerSelectionSettled]);
 
   // Let the fetched snapshot decide the initial read state. Once marking has

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -178,6 +178,7 @@ export function MailShell() {
     targets: ThreadSelection[];
   } | null>(null);
   const [replyToMessageId, setReplyToMessageId] = useState<string>();
+  const [forwardToMessageId, setForwardToMessageId] = useState<string>();
   const pendingReplyThreadKey = useRef<string | null>(null);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
@@ -500,6 +501,11 @@ export function MailShell() {
     pendingReplyThreadKey.current = openReaderThreadKey;
   }, [openMessages, openReaderThreadKey]);
 
+  const requestReaderForward = useCallback(() => {
+    const messageId = openMessages.at(-1)?.id;
+    if (messageId) setForwardToMessageId(messageId);
+  }, [openMessages]);
+
   useEffect(() => {
     const pendingThreadKey = pendingReplyThreadKey.current;
     if (!pendingThreadKey) return;
@@ -604,6 +610,7 @@ export function MailShell() {
       if (!thread) return;
       setFocusedIndex(index);
       setReplyToMessageId(undefined);
+      setForwardToMessageId(undefined);
       selection.clear();
       setOpenThread(getListThreadSelection(thread, emailAccountId));
     },
@@ -620,6 +627,7 @@ export function MailShell() {
       const nextThread = threads[next];
       if ((layout === "split" || openThreadId) && nextThread) {
         setReplyToMessageId(undefined);
+        setForwardToMessageId(undefined);
         setOpenThread(getListThreadSelection(nextThread, emailAccountId));
       }
     },
@@ -695,7 +703,10 @@ export function MailShell() {
     (until: Date) => runOn((ids) => snooze(ids, until), true),
     [runOn, snooze],
   );
-  const currentLabelTargets = actionTargets.map((target) => target.selection);
+  const currentLabelTargets = useMemo(
+    () => actionTargets.map((target) => target.selection),
+    [actionTargets],
+  );
   const labelAccountId = currentLabelTargets[0]?.emailAccountId;
   const labelAccount =
     labelAccountId === emailAccountId
@@ -709,14 +720,14 @@ export function MailShell() {
     currentLabelTargets.every(
       (target) => target.emailAccountId === labelAccountId,
     );
-  const openLabelPicker = () => {
+  const openLabelPicker = useCallback(() => {
     if (canLabel)
       setLabelPicker({ mode: "label", targets: currentLabelTargets });
-  };
-  const openMovePicker = () => {
+  }, [canLabel, currentLabelTargets]);
+  const openMovePicker = useCallback(() => {
     if (canLabel)
       setLabelPicker({ mode: "move", targets: currentLabelTargets });
-  };
+  }, [canLabel, currentLabelTargets]);
   const pickerAccount =
     labelPicker?.targets[0]?.emailAccountId === emailAccountId
       ? emailAccount
@@ -728,8 +739,15 @@ export function MailShell() {
     () => ({
       actions: {
         archive: archiveTargets,
+        forward: openThreadId ? requestReaderForward : undefined,
+        label: canLabel ? openLabelPicker : undefined,
         markRead: markReadTargets,
+        markSpam: markSpamTargets,
         markUnread: markUnreadTargets,
+        move: canLabel ? openMovePicker : undefined,
+        openExternal: openExternalUrl
+          ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
+          : undefined,
         snooze: snoozeTargets,
         trash: trashTargets,
       },
@@ -737,13 +755,24 @@ export function MailShell() {
       hasUnread: actionTargets.some((target) =>
         isThreadUnread(target.messages),
       ),
+      openExternalLabel: openExternalUrl
+        ? `Open in ${isMicrosoftProvider(readerEmailAccount?.account.provider) ? "Outlook" : "Gmail"}`
+        : undefined,
       targetCount: actionTargets.length,
     }),
     [
       archiveTargets,
       actionTargets,
+      canLabel,
       markReadTargets,
+      markSpamTargets,
       markUnreadTargets,
+      openLabelPicker,
+      openMovePicker,
+      openExternalUrl,
+      openThreadId,
+      readerEmailAccount?.account.provider,
+      requestReaderForward,
       snoozeTargets,
       trashTargets,
     ],
@@ -866,6 +895,7 @@ export function MailShell() {
         }
         setReplyToMessageId(openMessages.at(-1)?.id);
       },
+      forward: openThreadId ? requestReaderForward : undefined,
       moreActions: openThreadId
         ? () => setIsMenuOpen((open) => !open)
         : undefined,
@@ -1258,6 +1288,7 @@ export function MailShell() {
               showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}
               autoOpenReplyForMessageId={replyToMessageId}
+              autoOpenForwardForMessageId={forwardToMessageId}
               menu={
                 <ThreadActionsMenu
                   plans={openThread?.plans ?? []}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -497,6 +497,7 @@ export function MailShell() {
     const messageId = openMessages.at(-1)?.id;
     if (messageId) {
       pendingComposeRequest.current = null;
+      setForwardToMessageId(undefined);
       setReplyToMessageId(messageId);
       return;
     }
@@ -513,6 +514,7 @@ export function MailShell() {
     const messageId = openMessages.at(-1)?.id;
     if (messageId) {
       pendingComposeRequest.current = null;
+      setReplyToMessageId(undefined);
       setForwardToMessageId(messageId);
       return;
     }
@@ -537,8 +539,13 @@ export function MailShell() {
     if (!readerSelectionSettled || !messageId) return;
 
     pendingComposeRequest.current = null;
-    if (pendingRequest.mode === "reply") setReplyToMessageId(messageId);
-    else setForwardToMessageId(messageId);
+    if (pendingRequest.mode === "reply") {
+      setForwardToMessageId(undefined);
+      setReplyToMessageId(messageId);
+    } else {
+      setReplyToMessageId(undefined);
+      setForwardToMessageId(messageId);
+    }
   }, [openMessages, openReaderThreadKey, readerSelectionSettled]);
 
   // Let the fetched snapshot decide the initial read state. Once marking has
@@ -748,26 +755,48 @@ export function MailShell() {
     if (canLabel)
       setLabelPicker({ mode: "move", targets: currentLabelTargets });
   }, [canLabel, currentLabelTargets]);
+  const singleActionTarget =
+    actionTargets.length === 1 ? actionTargets.at(0) : undefined;
+  const requestForwardTarget = useCallback(() => {
+    if (!singleActionTarget) return;
+    if (singleActionTarget.key === openThreadKey) {
+      requestReaderForward();
+      return;
+    }
+
+    pendingComposeRequest.current = {
+      mode: "forward",
+      threadKey: singleActionTarget.key,
+    };
+    setReplyToMessageId(undefined);
+    setForwardToMessageId(undefined);
+    setOpenThread(singleActionTarget.selection);
+  }, [openThreadKey, requestReaderForward, setOpenThread, singleActionTarget]);
   const pickerAccount =
     labelPicker?.targets[0]?.emailAccountId === emailAccountId
       ? emailAccount
       : accountsData?.emailAccounts.find(
           (account) => account.id === labelPicker?.targets[0]?.emailAccountId,
         );
+  const isReaderTarget =
+    singleActionTarget !== undefined &&
+    singleActionTarget.key === openThreadKey;
 
   const mailCommandContext = useMemo(
     () => ({
       actions: {
         archive: archiveTargets,
-        forward: openThreadId ? requestReaderForward : undefined,
+        forward: singleActionTarget ? requestForwardTarget : undefined,
         label: canLabel ? openLabelPicker : undefined,
         markRead: markReadTargets,
         markSpam: markSpamTargets,
         markUnread: markUnreadTargets,
         move: canLabel ? openMovePicker : undefined,
-        openExternal: openExternalUrl
-          ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
-          : undefined,
+        openExternal:
+          isReaderTarget && openExternalUrl
+            ? () =>
+                window.open(openExternalUrl, "_blank", "noopener,noreferrer")
+            : undefined,
         snooze: snoozeTargets,
         trash: trashTargets,
       },
@@ -775,8 +804,15 @@ export function MailShell() {
       hasUnread: actionTargets.some((target) =>
         isThreadUnread(target.messages),
       ),
-      openExternalLabel: openExternalUrl
-        ? `Open in ${isMicrosoftProvider(readerEmailAccount?.account.provider) ? "Outlook" : "Gmail"}`
+      openExternalLabel:
+        isReaderTarget && openExternalUrl
+          ? `Open in ${isMicrosoftProvider(readerEmailAccount?.account.provider) ? "Outlook" : "Gmail"}`
+          : undefined,
+      target: singleActionTarget
+        ? {
+            emailAccountId: singleActionTarget.selection.emailAccountId,
+            threadId: singleActionTarget.selection.threadId,
+          }
         : undefined,
       targetCount: actionTargets.length,
     }),
@@ -784,15 +820,16 @@ export function MailShell() {
       archiveTargets,
       actionTargets,
       canLabel,
+      isReaderTarget,
       markReadTargets,
       markSpamTargets,
       markUnreadTargets,
       openLabelPicker,
       openMovePicker,
       openExternalUrl,
-      openThreadId,
       readerEmailAccount?.account.provider,
-      requestReaderForward,
+      requestForwardTarget,
+      singleActionTarget,
       snoozeTargets,
       trashTargets,
     ],
@@ -910,18 +947,20 @@ export function MailShell() {
       markUnread: markUnreadTargets,
       delete: trashTargets,
       reply: () => {
+        setForwardToMessageId(undefined);
         if (!openThreadId && focusedThread) {
           setOpenThread(getListThreadSelection(focusedThread, emailAccountId));
         }
         setReplyToMessageId(openMessages.at(-1)?.id);
       },
-      forward: openThreadId ? requestReaderForward : undefined,
+      forward: singleActionTarget ? requestForwardTarget : undefined,
       moreActions: openThreadId
         ? () => setIsMenuOpen((open) => !open)
         : undefined,
-      openExternal: openExternalUrl
-        ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
-        : undefined,
+      openExternal:
+        isReaderTarget && openExternalUrl
+          ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
+          : undefined,
       undo: () => undo(),
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
       help: () => setIsHelpOpen(true),

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { ComponentProps } from "react";
+import { useEffect, useMemo, type ComponentProps } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
 import {
   ArchiveIcon,
   ArchiveRestoreIcon,
@@ -40,6 +41,10 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import type { ParsedMessage } from "@/utils/types";
+import {
+  commandPaletteOpenAtom,
+  senderCommandContextAtom,
+} from "@/store/command-palette";
 
 type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
 
@@ -90,6 +95,8 @@ export function ThreadActionsMenu({
   onOpenChange,
 }: ThreadActionsMenuProps) {
   const hint = getShortcutHint("moreActions");
+  const isCommandPaletteOpen = useAtomValue(commandPaletteOpenAtom);
+  const setSenderCommandContext = useSetAtom(senderCommandContextAtom);
   const { provider, userEmail } = useAccount();
   const {
     canManageAutoArchive,
@@ -100,7 +107,9 @@ export function ThreadActionsMenu({
     onToggleAutoArchive,
     onUnsubscribe,
     PremiumModal,
-  } = useUnsubscribeSender(message, { loadStoredLink: Boolean(open) });
+  } = useUnsubscribeSender(message, {
+    loadStoredLink: Boolean(open || isCommandPaletteOpen),
+  });
   const openUrl = message
     ? getEmailMessageCellActions({
         externalUrl: message.externalUrl,
@@ -110,6 +119,37 @@ export function ThreadActionsMenu({
         userEmail,
       })?.openUrl
     : undefined;
+  const senderCommandContext = useMemo(
+    () =>
+      canManageAutoArchive
+        ? {
+            isAutoArchived,
+            isAutoArchiveDisabled:
+              isAutoArchiveStatusLoading || isUpdatingAutoArchive,
+            isUnsubscribeDisabled: !canUnsubscribe,
+            toggleAutoArchive: onToggleAutoArchive,
+            unsubscribe: onUnsubscribe,
+          }
+        : null,
+    [
+      canManageAutoArchive,
+      canUnsubscribe,
+      isAutoArchived,
+      isAutoArchiveStatusLoading,
+      isUpdatingAutoArchive,
+      onToggleAutoArchive,
+      onUnsubscribe,
+    ],
+  );
+
+  useEffect(() => {
+    setSenderCommandContext(senderCommandContext);
+  }, [senderCommandContext, setSenderCommandContext]);
+
+  useEffect(
+    () => () => setSenderCommandContext(null),
+    [setSenderCommandContext],
+  );
 
   return (
     <>

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -97,7 +97,7 @@ export function ThreadActionsMenu({
   const hint = getShortcutHint("moreActions");
   const isCommandPaletteOpen = useAtomValue(commandPaletteOpenAtom);
   const setSenderCommandContext = useSetAtom(senderCommandContextAtom);
-  const { provider, userEmail } = useAccount();
+  const { emailAccountId, provider, userEmail } = useAccount();
   const {
     canManageAutoArchive,
     canUnsubscribe,
@@ -123,10 +123,12 @@ export function ThreadActionsMenu({
     () =>
       canManageAutoArchive
         ? {
+            emailAccountId,
             isAutoArchived,
             isAutoArchiveDisabled:
               isAutoArchiveStatusLoading || isUpdatingAutoArchive,
             isUnsubscribeDisabled: !canUnsubscribe,
+            threadId: message?.threadId ?? "",
             toggleAutoArchive: onToggleAutoArchive,
             unsubscribe: onUnsubscribe,
           }
@@ -134,11 +136,13 @@ export function ThreadActionsMenu({
     [
       canManageAutoArchive,
       canUnsubscribe,
+      emailAccountId,
       isAutoArchived,
       isAutoArchiveStatusLoading,
       isUpdatingAutoArchive,
       onToggleAutoArchive,
       onUnsubscribe,
+      message?.threadId,
     ],
   );
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -53,6 +53,7 @@ export type ThreadReaderProps = {
    * a message that already has an AI draft.
    */
   autoOpenReplyForMessageId?: string;
+  autoOpenForwardForMessageId?: string;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
 };
@@ -74,6 +75,7 @@ export function ThreadReader({
   showSidebarToggle = false,
   refetch,
   autoOpenReplyForMessageId,
+  autoOpenForwardForMessageId,
   menu,
 }: ThreadReaderProps) {
   const [senderContext, setSenderContext] = useState<{
@@ -156,6 +158,7 @@ export function ThreadReader({
               renderToolbar={renderToolbar}
               enableMessageNavigation={enableMessageNavigation}
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
+              autoOpenForwardForMessageId={autoOpenForwardForMessageId}
               key={threadId}
               messages={messages}
               onMarkDone={onArchive}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.test.ts
@@ -3,10 +3,17 @@ import { buildMailCommandPalette } from "./mail-command-palette";
 
 const actions = {
   archive: vi.fn(),
+  forward: vi.fn(),
+  label: vi.fn(),
   markRead: vi.fn(),
+  markSpam: vi.fn(),
   markUnread: vi.fn(),
+  move: vi.fn(),
   openSnooze: vi.fn(),
+  openExternal: vi.fn(),
   trash: vi.fn(),
+  toggleAutoArchive: vi.fn(),
+  unsubscribe: vi.fn(),
 };
 
 describe("buildMailCommandPalette", () => {
@@ -82,5 +89,67 @@ describe("buildMailCommandPalette", () => {
     });
 
     expect(commands.map((command) => command.id)).toEqual(["mail-archive"]);
+  });
+
+  it("includes the reader actions with their shortcut hints", () => {
+    const commands = buildMailCommandPalette({
+      actions,
+      hasRead: true,
+      hasUnread: false,
+      isAutoArchived: false,
+      isAutoArchiveDisabled: false,
+      isUnsubscribeDisabled: true,
+      openExternalLabel: "Open in Gmail",
+      targetCount: 1,
+    });
+
+    expect(commands.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        "mail-forward",
+        "mail-label",
+        "mail-move",
+        "mail-mark-unread",
+        "mail-delete",
+        "mail-mark-spam",
+        "mail-unsubscribe",
+        "mail-auto-archive",
+        "mail-open-external",
+      ]),
+    );
+    expect(commands.find(({ id }) => id === "mail-forward")).toMatchObject({
+      shortcut: "F",
+    });
+    expect(commands.find(({ id }) => id === "mail-label")).toMatchObject({
+      shortcut: "L",
+    });
+    expect(commands.find(({ id }) => id === "mail-move")).toMatchObject({
+      shortcut: "V",
+    });
+    expect(commands.find(({ id }) => id === "mail-mark-unread")).toMatchObject({
+      shortcut: "U",
+    });
+    expect(commands.find(({ id }) => id === "mail-unsubscribe")).toMatchObject({
+      disabled: true,
+    });
+    expect(commands.find(({ id }) => id === "mail-auto-archive")).toMatchObject(
+      { label: "Auto archive future emails", disabled: false },
+    );
+    expect(
+      commands.find(({ id }) => id === "mail-open-external"),
+    ).toMatchObject({ label: "Open in Gmail", shortcut: "G G" });
+  });
+
+  it("labels the auto-archive action from its current state", () => {
+    const commands = buildMailCommandPalette({
+      actions: { archive: actions.archive, toggleAutoArchive: vi.fn() },
+      hasRead: false,
+      hasUnread: true,
+      isAutoArchived: true,
+      targetCount: 1,
+    });
+
+    expect(commands.find(({ id }) => id === "mail-auto-archive")).toMatchObject(
+      { label: "Disable auto archive" },
+    );
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-command-palette.ts
@@ -1,8 +1,15 @@
 import {
   ArchiveIcon,
+  ArchiveRestoreIcon,
   Clock3Icon,
+  ExternalLinkIcon,
+  FolderInputIcon,
+  ForwardIcon,
+  MailXIcon,
   MailIcon,
   MailOpenIcon,
+  ShieldAlertIcon,
+  TagIcon,
   Trash2Icon,
 } from "lucide-react";
 import type { Command } from "@/lib/commands/types";
@@ -10,21 +17,36 @@ import { getShortcutHint } from "@/lib/shortcuts/registry";
 
 type MailCommandActions = {
   archive: () => void;
+  forward?: () => void;
+  label?: () => void;
   markRead?: () => void;
+  markSpam?: () => void;
   markUnread?: () => void;
+  move?: () => void;
   openSnooze?: () => void;
+  openExternal?: () => void;
   trash?: () => void;
+  toggleAutoArchive?: () => void;
+  unsubscribe?: () => void;
 };
 
 export function buildMailCommandPalette({
   actions,
   hasRead,
   hasUnread,
+  isAutoArchived = false,
+  isAutoArchiveDisabled = false,
+  isUnsubscribeDisabled = false,
+  openExternalLabel = "Open in email provider",
   targetCount,
 }: {
   actions: MailCommandActions;
   hasRead: boolean;
   hasUnread: boolean;
+  isAutoArchived?: boolean;
+  isAutoArchiveDisabled?: boolean;
+  isUnsubscribeDisabled?: boolean;
+  openExternalLabel?: string;
   targetCount: number;
 }): Command[] {
   if (targetCount === 0) return [];
@@ -45,6 +67,45 @@ export function buildMailCommandPalette({
     },
   ];
 
+  if (targetCount === 1 && actions.forward) {
+    commands.push({
+      id: "mail-forward",
+      label: "Forward",
+      icon: ForwardIcon,
+      shortcut: getShortcutHint("forward"),
+      section: "actions",
+      priority: 1,
+      keywords: ["forward", "send", "share"],
+      action: actions.forward,
+    });
+  }
+
+  if (actions.label) {
+    commands.push({
+      id: "mail-label",
+      label: "Label",
+      icon: TagIcon,
+      shortcut: getShortcutHint("label"),
+      section: "actions",
+      priority: 2,
+      keywords: ["label", "tag", "categorize"],
+      action: actions.label,
+    });
+  }
+
+  if (actions.move) {
+    commands.push({
+      id: "mail-move",
+      label: "Move",
+      icon: FolderInputIcon,
+      shortcut: getShortcutHint("move"),
+      section: "actions",
+      priority: 3,
+      keywords: ["move", "folder"],
+      action: actions.move,
+    });
+  }
+
   if (hasUnread && actions.markRead) {
     commands.push({
       id: "mail-mark-read",
@@ -63,6 +124,7 @@ export function buildMailCommandPalette({
       label:
         targetCount === 1 ? "Mark as unread" : `Mark ${targetCount} as unread`,
       icon: MailIcon,
+      shortcut: getShortcutHint("markUnread"),
       section: "actions",
       priority: 2,
       keywords: ["unread", "unseen", "new"],
@@ -98,6 +160,60 @@ export function buildMailCommandPalette({
       priority: 10,
       keywords: ["delete", "trash", "remove"],
       action: actions.trash,
+    });
+  }
+
+  if (actions.markSpam) {
+    commands.push({
+      id: "mail-mark-spam",
+      label: "Mark as spam",
+      icon: ShieldAlertIcon,
+      shortcut: getShortcutHint("markSpam"),
+      section: "actions",
+      priority: 11,
+      keywords: ["spam", "junk", "report"],
+      action: actions.markSpam,
+    });
+  }
+
+  if (targetCount === 1 && actions.unsubscribe) {
+    commands.push({
+      id: "mail-unsubscribe",
+      label: "Unsubscribe from sender",
+      icon: MailXIcon,
+      section: "actions",
+      priority: 12,
+      keywords: ["unsubscribe", "newsletter", "sender"],
+      action: actions.unsubscribe,
+      disabled: isUnsubscribeDisabled,
+    });
+  }
+
+  if (targetCount === 1 && actions.toggleAutoArchive) {
+    commands.push({
+      id: "mail-auto-archive",
+      label: isAutoArchived
+        ? "Disable auto archive"
+        : "Auto archive future emails",
+      icon: isAutoArchived ? ArchiveRestoreIcon : ArchiveIcon,
+      section: "actions",
+      priority: 13,
+      keywords: ["auto archive", "future", "sender"],
+      action: actions.toggleAutoArchive,
+      disabled: isAutoArchiveDisabled,
+    });
+  }
+
+  if (targetCount === 1 && actions.openExternal) {
+    commands.push({
+      id: "mail-open-external",
+      label: openExternalLabel,
+      icon: ExternalLinkIcon,
+      shortcut: getShortcutHint("openExternal"),
+      section: "actions",
+      priority: 14,
+      keywords: ["open", "external", "provider", "gmail", "outlook"],
+      action: actions.openExternal,
     });
   }
 

--- a/apps/web/components/CommandK.test.tsx
+++ b/apps/web/components/CommandK.test.tsx
@@ -145,4 +145,16 @@ describe("CommandK side-panel archive", () => {
       description: "Email is still loading",
     });
   });
+
+  it("opens a forward composer for the latest side-panel message", () => {
+    render(<CommandK />);
+
+    act(() => shortcuts.handlers?.forward?.());
+
+    expect(displayedEmail.showEmail).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      autoOpenForwardForMessageId: "message-2",
+      showReplyButton: true,
+    });
+  });
 });

--- a/apps/web/components/CommandK.test.tsx
+++ b/apps/web/components/CommandK.test.tsx
@@ -76,7 +76,7 @@ vi.mock("@/components/ui/command", () => ({
   CommandShortcut: () => null,
 }));
 
-describe("CommandK side-panel archive", () => {
+describe("CommandK side-panel actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     displayedEmail.threadId = "thread-1";

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -19,8 +19,12 @@ import { useComposeModal } from "@/providers/ComposeModalProvider";
 import {
   commandPaletteOpenAtom,
   mailCommandContextAtom,
+  senderCommandContextAtom,
 } from "@/store/command-palette";
-import type { MailCommandContext } from "@/store/command-palette";
+import type {
+  MailCommandContext,
+  SenderCommandContext,
+} from "@/store/command-palette";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useCommandPaletteCommands } from "@/hooks/useCommandPaletteCommands";
@@ -68,6 +72,7 @@ export function CommandK() {
 
 function CommandPalette() {
   const mailCommandContext = useAtomValue(mailCommandContextAtom);
+  const senderCommandContext = useAtomValue(senderCommandContextAtom);
   const displayedEmail = useDisplayedEmail();
   const activeMailContext = displayedEmail.threadId ? null : mailCommandContext;
 
@@ -76,6 +81,7 @@ function CommandPalette() {
       key={activeMailContext ? "mail" : "default"}
       displayedEmail={displayedEmail}
       mailCommandContext={activeMailContext}
+      senderCommandContext={activeMailContext ? senderCommandContext : null}
     />
   );
 }
@@ -83,9 +89,11 @@ function CommandPalette() {
 function CommandPaletteContent({
   displayedEmail,
   mailCommandContext,
+  senderCommandContext,
 }: {
   displayedEmail: ReturnType<typeof useDisplayedEmail>;
   mailCommandContext: MailCommandContext | null;
+  senderCommandContext: SenderCommandContext | null;
 }) {
   const [open, setOpen] = useAtom(commandPaletteOpenAtom);
   const [page, setPage] = React.useState<"root" | "snooze">("root");
@@ -127,6 +135,18 @@ function CommandPaletteContent({
           }
         }
       : undefined,
+    forward:
+      threadId && displayedThread?.thread.id === threadId
+        ? () => {
+            const messageId = displayedThread.thread.messages.at(-1)?.id;
+            if (!messageId) return;
+            showEmail({
+              threadId,
+              autoOpenForwardForMessageId: messageId,
+              showReplyButton: true,
+            });
+          }
+        : undefined,
     snooze: mailCommandContext?.actions.snooze
       ? () => {
           setSearch("");
@@ -145,15 +165,26 @@ function CommandPaletteContent({
     ? buildMailCommandPalette({
         actions: {
           archive: mailCommandContext.actions.archive,
+          forward: mailCommandContext.actions.forward,
+          label: mailCommandContext.actions.label,
           markRead: mailCommandContext.actions.markRead,
+          markSpam: mailCommandContext.actions.markSpam,
           markUnread: mailCommandContext.actions.markUnread,
+          move: mailCommandContext.actions.move,
           openSnooze: mailCommandContext.actions.snooze
             ? () => setPage("snooze")
             : undefined,
           trash: mailCommandContext.actions.trash,
+          openExternal: mailCommandContext.actions.openExternal,
+          toggleAutoArchive: senderCommandContext?.toggleAutoArchive,
+          unsubscribe: senderCommandContext?.unsubscribe,
         },
         hasRead: mailCommandContext.hasRead,
         hasUnread: mailCommandContext.hasUnread,
+        isAutoArchived: senderCommandContext?.isAutoArchived,
+        isAutoArchiveDisabled: senderCommandContext?.isAutoArchiveDisabled,
+        isUnsubscribeDisabled: senderCommandContext?.isUnsubscribeDisabled,
+        openExternalLabel: mailCommandContext.openExternalLabel,
         targetCount: mailCommandContext.targetCount,
       })
     : [];
@@ -195,6 +226,7 @@ function CommandPaletteContent({
   const groupedCommands = groupCommands(filteredCommands);
 
   const executeCommand = (command: Command) => {
+    if (command.disabled) return;
     setSearch("");
     if (command.closeOnSelect !== false) {
       setOpen(false);
@@ -276,6 +308,7 @@ function CommandPaletteContent({
                       <CommandItem
                         key={command.id}
                         value={`${command.id} ${command.label} ${command.keywords?.join(" ") || ""}`}
+                        disabled={command.disabled}
                         onSelect={() => executeCommand(command)}
                       >
                         {command.icon && (
@@ -294,26 +327,6 @@ function CommandPaletteContent({
           </>
         )}
       </CommandList>
-      <div className="flex items-center justify-center gap-4 border-t px-3 py-2 text-xs text-muted-foreground">
-        <span className="flex items-center gap-1">
-          <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-            ↑↓
-          </kbd>
-          navigate
-        </span>
-        <span className="flex items-center gap-1">
-          <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-            ↵
-          </kbd>
-          select
-        </span>
-        <span className="flex items-center gap-1">
-          <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-            esc
-          </kbd>
-          {page === "snooze" ? "back" : "close"}
-        </span>
-      </div>
     </CommandDialog>
   );
 }

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -75,13 +75,22 @@ function CommandPalette() {
   const senderCommandContext = useAtomValue(senderCommandContextAtom);
   const displayedEmail = useDisplayedEmail();
   const activeMailContext = displayedEmail.threadId ? null : mailCommandContext;
+  const senderContextMatchesTarget = Boolean(
+    activeMailContext?.target &&
+      senderCommandContext &&
+      activeMailContext.target.emailAccountId ===
+        senderCommandContext.emailAccountId &&
+      activeMailContext.target.threadId === senderCommandContext.threadId,
+  );
 
   return (
     <CommandPaletteContent
       key={activeMailContext ? "mail" : "default"}
       displayedEmail={displayedEmail}
       mailCommandContext={activeMailContext}
-      senderCommandContext={activeMailContext ? senderCommandContext : null}
+      senderCommandContext={
+        senderContextMatchesTarget ? senderCommandContext : null
+      }
     />
   );
 }

--- a/apps/web/components/EmailViewer.tsx
+++ b/apps/web/components/EmailViewer.tsx
@@ -13,8 +13,13 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 export function EmailViewer() {
   const { provider } = useAccount();
 
-  const { threadId, showEmail, showReplyButton, autoOpenReplyForMessageId } =
-    useDisplayedEmail();
+  const {
+    threadId,
+    showEmail,
+    showReplyButton,
+    autoOpenForwardForMessageId,
+    autoOpenReplyForMessageId,
+  } = useDisplayedEmail();
 
   const hideEmail = useCallback(() => showEmail(null), [showEmail]);
   const supportsViewerReplies = isGoogleProvider(provider);
@@ -36,6 +41,11 @@ export function EmailViewer() {
                 ? (autoOpenReplyForMessageId ?? undefined)
                 : undefined
             }
+            autoOpenForwardForMessageId={
+              supportsViewerReplies
+                ? (autoOpenForwardForMessageId ?? undefined)
+                : undefined
+            }
           />
         )}
       </SheetContent>
@@ -47,12 +57,14 @@ export function ThreadContent({
   threadId,
   showReplyButton,
   autoOpenReplyForMessageId,
+  autoOpenForwardForMessageId,
   topRightComponent,
   onSendSuccess,
 }: {
   threadId: string;
   showReplyButton: boolean;
   autoOpenReplyForMessageId?: string;
+  autoOpenForwardForMessageId?: string;
   topRightComponent?: React.ReactNode;
   onSendSuccess?: (messageId: string, threadId: string) => void;
 }) {
@@ -68,6 +80,7 @@ export function ThreadContent({
             refetch={mutate}
             showReplyButton={showReplyButton}
             autoOpenReplyForMessageId={autoOpenReplyForMessageId}
+            autoOpenForwardForMessageId={autoOpenForwardForMessageId}
             topRightComponent={topRightComponent}
             onSendSuccess={onSendSuccess}
             withHeader

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -212,6 +212,25 @@ describe("HtmlEmail", () => {
     );
   });
 
+  it("forwards with F while focus is inside the email document", () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    const onForwardMessage = vi.fn();
+    const { getByTitle } = render(
+      <HtmlEmail
+        html="<p>Message body</p>"
+        messageId="message-forward"
+        onForwardMessage={onForwardMessage}
+      />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+
+    fireEvent.keyDown(iframe.contentDocument!.body, { key: "f" });
+
+    expect(onForwardMessage).toHaveBeenCalledOnce();
+  });
+
   it("remeasures from a minimal height when quoted content is toggled", async () => {
     vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByRole, getByTitle } = render(

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -37,6 +37,7 @@ export function HtmlEmail({
   emailAccountId,
   inlineAttachments = NO_INLINE_ATTACHMENTS,
   onReplyMessage,
+  onForwardMessage,
   onNavigateMessage,
   onFocusMessage,
 }: {
@@ -45,6 +46,7 @@ export function HtmlEmail({
   emailAccountId?: string;
   inlineAttachments?: ParsedMessage["inline"];
   onReplyMessage?: () => void;
+  onForwardMessage?: () => void;
   onNavigateMessage?: (direction: -1 | 1) => void;
   onFocusMessage?: () => void;
 }) {
@@ -124,6 +126,7 @@ export function HtmlEmail({
   );
 
   const iframeHeight = useEmailIframe(iframeRef, srcDoc, documentKey, {
+    onForwardMessage,
     onNavigateMessage,
     onReplyMessage,
     onFocusMessage,
@@ -421,6 +424,7 @@ function useEmailIframe(
   srcDoc: string,
   documentKey: string,
   callbacks: {
+    onForwardMessage?: () => void;
     onReplyMessage?: () => void;
     onNavigateMessage?: (direction: -1 | 1) => void;
     onFocusMessage?: () => void;
@@ -444,9 +448,15 @@ function useEmailIframe(
     const navigateMessage = (event: KeyboardEvent) => {
       const navigate = callbacksRef.current.onNavigateMessage;
       const reply = callbacksRef.current.onReplyMessage;
+      const forward = callbacksRef.current.onForwardMessage;
+      const key = event.key.toLowerCase();
+      const isNavigationKey = ["ArrowUp", "ArrowDown"].includes(event.key);
+      const handlesKey =
+        (event.key === "Enter" && Boolean(reply)) ||
+        (key === "f" && Boolean(forward)) ||
+        (isNavigationKey && Boolean(navigate));
       if (
-        !(event.key === "Enter" ? reply : navigate) ||
-        !["Enter", "ArrowUp", "ArrowDown"].includes(event.key) ||
+        !handlesKey ||
         event.altKey ||
         event.ctrlKey ||
         event.metaKey ||
@@ -465,6 +475,7 @@ function useEmailIframe(
       if (event.key === "Enter" && target?.closest?.("a, button")) return;
       event.preventDefault();
       if (event.key === "Enter") reply?.();
+      else if (key === "f") forward?.();
       else navigate?.(event.key === "ArrowUp" ? -1 : 1);
     };
     const stopObservingDocument = () => {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -173,6 +173,7 @@ export function EmailMessage({
 
           {message.textHtml ? (
             <HtmlEmail
+              onForwardMessage={showReplyButton ? onForward : undefined}
               onReplyMessage={showReplyButton ? onReply : undefined}
               onNavigateMessage={onNavigateMessage}
               onFocusMessage={onSelect}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -21,6 +21,7 @@ export function EmailThread({
   refetch,
   showReplyButton,
   autoOpenReplyForMessageId,
+  autoOpenForwardForMessageId,
   topRightComponent,
   onSendSuccess,
   onMarkDone,
@@ -33,6 +34,7 @@ export function EmailThread({
   refetch: () => void;
   showReplyButton: boolean;
   autoOpenReplyForMessageId?: string;
+  autoOpenForwardForMessageId?: string;
   topRightComponent?: React.ReactNode;
   onSendSuccess?: (messageId: string, threadId: string) => void;
   onMarkDone?: () => void;
@@ -84,11 +86,12 @@ export function EmailThread({
     version: number;
   }>();
   useEffect(() => {
-    if (autoOpenReplyForMessageId)
+    const messageId = autoOpenForwardForMessageId ?? autoOpenReplyForMessageId;
+    if (messageId)
       setExpansionOverrides((previous) =>
-        new Map(previous).set(autoOpenReplyForMessageId, true),
+        new Map(previous).set(messageId, true),
       );
-  }, [autoOpenReplyForMessageId]);
+  }, [autoOpenForwardForMessageId, autoOpenReplyForMessageId]);
   const expanded = (id: string, hasDraft: boolean) =>
     expansionOverrides.get(id) ?? (id === lastMessageId || hasDraft);
   const hasLocalDraft = (id: string) =>
@@ -97,6 +100,7 @@ export function EmailThread({
     expanded(
       message.id,
       autoOpenReplyForMessageId === message.id ||
+        autoOpenForwardForMessageId === message.id ||
         recoveredReply?.messageId === message.id ||
         Boolean(draftMessage) ||
         hasLocalDraft(message.id),
@@ -208,7 +212,12 @@ export function EmailThread({
       <ul className="pt-1">
         {organizedMessages.map(({ message, draftMessage }) => {
           const defaultComposeMode = getDefaultComposeMode({
-            autoOpen: autoOpenReplyForMessageId === message.id,
+            autoOpenMode:
+              autoOpenForwardForMessageId === message.id
+                ? "forward"
+                : autoOpenReplyForMessageId === message.id
+                  ? "reply"
+                  : undefined,
             draftMessage: Boolean(draftMessage),
             localDraftMode: getLocalDraftMode(localDrafts, message.id),
             recoveredReply:
@@ -304,17 +313,18 @@ function getLocalDraftMode(drafts: StoredReplyDraft[], messageId: string) {
 }
 
 function getDefaultComposeMode({
-  autoOpen,
+  autoOpenMode,
   draftMessage,
   localDraftMode,
   recoveredReply,
 }: {
-  autoOpen: boolean;
+  autoOpenMode?: ReplyDraftMode;
   draftMessage: boolean;
   localDraftMode?: ReplyDraftMode;
   recoveredReply?: { mode: ReplyDraftMode };
 }) {
   if (recoveredReply) return recoveredReply.mode;
-  if (autoOpen || draftMessage) return "reply" as const;
+  if (autoOpenMode) return autoOpenMode;
+  if (draftMessage) return "reply" as const;
   return localDraftMode;
 }

--- a/apps/web/hooks/useDisplayedEmail.ts
+++ b/apps/web/hooks/useDisplayedEmail.ts
@@ -6,6 +6,8 @@ export const useDisplayedEmail = () => {
   const [messageId, setMessageId] = useQueryState("side-panel-message-id");
   const [autoOpenReplyForMessageId, setAutoOpenReplyForMessageId] =
     useQueryState("auto-open-reply-for-message-id");
+  const [autoOpenForwardForMessageId, setAutoOpenForwardForMessageId] =
+    useQueryState("auto-open-forward-for-message-id");
   const [showReplyButton, setShowReplyButton] = useState(false);
 
   const showEmail = useCallback(
@@ -15,14 +17,23 @@ export const useDisplayedEmail = () => {
         messageId?: string;
         showReplyButton?: boolean;
         autoOpenReplyForMessageId?: string;
+        autoOpenForwardForMessageId?: string;
       } | null,
     ) => {
       setAutoOpenReplyForMessageId(options?.autoOpenReplyForMessageId || "");
+      setAutoOpenForwardForMessageId(
+        options?.autoOpenForwardForMessageId || "",
+      );
       setThreadId(options?.threadId ?? null);
       setMessageId(options?.messageId ?? null);
       setShowReplyButton(options?.showReplyButton ?? true);
     },
-    [setMessageId, setThreadId, setAutoOpenReplyForMessageId],
+    [
+      setAutoOpenForwardForMessageId,
+      setAutoOpenReplyForMessageId,
+      setMessageId,
+      setThreadId,
+    ],
   );
 
   return {
@@ -30,6 +41,7 @@ export const useDisplayedEmail = () => {
     messageId,
     showEmail,
     showReplyButton,
+    autoOpenForwardForMessageId,
     autoOpenReplyForMessageId,
   };
 };

--- a/apps/web/lib/commands/types.ts
+++ b/apps/web/lib/commands/types.ts
@@ -11,6 +11,7 @@ export interface Command {
   action: () => void | Promise<void>;
   closeOnSelect?: boolean;
   description?: string;
+  disabled?: boolean;
   icon?: LucideIcon;
   id: string;
   keywords?: string[];

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -75,6 +75,7 @@ describe("shortcut registry", () => {
     expect(formatShortcutKeys(getShortcut("toggleLayout"))).toBe("⇧V");
     expect(formatShortcutKeys(getShortcut("markSpam"))).toBe("!");
     expect(formatShortcutKeys(getShortcut("openExternal"))).toBe("G G");
+    expect(formatShortcutKeys(getShortcut("forward"))).toBe("F");
   });
 });
 
@@ -226,6 +227,22 @@ describe("buildShortcutPaletteCommands", () => {
     const commands = buildShortcutPaletteCommands({ reply: vi.fn() });
 
     expect(commands.map((command) => command.id)).not.toContain("reply");
+  });
+
+  it("surfaces forwarding in the palette when a message can be forwarded", () => {
+    const forward = vi.fn();
+    const commands = buildShortcutPaletteCommands({ forward });
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({
+      id: "forward",
+      label: "Forward",
+      section: "actions",
+      shortcut: "F",
+    });
+
+    commands[0].action();
+    expect(forward).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -234,14 +234,14 @@ describe("buildShortcutPaletteCommands", () => {
     const commands = buildShortcutPaletteCommands({ forward });
 
     expect(commands).toHaveLength(1);
-    expect(commands[0]).toMatchObject({
+    expect(commands.at(0)).toMatchObject({
       id: "forward",
       label: "Forward",
       section: "actions",
       shortcut: "F",
     });
 
-    commands[0].action();
+    commands.at(0)?.action();
     expect(forward).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -1,4 +1,9 @@
-import { ArchiveIcon, PenLineIcon, type LucideIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ForwardIcon,
+  PenLineIcon,
+  type LucideIcon,
+} from "lucide-react";
 import type { Command, CommandSection } from "@/lib/commands/types";
 import { createClientLogger } from "@/utils/logger-client";
 
@@ -260,6 +265,19 @@ const SHORTCUT_DEFINITIONS = [
     scope: "mail",
     group: "Triage",
     label: "Reply all",
+  },
+  {
+    id: "forward",
+    keys: ["f"],
+    scope: "mail",
+    group: "Triage",
+    label: "Forward",
+    palette: {
+      section: "actions",
+      keywords: ["forward", "send", "share"],
+      priority: 4,
+      icon: ForwardIcon,
+    },
   },
   {
     id: "moreActions",

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -10,14 +10,28 @@ export const commandPaletteOpenAtom = atom(false);
 export type MailCommandContext = {
   actions: {
     archive: () => void;
+    forward?: () => void;
+    label?: () => void;
     markRead?: () => void;
+    markSpam?: () => void;
     markUnread?: () => void;
+    move?: () => void;
+    openExternal?: () => void;
     snooze?: (until: Date) => void;
     trash?: () => void;
   };
   hasRead: boolean;
   hasUnread: boolean;
+  openExternalLabel?: string;
   targetCount: number;
+};
+
+export type SenderCommandContext = {
+  isAutoArchived: boolean;
+  isAutoArchiveDisabled: boolean;
+  isUnsubscribeDisabled: boolean;
+  toggleAutoArchive: () => void;
+  unsubscribe: () => void;
 };
 
 /**
@@ -25,3 +39,6 @@ export type MailCommandContext = {
  * the app-wide palette consume them without duplicating that state.
  */
 export const mailCommandContextAtom = atom<MailCommandContext | null>(null);
+
+/** Sender actions are resolved inside the reader's account-scoped provider. */
+export const senderCommandContextAtom = atom<SenderCommandContext | null>(null);

--- a/apps/web/store/command-palette.ts
+++ b/apps/web/store/command-palette.ts
@@ -23,13 +23,16 @@ export type MailCommandContext = {
   hasRead: boolean;
   hasUnread: boolean;
   openExternalLabel?: string;
+  target?: { emailAccountId: string; threadId: string };
   targetCount: number;
 };
 
 export type SenderCommandContext = {
+  emailAccountId: string;
   isAutoArchived: boolean;
   isAutoArchiveDisabled: boolean;
   isUnsubscribeDisabled: boolean;
+  threadId: string;
   toggleAutoArchive: () => void;
   unsubscribe: () => void;
 };


### PR DESCRIPTION
Adds forwarding keyboard support and exposes the available email actions in the command palette.

- Removes the command palette footer legend and preserves disabled sender-action states.
- Adds focused shortcut, palette, side-panel, iframe, and browser coverage.
- Validation: focused unit tests and lint passed; the emulated browser suite was blocked in shared authentication setup by local database credentials.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added message forwarding from the command palette, including the **F** keyboard shortcut.
  - Added reader actions for labeling, moving, marking spam, unsubscribing, auto-archiving, and opening messages in an external email provider.
  - Added forwarding support directly from email messages and the conversation reader.
  - Command palette actions now show availability and current state.

- **Bug Fixes**
  - Improved command palette behavior for unavailable actions, preventing disabled actions from being executed.
  - Improved transitions between reply and forward compose modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->