### PR TITLE
fix: consume existing Gmail drafts when sending replies

### DIFF
--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -1,0 +1,113 @@
+import type { gmail_v1 } from "@googleapis/gmail";
+import { describe, expect, it, vi } from "vitest";
+import { sendEmailWithHtml } from "./mail";
+
+vi.mock("@/utils/mail", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/mail")>()),
+  ensureEmailSendingEnabled: vi.fn(),
+}));
+
+const email = {
+  to: "recipient@example.com",
+  subject: "Re: Question",
+  messageHtml: "<p>Edited reply</p>",
+  replyToEmail: {
+    messageId: "draft-message",
+    threadId: "thread-1",
+    headerMessageId: "<draft@example.com>",
+  },
+};
+
+describe("sending a Gmail draft from the reader", () => {
+  it("consumes the existing draft and sends the edited content", async () => {
+    const { gmail, drafts, messages } = createGmail();
+
+    const result = await sendEmailWithHtml(gmail, email);
+
+    expect(result.data).toEqual({ id: "sent-1", threadId: "thread-1" });
+    expect(drafts.send).toHaveBeenCalledWith({
+      userId: "me",
+      requestBody: {
+        id: "r-123",
+        message: { threadId: "thread-1", raw: expect.any(String) },
+      },
+    });
+    const raw = drafts.send.mock.calls[0][0].requestBody.message.raw;
+    expect(Buffer.from(raw, "base64url").toString()).toContain("Edited reply");
+    expect(messages.send).not.toHaveBeenCalled();
+  });
+
+  it("does not send a second copy when sending the draft fails ambiguously", async () => {
+    const { gmail, drafts, messages } = createGmail();
+    drafts.send.mockRejectedValue(
+      Object.assign(new Error("Unavailable"), { code: 503 }),
+    );
+
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow(
+      "Unavailable",
+    );
+
+    expect(drafts.send).toHaveBeenCalledTimes(1);
+    expect(messages.send).not.toHaveBeenCalled();
+  });
+
+  it("does not send a separate message if the draft disappears during lookup", async () => {
+    const { gmail, drafts, messages } = createGmail();
+    drafts.list.mockResolvedValue({ data: { drafts: [] } });
+
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow(/draft/i);
+
+    expect(drafts.send).not.toHaveBeenCalled();
+    expect(messages.send).not.toHaveBeenCalled();
+  });
+
+  it("sends ordinary replies without consuming another draft in the thread", async () => {
+    const { gmail, drafts, messages } = createGmail();
+    messages.get.mockResolvedValue({ data: { labelIds: ["INBOX"] } });
+
+    await sendEmailWithHtml(gmail, email);
+
+    expect(messages.send).toHaveBeenCalledTimes(1);
+    expect(drafts.list).not.toHaveBeenCalled();
+    expect(drafts.send).not.toHaveBeenCalled();
+  });
+
+  it("sends new messages without looking up a draft", async () => {
+    const { gmail, drafts, messages } = createGmail();
+
+    await sendEmailWithHtml(gmail, { ...email, replyToEmail: undefined });
+
+    expect(messages.send).toHaveBeenCalledTimes(1);
+    expect(messages.get).not.toHaveBeenCalled();
+    expect(drafts.list).not.toHaveBeenCalled();
+  });
+});
+
+function createGmail() {
+  const sent = { data: { id: "sent-1", threadId: "thread-1" } };
+  const messages = {
+    get: vi.fn().mockResolvedValue({ data: { labelIds: ["DRAFT"] } }),
+    send: vi.fn().mockResolvedValue(sent),
+  };
+  const drafts = {
+    list: vi.fn().mockResolvedValue({
+      data: { drafts: [{ id: "r-123", message: { id: "draft-message" } }] },
+    }),
+    send: vi
+      .fn<
+        (params: {
+          userId: string;
+          requestBody: {
+            id: string;
+            message: { threadId: string; raw: string };
+          };
+        }) => Promise<typeof sent>
+      >()
+      .mockResolvedValue(sent),
+  };
+  return {
+    gmail: { users: { messages, drafts } } as unknown as gmail_v1.Gmail,
+    messages,
+    drafts,
+  };
+}

