### PR TITLE
Mail: Add theme selection to Command K

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/theme.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/theme.spec.ts
@@ -32,11 +32,13 @@ test("Command K changes the mail theme and remembers it after reload", async ({
     "Theme commands in dark mode",
   );
   await palette.getByRole("option", { name: "Set Theme: Light" }).click();
+  await expect(palette).toBeHidden();
   await expect(page.locator("html")).toHaveClass(/light/);
 
   await page.keyboard.press(`${commandModifier}+KeyK`);
   await palette.getByPlaceholder("Type a command or search...").fill("system");
   await palette.getByRole("option", { name: "Set Theme: System" }).click();
+  await expect(palette).toBeHidden();
   await expect(page.locator("html")).toHaveClass(/light/);
   await page.emulateMedia({ colorScheme: "dark" });
   await expect(page.locator("html")).toHaveClass(/dark/);

--- a/apps/web/__tests__/playwright/emulated/mail/theme.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/theme.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail } from "./mail-test-helpers";
+
+const commandModifier = process.platform === "darwin" ? "Meta" : "Control";
+
+test("Command K changes the mail theme and remembers it after reload", async ({
+  page,
+}, testInfo) => {
+  await page.emulateMedia({ colorScheme: "light" });
+  await openMail(page);
+
+  const palette = page.getByRole("dialog");
+  await page.keyboard.press(`${commandModifier}+KeyK`);
+  await palette.getByPlaceholder("Type a command or search...").fill("dark");
+  await palette.getByRole("option", { name: "Set Theme: Dark" }).click();
+  await expect(palette).toBeHidden();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await capturePlaywrightCheckpoint(page, testInfo, "Mail in dark mode");
+
+  await page.reload();
+  await expect(
+    page.getByRole("listbox", { name: "Conversations" }),
+  ).toBeVisible();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await page.keyboard.press(`${commandModifier}+KeyK`);
+  await palette.getByPlaceholder("Type a command or search...").fill("theme");
+  await capturePlaywrightCheckpoint(
+    palette,
+    testInfo,
+    "Theme commands in dark mode",
+  );
+  await palette.getByRole("option", { name: "Set Theme: Light" }).click();
+  await expect(page.locator("html")).toHaveClass(/light/);
+
+  await page.keyboard.press(`${commandModifier}+KeyK`);
+  await palette.getByPlaceholder("Type a command or search...").fill("system");
+  await palette.getByRole("option", { name: "Set Theme: System" }).click();
+  await expect(page.locator("html")).toHaveClass(/light/);
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(page.locator("html")).toHaveClass(/dark/);
+});

--- a/apps/web/components/CommandK.tsx
+++ b/apps/web/components/CommandK.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { ArrowLeftIcon, Loader2Icon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  Loader2Icon,
+  MonitorIcon,
+  MoonIcon,
+  SunIcon,
+} from "lucide-react";
+import { useTheme } from "next-themes";
 import { useAtom, useAtomValue } from "jotai";
 import { buildMailCommandPalette } from "@/app/(app)/[emailAccountId]/mail/mail-command-palette";
 import { buildSnoozeCommandPalette } from "@/app/(app)/[emailAccountId]/mail/snooze-command-palette";
@@ -107,6 +114,7 @@ function CommandPaletteContent({
   const [open, setOpen] = useAtom(commandPaletteOpenAtom);
   const [page, setPage] = React.useState<"root" | "snooze">("root");
   const [search, setSearch] = React.useState("");
+  const { setTheme } = useTheme();
 
   const { emailAccountId } = useAccount();
   const { threadId, showEmail } = displayedEmail;
@@ -225,7 +233,19 @@ function CommandPaletteContent({
           ...shortcutCommands.filter((command) => command.id === "compose"),
         ]
       : shortcutCommands;
-    allCommands = [...actionCommands, ...commands];
+    const themeCommands: Command[] = [
+      { theme: "dark", label: "Dark", icon: MoonIcon },
+      { theme: "light", label: "Light", icon: SunIcon },
+      { theme: "system", label: "System", icon: MonitorIcon },
+    ].map(({ theme, label, icon }) => ({
+      id: `theme-${theme}`,
+      label: `Set Theme: ${label}`,
+      icon,
+      section: "settings",
+      keywords: ["theme", "appearance", "mode", theme],
+      action: () => setTheme(theme),
+    }));
+    allCommands = [...actionCommands, ...commands, ...themeCommands];
   }
 
   const filteredCommands =


### PR DESCRIPTION
Adds Dark, Light, and System appearance commands to Command K, including the mail client, using the existing saved theme preference.

- Adds browser coverage for theme changes, reload persistence, and system appearance updates.
- Validation: build, unit tests, and the theme browser test pass in CI; dark-mode screenshots inspected. The browser test waits for the dialog to close before reopening it.
