### PR TITLE
mail: Show sent forwards in the message reader

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -426,6 +426,49 @@ test("opens and sends a reply from the reader with Enter", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "reply-sent-in-thread");
 });
 
+test("opens a sent forward in its provider thread", async ({
+  page,
+}, testInfo) => {
+  await stubMailboxSync(page);
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reply`);
+  const sourceMessage = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  await expect(sourceMessage).toBeVisible({ timeout: 60_000 });
+
+  await sourceMessage
+    .getByRole("button", { name: "Forward", exact: true })
+    .click();
+  await sourceMessage
+    .getByRole("textbox", { name: "To" })
+    .fill("recipient@example.com");
+  const editor = sourceMessage.getByRole("textbox", {
+    name: "Email message",
+  });
+  const forwardBody = `A forwarded message sent through the mail reader. ${testInfo.retry}`;
+  await editor.pressSequentially(forwardBody);
+  await sourceMessage
+    .getByRole("button", { name: "Send", exact: true })
+    .click();
+
+  await expect(page).not.toHaveURL(/thread-id=thr_playwright_reply/);
+  await expect(
+    page.getByRole("heading", { name: "Fwd: Reply Workflow Message" }),
+  ).toBeVisible();
+  await expect(
+    page
+      .frameLocator('iframe[title="Email content preview"]')
+      .getByText(forwardBody),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole("region", { name: "Reply delivery status" })
+      .getByText("Reply sent", { exact: true }),
+  ).toHaveCount(0);
+  await capturePlaywrightCheckpoint(page, testInfo, "forward-sent-in-thread");
+});
+
 test("keeps reply and forward drafts in separate composer sessions", async ({
   page,
 }) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1257,6 +1257,19 @@ export function MailShell() {
               onArchive={archiveTargets}
               showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}
+              onSendSuccess={(_messageId, sentThreadId) => {
+                if (
+                  !openThreadSelection ||
+                  !sentThreadId.trim() ||
+                  sentThreadId === openThreadSelection.threadId
+                )
+                  return;
+                setReplyToMessageId(undefined);
+                setOpenThread({
+                  emailAccountId: openThreadSelection.emailAccountId,
+                  threadId: sentThreadId,
+                });
+              }}
               autoOpenReplyForMessageId={replyToMessageId}
               menu={
                 <ThreadActionsMenu

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -48,6 +48,8 @@ export type ThreadReaderProps = {
   showSidebarToggle?: boolean;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
   refetch: () => void;
+  /** Opens a different provider thread when a sent message starts one. */
+  onSendSuccess?: (messageId: string, threadId: string) => void;
   /**
    * Set by the reply action. Left unset the composer still opens on its own for
    * a message that already has an AI draft.
@@ -73,6 +75,7 @@ export function ThreadReader({
   onArchive,
   showSidebarToggle = false,
   refetch,
+  onSendSuccess,
   autoOpenReplyForMessageId,
   menu,
 }: ThreadReaderProps) {
@@ -170,6 +173,7 @@ export function ThreadReader({
                 });
               }}
               refetch={refetch}
+              onSendSuccess={onSendSuccess}
               showReplyButton
             />
           ) : (

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -239,12 +239,12 @@ export function EmailThread({
               message={message}
               onOpenSenderContext={onOpenSenderContext}
               onMarkDone={onMarkDone}
-              onSendSuccess={(messageId) => {
+              onSendSuccess={(messageId, sentThreadId) => {
                 setExpansionOverrides((prev) =>
                   new Map(prev).set(messageId, true),
                 );
 
-                onSendSuccess?.(messageId, message.threadId);
+                onSendSuccess?.(messageId, sentThreadId);
               }}
               // A one-message thread has nothing to collapse back to.
               onToggle={


### PR DESCRIPTION
Displays the sent message when a forward is created in a different provider thread instead of leaving only a delivery status in the source thread.

- Propagates the provider thread identifier through the reader and navigates when the sent thread differs.
- Adds an emulated browser regression covering forwarded-message content.

Validation: focused unit tests and formatting checks pass; local browser execution was blocked by emulator setup instability.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

