### PR TITLE
mail: Show account switching shortcut hints

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
@@ -28,6 +28,24 @@ test("chooses which accounts appear in All Accounts", async ({
       for (const portal of portals) portal.remove();
     });
     await capturePlaywrightCheckpoint(page, testInfo, "all-accounts-menu");
+    await expect(page.getByRole("menu").locator("kbd")).toHaveCount(0);
+
+    await page.addInitScript(() => {
+      Object.assign(window, {
+        inboxZeroDesktop: { startAuth: async () => {} },
+      });
+    });
+    await page.reload();
+    await page
+      .getByRole("button", { name: /playwright-test\+/i })
+      .last()
+      .click();
+    await expect(page.getByRole("menu").locator("kbd")).toHaveText([
+      "⌘/Ctrl+0",
+      "⌘/Ctrl+1",
+      "⌘/Ctrl+2",
+    ]);
+    await capturePlaywrightCheckpoint(page, testInfo, "account-shortcuts");
 
     await chooseAccountsMenuItem.click();
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -10,6 +10,7 @@ import {
 import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/route";
 import { AllAccountsSelectionDialog } from "@/app/(app)/[emailAccountId]/mail/AllAccountsSelectionDialog";
 import { ProfileImage } from "@/components/ProfileImage";
+import { Kbd } from "@/components/Kbd";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,15 +25,22 @@ import {
 } from "@/components/ui/tooltip";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useAccounts } from "@/hooks/useAccounts";
+import {
+  formatShortcutKeys,
+  getShortcut,
+  getShortcutHint,
+} from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
 
 export function MailAccountSwitcher({
   isAllAccounts,
+  isDesktopApp,
   onSelectAccount,
   onSelectAll,
   variant,
 }: {
   isAllAccounts: boolean;
+  isDesktopApp: boolean;
   onSelectAccount: (accountId: string) => void;
   onSelectAll: () => void;
   variant: "compact" | "sidebar";
@@ -113,6 +121,11 @@ export function MailAccountSwitcher({
                 >
                   <AllAccountsIcon />
                   <span className="font-medium">All accounts</span>
+                  {isDesktopApp && (
+                    <Kbd className="ml-auto shrink-0">
+                      {getShortcutHint("switchAllAccounts")}
+                    </Kbd>
+                  )}
                 </DropdownMenuItem>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -130,11 +143,16 @@ export function MailAccountSwitcher({
               <DropdownMenuSeparator />
             </>
           ) : null}
-          {data.emailAccounts.map((account) => (
+          {data.emailAccounts.map((account, index) => (
             <AccountItem
               account={account}
               key={account.id}
               onSelect={onSelectAccount}
+              shortcutKey={
+                isDesktopApp
+                  ? getShortcut("switchAccount").keys[index]
+                  : undefined
+              }
             />
           ))}
           <DropdownMenuSeparator />
@@ -164,9 +182,11 @@ export function MailAccountSwitcher({
 function AccountItem({
   account,
   onSelect,
+  shortcutKey,
 }: {
   account: GetEmailAccountsResponse["emailAccounts"][number];
   onSelect: (accountId: string) => void;
+  shortcutKey: string | undefined;
 }) {
   return (
     <DropdownMenuItem
@@ -188,6 +208,14 @@ function AccountItem({
           </span>
         ) : null}
       </span>
+      {shortcutKey && (
+        <Kbd className="shrink-0">
+          {formatShortcutKeys({
+            ...getShortcut("switchAccount"),
+            display: [shortcutKey.replace("mod+", "modorctrl+")],
+          })}
+        </Kbd>
+      )}
     </DropdownMenuItem>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1259,6 +1259,7 @@ export function MailShell() {
               unified={isAllAccounts}
               footer={
                 <MailAccountSwitcher
+                  isDesktopApp={isDesktopApp}
                   isAllAccounts={isAllAccounts}
                   onSelectAccount={selectAccount}
                   onSelectAll={selectAllAccounts}
@@ -1421,6 +1422,7 @@ export function MailShell() {
       </div>
 
       <MailAccountSwitcher
+        isDesktopApp={isDesktopApp}
         isAllAccounts={isAllAccounts}
         onSelectAccount={selectAccount}
         onSelectAll={selectAllAccounts}


### PR DESCRIPTION
Shows keyboard shortcut hints beside accounts and All accounts in the desktop account switcher, using the existing shortcut registry and account order.

- Keeps hints hidden in the browser and adds browser coverage for both environments.
- Validation: focused Biome checks, secret scanning, CI build, unit tests, and account-selection browser tests passed; the shortcut screenshot was visually inspected.
- Performance: small menu-rendering change with no added database or network calls.