--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -1,5 +1,5 @@
 import type { gmail_v1 } from "@googleapis/gmail";
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 import { sendEmailWithHtml } from "./mail";
 
 vi.mock("@/utils/mail", async (importOriginal) => ({
@@ -32,7 +32,10 @@ describe("sending a Gmail draft from the reader", () => {
         message: { threadId: "thread-1", raw: expect.any(String) },
       },
     });
-    const raw = drafts.send.mock.calls[0][0].requestBody.message.raw;
+    const call = drafts.send.mock.calls.at(0);
+    assert.isDefined(call);
+    const [request] = call;
+    const raw = request.requestBody.message.raw;
     expect(Buffer.from(raw, "base64url").toString()).toContain("Edited reply");
     expect(messages.send).not.toHaveBeenCalled();
   });
@@ -56,6 +59,30 @@ describe("sending a Gmail draft from the reader", () => {
     drafts.list.mockResolvedValue({ data: { drafts: [] } });
 
     await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow(/draft/i);
+
+    expect(drafts.send).not.toHaveBeenCalled();
+    expect(messages.send).not.toHaveBeenCalled();
+  });
+
+  it("does not resend a stale draft that is already marked sent", async () => {
+    const { gmail, drafts, messages } = createGmail();
+    messages.get.mockResolvedValue({ data: { labelIds: ["DRAFT", "SENT"] } });
+
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow(
+      /already.*sent/i,
+    );
+
+    expect(drafts.send).not.toHaveBeenCalled();
+    expect(messages.send).not.toHaveBeenCalled();
+  });
+
+  it("does not send a new copy when the source draft message is already gone", async () => {
+    const { gmail, drafts, messages } = createGmail();
+    messages.get.mockRejectedValue(
+      Object.assign(new Error("Not found"), { code: 404 }),
+    );
+
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow("Not found");
 
     expect(drafts.send).not.toHaveBeenCalled();
     expect(messages.send).not.toHaveBeenCalled();

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -25,6 +25,9 @@ import {
 import { formatReplySubject } from "@/utils/email/subject";
 import { buildThreadingHeaders } from "@/utils/email/threading";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
+import { getMessage } from "@/utils/gmail/message";
+import { getDraftIdForMessage } from "@/utils/gmail/draft";
+import { GmailLabel } from "@/utils/gmail/label";
 import { convertNewlinesToBr, textToHtmlParagraphs } from "@/utils/string";
 import {
   buildQuotedPlainText,
@@ -110,6 +113,29 @@ export async function sendEmailWithHtml(
   }
 
   const raw = await createRawMailMessage({ ...body, messageText });
+  const { replyToEmail } = body;
+  if (replyToEmail?.messageId) {
+    const message = await getMessage(replyToEmail.messageId, gmail, "metadata");
+    if (message.labelIds?.includes(GmailLabel.DRAFT)) {
+      const draftId = await getDraftIdForMessage(gmail, replyToEmail.messageId);
+      if (!draftId) {
+        throw new Error(
+          "The draft changed or is no longer available. Reopen the thread before sending.",
+        );
+      }
+
+      // Sending the existing draft consumes it and applies edits in one request.
+      return withGmailNonIdempotentWriteRetry(() =>
+        gmail.users.drafts.send({
+          userId: "me",
+          requestBody: {
+            id: draftId,
+            message: { threadId: replyToEmail.threadId, raw },
+          },
+        }),
+      );
+    }
+  }
   const result = await withGmailNonIdempotentWriteRetry(() =>
     gmail.users.messages.send({
       userId: "me",

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -117,6 +117,11 @@ export async function sendEmailWithHtml(
   if (replyToEmail?.messageId) {
     const message = await getMessage(replyToEmail.messageId, gmail, "metadata");
     if (message.labelIds?.includes(GmailLabel.DRAFT)) {
+      if (message.labelIds.includes(GmailLabel.SENT)) {
+        throw new Error(
+          "This draft is already marked as sent. Reopen the thread before sending.",
+        );
+      }
       const draftId = await getDraftIdForMessage(gmail, replyToEmail.messageId);
       if (!draftId) {
         throw new Error(


### PR DESCRIPTION
Sending a reply from an existing Gmail draft previously sent a separate message and left the draft behind. Use the existing draft's send endpoint with the edited content so successful delivery consumes the draft.

- Stop if the source disappears or a stale draft is already marked sent, and avoid duplicate sends after ambiguous failures.
- TDD: reproduced three failing cases before the fix; all 71 focused tests now pass, including seven new regression tests. Biome and diff checks pass.
- Adds a metadata lookup for Gmail replies with a source message ID and a draft lookup when that message is a draft. No database changes.
