### PR TITLE
Mail: preserve forward target state

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -764,14 +764,26 @@ export function MailShell() {
       return;
     }
 
+    const targetIndex = threads.findIndex(
+      (thread) => getListThreadKey(thread) === singleActionTarget.key,
+    );
+    const targetThreadKey = getThreadSelectionKey(singleActionTarget.selection);
+    if (!targetThreadKey) return;
     pendingComposeRequest.current = {
       mode: "forward",
-      threadKey: singleActionTarget.key,
+      threadKey: targetThreadKey,
     };
+    if (targetIndex >= 0) setFocusedIndex(targetIndex);
     setReplyToMessageId(undefined);
     setForwardToMessageId(undefined);
     setOpenThread(singleActionTarget.selection);
-  }, [openThreadKey, requestReaderForward, setOpenThread, singleActionTarget]);
+  }, [
+    openThreadKey,
+    requestReaderForward,
+    setOpenThread,
+    singleActionTarget,
+    threads,
+  ]);
   const pickerAccount =
     labelPicker?.targets[0]?.emailAccountId === emailAccountId
       ? emailAccount


### PR DESCRIPTION
Keeps deferred forwarding aligned with the selected conversation.

- Use a stable account-scoped thread key for pending forwarding.
- Move the list cursor to the forwarded conversation before opening the reader.
- Validated with focused unit tests and lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forwarding a message from a non-open selection now focuses the correct conversation before opening the compose window.
  * Pending compose actions now remain associated with the selected conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->