### PR TITLE
Mail: Add draft divider and automatic URL highlighting

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -100,9 +100,10 @@ test("highlights URLs while typing and pasting", async ({ page }, testInfo) => {
       }),
     );
   });
-  await expect(
-    editor.getByRole("link", { name: "example.org/help" }),
-  ).toHaveCSS("color", "rgb(37, 99, 235)");
+  await expect(editor.getByText("example.org/help", { exact: true })).toHaveCSS(
+    "color",
+    "rgb(37, 99, 235)",
+  );
   await capturePlaywrightCheckpoint(
     page,
     testInfo,

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -75,6 +75,41 @@ test("focuses the message field from the empty composer body", async ({
   await expect(editor).toBeFocused();
 });
 
+test("highlights URLs while typing and pasting", async ({ page }, testInfo) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const editor = dialog.getByRole("textbox", { name: "Email message" });
+  await editor.pressSequentially("Visit example.com/docs");
+  await expect(editor.locator("[data-email-url-highlight]")).toHaveText(
+    "example.com/docs",
+  );
+  await expect(editor.locator("[data-email-url-highlight]")).toHaveCSS(
+    "color",
+    "rgb(37, 99, 235)",
+  );
+  await editor.press("Space");
+  await editor.evaluate((element) => {
+    const clipboardData = new DataTransfer();
+    clipboardData.setData("text/plain", "More at example.org/help.");
+    element.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }),
+    );
+  });
+  await expect(
+    editor.getByRole("link", { name: "example.org/help" }),
+  ).toHaveCSS("color", "rgb(37, 99, 235)");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "automatic-url-highlighting",
+  );
+});
+
 test("keeps editing state stable across formatting, links, paste, and files", async ({
   page,
 }, testInfo) => {
@@ -402,6 +437,7 @@ test("opens and sends a reply from the reader with Enter", async ({
   const replyBody = `A reply sent through the mail reader. ${testInfo.retry}`;
   await replyEditor.pressSequentially(replyBody);
   await expect(replyEditor).toContainText(replyBody);
+  await capturePlaywrightCheckpoint(page, testInfo, "inline-reply-divider");
   const sendButton = page.getByRole("button", { name: "Send", exact: true });
   await expect(sendButton).toHaveText("Send");
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -949,7 +949,7 @@ function ComposeEmailFormContent({
         isComposeWindow
           ? "flex h-full min-h-0 flex-col overflow-hidden [&_[data-email-editor-root]]:min-h-0 [&_[data-email-editor-root]]:flex-1"
           : "space-y-2",
-        isInlineReply && "space-y-2",
+        isInlineReply && "space-y-2 border-t border-border pt-4",
       )}
     >
       <div className={cn(isComposeWindow ? "shrink-0 px-4" : "contents")}>

--- a/packages/email-editor/package.json
+++ b/packages/email-editor/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "linkifyjs": "4.3.3",
     "parse5": "8.0.0"
   },
   "peerDependencies": {

--- a/packages/email-editor/scripts/prepare-package.mjs
+++ b/packages/email-editor/scripts/prepare-package.mjs
@@ -48,6 +48,7 @@ const publishedPackageJson = {
 const javascriptFiles = [
   resolve(outputDirectory, "web/EmailEditor.js"),
   resolve(outputDirectory, "web/email-extensions.js"),
+  resolve(outputDirectory, "web/url-highlight.js"),
 ];
 
 await Promise.all(

--- a/packages/email-editor/src/web/EmailEditor.module.css
+++ b/packages/email-editor/src/web/EmailEditor.module.css
@@ -86,7 +86,8 @@
   border-inline-start: 3px solid var(--email-editor-border);
 }
 
-.editor [data-email-editor-content] a {
+.editor [data-email-editor-content] a,
+.editor [data-email-url-highlight] {
   color: #2563eb;
   text-decoration: underline;
   text-underline-offset: 2px;

--- a/packages/email-editor/src/web/email-extensions.tsx
+++ b/packages/email-editor/src/web/email-extensions.tsx
@@ -13,6 +13,7 @@ import {
   type RenderedPreservedEmailBlock,
 } from "./preserved-block";
 import styles from "./EmailEditor.module.css";
+import { UrlHighlight } from "./url-highlight";
 
 const PreservedEmailBlockNode = Node.create({
   name: "preservedEmailBlock",
@@ -112,6 +113,7 @@ export function createEmailEditorExtensions(placeholder: string) {
     }),
     EmailImage,
     EmailDirection,
+    UrlHighlight,
     PreservedEmailBlockNode,
     Placeholder.configure({
       placeholder,

--- a/packages/email-editor/src/web/url-highlight.test.ts
+++ b/packages/email-editor/src/web/url-highlight.test.ts
@@ -38,7 +38,7 @@ describe("URL highlighting", () => {
     expect(findUrlHighlights(doc).find()).toEqual([]);
   });
 
-  it("removes highlighting when an edit stops being a URL", () => {
+  it("does not highlight ordinary words", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, schema.text("example")),
     ]);

--- a/packages/email-editor/src/web/url-highlight.test.ts
+++ b/packages/email-editor/src/web/url-highlight.test.ts
@@ -1,0 +1,47 @@
+import { Schema } from "@tiptap/pm/model";
+import { describe, expect, it } from "vitest";
+import { findUrlHighlights } from "./url-highlight";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*" },
+    text: {},
+  },
+  marks: { link: { attrs: { href: {} } } },
+});
+
+describe("URL highlighting", () => {
+  it("highlights loaded plain URLs without changing the document", () => {
+    const text = "Visit example.com/docs, https://example.org or example.net.";
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, schema.text(text)),
+    ]);
+    const original = doc.toJSON();
+    const highlights = findUrlHighlights(doc).find();
+
+    expect(highlights.map(({ from, to }) => doc.textBetween(from, to))).toEqual(
+      ["example.com/docs", "https://example.org", "example.net"],
+    );
+    expect(doc.toJSON()).toEqual(original);
+  });
+
+  it("leaves existing links and ordinary text alone", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("Read the documentation at "),
+        schema.text("example.com", [
+          schema.mark("link", { href: "https://example.org" }),
+        ]),
+      ]),
+    ]);
+    expect(findUrlHighlights(doc).find()).toEqual([]);
+  });
+
+  it("removes highlighting when an edit stops being a URL", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, schema.text("example")),
+    ]);
+    expect(findUrlHighlights(doc).find()).toEqual([]);
+  });
+});

