### PR TITLE
Mail: add an expanded preview text toggle

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { expect, type Locator } from "@playwright/test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
@@ -44,3 +44,36 @@ test("switches between list and split reading layouts", async ({
   await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();
 });
+
+test("expands and shortens the conversation preview text", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  const toggle = page.getByRole("button", {
+    name: "Expand or shorten preview text",
+  });
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+  const row = conversations.getByRole("option").first();
+  const shortHeight = await rowHeight(row);
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect
+    .poll(async () => await rowHeight(row))
+    .toBeGreaterThan(shortHeight);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-expanded-preview");
+
+  // The preference is stored per account, so a reload has to keep it on.
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect.poll(async () => await rowHeight(row)).toBe(shortHeight);
+});
+
+async function rowHeight(row: Locator) {
+  const box = await row.boundingBox();
+  return box?.height ?? 0;
+}

--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -1,7 +1,9 @@
-import { expect, type Locator } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
+import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
 
 test("switches between list and split reading layouts", async ({
   page,
@@ -48,11 +50,22 @@ test("switches between list and split reading layouts", async ({
 test("expands and shortens the conversation preview text", async ({
   page,
 }, testInfo) => {
-  const { conversations } = await openMail(page);
+  const { conversations, emailAccountId } = await openMail(page);
+  // Only the wide list puts the snippet beside the subject, so the split
+  // preference has to be off for the two preview branches to differ.
+  await expect(
+    page.getByText("Nothing selected", { exact: true }),
+  ).toBeHidden();
+
   const toggle = page.getByRole("button", {
     name: "Expand or shorten preview text",
   });
-  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  // Both preferences outlive a test, so start from short rather than assume it.
+  if ((await toggle.getAttribute("aria-pressed")) === "true") {
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  }
+  await expectStoredPreview(page, emailAccountId, false);
 
   const row = conversations.getByRole("option").first();
   const shortHeight = await rowHeight(row);
@@ -65,13 +78,36 @@ test("expands and shortens the conversation preview text", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "mail-expanded-preview");
 
   // The preference is stored per account, so a reload has to keep it on.
+  await expectStoredPreview(page, emailAccountId, true);
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
 
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-pressed", "false");
   await expect.poll(async () => await rowHeight(row)).toBe(shortHeight);
+  await expectStoredPreview(page, emailAccountId, false);
 });
+
+/**
+ * Waits on the stored preference rather than the action's response, so a
+ * concurrent server action can't settle the wait early and let a reload abort
+ * the write that is still in flight.
+ */
+async function expectStoredPreview(
+  page: Page,
+  emailAccountId: string,
+  expected: boolean,
+) {
+  await expect
+    .poll(async () => {
+      const response = await page.request.get("/api/mail/settings", {
+        headers: { [EMAIL_ACCOUNT_HEADER]: emailAccountId },
+      });
+      const settings = (await response.json()) as MailSettingsResponse;
+      return settings.expandedPreview;
+    })
+    .toBe(expected);
+}
 
 async function rowHeight(row: Locator) {
   const box = await row.boundingBox();

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -8,6 +8,7 @@ import {
   SearchIcon,
   SparklesIcon,
   TagIcon,
+  TextIcon,
   Trash2Icon,
   XIcon,
 } from "lucide-react";
@@ -21,12 +22,14 @@ import { cn } from "@/utils";
 export type ListToolbarProps = {
   layout: MailLayoutMode;
   showLayoutToggle?: boolean;
+  expandedPreview: boolean;
   /** Committed search query. Only meaningful when `onSearch` is provided. */
   searchQuery?: string;
   /** When provided, the toolbar shows a real mail search input. */
   onSearch?: (query: string) => void;
   onOpenSearch: () => void;
   onToggleLayout: () => void;
+  onTogglePreview: () => void;
   onToggleAssistant: () => void;
   showSidebarToggle?: boolean;
   selectedCount: number;
@@ -40,10 +43,12 @@ export type ListToolbarProps = {
 export function ListToolbar({
   layout,
   showLayoutToggle = true,
+  expandedPreview,
   searchQuery = "",
   onSearch,
   onOpenSearch,
   onToggleLayout,
+  onTogglePreview,
   onToggleAssistant,
   showSidebarToggle = false,
   selectedCount,
@@ -141,6 +146,26 @@ export function ListToolbar({
           <Kbd>{getShortcutHint("commandPalette")}</Kbd>
         </button>
       )}
+
+      {selectedCount === 0 ? (
+        <Tooltip
+          content={`${expandedPreview ? "Shorten" : "Expand"} preview text (${getShortcutHint("togglePreview")})`}
+        >
+          <button
+            type="button"
+            onClick={onTogglePreview}
+            aria-label="Expand or shorten preview text"
+            aria-pressed={expandedPreview}
+            className={cn(
+              toolbarButton,
+              "w-8 justify-center px-0",
+              expandedPreview && "bg-muted text-foreground",
+            )}
+          >
+            <TextIcon className="size-3.5" />
+          </button>
+        </Tooltip>
+      ) : null}
 
       {showLayoutToggle && selectedCount === 0 ? (
         <Tooltip

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -91,6 +91,7 @@ import {
   setDefaultMailSplitsAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
+import type { UpdateMailPreferencesBody } from "@/utils/actions/mail-split.validation";
 import {
   createLabelAction,
   deleteMailboxItemAction,
@@ -218,40 +219,56 @@ export function MailShell() {
   const accountLayout: MailLayoutMode =
     settings?.layout === MailLayout.SPLIT ? "split" : "list";
   const layout = isAllAccounts ? "list" : accountLayout;
+  const expandedPreview = settings?.expandedPreview ?? false;
 
   // Written through the SWR cache rather than mirrored in local state, so the
   // preference has one source of truth and every reader sees the new value.
-  const toggleLayout = useCallback(() => {
-    if (!settings) return;
+  const updatePreferences = useCallback(
+    (preferences: UpdateMailPreferencesBody) => {
+      if (!settings) return;
+      const loadedSettings = settings;
 
-    const next = layout === "split" ? MailLayout.LIST : MailLayout.SPLIT;
-    const loadedSettings = settings;
+      mutateSettings(
+        async (current) => {
+          const result = await updateMailPreferencesAction(
+            emailAccountId,
+            preferences,
+          );
+          // Thrown so SWR rolls the optimistic value back rather than leaving
+          // the UI showing a preference the server never accepted.
+          if (result?.serverError || result?.validationErrors)
+            throw new Error(getActionErrorMessage(result));
+          return { ...(current ?? loadedSettings), ...preferences };
+        },
+        {
+          optimisticData: (current) => ({
+            ...(current ?? loadedSettings),
+            ...preferences,
+          }),
+          revalidate: false,
+          rollbackOnError: true,
+        },
+      ).catch((error) => {
+        toast.error(
+          error instanceof Error ? error.message : "Couldn't save that",
+        );
+      });
+    },
+    [emailAccountId, mutateSettings, settings],
+  );
 
-    mutateSettings(
-      async (current) => {
-        const result = await updateMailPreferencesAction(emailAccountId, {
-          layout: next,
-        });
-        // Thrown so SWR rolls the optimistic value back rather than leaving
-        // the UI showing a preference the server never accepted.
-        if (result?.serverError || result?.validationErrors)
-          throw new Error(getActionErrorMessage(result));
-        return { ...(current ?? loadedSettings), layout: next };
-      },
-      {
-        optimisticData: (current) => ({
-          ...(current ?? loadedSettings),
-          layout: next,
-        }),
-        revalidate: false,
-        rollbackOnError: true,
-      },
-    ).catch((error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Couldn't save that",
-      );
-    });
-  }, [emailAccountId, layout, mutateSettings, settings]);
+  const toggleLayout = useCallback(
+    () =>
+      updatePreferences({
+        layout: layout === "split" ? MailLayout.LIST : MailLayout.SPLIT,
+      }),
+    [layout, updatePreferences],
+  );
+
+  const togglePreview = useCallback(
+    () => updatePreferences({ expandedPreview: !expandedPreview }),
+    [expandedPreview, updatePreferences],
+  );
 
   // A sidebar selection scopes the whole list, which replaces the split tabs —
   // splits are a way of slicing the inbox, not of slicing an arbitrary view.
@@ -984,6 +1001,7 @@ export function MailShell() {
           : undefined,
       undo: () => undo(),
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
+      togglePreview,
       help: () => setIsHelpOpen(true),
     };
   })();
@@ -1286,6 +1304,8 @@ export function MailShell() {
               onSearch={isAllAccounts ? undefined : setSearch}
               onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
+              expandedPreview={expandedPreview}
+              onTogglePreview={togglePreview}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
               showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
@@ -1323,6 +1343,7 @@ export function MailShell() {
               <ThreadList
                 threads={threads}
                 layout={layout}
+                expandedPreview={expandedPreview}
                 userEmail={userEmail}
                 userLabels={isAllAccounts ? NO_LABELS : userLabels}
                 labelsByAccount={labelsByAccount}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -20,6 +20,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 export type ThreadListProps = {
   threads: ListThread[];
   layout: MailLayoutMode;
+  expandedPreview: boolean;
   userEmail: string;
   userLabels: EmailLabels;
   labelsByAccount?: Record<string, EmailLabels>;
@@ -41,6 +42,7 @@ export type ThreadListProps = {
 export function ThreadList({
   threads,
   layout,
+  expandedPreview,
   userEmail,
   userLabels,
   labelsByAccount,
@@ -138,6 +140,7 @@ export function ThreadList({
                   <ThreadRow
                     hasAnySelection={selectionEnabled && selectedCount > 0}
                     compact={isMobile}
+                    expandedPreview={expandedPreview}
                     index={index}
                     isFocused={index === focusedIndex}
                     isSelected={selectionEnabled && isSelected(threadKey)}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -37,6 +37,8 @@ export type ThreadRowProps = {
   /** Keeps every checkbox visible once the list has a selection. */
   hasAnySelection: boolean;
   compact?: boolean;
+  /** Wraps the snippet onto its own line so more of it is readable. */
+  expandedPreview?: boolean;
   selectionEnabled?: boolean;
   onOpen: (index: number) => void;
   onToggleSelect: (index: number) => void;
@@ -54,6 +56,7 @@ export const ThreadRow = memo(function ThreadRow({
   isSelected,
   hasAnySelection,
   compact = false,
+  expandedPreview = false,
   selectionEnabled = true,
   onOpen,
   onToggleSelect,
@@ -98,7 +101,12 @@ export const ThreadRow = memo(function ThreadRow({
   }
 
   const leadingIndicator = (
-    <span className={cn("relative size-3.5 shrink-0", !isWide && "mt-0.5")}>
+    <span
+      className={cn(
+        "relative size-3.5 shrink-0",
+        (!isWide || expandedPreview) && "mt-0.5",
+      )}
+    >
       {selectionEnabled ? (
         <Checkbox
           aria-label={`Select conversation with ${participantSummary}`}
@@ -145,6 +153,27 @@ export const ThreadRow = memo(function ThreadRow({
         {messageCount}
       </span>
     ) : null;
+  // The chips and subject sit on the snippet's line in short mode and above it
+  // in expanded mode, so they're built once and placed by each layout.
+  const headline = (
+    <>
+      {account ? <AccountAvatar account={account} /> : null}
+      {chips.map((label) => (
+        <MailLabelChip color={label.color} key={label.id} name={label.name} />
+      ))}
+      <span
+        className={cn(
+          "truncate whitespace-nowrap text-sm",
+          expandedPreview ? "min-w-0" : "max-w-[46%] shrink-0",
+          isUnread
+            ? "font-semibold text-foreground"
+            : "font-normal text-foreground",
+        )}
+      >
+        {subject}
+      </span>
+    </>
+  );
   const participantLine = (
     <>
       <span
@@ -167,7 +196,10 @@ export const ThreadRow = memo(function ThreadRow({
       className={cn(
         "group relative flex cursor-pointer border-b border-border/60 outline-none",
         isWide
-          ? "items-center gap-2.5 py-2.5 pr-5 pl-3"
+          ? cn(
+              "gap-2.5 py-2.5 pr-5 pl-3",
+              expandedPreview ? "items-start" : "items-center",
+            )
           : "items-start gap-2 px-3.5 py-2.5",
         rowBackground({ isSelected, isFocused }),
         isFocused &&
@@ -194,29 +226,23 @@ export const ThreadRow = memo(function ThreadRow({
           <div className="flex w-48 shrink-0 items-baseline gap-1 overflow-hidden whitespace-nowrap">
             {participantLine}
           </div>
-          <div className="flex min-w-0 flex-1 items-center gap-2.5">
-            {account ? <AccountAvatar account={account} /> : null}
-            {chips.map((label) => (
-              <MailLabelChip
-                color={label.color}
-                key={label.id}
-                name={label.name}
-              />
-            ))}
-            <span
-              className={cn(
-                "max-w-[46%] shrink-0 truncate whitespace-nowrap text-sm",
-                isUnread
-                  ? "font-semibold text-foreground"
-                  : "font-normal text-foreground",
-              )}
-            >
-              {subject}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-muted-foreground text-sm">
-              {snippet}
-            </span>
-          </div>
+          {expandedPreview ? (
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <div className="flex min-w-0 items-center gap-2.5">
+                {headline}
+              </div>
+              <span className="line-clamp-2 text-muted-foreground text-sm">
+                {snippet}
+              </span>
+            </div>
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-2.5">
+              {headline}
+              <span className="min-w-0 flex-1 truncate text-muted-foreground text-sm">
+                {snippet}
+              </span>
+            </div>
+          )}
           <div className="w-16 shrink-0 text-right">{date}</div>
         </>
       ) : (
@@ -235,7 +261,12 @@ export const ThreadRow = memo(function ThreadRow({
           >
             {subject}
           </div>
-          <div className="truncate text-muted-foreground text-xs">
+          <div
+            className={cn(
+              "text-muted-foreground text-xs",
+              expandedPreview ? "line-clamp-3" : "truncate",
+            )}
+          >
             {snippet}
           </div>
           {account ? (

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -11,6 +11,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
       where: { id: emailAccountId },
       select: {
         mailLayout: true,
+        mailExpandedPreview: true,
         mailSplits: {
           // createdAt breaks ties so tab order can't shuffle between requests
           orderBy: [{ order: "asc" }, { createdAt: "asc" }],
@@ -29,6 +30,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
 
   return {
     layout: emailAccount?.mailLayout ?? null,
+    expandedPreview: emailAccount?.mailExpandedPreview ?? false,
     splits: emailAccount?.mailSplits ?? [],
     defaultSplits,
   };

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -301,6 +301,13 @@ const SHORTCUT_DEFINITIONS = [
     label: "List view / split view",
   },
   {
+    id: "togglePreview",
+    keys: ["shift+p"],
+    scope: "mail",
+    group: "View",
+    label: "Short / expanded preview text",
+  },
+  {
     id: "help",
     keys: ["shift+?", "?"],
     display: ["?"],

--- a/apps/web/prisma/migrations/20260907120000_add_mail_expanded_preview/migration.sql
+++ b/apps/web/prisma/migrations/20260907120000_add_mail_expanded_preview/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "EmailAccount"
+ADD COLUMN     "mailExpandedPreview" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -157,7 +157,8 @@ model EmailAccount {
   allowHiddenAiDraftLinks   Boolean              @default(false)
   rulesRevision             Int                  @default(0)
 
-  mailLayout MailLayout @default(LIST)
+  mailLayout          MailLayout @default(LIST)
+  mailExpandedPreview Boolean    @default(false)
 
   includeInAllAccounts Boolean @default(true)
 

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -117,12 +117,22 @@ export const setDefaultMailSplitsAction = actionClient
 export const updateMailPreferencesAction = actionClient
   .metadata({ name: "updateMailPreferences" })
   .inputSchema(updateMailPreferencesBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { layout } }) => {
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { mailLayout: layout },
-    });
-  });
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { layout, expandedPreview },
+    }) => {
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: {
+          ...(layout === undefined ? {} : { mailLayout: layout }),
+          ...(expandedPreview === undefined
+            ? {}
+            : { mailExpandedPreview: expandedPreview }),
+        },
+      });
+    },
+  );
 
 async function createMailSplitOrThrow(
   data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">,

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -53,10 +53,16 @@ export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
 export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
-export const updateMailPreferencesBody = z.object({
-  layout: z.nativeEnum(MailLayout).optional(),
-  expandedPreview: z.boolean().optional(),
-});
+export const updateMailPreferencesBody = z
+  .object({
+    layout: z.nativeEnum(MailLayout).optional(),
+    expandedPreview: z.boolean().optional(),
+  })
+  // Every field is optional so a caller can update one preference without
+  // restating the others, which would otherwise also accept an empty update.
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: "Provide at least one preference",
+  });
 export type UpdateMailPreferencesBody = z.infer<
   typeof updateMailPreferencesBody
 >;

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -54,7 +54,8 @@ export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
 export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
 export const updateMailPreferencesBody = z.object({
-  layout: z.nativeEnum(MailLayout),
+  layout: z.nativeEnum(MailLayout).optional(),
+  expandedPreview: z.boolean().optional(),
 });
 export type UpdateMailPreferencesBody = z.infer<
   typeof updateMailPreferencesBody


### PR DESCRIPTION
The conversation list truncated the snippet to a few words on a line shared with the subject. A toolbar toggle now wraps the snippet onto its own line so the full provider preview is readable.

- Toolbar button next to the layout toggle, plus a `Shift+P` shortcut listed under **View** in the shortcuts dialog
- Snippet clamps to two lines in the wide list and three in the narrow split/mobile column; short mode is unchanged
- Preference is stored per email account (`EmailAccount.mailExpandedPreview` + migration) and written optimistically through the SWR cache, alongside the existing layout preference
- Both preference toggles now share one update helper instead of duplicating the optimistic-mutate block
- Adds an emulated Playwright case covering the toggle, the row growing, and the preference surviving a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mail preference for compact or expanded message previews.
  - Expanded previews show more message text while preserving conversation context.
  - Added a toolbar control and keyboard shortcut to switch preview length.
  - Preview preferences persist across page reloads and update with clear feedback.

- **Bug Fixes**
  - Improved preference handling when saving settings fails.
  - Added coverage for toggling, layout changes, persistence, and restoring compact previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->