### PR TITLE
auth: Preserve Microsoft credentials after operation access errors

### DIFF
--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -174,7 +174,7 @@ describe("provider health", () => {
     expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
-  it("records Outlook authorization failures case-insensitively", async () => {
+  it("does not disconnect Outlook accounts for message access denials", async () => {
     const logger = createScopedLogger("provider-health-test");
 
     await recordEmailAccountProviderIssue({
@@ -185,11 +185,8 @@ describe("provider health", () => {
       operation: "getMessage",
     });
 
-    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
-      emailAccountId: "email-account-1",
-      reason: "insufficient_permissions",
-      logger,
-    });
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+    expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
   });
 
   it("does not disconnect Outlook accounts for code-only access denials", async () => {

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -92,22 +92,11 @@ export function classifyEmailAccountProviderIssue({
   provider: "google" | "microsoft";
 }): ProviderIssue | null {
   const message = getErrorMessage(error);
-  const normalizedMessage = message?.toLowerCase() ?? "";
 
   if (
     provider === "google" &&
     (isGmailInsufficientPermissionsError(error) ||
       message?.includes("Request had insufficient authentication scopes"))
-  ) {
-    return { reason: "insufficient_permissions" };
-  }
-
-  if (
-    provider === "microsoft" &&
-    normalizedMessage.includes(
-      "access is denied. check credentials and try again",
-    ) &&
-    !normalizedMessage.includes("cannot save changes made to an item to store")
   ) {
     return { reason: "insufficient_permissions" };
   }


### PR DESCRIPTION
Keep account credentials when a Microsoft Graph operation returns an access-denied response. Linking continues to validate required consent, while definitive authentication failures still require reconnection.

- treat Microsoft operation-level access denials as non-terminal account errors
- retain existing invalid-grant and explicit permission validation behavior
- add a regression test for message access failures
- validate the related provider, cleanup, and watch-management test suites

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft email access-denial errors are no longer incorrectly treated as permanent credential failures.
  * These errors no longer trigger automatic invalid-token cleanup or related account cleanup actions.
  * Google provider error classification remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->