### PR TITLE
mail: Expand unread messages when opening threads

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -24,6 +24,7 @@ test("expands unread messages when opening a thread", async ({
       {
         ...first,
         id: "msg_playwright_reader_unread_history",
+        labelIds: ["INBOX", "UNREAD"],
         textPlain: "Another unread message opens with the conversation.",
         snippet: "Another unread message opens with the conversation.",
       },
@@ -37,7 +38,9 @@ test("expands unread messages when opening a thread", async ({
     waitUntil: "domcontentloaded",
   });
 
-  const headers = page.locator('[role="button"][aria-expanded]');
+  const headers = page.locator(
+    'li[data-thread-message-id] [role="button"][aria-expanded]',
+  );
   await expect(headers).toHaveCount(4);
   await expect(headers.nth(0)).toHaveAttribute("aria-expanded", "false");
   await expect(headers.nth(1)).toHaveAttribute("aria-expanded", "true");

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -1,14 +1,57 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { openMail } from "./mail-test-helpers";
+
+test("expands unread messages when opening a thread", async ({
+  page,
+}, testInfo) => {
+  await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
+    const response = await route.fetch();
+    const body: ThreadResponse = await response.json();
+    const first = body.thread.messages[0];
+    expect(first).toBeDefined();
+    if (!first) throw new Error("Reader fixture has no messages");
+    body.thread.messages = [
+      {
+        ...first,
+        id: "msg_playwright_reader_read_history",
+        labelIds: ["INBOX"],
+        textPlain: "An earlier read message stays collapsed.",
+        snippet: "An earlier read message stays collapsed.",
+      },
+      {
+        ...first,
+        id: "msg_playwright_reader_unread_history",
+        textPlain: "Another unread message opens with the conversation.",
+        snippet: "Another unread message opens with the conversation.",
+      },
+      ...body.thread.messages,
+    ];
+    await route.fulfill({ response, json: body });
+  });
+
+  const { emailAccountId } = await openMail(page);
+  await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  const headers = page.locator('[role="button"][aria-expanded]');
+  await expect(headers).toHaveCount(4);
+  await expect(headers.nth(0)).toHaveAttribute("aria-expanded", "false");
+  await expect(headers.nth(1)).toHaveAttribute("aria-expanded", "true");
+  await expect(headers.nth(2)).toHaveAttribute("aria-expanded", "true");
+  await expect(headers.nth(3)).toHaveAttribute("aria-expanded", "true");
+  await capturePlaywrightCheckpoint(page, testInfo, "unread-messages-expanded");
+});
 
 test("keeps arrow navigation inside the thread and expands from its toolbar", async ({
   page,
 }, testInfo) => {
   page.setDefaultTimeout(15_000);
   page.setDefaultNavigationTimeout(30_000);
+  await makeReaderHistoryRead(page);
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
     waitUntil: "domcontentloaded",
@@ -131,6 +174,7 @@ test("navigates messages from inside a rich email body", async ({ page }) => {
 test("expands a collapsed message before Enter opens a reply", async ({
   page,
 }, testInfo) => {
+  await makeReaderHistoryRead(page);
   const { emailAccountId } = await openMail(page);
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
     waitUntil: "domcontentloaded",
@@ -160,3 +204,15 @@ test("expands a collapsed message before Enter opens a reply", async ({
     page.getByRole("textbox", { name: "Email message" }),
   ).toHaveCount(1);
 });
+
+async function makeReaderHistoryRead(page: Page) {
+  await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
+    const response = await route.fetch();
+    const body: ThreadResponse = await response.json();
+    body.thread.messages = body.thread.messages.map((message) => ({
+      ...message,
+      labelIds: message.labelIds?.filter((labelId) => labelId !== "UNREAD"),
+    }));
+    await route.fulfill({ response, json: body });
+  });
+}

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -15,6 +15,7 @@ import {
   type ReplyDraftMode,
 } from "@/utils/email-cache/reply-drafts";
 import type { StoredReplyDraft } from "@/utils/email-cache/database";
+import { GmailLabel } from "@/utils/gmail/label";
 
 export function EmailThread({
   messages,
@@ -79,7 +80,16 @@ export function EmailThread({
 
   const [expansionOverrides, setExpansionOverrides] = useState<
     Map<string, boolean>
-  >(() => new Map());
+  >(
+    () =>
+      new Map(
+        organizedMessages
+          .filter(({ message }) =>
+            message.labelIds?.includes(GmailLabel.UNREAD),
+          )
+          .map(({ message }) => [message.id, true]),
+      ),
+  );
   const [recoveredReply, setRecoveredReply] = useState<{
     messageId: string;
     mode: ReplyDraftMode;


### PR DESCRIPTION
Open unread messages when a conversation is first viewed while preserving existing manual expansion behavior.

- initialize message expansion from unread state
- cover mixed read and unread history in browser tests
- validate existing navigation and reply interactions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unread messages in email threads now expand automatically when opened, while read messages remain collapsed.
* **Bug Fixes**
  * Improved thread navigation and message expansion behavior for fully read conversations.
  * Ensured message expansion states accurately reflect whether messages have been read.
* **Tests**
  * Added coverage for unread-message expansion, read-message collapse states, and navigation through fully read conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->