--- a/packages/email-editor/src/web/url-highlight.ts
+++ b/packages/email-editor/src/web/url-highlight.ts
@@ -1,0 +1,47 @@
+import { Extension } from "@tiptap/core";
+import type { Node } from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { find } from "linkifyjs";
+import { isSafeEmailUrl } from "../core/email-html";
+
+export const UrlHighlight = Extension.create({
+  name: "urlHighlight",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<DecorationSet>({
+        state: {
+          init: (_, state) => findUrlHighlights(state.doc),
+          apply: (transaction, decorations) =>
+            transaction.docChanged
+              ? findUrlHighlights(transaction.doc)
+              : decorations,
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+export function findUrlHighlights(doc: Node) {
+  const decorations: Decoration[] = [];
+  doc.descendants((node, position) => {
+    if (!node.isText || !node.text) return;
+    if (node.marks.some((mark) => mark.type.name === "link")) return;
+
+    for (const match of find(node.text, { defaultProtocol: "https" })) {
+      if (!isSafeEmailUrl(match.href)) continue;
+      decorations.push(
+        Decoration.inline(position + match.start, position + match.end, {
+          "data-email-url-highlight": "",
+        }),
+      );
+    }
+  });
+  return DecorationSet.create(doc, decorations);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -858,6 +858,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: 3.30.2
         version: 3.30.2
+      linkifyjs:
+        specifier: 4.3.3
+        version: 4.3.3
       parse5:
         specifier: 8.0.0
         version: 8.0.0


### PR DESCRIPTION
Adds a thin divider above inline reply drafts and automatically highlights plain URLs in blue in the email editor, including loaded drafts and text being typed or pasted.

Highlighting runs entirely on the client using display-only editor decorations. Existing link behavior is preserved, with no AI prompt or generated-content changes.

Validation: 27 editor unit tests, package type check, formatting, and secret scan passed. All compose/reply browser scenarios passed across the full run and focused URL-test rerun, using an isolated local database and a longer setup navigation timeout. Inspected screenshots for URL styling and the inline reply divider.

Performance: URL detection runs on document changes and reuses decorations for selection changes; no added database, network, or AI calls.
