### PR TITLE
mail: Keep outgoing replies visible during thread refresh

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -422,7 +422,7 @@ test("opens and sends a reply from the reader with Enter", async ({
   await page.keyboard.press("Escape");
 
   await sendButton.hover();
-  const sendTooltip = page.getByRole("tooltip");
+  const sendTooltip = page.getByRole("tooltip", { name: /Send and mark done/ });
   await expect(sendTooltip).toContainText("Send and mark done");
   await expect(sendTooltip.locator("kbd")).toHaveText([
     "⌘",

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -432,9 +432,44 @@ test("opens and sends a reply from the reader with Enter", async ({
     "enter",
   ]);
   await capturePlaywrightCheckpoint(page, testInfo, "protected-quoted-reply");
+  const releaseSentRefresh = Promise.withResolvers<void>();
+  await page.route("**/api/mobile/mailbox-sync", async (route) => {
+    await releaseSentRefresh.promise;
+    await route.continue();
+  });
+  await page.route(
+    "**/api/threads/thr_playwright_reply?includeDrafts=true",
+    async (route) => {
+      const response = await route.fetch();
+      await releaseSentRefresh.promise;
+      await route.fulfill({ response });
+    },
+  );
   await sendButton.click();
 
-  await expect(replyEditor).toHaveCount(0);
+  const localReply = page.locator('[data-thread-message-id^="outbox:"]');
+  try {
+    await expect(replyEditor).toHaveCount(0);
+    await expect(
+      localReply
+        .frameLocator('iframe[title="Email content preview"]')
+        .getByText(replyBody, { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole("region", { name: "Reply delivery status" })
+        .getByText("Reply sent", { exact: true }),
+    ).toBeVisible();
+    await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "reply-awaiting-thread-refresh",
+    );
+  } finally {
+    releaseSentRefresh.resolve();
+  }
+  await expect(localReply).toHaveCount(0);
   await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
   await capturePlaywrightCheckpoint(page, testInfo, "reply-sent-in-thread");
 });

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -702,6 +702,11 @@ function ComposeEmailFormContent({
                           "Reply queued, but its local draft copy could not be cleared.",
                       });
                     }
+                    await mutate([
+                      "thread-deliveries",
+                      selectedEmailAccountId,
+                      readerThreadId,
+                    ]);
                     onClose?.();
                   }
                 : undefined,

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -32,9 +32,8 @@ import {
 import { getActionErrorMessage } from "@/utils/error";
 import { getLatestScheduledSendId } from "@/components/email-list/latest-scheduled-send";
 import { EmailMessage } from "@/components/email-list/EmailMessage";
-import { getOutboxReplyMessage } from "@/components/email-list/outbox-reply";
+import { getOutboxReplyPreview } from "@/components/email-list/outbox-reply";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import type { SendEmailBody } from "@/utils/types/mail";
 
 export function ThreadDeliveryStatus({
   emailAccountId,
@@ -157,35 +156,33 @@ export function ThreadDeliveryStatus({
         .filter((row, index) => row.status !== "succeeded" || index === 0)
         .map((row) => ({
           row,
-          message: getOutboxReplyMessage(row, messageIds, userEmail),
-          attachments:
-            (row.payload as { email: SendEmailBody }).email.attachments ?? [],
+          preview: getOutboxReplyPreview(row, messageIds, userEmail),
         }))
-        .filter(({ row, message }) => row.status !== "succeeded" || message)
+        .filter(({ row, preview }) => row.status !== "succeeded" || preview)
         .reverse(),
     [outbox, messageIds, userEmail],
   );
   return (
     <section className="space-y-1" aria-label="Reply delivery status">
-      {visible.map(({ row, message, attachments }) => (
+      {visible.map(({ row, preview }) => (
         <div key={row.id}>
-          {message && (
+          {preview && (
             <>
               <ul>
                 <EmailMessage
-                  message={message}
+                  message={preview.message}
                   expanded
                   showReplyButton={false}
                   refetch={refetch}
                   onSendSuccess={refetch}
                 />
               </ul>
-              {attachments.length > 0 && (
+              {preview.attachments.length > 0 && (
                 <ul
                   aria-label="Attachments"
                   className="flex flex-wrap gap-3 px-2 sm:pl-14 text-sm"
                 >
-                  {attachments.map((attachment, index) => (
+                  {preview.attachments.map((attachment, index) => (
                     <li key={attachment.id ?? index}>
                       <a
                         className="underline underline-offset-4"

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   AlertCircleIcon,
   CheckIcon,
@@ -25,6 +31,10 @@ import {
 } from "@/utils/actions/scheduled-email";
 import { getActionErrorMessage } from "@/utils/error";
 import { getLatestScheduledSendId } from "@/components/email-list/latest-scheduled-send";
+import { EmailMessage } from "@/components/email-list/EmailMessage";
+import { getOutboxReplyMessage } from "@/components/email-list/outbox-reply";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import type { SendEmailBody } from "@/utils/types/mail";
 
 export function ThreadDeliveryStatus({
   emailAccountId,
@@ -41,6 +51,7 @@ export function ThreadDeliveryStatus({
   refetch: () => void;
   canEditReply: boolean;
 }) {
+  const { userEmail } = useAccount();
   const online = useSyncExternalStore(
     subscribeToConnectivity,
     () => navigator.onLine,
@@ -140,70 +151,106 @@ export function ThreadDeliveryStatus({
     if (result?.serverError || result?.validationErrors)
       throw new Error(getActionErrorMessage(result));
   };
-  const visible = outbox.filter(
-    (row, index) =>
-      row.status !== "succeeded" ||
-      (index === 0 &&
-        !messageIds.includes(
-          (row.result as { messageId?: string } | undefined)?.messageId ?? "",
-        )),
+  const visible = useMemo(
+    () =>
+      outbox
+        .filter((row, index) => row.status !== "succeeded" || index === 0)
+        .map((row) => ({
+          row,
+          message: getOutboxReplyMessage(row, messageIds, userEmail),
+          attachments:
+            (row.payload as { email: SendEmailBody }).email.attachments ?? [],
+        }))
+        .filter(({ row, message }) => row.status !== "succeeded" || message)
+        .reverse(),
+    [outbox, messageIds, userEmail],
   );
   return (
     <section className="space-y-1" aria-label="Reply delivery status">
-      {visible.map((row) => (
-        <div
-          key={row.id}
-          className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 py-2 text-xs text-muted-foreground"
-        >
-          <p
-            role="status"
-            className="flex items-center gap-2 font-medium text-foreground"
-          >
-            <DeliveryIcon
-              status={
-                online && row.status === "pending" ? "processing" : row.status
-              }
-              offline={!online}
-            />
-            {deliveryLabel(row, online)}
-          </p>
-          {row.status !== "succeeded" && row.lastError && (
-            <p className="order-last basis-full pl-5 text-muted-foreground">
-              {row.lastError}
-            </p>
+      {visible.map(({ row, message, attachments }) => (
+        <div key={row.id}>
+          {message && (
+            <>
+              <ul>
+                <EmailMessage
+                  message={message}
+                  expanded
+                  showReplyButton={false}
+                  refetch={refetch}
+                  onSendSuccess={refetch}
+                />
+              </ul>
+              {attachments.length > 0 && (
+                <ul
+                  aria-label="Attachments"
+                  className="flex flex-wrap gap-3 px-2 sm:pl-14 text-sm"
+                >
+                  {attachments.map((attachment, index) => (
+                    <li key={attachment.id ?? index}>
+                      <a
+                        className="underline underline-offset-4"
+                        download={attachment.filename}
+                        href={`data:${attachment.contentType};base64,${attachment.content}`}
+                      >
+                        {attachment.filename}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
-          {row.status === "uncertain" && (
-            <a
-              className="underline underline-offset-4"
-              href={`/${emailAccountId}/mail?type=sent`}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 py-2 text-xs text-muted-foreground">
+            <p
+              role="status"
+              className="flex items-center gap-2 font-medium text-foreground"
             >
-              Check Sent
-            </a>
-          )}
-          {canEditReply &&
-            !(online && row.status === "pending") &&
-            ["pending", "retry_wait", "blocked_auth", "failed"].includes(
-              row.status,
-            ) && (
-              <Button
-                disabled={busy}
-                type="button"
-                variant="ghost"
-                className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
-                size="sm"
-                onClick={() =>
-                  act(async () => {
-                    const restored = await restoreReplyFromOutbox(
-                      row.id,
-                      emailAccountId,
-                    );
-                    onEditReply(restored.messageId, restored.mode);
-                  })
+              <DeliveryIcon
+                status={
+                  online && row.status === "pending" ? "processing" : row.status
                 }
-              >
-                Edit reply
-              </Button>
+                offline={!online}
+              />
+              {deliveryLabel(row, online)}
+            </p>
+            {row.status !== "succeeded" && row.lastError && (
+              <p className="order-last basis-full pl-5 text-muted-foreground">
+                {row.lastError}
+              </p>
             )}
+            {row.status === "uncertain" && (
+              <a
+                className="underline underline-offset-4"
+                href={`/${emailAccountId}/mail?type=sent`}
+              >
+                Check Sent
+              </a>
+            )}
+            {canEditReply &&
+              !(online && row.status === "pending") &&
+              ["pending", "retry_wait", "blocked_auth", "failed"].includes(
+                row.status,
+              ) && (
+                <Button
+                  disabled={busy}
+                  type="button"
+                  variant="ghost"
+                  className="h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
+                  size="sm"
+                  onClick={() =>
+                    act(async () => {
+                      const restored = await restoreReplyFromOutbox(
+                        row.id,
+                        emailAccountId,
+                      );
+                      onEditReply(restored.messageId, restored.mode);
+                    })
+                  }
+                >
+                  Edit reply
+                </Button>
+              )}
+          </div>
         </div>
       ))}
       {data?.scheduledEmails

--- a/apps/web/components/email-list/outbox-reply.test.ts
+++ b/apps/web/components/email-list/outbox-reply.test.ts
@@ -1,0 +1,103 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { StoredMailMutation } from "@/utils/email-cache/database";
+import { getOutboxReplyMessage } from "./outbox-reply";
+
+describe("getOutboxReplyMessage", () => {
+  it.each([
+    "pending",
+    "processing",
+    "succeeded",
+    "failed",
+    "uncertain",
+  ] as const)("keeps the submitted reply visible while delivery is %s", (status) => {
+    const message = getOutboxReplyMessage(
+      { ...reply, status },
+      ["original-message"],
+      "sender@example.com",
+    );
+    expect(message?.textHtml).toBe("<p>Reply body</p>");
+    expect(message?.headers).toMatchObject({
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      cc: "copy@example.com",
+    });
+  });
+
+  it("replaces the local copy only when its provider message is present", () => {
+    const sent = {
+      ...reply,
+      status: "succeeded" as const,
+      result: { messageId: "sent-message", threadId: reply.threadId },
+    };
+    expect(
+      getOutboxReplyMessage(sent, ["original-message"], "sender@example.com"),
+    ).toBeDefined();
+    expect(
+      getOutboxReplyMessage(sent, ["sent-message"], "sender@example.com"),
+    ).toBeUndefined();
+  });
+
+  it("does not leave a sent forward in the original thread", () => {
+    expect(
+      getOutboxReplyMessage(
+        {
+          ...reply,
+          status: "succeeded",
+          result: { messageId: "sent-message", threadId: "other-thread" },
+        },
+        [],
+        "sender@example.com",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("renders inline images from the submitted attachment bytes", () => {
+    const message = getOutboxReplyMessage(
+      {
+        ...reply,
+        payload: {
+          email: {
+            ...reply.payload.email,
+            messageHtml: '<p>Reply<img src="cid:image@example.com"></p>',
+            attachments: [
+              {
+                filename: "image.png",
+                contentType: "image/png",
+                content: "aW1hZ2U=",
+                disposition: "inline",
+                contentId: "image@example.com",
+              },
+            ],
+          },
+        },
+      },
+      [],
+      "sender@example.com",
+    );
+    expect(message?.textHtml).toContain('src="data:image/png;base64,aW1hZ2U="');
+  });
+});
+
+const reply = {
+  id: "queued-reply",
+  batchId: "batch",
+  emailAccountId: "account",
+  threadId: "thread",
+  messageIds: ["original-message"],
+  kind: "reply",
+  status: "pending",
+  attempts: 0,
+  nextAttemptAt: 0,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  payload: {
+    email: {
+      to: "recipient@example.com",
+      cc: "copy@example.com",
+      subject: "Re: Message",
+      messageHtml: "<p>Reply body</p>",
+    },
+  },
+} satisfies StoredMailMutation;

--- a/apps/web/components/email-list/outbox-reply.test.ts
+++ b/apps/web/components/email-list/outbox-reply.test.ts
@@ -2,9 +2,32 @@
 
 import { describe, expect, it } from "vitest";
 import type { StoredMailMutation } from "@/utils/email-cache/database";
-import { getOutboxReplyMessage } from "./outbox-reply";
+import { getOutboxReplyPreview } from "./outbox-reply";
 
-describe("getOutboxReplyMessage", () => {
+describe("getOutboxReplyPreview", () => {
+  it.each([
+    null,
+    {},
+    { email: null },
+    { email: {} },
+  ])("ignores invalid persisted reply data: %j", (payload) => {
+    expect(
+      getOutboxReplyPreview({ ...reply, payload }, [], "sender@example.com"),
+    ).toBeUndefined();
+  });
+
+  it("ignores malformed attachment data", () => {
+    expect(
+      getOutboxReplyPreview(
+        {
+          ...reply,
+          payload: { email: { ...reply.payload.email, attachments: [null] } },
+        },
+        [],
+        "sender@example.com",
+      ),
+    ).toBeUndefined();
+  });
   it.each([
     "pending",
     "processing",
@@ -12,13 +35,13 @@ describe("getOutboxReplyMessage", () => {
     "failed",
     "uncertain",
   ] as const)("keeps the submitted reply visible while delivery is %s", (status) => {
-    const message = getOutboxReplyMessage(
+    const preview = getOutboxReplyPreview(
       { ...reply, status },
       ["original-message"],
       "sender@example.com",
     );
-    expect(message?.textHtml).toBe("<p>Reply body</p>");
-    expect(message?.headers).toMatchObject({
+    expect(preview?.message.textHtml).toBe("<p>Reply body</p>");
+    expect(preview?.message.headers).toMatchObject({
       from: "sender@example.com",
       to: "recipient@example.com",
       cc: "copy@example.com",
@@ -32,16 +55,16 @@ describe("getOutboxReplyMessage", () => {
       result: { messageId: "sent-message", threadId: reply.threadId },
     };
     expect(
-      getOutboxReplyMessage(sent, ["original-message"], "sender@example.com"),
+      getOutboxReplyPreview(sent, ["original-message"], "sender@example.com"),
     ).toBeDefined();
     expect(
-      getOutboxReplyMessage(sent, ["sent-message"], "sender@example.com"),
+      getOutboxReplyPreview(sent, ["sent-message"], "sender@example.com"),
     ).toBeUndefined();
   });
 
   it("does not leave a sent forward in the original thread", () => {
     expect(
-      getOutboxReplyMessage(
+      getOutboxReplyPreview(
         {
           ...reply,
           status: "succeeded",
@@ -54,7 +77,9 @@ describe("getOutboxReplyMessage", () => {
   });
 
   it("renders inline images from the submitted attachment bytes", () => {
-    const message = getOutboxReplyMessage(
+    const imageContent =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+    const preview = getOutboxReplyPreview(
       {
         ...reply,
         payload: {
@@ -65,7 +90,7 @@ describe("getOutboxReplyMessage", () => {
               {
                 filename: "image.png",
                 contentType: "image/png",
-                content: "aW1hZ2U=",
+                content: imageContent,
                 disposition: "inline",
                 contentId: "image@example.com",
               },
@@ -76,7 +101,12 @@ describe("getOutboxReplyMessage", () => {
       [],
       "sender@example.com",
     );
-    expect(message?.textHtml).toContain('src="data:image/png;base64,aW1hZ2U="');
+    expect(preview?.message.textHtml).toContain(
+      `src="data:image/png;base64,${imageContent}"`,
+    );
+    expect(preview?.attachments).toEqual([
+      expect.objectContaining({ filename: "image.png", content: imageContent }),
+    ]);
   });
 });
 

--- a/apps/web/components/email-list/outbox-reply.ts
+++ b/apps/web/components/email-list/outbox-reply.ts
@@ -1,0 +1,55 @@
+import type { StoredMailMutation } from "@/utils/email-cache/database";
+import { rewriteInlineImageSources } from "@/utils/email/inline-images";
+import type { ParsedMessage } from "@/utils/types";
+import type { SendEmailBody } from "@/utils/types/mail";
+
+export function getOutboxReplyMessage(
+  row: StoredMailMutation,
+  messageIds: string[],
+  userEmail: string,
+): ParsedMessage | undefined {
+  const result = row.result as
+    | { messageId?: string; threadId?: string }
+    | undefined;
+  if (
+    row.kind !== "reply" ||
+    (result?.messageId && messageIds.includes(result.messageId)) ||
+    (result?.threadId && result.threadId !== row.threadId)
+  )
+    return;
+
+  const { email } = row.payload as { email: SendEmailBody };
+  const date = new Date(row.createdAt).toISOString();
+  const inlineSources = Object.fromEntries(
+    (email.attachments ?? []).flatMap((attachment) =>
+      attachment.disposition === "inline" && attachment.contentId
+        ? [
+            [
+              attachment.contentId,
+              `data:${attachment.contentType};base64,${attachment.content}`,
+            ],
+          ]
+        : [],
+    ),
+  );
+  return {
+    id: `outbox:${row.id}`,
+    threadId: row.threadId,
+    date,
+    internalDate: String(row.createdAt),
+    headers: {
+      from: email.from || userEmail,
+      to: email.to,
+      cc: email.cc,
+      bcc: email.bcc,
+      subject: email.subject,
+      date,
+    },
+    subject: email.subject,
+    textHtml: rewriteInlineImageSources(email.messageHtml, inlineSources),
+    snippet: "",
+    historyId: "",
+    inline: [],
+    labelIds: row.status === "succeeded" ? ["SENT"] : [],
+  };
+}

--- a/apps/web/components/email-list/outbox-reply.ts
+++ b/apps/web/components/email-list/outbox-reply.ts
@@ -1,13 +1,13 @@
 import type { StoredMailMutation } from "@/utils/email-cache/database";
 import { rewriteInlineImageSources } from "@/utils/email/inline-images";
 import type { ParsedMessage } from "@/utils/types";
-import type { SendEmailBody } from "@/utils/types/mail";
+import { sendEmailBody } from "@/utils/types/mail";
 
-export function getOutboxReplyMessage(
+export function getOutboxReplyPreview(
   row: StoredMailMutation,
   messageIds: string[],
   userEmail: string,
-): ParsedMessage | undefined {
+) {
   const result = row.result as
     | { messageId?: string; threadId?: string }
     | undefined;
@@ -18,7 +18,15 @@ export function getOutboxReplyMessage(
   )
     return;
 
-  const { email } = row.payload as { email: SendEmailBody };
+  if (
+    !row.payload ||
+    typeof row.payload !== "object" ||
+    !("email" in row.payload)
+  )
+    return;
+  const parsed = sendEmailBody.safeParse(row.payload.email);
+  if (!parsed.success) return;
+  const email = parsed.data;
   const date = new Date(row.createdAt).toISOString();
   const inlineSources = Object.fromEntries(
     (email.attachments ?? []).flatMap((attachment) =>
@@ -32,7 +40,7 @@ export function getOutboxReplyMessage(
         : [],
     ),
   );
-  return {
+  const message: ParsedMessage = {
     id: `outbox:${row.id}`,
     threadId: row.threadId,
     date,
@@ -52,4 +60,5 @@ export function getOutboxReplyMessage(
     inline: [],
     labelIds: row.status === "succeeded" ? ["SENT"] : [],
   };
+  return { message, attachments: email.attachments ?? [] };
 }

--- a/apps/web/components/email-list/outbox-reply.ts
+++ b/apps/web/components/email-list/outbox-reply.ts
@@ -1,7 +1,11 @@
+import { z } from "zod";
 import type { StoredMailMutation } from "@/utils/email-cache/database";
 import { rewriteInlineImageSources } from "@/utils/email/inline-images";
 import type { ParsedMessage } from "@/utils/types";
 import { sendEmailBody } from "@/utils/types/mail";
+
+// Previewing saved data needs field validation, not send-time byte and size checks.
+const outboxReplyEmail = z.object(sendEmailBody.shape);
 
 export function getOutboxReplyPreview(
   row: StoredMailMutation,
@@ -24,7 +28,7 @@ export function getOutboxReplyPreview(
     !("email" in row.payload)
   )
     return;
-  const parsed = sendEmailBody.safeParse(row.payload.email);
+  const parsed = outboxReplyEmail.safeParse(row.payload.email);
   if (!parsed.success) return;
   const email = parsed.data;
   const date = new Date(row.createdAt).toISOString();


### PR DESCRIPTION
Keep outgoing replies visible from the saved outbox message while delivery and thread refresh are in progress, replacing the local copy when the provider message arrives.

- Preserve reply content, inline images, and attachment downloads while retaining delivery status and recovery controls.
- Validate saved reply payloads and cover malformed data, delivery states, duplicate prevention, and delayed thread refresh.
- Validation: 24 focused unit tests, formatting checks, and the delayed-refresh browser regression pass; browser screenshots were inspected after allowing extra time for local sign-in.
