### PR TITLE
billing: Prevent repeat trials on replacement subscriptions

### DIFF
--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -322,7 +322,7 @@ describe("generateCheckoutSessionAction", () => {
     expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 
-  it("uses a stable idempotency key for concurrent checkout requests", async () => {
+  it("includes a trial and uses a stable idempotency key for concurrent first checkouts", async () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
@@ -358,6 +358,9 @@ describe("generateCheckoutSessionAction", () => {
     expect(mocks.createCheckoutSession.mock.calls[0][1]).toEqual(
       mocks.createCheckoutSession.mock.calls[1][1],
     );
+    expect(
+      mocks.createCheckoutSession.mock.calls[0]?.[0].subscription_data,
+    ).toHaveProperty("trial_period_days", 7);
   });
 
   it("uses a new idempotency key when the checkout quantity changes", async () => {
@@ -393,7 +396,7 @@ describe("generateCheckoutSessionAction", () => {
     );
   });
 
-  it("allows a new checkout after the previous subscription has ended", async () => {
+  it("allows a new paid checkout after the previous subscription has ended", async () => {
     prisma.user.findUnique.mockResolvedValue({
       email: "user@example.com",
       utms: null,
@@ -418,5 +421,8 @@ describe("generateCheckoutSessionAction", () => {
     });
 
     expect(result?.data).toEqual({ url: "https://stripe.test" });
+    expect(
+      mocks.createCheckoutSession.mock.calls[0]?.[0].subscription_data,
+    ).not.toHaveProperty("trial_period_days");
   });
 });

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -637,6 +637,7 @@ export const generateCheckoutSessionAction = actionClientUser
         fbp: cookieStore.get("_fbp")?.value,
       }),
     };
+    const isFirstStripeSubscription = !user.premium?.stripeSubscriptionId;
 
     const checkoutParams: Stripe.Checkout.SessionCreateParams = {
       customer: stripeCustomerId,
@@ -644,7 +645,7 @@ export const generateCheckoutSessionAction = actionClientUser
       cancel_url: `${env.NEXT_PUBLIC_BASE_URL}/premium`,
       mode: "subscription",
       subscription_data: {
-        trial_period_days: 7,
+        ...(isFirstStripeSubscription ? { trial_period_days: 7 } : {}),
         ...(Object.keys(conversionMetadata).length
           ? {
               metadata: conversionMetadata,


### PR DESCRIPTION
Ensure customers restarting after an ended Stripe subscription enter a paid checkout instead of receiving another trial.

- Limit seven-day trials to the first Stripe subscription
- Cover first-time and replacement checkout behavior with unit tests

Validation:
- `pnpm test utils/actions/premium.test.ts`
- `pnpm exec ultracite check apps/web/utils/actions/premium.ts apps/web/utils/actions/premium.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trial periods are now applied only to a customer’s first checkout.
  * Customers returning after an ended subscription no longer receive another trial period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->