### PR TITLE
mail: Render compose shortcut hints as one key per block

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -253,7 +253,11 @@ test("attaches files and discards a compose draft with shortcuts", async ({
   const attachButton = dialog.getByRole("button", { name: "Attach files" });
   await attachButton.hover();
   await expect(page.getByRole("tooltip")).toContainText("Attach files");
-  await expect(page.getByRole("tooltip").locator("kbd")).toHaveText("⌘⇧U");
+  await expect(page.getByRole("tooltip").locator("kbd")).toHaveText([
+    "⌘",
+    "shift",
+    "U",
+  ]);
   await capturePlaywrightCheckpoint(page, testInfo, "composer-shortcut-hint");
 
   const fileChooserPromise = page.waitForEvent("filechooser");
@@ -417,7 +421,13 @@ test("opens and sends a reply from the reader with Enter", async ({
   await sendButton.hover();
   const sendTooltip = page.getByRole("tooltip");
   await expect(sendTooltip).toContainText("Send and mark done");
-  await expect(sendTooltip.locator("kbd")).toHaveText(["⌘↵", "⌘⇧↵"]);
+  await expect(sendTooltip.locator("kbd")).toHaveText([
+    "⌘",
+    "enter",
+    "⌘",
+    "shift",
+    "enter",
+  ]);
   await capturePlaywrightCheckpoint(page, testInfo, "protected-quoted-reply");
   await sendButton.click();
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeShortcutTooltipContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeShortcutTooltipContent.tsx
@@ -1,7 +1,7 @@
 import { Kbd } from "@/components/Kbd";
 import {
   getShortcut,
-  getShortcutHint,
+  getShortcutKeyLabels,
   type ShortcutId,
 } from "@/lib/shortcuts/registry";
 
@@ -11,11 +11,21 @@ export function ComposeShortcutTooltipContent({
   shortcuts: readonly ShortcutId[];
 }) {
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-1.5 py-0.5">
       {shortcuts.map((shortcut) => (
-        <div className="flex items-center justify-between gap-4" key={shortcut}>
-          <span>{getShortcut(shortcut).label}</span>
-          <Kbd variant="onColor">{getShortcutHint(shortcut)}</Kbd>
+        <div className="flex items-center justify-between gap-6" key={shortcut}>
+          <span className="font-medium">{getShortcut(shortcut).label}</span>
+          <div className="flex items-center gap-1">
+            {getShortcutKeyLabels(shortcut).map((key) => (
+              <Kbd
+                className="h-5 min-w-5 px-1.5 font-sans text-[11px]"
+                key={`${shortcut}-${key}`}
+                variant="onColor"
+              >
+                {key}
+              </Kbd>
+            ))}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -8,6 +8,7 @@ import {
   findShortcutConflicts,
   formatShortcutKeys,
   getShortcut,
+  getShortcutKeyLabels,
   getShortcutGroups,
   isTypingTarget,
   SEQUENCE_TIMEOUT_MS,
@@ -75,6 +76,17 @@ describe("shortcut registry", () => {
     expect(formatShortcutKeys(getShortcut("toggleLayout"))).toBe("⇧V");
     expect(formatShortcutKeys(getShortcut("markSpam"))).toBe("!");
     expect(formatShortcutKeys(getShortcut("openExternal"))).toBe("G G");
+  });
+
+  it("splits keys into one spelled-out label per block", () => {
+    expect(getShortcutKeyLabels("send")).toEqual(["⌘", "enter"]);
+    expect(getShortcutKeyLabels("sendAndMarkDone")).toEqual([
+      "⌘",
+      "shift",
+      "enter",
+    ]);
+    expect(getShortcutKeyLabels("sendLater")).toEqual(["⌘", "shift", "L"]);
+    expect(getShortcutKeyLabels("backToApp")).toEqual(["G", "A"]);
   });
 });
 

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -417,6 +417,23 @@ export function getShortcutHint(id: ShortcutId): string {
   return formatShortcutKeys(getShortcut(id));
 }
 
+/**
+ * One label per key of the first binding, e.g. `["⌘", "shift", "enter"]`, for
+ * surfaces that render a key per block. Modifiers are spelled out because the
+ * stacked symbols (`⌘⇧↵`) are unreadable at tooltip size.
+ */
+export function getShortcutKeyLabels(id: ShortcutId): string[] {
+  const entry = getShortcut(id);
+  const [binding] = entry.display ?? entry.keys;
+
+  return binding
+    .split(SEQUENCE_SPLIT_KEY)
+    .flatMap((step) => step.split("+"))
+    .map(
+      (token) => KEY_WORDS[token] ?? KEY_SYMBOLS[token] ?? token.toUpperCase(),
+    );
+}
+
 /** Feeds ⌘K: an entry appears once its handler is registered. */
 export function buildShortcutPaletteCommands(
   handlers: ShortcutHandlers,
@@ -575,6 +592,19 @@ const KEY_SYMBOLS: Record<string, string> = {
   arrowdown: "↓",
   arrowleft: "←",
   arrowright: "→",
+};
+
+/** Overrides `KEY_SYMBOLS` where a word reads better than a symbol. */
+const KEY_WORDS: Record<string, string> = {
+  modorctrl: "⌘/ctrl",
+  ctrl: "ctrl",
+  alt: "option",
+  shift: "shift",
+  enter: "enter",
+  escape: "esc",
+  tab: "tab",
+  backspace: "delete",
+  space: "space",
 };
 
 function formatKey(key: string): string {


### PR DESCRIPTION
The compose tooltips packed a whole shortcut into a single key cap (`⌘⇧↵`), which is hard to read at tooltip size. Each key now gets its own block with modifiers spelled out (`⌘` `shift` `enter`).

- Added `getShortcutKeyLabels` to the shortcut registry so a binding can be rendered one key per block, with word labels for modifiers.
- Updated the compose tooltip to render the blocks and bump the key cap size.
- Updated the registry unit tests and the emulated Playwright assertions for the new labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

