### PR TITLE
mail: Remove redundant split shortcut hint

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -22,6 +22,8 @@ test("moves focus with the active split when cycling by keyboard", async ({
 }, testInfo) => {
   await openMail(page);
 
+  await expect(page.getByTitle("Next split")).toHaveCount(0);
+
   const activeSplit = page.locator('button[aria-current="true"]');
   await expect(activeSplit).toBeVisible();
   await activeSplit.click();

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -7,8 +7,6 @@ import {
   type NewSplitOption,
   NewSplitPopover,
 } from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
-import { Kbd } from "@/components/Kbd";
-import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
 
 export type MailSplitTab = {
@@ -124,9 +122,6 @@ export function SplitTabs({
           onSetDefaultSplits={onSetDefaultSplits}
         />
       )}
-
-      <div className="flex-1" />
-      <Kbd title="Next split">{getShortcutHint("nextSplit")}</Kbd>
     </div>
   );
 }


### PR DESCRIPTION
mail: Remove redundant split shortcut hint

Removes an unnecessary shortcut badge from the mail split navigation while preserving keyboard behavior.

- Removes the visible shortcut hint from the split tab bar
- Adds browser coverage for the hidden hint
- Validated with Biome; local browser setup requires a configured database


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the keyboard-shortcut hint for cycling to the next split from the mail tab bar.
  * Ensured the emulated mail interface does not display an unexpected “Next split” control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->