### PR TITLE
fix: Keep unread indicator visible on hover

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -90,21 +90,20 @@ export const ThreadRow = memo(function ThreadRow({
   const snippet = decodeSnippet(thread.snippet || message.snippet);
   const chips = labels.slice(0, isWide ? 3 : 2);
   const showCheckbox = isSelected || hasAnySelection;
-  let unreadIndicatorOpacity = "opacity-0";
-  if (isUnread && !showCheckbox) {
-    unreadIndicatorOpacity = selectionEnabled
-      ? "opacity-100 group-focus-within:opacity-0 group-hover:opacity-0"
-      : "opacity-100";
-  }
 
   const leadingIndicator = (
-    <span className={cn("relative size-3.5 shrink-0", !isWide && "mt-0.5")}>
+    <span
+      className={cn(
+        "flex h-3.5 shrink-0 items-center gap-1.5",
+        !isWide && "mt-0.5",
+      )}
+    >
       {selectionEnabled ? (
         <Checkbox
           aria-label={`Select conversation with ${participantSummary}`}
           checked={isSelected}
           className={cn(
-            "absolute inset-0 size-3.5 rounded border-input transition-opacity [&_svg]:size-2.5",
+            "size-3.5 rounded border-input transition-opacity [&_svg]:size-2.5",
             showCheckbox
               ? "opacity-100"
               : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100",
@@ -120,12 +119,10 @@ export const ThreadRow = memo(function ThreadRow({
       <span
         aria-hidden
         className={cn(
-          "pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity",
-          unreadIndicatorOpacity,
+          "pointer-events-none size-1.5 shrink-0 rounded-full bg-primary",
+          !isUnread && "invisible",
         )}
-      >
-        <span className="size-1.5 rounded-full bg-primary" />
-      </span>
+      />
     </span>
   );
 


### PR DESCRIPTION
Keep the unread indicator visible when hovering, focusing, or selecting an email row. Give the checkbox and indicator separate space so interaction does not shift the row contents.

- Preserve unread state visibility alongside selection controls.
- Validation: Biome and diff checks passed. The focused browser layout test was blocked during authentication by invalid local database credentials.
- Performance: styling-only change with no added database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

