### PR TITLE
Mail: support nested sidebar labels

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -328,6 +328,15 @@ test("creates and edits a label and shows every keyboard workflow", async ({
     .click();
   await grandchild.click();
   await expect(grandchild).toHaveAttribute("aria-current", "page");
+  await page
+    .getByRole("button", { name: `Collapse ${updatedLabelName}`, exact: true })
+    .click();
+  await expect(grandchild).toBeHidden();
+  await page.getByRole("link", { name: /^Inbox(?:\s+\d+)?$/ }).click();
+  await expect(grandchild).toBeHidden();
+  await page.goBack();
+  await expect(grandchild).toBeVisible();
+  await expect(grandchild).toHaveAttribute("aria-current", "page");
   await grandchild.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Edit", exact: true }).click();
   await expect(

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -328,13 +328,16 @@ test("creates and edits a label and shows every keyboard workflow", async ({
     .click();
   await grandchild.click();
   await expect(grandchild).toHaveAttribute("aria-current", "page");
+  const selectedLabelUrl = page.url();
   await page
     .getByRole("button", { name: `Collapse ${updatedLabelName}`, exact: true })
     .click();
   await expect(grandchild).toBeHidden();
   await page.getByRole("link", { name: /^Inbox(?:\s+\d+)?$/ }).click();
+  await expect(page).toHaveURL(/type=inbox/);
   await expect(grandchild).toBeHidden();
   await page.goBack();
+  await expect(page).toHaveURL(selectedLabelUrl);
   await expect(grandchild).toBeVisible();
   await expect(grandchild).toHaveAttribute("aria-current", "page");
   await grandchild.click({ button: "right" });
@@ -350,7 +353,7 @@ test("creates and edits a label and shows every keyboard workflow", async ({
   await expect(dialog.getByText("Next message", { exact: true })).toBeVisible();
   await expect(dialog.getByText("Archive", { exact: true })).toBeVisible();
   await expect(dialog.getByText("New message", { exact: true })).toBeVisible();
-  await expect(dialog.getByText("Send reply", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("Send", { exact: true })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(dialog).toBeHidden();
 });

--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -302,6 +302,39 @@ test("creates and edits a label and shows every keyboard workflow", async ({
     page.getByRole("link", { name: updatedLabelName, exact: true }),
   ).toBeVisible();
 
+  for (const name of [
+    `${updatedLabelName}/Clients`,
+    `${updatedLabelName}/Clients/Acme`,
+  ]) {
+    await page.getByRole("button", { name: "Create label" }).click();
+    await page.getByRole("textbox", { name: "New label name" }).fill(name);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(
+      page.getByRole("link", { name: name.split("/").at(-1), exact: true }),
+    ).toBeVisible();
+  }
+  const child = page.getByRole("link", { name: "Clients", exact: true });
+  const grandchild = page.getByRole("link", { name: "Acme", exact: true });
+  await expect(child).toBeVisible();
+  await expect(grandchild).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "gmail-nested-labels");
+  await page
+    .getByRole("button", { name: `Collapse ${updatedLabelName}`, exact: true })
+    .click();
+  await expect(child).toBeHidden();
+  await expect(grandchild).toBeHidden();
+  await page
+    .getByRole("button", { name: `Expand ${updatedLabelName}`, exact: true })
+    .click();
+  await grandchild.click();
+  await expect(grandchild).toHaveAttribute("aria-current", "page");
+  await grandchild.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit", exact: true }).click();
+  await expect(
+    editDialog.getByRole("textbox", { name: "label name" }),
+  ).toHaveValue(`${updatedLabelName}/Clients/Acme`);
+  await editDialog.getByRole("button", { name: "Cancel" }).click();
+
   await page.getByRole("button", { name: /^Keyboard shortcuts/ }).click();
   const dialog = page.getByRole("dialog", { name: "Keyboard shortcuts" });
   await expect(dialog).toBeVisible();

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -33,6 +33,7 @@ import { GmailLabel } from "@/utils/gmail/label";
 import { cn } from "@/utils";
 import type { OutlookFolder } from "@/utils/outlook/folders";
 import { OUTLOOK_INBOX_SECTIONS } from "@/utils/mail/outlook-inbox";
+import { getLabelTree, type SidebarLabel } from "./label-tree";
 import { getMailSidebarFolders } from "./outlook-folder-list";
 import {
   MailboxItemContextMenu,
@@ -169,6 +170,7 @@ export function MailSidebar({
   const [isAddingLabel, setIsAddingLabel] = useState(false);
   const [newLabelName, setNewLabelName] = useState("");
   const sidebarFolders = getMailSidebarFolders(folders);
+  const labelTree = getLabelTree(labels, labelEditMode === "name-and-color");
 
   const isCategoryActive =
     !activeLabelId &&
@@ -333,34 +335,19 @@ export function MailSidebar({
               {labelsHeading}
             </GroupHeading>
             <nav className="flex flex-col gap-px">
-              {labels.map((label) => (
-                <MailboxItemContextMenu
-                  key={label.id}
-                  item={{ kind: "label", id: label.id, name: label.name }}
-                  typeName={labelSingular}
-                  editMode={labelEditMode}
-                  currentColor={label.color}
-                  colorOptions={labelColorOptions}
-                  onEdit={onEditMailboxItem}
-                  onDelete={onDeleteMailboxItem}
-                >
-                  <NavRow
-                    href={hrefFor({ kind: "label", labelId: label.id })}
-                    active={activeLabelId === label.id}
-                    icon={
-                      <span
-                        className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
-                        style={
-                          label.color?.backgroundColor
-                            ? { backgroundColor: label.color.backgroundColor }
-                            : undefined
-                        }
-                      />
-                    }
-                    name={label.name}
-                    count={displayCount(countsById.get(label.id))}
-                  />
-                </MailboxItemContextMenu>
+              {labelTree.map((node) => (
+                <LabelBranch
+                  key={node.label.id}
+                  node={node}
+                  activeLabelId={activeLabelId}
+                  hrefFor={hrefFor}
+                  countsById={countsById}
+                  labelSingular={labelSingular}
+                  labelEditMode={labelEditMode}
+                  labelColorOptions={labelColorOptions}
+                  onEditMailboxItem={onEditMailboxItem}
+                  onDeleteMailboxItem={onDeleteMailboxItem}
+                />
               ))}
             </nav>
 
@@ -405,6 +392,90 @@ export function MailSidebar({
       </button>
       {footer}
     </aside>
+  );
+}
+
+function LabelBranch({
+  node,
+  ...props
+}: Pick<
+  MailSidebarProps,
+  | "activeLabelId"
+  | "hrefFor"
+  | "countsById"
+  | "labelSingular"
+  | "labelEditMode"
+  | "labelColorOptions"
+  | "onEditMailboxItem"
+  | "onDeleteMailboxItem"
+> & { node: SidebarLabel }) {
+  const [collapsedFor, setCollapsedFor] = useState<string | null | undefined>();
+  const { label, children } = node;
+  const activeDescendantId = children.some((child) =>
+    containsLabel(child, props.activeLabelId),
+  )
+    ? props.activeLabelId
+    : null;
+  // Reveal a newly selected descendant without opening unrelated branches.
+  const expanded =
+    collapsedFor === undefined || collapsedFor !== activeDescendantId;
+
+  return (
+    <div>
+      <MailboxItemContextMenu
+        item={{ kind: "label", id: label.id, name: label.name }}
+        typeName={props.labelSingular}
+        editMode={props.labelEditMode}
+        currentColor={label.color}
+        colorOptions={props.labelColorOptions}
+        onEdit={props.onEditMailboxItem}
+        onDelete={props.onDeleteMailboxItem}
+      >
+        <div className="relative">
+          {children.length > 0 && (
+            <button
+              type="button"
+              aria-label={`${expanded ? "Collapse" : "Expand"} ${label.name}`}
+              aria-expanded={expanded}
+              onClick={() =>
+                setCollapsedFor(expanded ? activeDescendantId : undefined)
+              }
+              className="absolute top-1/2 left-0 z-10 -translate-y-1/2 rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {expanded ? (
+                <ChevronDownIcon className="size-3" />
+              ) : (
+                <ChevronRightIcon className="size-3" />
+              )}
+            </button>
+          )}
+          <NavRow
+            href={props.hrefFor({ kind: "label", labelId: label.id })}
+            active={props.activeLabelId === label.id}
+            icon={
+              <span
+                className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
+                style={
+                  label.color?.backgroundColor
+                    ? { backgroundColor: label.color.backgroundColor }
+                    : undefined
+                }
+              />
+            }
+            name={node.name}
+            count={displayCount(props.countsById.get(label.id))}
+            nested
+          />
+        </div>
+      </MailboxItemContextMenu>
+      {expanded && children.length > 0 && (
+        <div className="ml-3">
+          {children.map((child) => (
+            <LabelBranch key={child.label.id} node={child} {...props} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -457,6 +528,7 @@ function NavRow({
   name,
   count,
   emphasizeCount,
+  nested,
 }: {
   href?: string;
   active: boolean;
@@ -464,9 +536,11 @@ function NavRow({
   name: string;
   count: number | null;
   emphasizeCount?: boolean;
+  nested?: boolean;
 }) {
   const className = cn(
     "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+    nested && "pl-4",
     active
       ? "bg-primary/10 font-medium text-foreground"
       : "text-muted-foreground hover:bg-accent hover:text-foreground",
@@ -517,4 +591,11 @@ function displayCount(count: LabelCount | undefined): number | null {
   if (!count) return null;
   const value = count.id === "DRAFT" ? count.total : count.unread;
   return value > 0 ? value : null;
+}
+
+function containsLabel(node: SidebarLabel, labelId: string | null): boolean {
+  return (
+    node.label.id === labelId ||
+    node.children.some((child) => containsLabel(child, labelId))
+  );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -339,6 +339,9 @@ export function MailSidebar({
                 <LabelBranch
                   key={node.label.id}
                   node={node}
+                  hasNestedLabels={labelTree.some(
+                    (root) => root.children.length > 0,
+                  )}
                   activeLabelId={activeLabelId}
                   hrefFor={hrefFor}
                   countsById={countsById}
@@ -397,6 +400,7 @@ export function MailSidebar({
 
 function LabelBranch({
   node,
+  hasNestedLabels,
   ...props
 }: Pick<
   MailSidebarProps,
@@ -408,17 +412,25 @@ function LabelBranch({
   | "labelColorOptions"
   | "onEditMailboxItem"
   | "onDeleteMailboxItem"
-> & { node: SidebarLabel }) {
-  const [collapsedFor, setCollapsedFor] = useState<string | null | undefined>();
+> & { node: SidebarLabel; hasNestedLabels: boolean }) {
   const { label, children } = node;
   const activeDescendantId = children.some((child) =>
     containsLabel(child, props.activeLabelId),
   )
     ? props.activeLabelId
     : null;
-  // Reveal a newly selected descendant without opening unrelated branches.
-  const expanded =
-    collapsedFor === undefined || collapsedFor !== activeDescendantId;
+  const [expansion, setExpansion] = useState({
+    activeDescendantId,
+    expanded: true,
+  });
+  // Reveal each newly selected descendant while retaining unrelated collapse choices.
+  if (expansion.activeDescendantId !== activeDescendantId) {
+    setExpansion({
+      activeDescendantId,
+      expanded: activeDescendantId !== null || expansion.expanded,
+    });
+  }
+  const { expanded } = expansion;
 
   return (
     <div>
@@ -438,9 +450,9 @@ function LabelBranch({
               aria-label={`${expanded ? "Collapse" : "Expand"} ${label.name}`}
               aria-expanded={expanded}
               onClick={() =>
-                setCollapsedFor(expanded ? activeDescendantId : undefined)
+                setExpansion({ activeDescendantId, expanded: !expanded })
               }
-              className="absolute top-1/2 left-0 z-10 -translate-y-1/2 rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="absolute top-1/2 left-0 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               {expanded ? (
                 <ChevronDownIcon className="size-3" />
@@ -464,14 +476,19 @@ function LabelBranch({
             }
             name={node.name}
             count={displayCount(props.countsById.get(label.id))}
-            nested
+            nested={hasNestedLabels}
           />
         </div>
       </MailboxItemContextMenu>
       {expanded && children.length > 0 && (
         <div className="ml-3">
           {children.map((child) => (
-            <LabelBranch key={child.label.id} node={child} {...props} />
+            <LabelBranch
+              key={child.label.id}
+              node={child}
+              hasNestedLabels={hasNestedLabels}
+              {...props}
+            />
           ))}
         </div>
       )}
@@ -540,7 +557,7 @@ function NavRow({
 }) {
   const className = cn(
     "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-    nested && "pl-4",
+    nested && "pl-7",
     active
       ? "bg-primary/10 font-medium text-foreground"
       : "text-muted-foreground hover:bg-accent hover:text-foreground",

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -171,6 +171,7 @@ export function MailSidebar({
   const [newLabelName, setNewLabelName] = useState("");
   const sidebarFolders = getMailSidebarFolders(folders);
   const labelTree = getLabelTree(labels, labelEditMode === "name-and-color");
+  const hasNestedLabels = labelTree.some((root) => root.children.length > 0);
 
   const isCategoryActive =
     !activeLabelId &&
@@ -339,9 +340,7 @@ export function MailSidebar({
                 <LabelBranch
                   key={node.label.id}
                   node={node}
-                  hasNestedLabels={labelTree.some(
-                    (root) => root.children.length > 0,
-                  )}
+                  hasNestedLabels={hasNestedLabels}
                   activeLabelId={activeLabelId}
                   hrefFor={hrefFor}
                   countsById={countsById}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailboxItemContextMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailboxItemContextMenu.tsx
@@ -23,7 +23,6 @@ import {
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -167,16 +166,9 @@ export function MailboxItemContextMenu({
       </ContextMenu>
 
       <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
-        <DialogContent>
+        <DialogContent aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Edit {typeName}</DialogTitle>
-            <DialogDescription>
-              {editMode === "name-and-color"
-                ? `Choose a new name or color for “${item.name}”.`
-                : editMode === "color"
-                  ? `Choose a color for “${item.name}”.`
-                  : `Choose a new name for “${item.name}”.`}
-            </DialogDescription>
           </DialogHeader>
           <form onSubmit={submitEdit}>
             {showsName && (

--- a/apps/web/app/(app)/[emailAccountId]/mail/label-tree.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/label-tree.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { getLabelTree } from "./label-tree";
+
+describe("getLabelTree", () => {
+  it("groups descendants regardless of input order and retains original labels", () => {
+    const child = { id: "child", name: "Work/Clients/Acme" };
+    const tree = getLabelTree(
+      [
+        child,
+        { id: "other", name: "Other" },
+        { id: "work", name: "Work" },
+        { id: "clients", name: "Work/Clients" },
+      ],
+      true,
+    );
+    expect(tree.map((node) => node.name)).toEqual(["Other", "Work"]);
+    expect(tree[1].children[0].name).toBe("Clients");
+    expect(tree[1].children[0].children[0]).toEqual({
+      label: child,
+      name: "Acme",
+      children: [],
+    });
+  });
+
+  it("keeps missing path segments and does not group mere name prefixes", () => {
+    const tree = getLabelTree(
+      [
+        { id: "work", name: "Work" },
+        { id: "child", name: "Work/Clients/Acme" },
+        { id: "prefix", name: "Workshop/Notes" },
+      ],
+      true,
+    );
+    expect(tree[0].children[0].name).toBe("Clients/Acme");
+    expect(tree[1].name).toBe("Workshop/Notes");
+  });
+
+  it("keeps categories flat when nesting is disabled", () => {
+    const tree = getLabelTree(
+      [
+        { id: "work", name: "Work" },
+        { id: "child", name: "Work/Clients" },
+      ],
+      false,
+    );
+    expect(tree.map((node) => node.name)).toEqual(["Work", "Work/Clients"]);
+    expect(tree.every((node) => node.children.length === 0)).toBe(true);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/label-tree.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/label-tree.ts
@@ -1,0 +1,38 @@
+import type { EmailLabel } from "@/providers/email-label-types";
+
+export type SidebarLabel = {
+  label: EmailLabel;
+  name: string;
+  children: SidebarLabel[];
+};
+
+export function getLabelTree(
+  labels: EmailLabel[],
+  nested: boolean,
+): SidebarLabel[] {
+  const nodes = labels.map((label) => ({
+    label,
+    name: label.name,
+    children: [] as SidebarLabel[],
+  }));
+  if (!nested) return nodes;
+
+  const byName = new Map(nodes.map((node) => [node.label.name, node]));
+  const roots: SidebarLabel[] = [];
+  for (const node of nodes) {
+    let separator = node.label.name.lastIndexOf("/");
+    let parent: SidebarLabel | undefined;
+    while (separator > 0) {
+      parent = byName.get(node.label.name.slice(0, separator));
+      if (parent) break;
+      separator = node.label.name.lastIndexOf("/", separator - 1);
+    }
+    if (parent) {
+      node.name = node.label.name.slice(separator + 1);
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}


### PR DESCRIPTION
Gmail labels such as `Inbox Zero/Archived` now appear as `Archived` beneath a collapsible `Inbox Zero` row. The label editor no longer repeats instructions beneath its title.

- Supports multiple nesting levels, preserves full label paths for edits, and keeps Outlook categories flat.
- Adds unit coverage for hierarchy construction and browser coverage for collapse, navigation, and editing nested labels.
- Validation: 3 focused unit tests, Biome, and the label create/edit/nesting browser flow pass. Screenshots inspected. The broader navigation spec hit an existing mark-unread mutation timeout.
- Builds the hierarchy locally; adds no database or network calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail labels now appear in a nested, hierarchical tree based on their paths.
  * Added expand and collapse controls for nested labels, with automatic expansion when viewing a descendant.
  * Nested labels remain selected after navigating back, and their full paths are shown when editing.

* **Bug Fixes**
  * Updated the keyboard-shortcut dialog to display the correct “Send” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->