### PR TITLE
Mail: preserve message keyboard interactions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -127,3 +127,36 @@ test("navigates messages from inside a rich email body", async ({ page }) => {
     page.getByRole("textbox", { name: "Email message" }),
   ).toBeVisible();
 });
+
+test("expands a collapsed message before Enter opens a reply", async ({
+  page,
+}, testInfo) => {
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  const message = page.locator("li[data-thread-message-id]").first();
+  const header = message.locator('[role="button"][aria-expanded]');
+  const editor = message.getByRole("textbox", { name: "Email message" });
+  await expect(header).toHaveAttribute("aria-expanded", "false");
+
+  await message.focus();
+  await page.keyboard.press("Enter");
+
+  await expect(header).toHaveAttribute("aria-expanded", "true");
+  await expect(message.locator(".animate-spin")).toHaveCount(0);
+  await expect(editor).toHaveCount(0);
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "collapsed-message-expanded-with-enter",
+  );
+
+  await message.focus();
+  await page.keyboard.press("Enter");
+  await expect(editor).toBeFocused();
+  await expect(
+    page.getByRole("textbox", { name: "Email message" }),
+  ).toHaveCount(1);
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -906,7 +906,16 @@ export function MailShell() {
         if (openThreadId && event?.key === "ArrowUp") return;
         move(-1);
       },
-      open: openThreadId ? requestReaderReply : () => openAt(clampedIndex),
+      open: openThreadId
+        ? (event) => {
+            if (
+              event?.target instanceof Element &&
+              event.target.closest("[data-thread-message-id]")
+            )
+              return;
+            requestReaderReply();
+          }
+        : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
         : () => {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -121,6 +121,24 @@ export function EmailMessage({
     setShowDetails((prev) => !prev);
   }, []);
 
+  const onMessageKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (
+        event.target !== event.currentTarget ||
+        (event.key !== "Enter" && event.key !== " ")
+      )
+        return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Enter" && expanded && showReplyButton) {
+        onReply();
+      } else {
+        onToggle?.();
+      }
+    },
+    [expanded, onReply, onToggle, showReplyButton],
+  );
+
   return (
     <li
       data-thread-message-id={message.id}
@@ -129,21 +147,7 @@ export function EmailMessage({
       aria-current={selected || undefined}
       onFocusCapture={onSelect}
       onClickCapture={onSelect}
-      onKeyDown={(event) => {
-        if (
-          event.target !== event.currentTarget ||
-          (event.key !== "Enter" && event.key !== " ")
-        )
-          return;
-        event.preventDefault();
-        event.stopPropagation();
-        if (event.key === "Enter" && showReplyButton) {
-          if (!expanded) onToggle?.();
-          onReply();
-        } else {
-          onToggle?.();
-        }
-      }}
+      onKeyDown={onMessageKeyDown}
       className={cn(
         "group/message min-w-0 border-l-2 border-transparent outline-none transition-colors focus-within:border-primary",
         selected && "border-primary",
@@ -159,6 +163,7 @@ export function EmailMessage({
         onOpenSenderContext={onOpenSenderContext}
         onReply={onReply}
         onToggle={onToggle}
+        onToggleKeyDown={onMessageKeyDown}
         showDetails={showDetails}
         showReplyButton={showReplyButton}
         toggleDetails={toggleDetails}
@@ -222,6 +227,7 @@ function MessageHeader({
   onForward,
   onOpenSenderContext,
   onToggle,
+  onToggleKeyDown,
   hasDraft,
 }: {
   message: ParsedMessage;
@@ -233,6 +239,7 @@ function MessageHeader({
   onForward: () => void;
   onOpenSenderContext?: (message: ThreadMessage) => void;
   onToggle?: () => void;
+  onToggleKeyDown: React.KeyboardEventHandler<HTMLElement>;
   hasDraft: boolean;
 }) {
   const { emailAccount, emailAccountId, userEmail } = useAccount();
@@ -271,20 +278,7 @@ function MessageHeader({
   const toggleProps: React.ComponentProps<"div"> | undefined = onToggle && {
     "aria-expanded": expanded,
     onClick: onToggle,
-    onKeyDown: (event: React.KeyboardEvent) => {
-      // Keydown bubbles, so without this the row would swallow Enter/Space
-      // aimed at the buttons nested inside it.
-      if (event.target !== event.currentTarget) return;
-      if (event.key !== "Enter" && event.key !== " ") return;
-      event.preventDefault();
-      event.stopPropagation();
-      if (event.key === "Enter" && showReplyButton) {
-        if (!expanded) onToggle();
-        onReply();
-      } else {
-        onToggle();
-      }
-    },
+    onKeyDown: onToggleKeyDown,
     role: "button",
     tabIndex: 0,
   };


### PR DESCRIPTION
Ensure Enter and Space remain scoped to the focused message row while preserving reply behavior for expanded messages. Add an emulated browser regression test for expanding a collapsed message before replying.

- Updated message and reader keyboard handling
- Added focused Playwright coverage
- Validation: Biome passed; Playwright setup was blocked by local PostgreSQL authentication credentials

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

