### PR TITLE
mail: Autosave edits to existing mailbox drafts

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -63,13 +63,14 @@ import {
 import { env } from "@/env";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useLocalReplyDraft } from "@/hooks/useLocalReplyDraft";
+import { useProviderDraftAutosave } from "@/hooks/useProviderDraftAutosave";
 import { useReplyDraftPersistence } from "@/hooks/useReplyDraftPersistence";
 import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
 import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
-import { sendEmailAction } from "@/utils/actions/mail";
+import { sendEmailAction, updateDraftAction } from "@/utils/actions/mail";
 import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import {
   extractNameFromEmail,
@@ -123,6 +124,7 @@ export type ReplyingToEmail = {
 type ComposeEmailFormProps = {
   fromAccounts?: GetEmailAccountsResponse["emailAccounts"];
   layout?: "default" | "window";
+  providerDraftMessageId?: string;
   draftKeyMessageId?: string;
   draftMode?: ReplyDraftMode;
   draftSessionId?: string;
@@ -131,7 +133,7 @@ type ComposeEmailFormProps = {
   onSuccess?: (messageId: string, threadId: string) => void;
   onMarkDone?: () => void;
   onClose?: () => void;
-  onDiscard?: () => boolean | Promise<boolean>;
+  onDiscard?: (draftId?: string) => boolean | Promise<boolean>;
 };
 
 type ComposeAttachment = EmailComposerAttachment & {
@@ -197,6 +199,7 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
 function ComposeEmailFormContent({
   layout = "default",
   draftKeyMessageId,
+  providerDraftMessageId,
   draftMode,
   draftSessionId,
   storedDraft,
@@ -236,6 +239,7 @@ function ComposeEmailFormContent({
     return times.valid ? "" : times.error;
   });
   const editorInitialized = useRef(false);
+  const providerDraftId = useRef(storedDraft?.content?.providerDraftId);
 
   const [restoredAttachments] = useState<ComposeAttachment[]>(() =>
     (storedDraft?.content?.attachments ?? []).map((attachment) => ({
@@ -343,11 +347,18 @@ function ComposeEmailFormContent({
     },
   });
 
+  const lastDraftContent = useRef<ReplyDraftContent | undefined>(undefined);
   const getDraftContent = (options?: {
     sendAt?: string;
     remindAt?: string;
   }): ReplyDraftContent | undefined => {
-    if (!editorRef.current) return;
+    if (!editorRef.current)
+      return lastDraftContent.current
+        ? {
+            ...lastDraftContent.current,
+            providerDraftId: providerDraftId.current,
+          }
+        : undefined;
     const value = editorRef.current.getValue();
     const values = { ...getValues() };
     for (const field of ["to", "cc", "bcc"] as const) {
@@ -355,7 +366,8 @@ function ComposeEmailFormContent({
       if (pending)
         values[field] = [values[field], pending].filter(Boolean).join(", ");
     }
-    return {
+    const content: ReplyDraftContent = {
+      providerDraftId: providerDraftId.current,
       composeMode: draftMode,
       requestId,
       deliveryPath: deliveryPath.current,
@@ -374,9 +386,11 @@ function ComposeEmailFormContent({
       sendAt: options?.sendAt ?? sendAt,
       remindAt: options?.remindAt ?? remindAt,
     };
+    lastDraftContent.current = content;
+    return content;
   };
   const {
-    capture: captureDraft,
+    capture: captureLocalDraft,
     clear: clearLocalDraft,
     flush: flushDraft,
     saveError: draftSaveError,
@@ -393,6 +407,61 @@ function ComposeEmailFormContent({
     loadError: draftLoadError,
     getContent: getDraftContent,
   });
+  const providerAutosave = useProviderDraftAutosave({
+    enabled: Boolean(providerDraftMessageId),
+    getContent: () => {
+      const content = getDraftContent();
+      if (!content) return;
+      const blocks = new Set(content.preservedBlocks.map((block) => block.id));
+      return {
+        subject: content.values.subject ?? "",
+        to: content.values.to ?? "",
+        cc: content.values.cc ?? "",
+        bcc: content.values.bcc ?? "",
+        hasNewAttachments: content.attachments.length > 0,
+        messageHtml: combineEmailHtml({
+          editableHtml:
+            content.draft.mode === "fallback"
+              ? content.draft.editableHtml
+              : finalizeEditableEmailHtml({
+                  html: content.draft.editableHtml,
+                  inlineAttachments: content.attachments,
+                }),
+          signatureHtml: blocks.has("signature")
+            ? content.draft.signatureHtml
+            : "",
+          quotedHtml: blocks.has("quote") ? content.draft.quotedHtml : "",
+        }),
+      };
+    },
+    save: async ({ hasNewAttachments, ...content }) => {
+      if (hasNewAttachments)
+        throw new Error(
+          "Drafts with newly added attachments are saved on this device until sent.",
+        );
+      const result = await updateDraftAction(selectedEmailAccountId, {
+        ...content,
+        draftMessageId: providerDraftMessageId!,
+        draftId: providerDraftId.current,
+      });
+      if (!result?.data) throw new Error(getActionErrorMessage(result ?? {}));
+      providerDraftId.current = result.data.draftId;
+      captureLocalDraft();
+      await flushDraft();
+    },
+  });
+  const { stop: stopProviderAutosave, resume: resumeProviderAutosave } =
+    providerAutosave;
+  const captureDraft = useCallback(
+    (options?: { sendAt?: string; remindAt?: string }) => {
+      captureLocalDraft(options);
+      providerAutosave.capture();
+    },
+    [captureLocalDraft, providerAutosave.capture],
+  );
+  useEffect(() => {
+    if (storedDraft?.content) captureDraft();
+  }, [storedDraft, captureDraft]);
   useEffect(() => {
     const subscription = watch(() => captureDraft());
     return () => subscription.unsubscribe();
@@ -632,6 +701,7 @@ function ComposeEmailFormContent({
         return;
       }
       setSubmissionError("");
+      await stopProviderAutosave();
       try {
         if (isInlineReply) {
           if (deliveryPath.current === "outbox" && (sendAt || remindAt)) {
@@ -763,11 +833,15 @@ function ComposeEmailFormContent({
           "Could not confirm delivery. Check the thread status before trying again.",
         );
         toastError({ description: "There was an error sending the email :(" });
+      } finally {
+        resumeProviderAutosave();
       }
 
       refetch?.();
     },
     [
+      stopProviderAutosave,
+      resumeProviderAutosave,
       initialDraft,
       isInlineReply,
       sendAt,
@@ -869,9 +943,14 @@ function ComposeEmailFormContent({
   const handleDiscard = useCallback(async () => {
     if (!onDiscard || isSubmitting) return;
     try {
-      if ((await onDiscard()) === false) return;
+      await stopProviderAutosave();
+      if ((await onDiscard(providerDraftId.current)) === false) {
+        resumeProviderAutosave();
+        return;
+      }
       await clearLocalDraft();
     } catch (error) {
+      resumeProviderAutosave();
       toastError({
         description:
           error instanceof Error
@@ -879,7 +958,13 @@ function ComposeEmailFormContent({
             : "Could not discard this draft.",
       });
     }
-  }, [clearLocalDraft, isSubmitting, onDiscard]);
+  }, [
+    clearLocalDraft,
+    isSubmitting,
+    onDiscard,
+    stopProviderAutosave,
+    resumeProviderAutosave,
+  ]);
 
   useShortcuts({
     send: (event) => {
@@ -1372,6 +1457,11 @@ function ComposeEmailFormContent({
           )}
         </div>
       </div>
+      {providerAutosave.error && (
+        <p role="alert" className="text-xs text-destructive">
+          {providerAutosave.error}
+        </p>
+      )}
       {isInlineReply && draftSaveError && (
         <p role="alert" className="text-xs text-destructive">
           {draftSaveError}

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -435,13 +435,14 @@ function ComposeEmailFormContent({
       };
     },
     save: async ({ hasNewAttachments, ...content }) => {
+      if (!providerDraftMessageId) return;
       if (hasNewAttachments)
         throw new Error(
           "Drafts with newly added attachments are saved on this device until sent.",
         );
       const result = await updateDraftAction(selectedEmailAccountId, {
         ...content,
-        draftMessageId: providerDraftMessageId!,
+        draftMessageId: providerDraftMessageId,
         draftId: providerDraftId.current,
       });
       if (!result?.data) throw new Error(getActionErrorMessage(result ?? {}));
@@ -702,6 +703,7 @@ function ComposeEmailFormContent({
       }
       setSubmissionError("");
       await stopProviderAutosave();
+      let deliveryAccepted = false;
       try {
         if (isInlineReply) {
           if (deliveryPath.current === "outbox" && (sendAt || remindAt)) {
@@ -731,6 +733,7 @@ function ComposeEmailFormContent({
             );
             return;
           }
+          deliveryAccepted = true;
           try {
             await clearLocalDraft();
           } catch {
@@ -764,6 +767,7 @@ function ComposeEmailFormContent({
               threadId: readerThreadId,
               onQueued: isInlineReply
                 ? async () => {
+                    deliveryAccepted = true;
                     try {
                       await clearLocalDraft();
                     } catch {
@@ -787,11 +791,13 @@ function ComposeEmailFormContent({
             return;
           }
           if (outcome.status === "sent") {
+            deliveryAccepted = true;
             if (!isInlineReply) toastSuccess({ description: "Email sent!" });
             if (markDoneAfterSend) onMarkDone?.();
             onSuccess?.(outcome.messageId, outcome.threadId);
             refetch?.();
           } else if (outcome.status === "queued") {
+            deliveryAccepted = true;
             if (!isInlineReply)
               toastSuccess({
                 description: getQueuedEmailDescription(outcome.reason),
@@ -799,6 +805,7 @@ function ComposeEmailFormContent({
             if (markDoneAfterSend) onMarkDone?.();
             onClose?.();
           } else if (outcome.status === "uncertain") {
+            deliveryAccepted = true;
             if (outcome.ownsNotification) {
               toastError({
                 description:
@@ -817,6 +824,7 @@ function ComposeEmailFormContent({
           enrichedData,
         );
         if (result?.data) {
+          deliveryAccepted = true;
           toastSuccess({ description: "Email sent!" });
           if (markDoneAfterSend) onMarkDone?.();
           onSuccess?.(result.data.messageId ?? "", result.data.threadId ?? "");
@@ -834,7 +842,7 @@ function ComposeEmailFormContent({
         );
         toastError({ description: "There was an error sending the email :(" });
       } finally {
-        resumeProviderAutosave();
+        if (!deliveryAccepted) resumeProviderAutosave();
       }
 
       refetch?.();

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -481,48 +481,57 @@ function ReplyPanel({
     deleteDraftAction.bind(null, emailAccountId),
   );
 
-  const onDiscard = useCallback(async () => {
-    if (composeMode === "forward" || !draftMessage) {
-      onCloseCompose();
-      return true;
-    }
+  const onDiscard = useCallback(
+    async (draftId?: string) => {
+      if (composeMode === "forward" || !draftMessage) {
+        onCloseCompose();
+        return true;
+      }
 
-    const discardPromise = discardDraft({ draftMessageId: draftMessage.id });
-    const composeSession = onStartDiscard();
-    if (!composeSession) return false;
+      const discardPromise = discardDraft({
+        draftMessageId: draftMessage.id,
+        draftId,
+      });
+      const composeSession = onStartDiscard();
+      if (!composeSession) return false;
 
-    try {
-      const result = await discardPromise;
-      if (result?.serverError || result?.validationErrors) {
-        toastError({
-          description: getActionErrorMessage(result, {
-            prefix: "Failed to discard draft",
-          }),
-        });
+      try {
+        const result = await discardPromise;
+        if (result?.serverError || result?.validationErrors) {
+          toastError({
+            description: getActionErrorMessage(result, {
+              prefix: "Failed to discard draft",
+            }),
+          });
+          onRestoreCompose(composeSession);
+          return false;
+        }
+      } catch {
+        toastError({ description: "Failed to discard draft" });
         onRestoreCompose(composeSession);
         return false;
+      } finally {
+        refetch();
       }
-    } catch {
-      toastError({ description: "Failed to discard draft" });
-      onRestoreCompose(composeSession);
-      return false;
-    } finally {
-      refetch();
-    }
-    return true;
-  }, [
-    composeMode,
-    draftMessage,
-    discardDraft,
-    onCloseCompose,
-    onRestoreCompose,
-    onStartDiscard,
-    refetch,
-  ]);
+      return true;
+    },
+    [
+      composeMode,
+      draftMessage,
+      discardDraft,
+      onCloseCompose,
+      onRestoreCompose,
+      onStartDiscard,
+      refetch,
+    ],
+  );
 
   return (
     <div className="mt-5" ref={replyRef}>
       <ComposeEmailFormLazy
+        providerDraftMessageId={
+          composeMode === "reply" ? draftMessage?.id : undefined
+        }
         draftKeyMessageId={message.id}
         draftMode={composeMode}
         draftSessionId={getReplyDraftSessionId(message.id, composeMode)}

--- a/apps/web/hooks/useProviderDraftAutosave.test.ts
+++ b/apps/web/hooks/useProviderDraftAutosave.test.ts
@@ -3,7 +3,10 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { useProviderDraftAutosave } from "./useProviderDraftAutosave";
 
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 it("saves during continuous editing and skips unchanged drafts", async () => {
   vi.useFakeTimers();
@@ -78,7 +81,7 @@ it("retries failed saves without requiring another edit", async () => {
   );
   act(() => result.current.capture());
   await act(() => vi.advanceTimersByTimeAsync(3000));
-  expect(result.current.error).toBeTruthy();
+  expect(result.current.error).toBe("Offline");
   await act(() => vi.advanceTimersByTimeAsync(3000));
   expect(save).toHaveBeenCalledTimes(2);
   expect(result.current.error).toBe("");
@@ -116,4 +119,57 @@ it("saves the latest edit on close even while an earlier save is pending", async
   });
   expect(save).toHaveBeenLastCalledWith("last edit");
   expect(save).toHaveBeenCalledTimes(2);
+});
+
+it("flushes the latest edit when hidden during an active save", async () => {
+  vi.useFakeTimers();
+  let finish!: () => void;
+  const save = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    )
+    .mockResolvedValue(undefined);
+  let content = "first";
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({
+      enabled: true,
+      getContent: () => content,
+      save,
+    }),
+  );
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  content = "last edit";
+  act(() => result.current.capture());
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+  act(() => document.dispatchEvent(new Event("visibilitychange")));
+  await act(async () => {
+    finish();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  expect(save).toHaveBeenLastCalledWith("last edit");
+  expect(save).toHaveBeenCalledTimes(2);
+  unmount();
+});
+
+it("does not write an opened draft until an edit or local recovery is captured", async () => {
+  vi.useFakeTimers();
+  const save = vi.fn().mockResolvedValue(undefined);
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({
+      enabled: true,
+      getContent: () => "draft",
+      save,
+    }),
+  );
+  await act(() => vi.advanceTimersByTimeAsync(6000));
+  expect(save).not.toHaveBeenCalled();
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(save).toHaveBeenCalledWith("draft");
+  unmount();
 });

--- a/apps/web/hooks/useProviderDraftAutosave.test.ts
+++ b/apps/web/hooks/useProviderDraftAutosave.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { useProviderDraftAutosave } from "./useProviderDraftAutosave";
+
+afterEach(() => vi.useRealTimers());
+
+it("saves during continuous editing and skips unchanged drafts", async () => {
+  vi.useFakeTimers();
+  const save = vi.fn().mockResolvedValue(undefined);
+  let content = "initial";
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({
+      enabled: true,
+      getContent: () => content,
+      save,
+    }),
+  );
+  for (let i = 0; i < 6; i++) {
+    content = `edit ${i}`;
+    act(() => result.current.capture());
+    await act(() => vi.advanceTimersByTimeAsync(1000));
+  }
+  expect(save).toHaveBeenCalledTimes(2);
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(save).toHaveBeenCalledTimes(2);
+  unmount();
+});
+
+it("serializes writes and waits for an active save before stopping", async () => {
+  vi.useFakeTimers();
+  let finish!: () => void;
+  const save = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    )
+    .mockResolvedValue(undefined);
+  let content = "first";
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({
+      enabled: true,
+      getContent: () => content,
+      save,
+    }),
+  );
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  content = "second";
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(6000));
+  expect(save).toHaveBeenCalledTimes(1);
+  let stopped = false;
+  const stopping = result.current.stop().then(() => {
+    stopped = true;
+  });
+  expect(stopped).toBe(false);
+  await act(async () => {
+    finish();
+    await stopping;
+  });
+  await act(() => vi.advanceTimersByTimeAsync(6000));
+  expect(save).toHaveBeenCalledTimes(1);
+  unmount();
+});
+
+it("retries failed saves without requiring another edit", async () => {
+  vi.useFakeTimers();
+  const save = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("Offline"))
+    .mockResolvedValue(undefined);
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({ enabled: true, getContent: () => "edit", save }),
+  );
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(result.current.error).toBeTruthy();
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(save).toHaveBeenCalledTimes(2);
+  expect(result.current.error).toBe("");
+  unmount();
+});
+
+it("saves the latest edit on close even while an earlier save is pending", async () => {
+  vi.useFakeTimers();
+  let finish!: () => void;
+  const save = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    )
+    .mockResolvedValue(undefined);
+  let content = "first";
+  const { result, unmount } = renderHook(() =>
+    useProviderDraftAutosave({
+      enabled: true,
+      getContent: () => content,
+      save,
+    }),
+  );
+  act(() => result.current.capture());
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  content = "last edit";
+  act(() => result.current.capture());
+  unmount();
+  await act(async () => {
+    finish();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  expect(save).toHaveBeenLastCalledWith("last edit");
+  expect(save).toHaveBeenCalledTimes(2);
+});

--- a/apps/web/hooks/useProviderDraftAutosave.ts
+++ b/apps/web/hooks/useProviderDraftAutosave.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useProviderDraftAutosave<T>({
+  enabled,
+  getContent,
+  save,
+}: {
+  enabled: boolean;
+  getContent: () => T | undefined;
+  save: (content: T) => Promise<void>;
+}) {
+  const [error, setError] = useState("");
+  const latest = useRef({ enabled, getContent, save });
+  latest.current = { enabled, getContent, save };
+  const pending = useRef<T | undefined>(undefined);
+  const saved = useRef<string | undefined>(undefined);
+  const active = useRef<Promise<void> | undefined>(undefined);
+  const paused = useRef(false);
+  const mounted = useRef(true);
+
+  const capture = useCallback(() => {
+    if (latest.current.enabled && !paused.current)
+      pending.current = latest.current.getContent();
+  }, []);
+
+  const flush = useCallback(() => {
+    if (active.current) return active.current;
+    const content = pending.current;
+    if (!latest.current.enabled || paused.current || content === undefined)
+      return Promise.resolve();
+    const snapshot = JSON.stringify(content);
+    if (snapshot === saved.current) return Promise.resolve();
+    const request = Promise.resolve()
+      .then(() => latest.current.save(content))
+      .then(() => {
+        saved.current = snapshot;
+        if (mounted.current) setError("");
+      })
+      .catch((error: unknown) => {
+        if (mounted.current)
+          setError(
+            error instanceof Error
+              ? error.message
+              : "Could not sync draft to your mailbox. Retrying…",
+          );
+      })
+      .finally(() => {
+        active.current = undefined;
+      });
+    active.current = request;
+    return request;
+  }, []);
+
+  const stop = useCallback(async () => {
+    paused.current = true;
+    await active.current;
+  }, []);
+  const resume = useCallback(() => {
+    paused.current = false;
+    capture();
+  }, [capture]);
+
+  useEffect(() => {
+    mounted.current = true;
+    const timer = setInterval(flush, 3000);
+    const onHidden = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    document.addEventListener("visibilitychange", onHidden);
+    window.addEventListener("online", flush);
+    return () => {
+      mounted.current = false;
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", onHidden);
+      window.removeEventListener("online", flush);
+      if (active.current) active.current.then(flush);
+      else flush();
+    };
+  }, [flush]);
+
+  return { capture, stop, resume, error };
+}

--- a/apps/web/hooks/useProviderDraftAutosave.ts
+++ b/apps/web/hooks/useProviderDraftAutosave.ts
@@ -65,18 +65,19 @@ export function useProviderDraftAutosave<T>({
   useEffect(() => {
     mounted.current = true;
     const timer = setInterval(flush, 3000);
+    const flushLatest = () =>
+      active.current ? active.current.then(flush) : flush();
     const onHidden = () => {
-      if (document.visibilityState === "hidden") flush();
+      if (document.visibilityState === "hidden") flushLatest();
     };
     document.addEventListener("visibilitychange", onHidden);
-    window.addEventListener("online", flush);
+    window.addEventListener("online", flushLatest);
     return () => {
       mounted.current = false;
       clearInterval(timer);
       document.removeEventListener("visibilitychange", onHidden);
-      window.removeEventListener("online", flush);
-      if (active.current) active.current.then(flush);
-      else flush();
+      window.removeEventListener("online", flushLatest);
+      flushLatest();
     };
   }, [flush]);
 

--- a/apps/web/utils/actions/mail-draft.test.ts
+++ b/apps/web/utils/actions/mail-draft.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
+import { SafeError } from "@/utils/error";
 import { deleteDraftAction, updateDraftAction } from "@/utils/actions/mail";
 
 vi.mock("@/utils/prisma");
@@ -72,8 +73,10 @@ describe("deleteDraftAction", () => {
     });
   });
 
-  it("does not update a draft that has been sent or deleted", async () => {
-    mocks.getDraft.mockResolvedValue(null);
+  it("reports a provider rejection when a draft has been sent or deleted", async () => {
+    mocks.updateDraft.mockRejectedValueOnce(
+      new SafeError("Could not find this draft to update."),
+    );
     const result = await updateDraftAction(EMAIL_ACCOUNT_ID, {
       draftMessageId: "old-message",
       draftId: "draft-1",
@@ -84,7 +87,7 @@ describe("deleteDraftAction", () => {
       bcc: "",
     });
     expect(result?.serverError).toBeTruthy();
-    expect(mocks.updateDraft).not.toHaveBeenCalled();
+    expect(result?.serverError).toBe("Could not find this draft to update.");
   });
 
   it("discards an autosaved draft using its current message and version", async () => {

--- a/apps/web/utils/actions/mail-draft.test.ts
+++ b/apps/web/utils/actions/mail-draft.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
-import { deleteDraftAction } from "@/utils/actions/mail";
+import { deleteDraftAction, updateDraftAction } from "@/utils/actions/mail";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
@@ -13,6 +13,8 @@ vi.mock("@/utils/auth", () => ({
 const mocks = vi.hoisted(() => ({
   createEmailProvider: vi.fn(),
   deleteDraft: vi.fn(),
+  updateDraft: vi.fn(),
+  getDraft: vi.fn(),
   getDraftReferenceForMessage: vi.fn(),
   markTrackedDraftDeleted: vi.fn(),
 }));
@@ -38,6 +40,8 @@ describe("deleteDraftAction", () => {
     );
     mocks.createEmailProvider.mockResolvedValue({
       deleteDraft: mocks.deleteDraft,
+      updateDraft: mocks.updateDraft,
+      getDraft: mocks.getDraft,
       getDraftReferenceForMessage: mocks.getDraftReferenceForMessage,
     });
     mocks.getDraftReferenceForMessage.mockResolvedValue({
@@ -45,6 +49,54 @@ describe("deleteDraftAction", () => {
       version: 'W/"version-1"',
     });
     mocks.deleteDraft.mockResolvedValue(true);
+  });
+
+  it("saves edits using the stable draft ID after Gmail replaces its message ID", async () => {
+    mocks.getDraft.mockResolvedValue({ id: "new-message" });
+    const result = await updateDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "old-message",
+      draftId: "draft-1",
+      messageHtml: "<p>Edited</p>",
+      subject: "",
+      to: "person@example.com",
+      cc: "",
+      bcc: "",
+    });
+    expect(result?.data).toEqual({ draftId: "draft-1" });
+    expect(mocks.updateDraft).toHaveBeenCalledWith("draft-1", {
+      messageHtml: "<p>Edited</p>",
+      subject: "",
+      to: "person@example.com",
+      cc: "",
+      bcc: "",
+    });
+  });
+
+  it("does not update a draft that has been sent or deleted", async () => {
+    mocks.getDraft.mockResolvedValue(null);
+    const result = await updateDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "old-message",
+      draftId: "draft-1",
+      messageHtml: "<p>Edited</p>",
+      subject: "Reply",
+      to: "person@example.com",
+      cc: "",
+      bcc: "",
+    });
+    expect(result?.serverError).toBeTruthy();
+    expect(mocks.updateDraft).not.toHaveBeenCalled();
+  });
+
+  it("discards an autosaved draft using its current message and version", async () => {
+    mocks.getDraft.mockResolvedValue({ id: "new-message" });
+    await deleteDraftAction(EMAIL_ACCOUNT_ID, {
+      draftMessageId: "old-message",
+      draftId: "draft-1",
+    });
+    expect(mocks.getDraftReferenceForMessage).toHaveBeenCalledWith(
+      "new-message",
+    );
+    expect(mocks.deleteDraft).toHaveBeenCalledWith("draft-1", 'W/"version-1"');
   });
 
   it("updates tracking after the provider deletes the draft", async () => {

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -435,8 +435,7 @@ export const updateDraftAction = actionClient
         parsedInput.draftId ??
         (await provider.getDraftReferenceForMessage(parsedInput.draftMessageId))
           ?.id;
-      if (!draftId || !(await provider.getDraft(draftId)))
-        throw new SafeError("Could not find this draft to update.");
+      if (!draftId) throw new SafeError("Could not find this draft to update.");
       const {
         draftMessageId: _messageId,
         draftId: _draftId,

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -12,6 +12,7 @@ import {
   unarchiveThreadBody,
   untrashThreadBody,
   updateMailboxItemBody,
+  updateDraftBody,
 } from "@/utils/actions/mail.validation";
 import {
   isGoogleProvider,
@@ -417,20 +418,57 @@ export const sendEmailAction = actionClient
     },
   );
 
-export const deleteDraftAction = actionClient
-  .metadata({ name: "deleteDraft" })
-  .inputSchema(z.object({ draftMessageId: z.string() }))
+export const updateDraftAction = actionClient
+  .metadata({ name: "updateDraft" })
+  .inputSchema(updateDraftBody)
   .action(
     async ({
       ctx: { emailAccountId, provider: providerName, logger },
-      parsedInput: { draftMessageId },
+      parsedInput,
     }) => {
       const provider = await createEmailProvider({
         emailAccountId,
         provider: providerName,
         logger,
       });
-      const draft = await provider.getDraftReferenceForMessage(draftMessageId);
+      const draftId =
+        parsedInput.draftId ??
+        (await provider.getDraftReferenceForMessage(parsedInput.draftMessageId))
+          ?.id;
+      if (!draftId || !(await provider.getDraft(draftId)))
+        throw new SafeError("Could not find this draft to update.");
+      const {
+        draftMessageId: _messageId,
+        draftId: _draftId,
+        ...content
+      } = parsedInput;
+      await provider.updateDraft(draftId, content);
+      return { draftId };
+    },
+  );
+
+export const deleteDraftAction = actionClient
+  .metadata({ name: "deleteDraft" })
+  .inputSchema(
+    z.object({ draftMessageId: z.string(), draftId: z.string().optional() }),
+  )
+  .action(
+    async ({
+      ctx: { emailAccountId, provider: providerName, logger },
+      parsedInput: { draftMessageId, draftId },
+    }) => {
+      const provider = await createEmailProvider({
+        emailAccountId,
+        provider: providerName,
+        logger,
+      });
+      const draft = draftId
+        ? await provider
+            .getDraft(draftId)
+            .then((message) =>
+              message ? provider.getDraftReferenceForMessage(message.id) : null,
+            )
+        : await provider.getDraftReferenceForMessage(draftMessageId);
       if (!draft) {
         throw new SafeError("Could not find this draft to delete.");
       }

--- a/apps/web/utils/actions/mail.validation.ts
+++ b/apps/web/utils/actions/mail.validation.ts
@@ -62,3 +62,13 @@ export const deleteMailboxItemBody = z.object({
   kind: mailboxItemKind,
   id: z.string().min(1, "Mailbox item ID is required"),
 });
+
+export const updateDraftBody = z.object({
+  draftMessageId: z.string().min(1),
+  draftId: z.string().min(1).optional(),
+  messageHtml: z.string().max(1_000_000),
+  subject: z.string().max(10_000),
+  to: z.string(),
+  cc: z.string(),
+  bcc: z.string(),
+});

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -16,6 +16,7 @@ import {
 } from "./database";
 
 export type ReplyDraftContent = {
+  providerDraftId?: string;
   composeMode?: ReplyDraftMode;
   requestId?: string;
   deliveryPath?: "scheduled" | "outbox";

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -548,6 +548,18 @@ describe("GmailProvider.searchThreads", () => {
 });
 
 describe("GmailProvider.updateDraft", () => {
+  it("does not write a draft that has been sent or deleted", async () => {
+    const update = vi.fn();
+    const provider = new GmailProvider({
+      users: { drafts: { update } },
+    } as any);
+    gmailDraftMock.getDraft.mockResolvedValueOnce(null);
+    await expect(
+      provider.updateDraft("draft-1", { messageHtml: "<p>Edit</p>" }),
+    ).rejects.toThrow("Could not find this draft to update.");
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it.each([
     true,
     false,
@@ -659,6 +671,8 @@ describe("GmailProvider.updateDraft", () => {
         labelIds: [GmailLabel.DRAFT],
         headers: {
           to: "sender@example.com",
+          cc: "old-cc@example.com",
+          bcc: "old-bcc@example.com",
           subject,
           "in-reply-to": "<original@example.com>",
           references: "<root@example.com> <original@example.com>",
@@ -695,6 +709,10 @@ describe("GmailProvider.updateDraft", () => {
     );
     expect(decodedMessage).toContain("Edited response.");
     expect(decodedMessage).toContain("To: updated@example.com");
+    expect(decodedMessage).not.toMatch(/^Cc:/im);
+    expect(decodedMessage).not.toMatch(/^Bcc:/im);
+    expect(decodedMessage).not.toContain("old-cc@example.com");
+    expect(decodedMessage).not.toContain("old-bcc@example.com");
     expect(decodedMessage).not.toContain("To: sender@example.com");
   });
 });

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -669,6 +669,9 @@ describe("GmailProvider.updateDraft", () => {
     await provider.updateDraft("r-123", {
       subject,
       messageHtml: "<p>Edited response.</p>",
+      to: "updated@example.com",
+      cc: "",
+      bcc: "",
     });
 
     expect(update).toHaveBeenCalledWith({
@@ -691,6 +694,8 @@ describe("GmailProvider.updateDraft", () => {
       "References: <root@example.com> <original@example.com>",
     );
     expect(decodedMessage).toContain("Edited response.");
+    expect(decodedMessage).toContain("To: updated@example.com");
+    expect(decodedMessage).not.toContain("To: sender@example.com");
   });
 });
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -959,6 +959,9 @@ export class GmailProvider implements EmailProvider {
     params: {
       messageHtml?: string;
       subject?: string;
+      to?: string;
+      cc?: string;
+      bcc?: string;
     },
   ): Promise<void> {
     this.logger.info("Updating Gmail draft", { draftId });
@@ -978,10 +981,10 @@ export class GmailProvider implements EmailProvider {
 
     const encodedMessage = await createMail({
       from: currentDraft.headers?.from,
-      to: currentDraft.headers?.to || "",
+      to: params.to ?? currentDraft.headers?.to ?? "",
       attachments,
-      cc: currentDraft.headers?.cc,
-      bcc: currentDraft.headers?.bcc,
+      cc: params.cc ?? currentDraft.headers?.cc,
+      bcc: params.bcc ?? currentDraft.headers?.bcc,
       replyTo: currentDraft.headers?.["reply-to"],
       subject,
       text: convertEmailHtmlToText({ htmlText: content }),

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1,5 +1,6 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import chunk from "lodash/chunk";
+import { SafeError } from "@/utils/error";
 import type { Attachment as MailAttachment } from "nodemailer/lib/mailer";
 import { mapWithConcurrency } from "@/utils/async";
 import { toMailerAttachments } from "@/utils/types/mail";
@@ -968,7 +969,7 @@ export class GmailProvider implements EmailProvider {
 
     const currentDraft = await getDraft(draftId, this.client);
     if (!currentDraft) {
-      throw new Error(`Draft ${draftId} not found`);
+      throw new SafeError("Could not find this draft to update.");
     }
 
     const subject = params.subject ?? currentDraft.subject ?? "";

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -66,19 +66,44 @@ describe("OutlookProvider.updateDraft", () => {
     const client = createMockOutlookClient([]);
     client.getClient = () => ({ api: () => ({ patch }) });
     const provider = new OutlookProvider(client, createTestLogger());
-    vi.spyOn(provider, "getDraft").mockResolvedValue(null);
+    vi.spyOn(provider, "getDraftReferenceForMessage").mockResolvedValue(null);
     await expect(
       provider.updateDraft("draft-1", { messageHtml: "<p>Edit</p>" }),
     ).rejects.toThrow("Could not find this draft to update.");
     expect(patch).not.toHaveBeenCalled();
   });
 
+  it("does not update a message when the Drafts folder cannot be verified", async () => {
+    getFolderIdsMock.mockResolvedValueOnce({});
+    const patch = vi.fn();
+    const client = createMockOutlookClient([]);
+    client.getClient = () => ({
+      api: () => ({
+        get: async () => ({
+          id: "message-1",
+          parentFolderId: "sent-folder-id",
+          isDraft: false,
+        }),
+        patch,
+      }),
+    });
+    const provider = new OutlookProvider(client, createTestLogger());
+    await expect(
+      provider.updateDraft("message-1", { messageHtml: "<p>Edit</p>" }),
+    ).rejects.toThrow("Could not find this draft to update.");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("clears draft fields and updates recipients", async () => {
     const patch = vi.fn().mockResolvedValue({});
+    const header = vi.fn().mockReturnValue({ patch });
     const client = createMockOutlookClient([]);
-    client.getClient = () => ({ api: () => ({ patch }) });
+    client.getClient = () => ({ api: () => ({ header, patch }) });
     const provider = new OutlookProvider(client, createTestLogger());
-    vi.spyOn(provider, "getDraft").mockResolvedValue({ id: "draft-1" } as any);
+    vi.spyOn(provider, "getDraftReferenceForMessage").mockResolvedValue({
+      id: "draft-1",
+      version: 'W/"version-1"',
+    });
     await provider.updateDraft("draft-1", {
       messageHtml: "",
       subject: "",
@@ -86,6 +111,7 @@ describe("OutlookProvider.updateDraft", () => {
       cc: "",
       bcc: "",
     });
+    expect(header).toHaveBeenCalledWith("If-Match", 'W/"version-1"');
     expect(patch).toHaveBeenCalledWith({
       body: { contentType: "html", content: "" },
       subject: "",

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -61,11 +61,24 @@ afterEach(() => {
 });
 
 describe("OutlookProvider.updateDraft", () => {
+  it("does not write a draft that has been sent or deleted", async () => {
+    const patch = vi.fn();
+    const client = createMockOutlookClient([]);
+    client.getClient = () => ({ api: () => ({ patch }) });
+    const provider = new OutlookProvider(client, createTestLogger());
+    vi.spyOn(provider, "getDraft").mockResolvedValue(null);
+    await expect(
+      provider.updateDraft("draft-1", { messageHtml: "<p>Edit</p>" }),
+    ).rejects.toThrow("Could not find this draft to update.");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("clears draft fields and updates recipients", async () => {
     const patch = vi.fn().mockResolvedValue({});
     const client = createMockOutlookClient([]);
     client.getClient = () => ({ api: () => ({ patch }) });
     const provider = new OutlookProvider(client, createTestLogger());
+    vi.spyOn(provider, "getDraft").mockResolvedValue({ id: "draft-1" } as any);
     await provider.updateDraft("draft-1", {
       messageHtml: "",
       subject: "",

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -60,6 +60,29 @@ afterEach(() => {
   });
 });
 
+describe("OutlookProvider.updateDraft", () => {
+  it("clears draft fields and updates recipients", async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const client = createMockOutlookClient([]);
+    client.getClient = () => ({ api: () => ({ patch }) });
+    const provider = new OutlookProvider(client, createTestLogger());
+    await provider.updateDraft("draft-1", {
+      messageHtml: "",
+      subject: "",
+      to: "person@example.com",
+      cc: "",
+      bcc: "",
+    });
+    expect(patch).toHaveBeenCalledWith({
+      body: { contentType: "html", content: "" },
+      subject: "",
+      toRecipients: [{ emailAddress: { address: "person@example.com" } }],
+      ccRecipients: [],
+      bccRecipients: [],
+    });
+  });
+});
+
 describe("OutlookProvider.sendEmail", () => {
   it("returns the immutable provider message ID", async () => {
     outlookMailMock.sendEmailWithPlainText.mockResolvedValueOnce({

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -699,8 +699,8 @@ export class OutlookProvider implements EmailProvider {
   ): Promise<void> {
     this.logger.info("Updating draft", { draftId });
 
-    if (!(await this.getDraft(draftId)))
-      throw new SafeError("Could not find this draft to update.");
+    const draft = await this.getDraftReferenceForMessage(draftId);
+    if (!draft) throw new SafeError("Could not find this draft to update.");
 
     const body: Partial<Message> = {};
     if (params.messageHtml !== undefined) {
@@ -718,7 +718,12 @@ export class OutlookProvider implements EmailProvider {
       body.bccRecipients = toGraphRecipients(params.bcc, this.logger);
 
     await withMicrosoftGraphWriteRetry(
-      () => this.client.getClient().api(`/me/messages/${draftId}`).patch(body),
+      () =>
+        this.client
+          .getClient()
+          .api(`/me/messages/${draftId}`)
+          .header("If-Match", draft.version)
+          .patch(body),
       this.logger,
     );
 

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1,3 +1,4 @@
+import { SafeError } from "@/utils/error";
 import type { Message } from "@microsoft/microsoft-graph-types";
 import type { OutlookClient } from "@/utils/outlook/client";
 import type { ParsedMessage } from "@/utils/types";
@@ -698,7 +699,10 @@ export class OutlookProvider implements EmailProvider {
   ): Promise<void> {
     this.logger.info("Updating draft", { draftId });
 
-    const body: Record<string, unknown> = {};
+    if (!(await this.getDraft(draftId)))
+      throw new SafeError("Could not find this draft to update.");
+
+    const body: Partial<Message> = {};
     if (params.messageHtml !== undefined) {
       body.body = { contentType: "html", content: params.messageHtml };
     }
@@ -706,13 +710,12 @@ export class OutlookProvider implements EmailProvider {
       body.subject = params.subject;
     }
 
-    for (const field of ["to", "cc", "bcc"] as const) {
-      if (params[field] !== undefined)
-        body[`${field}Recipients`] = toGraphRecipients(
-          params[field],
-          this.logger,
-        );
-    }
+    if (params.to !== undefined)
+      body.toRecipients = toGraphRecipients(params.to, this.logger);
+    if (params.cc !== undefined)
+      body.ccRecipients = toGraphRecipients(params.cc, this.logger);
+    if (params.bcc !== undefined)
+      body.bccRecipients = toGraphRecipients(params.bcc, this.logger);
 
     await withMicrosoftGraphWriteRetry(
       () => this.client.getClient().api(`/me/messages/${draftId}`).patch(body),

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -691,16 +691,27 @@ export class OutlookProvider implements EmailProvider {
     params: {
       messageHtml?: string;
       subject?: string;
+      to?: string;
+      cc?: string;
+      bcc?: string;
     },
   ): Promise<void> {
     this.logger.info("Updating draft", { draftId });
 
     const body: Record<string, unknown> = {};
-    if (params.messageHtml) {
+    if (params.messageHtml !== undefined) {
       body.body = { contentType: "html", content: params.messageHtml };
     }
-    if (params.subject) {
+    if (params.subject !== undefined) {
       body.subject = params.subject;
+    }
+
+    for (const field of ["to", "cc", "bcc"] as const) {
+      if (params[field] !== undefined)
+        body[`${field}Recipients`] = toGraphRecipients(
+          params[field],
+          this.logger,
+        );
     }
 
     await withMicrosoftGraphWriteRetry(

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -370,6 +370,9 @@ export interface EmailProvider {
     params: {
       messageHtml?: string;
       subject?: string;
+      to?: string;
+      cc?: string;
+      bcc?: string;
     },
   ): Promise<void>;
   updateLabel(labelId: string, update: EmailLabelUpdate): Promise<void>;


### PR DESCRIPTION
Edits to existing mailbox drafts now sync the body, subject, and recipients every three seconds, so changes appear in the provider's email client. Saves are serialized, retried after failures, and flushed when the composer closes or the tab becomes hidden.

- Preserve the stable provider draft ID across saves and local recovery, and wait for active saves before sending or discarding.
- Preserve existing provider attachments; newly added attachments keep the draft local until sent and display a notice.
- Validation: 93 focused tests passed, repository-wide lint passed, and the CI build and both unit-test shards passed. The compose-and-reply browser suite passed in CI, and its screenshots were inspected (local emulator login was blocked).

Runtime: unchanged snapshots do not write; edited drafts issue provider reads and an update at most once per three-second interval, with additional flushes on lifecycle events. No database migration is needed.
