### PR TITLE
mail: group the thread list by date

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -144,16 +144,18 @@ export function ThreadList({
             >
               {dateGroups.map((group) => (
                 <div
-                  aria-label={group.label}
+                  aria-label={group.label ?? undefined}
                   key={`${group.label}-${group.startIndex}`}
                   role="group"
                 >
-                  <div
-                    aria-hidden
-                    className="pt-4 pr-5 pb-1.5 pl-9 font-medium text-muted-foreground text-sm"
-                  >
-                    {group.label}
-                  </div>
+                  {group.label ? (
+                    <div
+                      aria-hidden
+                      className="pt-4 pr-5 pb-1.5 pl-9 font-medium text-muted-foreground text-sm"
+                    >
+                      {group.label}
+                    </div>
+                  ) : null}
                   {group.threads.map((thread, offset) => {
                     const index = group.startIndex + offset;
                     const threadKey = getListThreadKey(thread);

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { addDays } from "date-fns/addDays";
+import { startOfDay } from "date-fns/startOfDay";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
 import type {
@@ -70,7 +72,11 @@ export function ThreadList({
   const focusedThreadId = threads[focusedIndex]
     ? getListThreadKey(threads[focusedIndex])
     : undefined;
-  const dateGroups = useMemo(() => groupThreadsByDate(threads), [threads]);
+  const dayStart = useDayStart();
+  const dateGroups = useMemo(
+    () => groupThreadsByDate(threads, dayStart),
+    [dayStart, threads],
+  );
 
   // Keep the J/K cursor on screen without centering every row. Layout phase so
   // a held arrow key never paints a selected row that's already off-screen.
@@ -204,4 +210,19 @@ export function ThreadList({
       </div>
     </div>
   );
+}
+
+/** Re-renders the list at local midnight so "Today" and "Yesterday" stay true. */
+function useDayStart() {
+  const [dayStart, setDayStart] = useState(() => startOfDay(new Date()));
+
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setDayStart(startOfDay(new Date())),
+      addDays(dayStart, 1).getTime() - Date.now(),
+    );
+    return () => clearTimeout(timeout);
+  }, [dayStart]);
+
+  return dayStart;
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ThreadRow } from "@/app/(app)/[emailAccountId]/mail/ThreadRow";
 import type {
   ListThread,
@@ -8,6 +8,7 @@ import type {
 } from "@/app/(app)/[emailAccountId]/mail/types";
 import { getListThreadKey } from "@/app/(app)/[emailAccountId]/mail/types";
 import {
+  groupThreadsByDate,
   scrollElementIntoContainer,
   shouldPrefetchMoreThreads,
   THREAD_LOAD_MORE_ROOT_MARGIN,
@@ -69,6 +70,7 @@ export function ThreadList({
   const focusedThreadId = threads[focusedIndex]
     ? getListThreadKey(threads[focusedIndex])
     : undefined;
+  const dateGroups = useMemo(() => groupThreadsByDate(threads), [threads]);
 
   // Keep the J/K cursor on screen without centering every row. Layout phase so
   // a held arrow key never paints a selected row that's already off-screen.
@@ -134,33 +136,50 @@ export function ThreadList({
               aria-multiselectable={selectionEnabled || undefined}
               role="listbox"
             >
-              {threads.map((thread, index) => {
-                const threadKey = getListThreadKey(thread);
-                return (
-                  <ThreadRow
-                    hasAnySelection={selectionEnabled && selectedCount > 0}
-                    compact={isMobile}
-                    expandedPreview={expandedPreview}
-                    index={index}
-                    isFocused={index === focusedIndex}
-                    isSelected={selectionEnabled && isSelected(threadKey)}
-                    key={threadKey}
-                    layout={layout}
-                    onOpen={onOpenThread}
-                    onSelectRangeTo={onSelectRangeTo}
-                    onToggleSelect={onToggleSelect}
-                    rowRef={index === focusedIndex ? focusedRowRef : undefined}
-                    selectionEnabled={selectionEnabled}
-                    thread={thread}
-                    userEmail={userEmail}
-                    userLabels={
-                      "account" in thread
-                        ? (labelsByAccount?.[thread.account.id] ?? {})
-                        : userLabels
-                    }
-                  />
-                );
-              })}
+              {dateGroups.map((group) => (
+                <div
+                  aria-label={group.label}
+                  key={`${group.label}-${group.startIndex}`}
+                  role="group"
+                >
+                  <div
+                    aria-hidden
+                    className="pt-4 pr-5 pb-1.5 pl-9 font-medium text-muted-foreground text-sm"
+                  >
+                    {group.label}
+                  </div>
+                  {group.threads.map((thread, offset) => {
+                    const index = group.startIndex + offset;
+                    const threadKey = getListThreadKey(thread);
+                    return (
+                      <ThreadRow
+                        hasAnySelection={selectionEnabled && selectedCount > 0}
+                        compact={isMobile}
+                        expandedPreview={expandedPreview}
+                        index={index}
+                        isFocused={index === focusedIndex}
+                        isSelected={selectionEnabled && isSelected(threadKey)}
+                        key={threadKey}
+                        layout={layout}
+                        onOpen={onOpenThread}
+                        onSelectRangeTo={onSelectRangeTo}
+                        onToggleSelect={onToggleSelect}
+                        rowRef={
+                          index === focusedIndex ? focusedRowRef : undefined
+                        }
+                        selectionEnabled={selectionEnabled}
+                        thread={thread}
+                        userEmail={userEmail}
+                        userLabels={
+                          "account" in thread
+                            ? (labelsByAccount?.[thread.account.id] ?? {})
+                            : userLabels
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              ))}
             </div>
 
             {showLoadMore ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getActiveThreadIndex,
+  groupThreadsByDate,
   getNextThreadAfterRemoval,
   resolveThreadActionTargets,
   scrollElementIntoContainer,
@@ -301,6 +302,67 @@ describe("scrollElementIntoContainer", () => {
     expect(container.scrollTop).toBe(12);
   });
 });
+
+describe("groupThreadsByDate", () => {
+  const now = new Date("2025-09-05T12:00:00");
+
+  it("groups consecutive threads under one heading and keeps list positions", () => {
+    const groups = groupThreadsByDate(
+      [
+        createDatedThread("2025-09-05T11:00:00"),
+        createDatedThread("2025-09-05T08:00:00"),
+        createDatedThread("2025-09-04T18:00:00"),
+        createDatedThread("2025-08-30T18:00:00"),
+        createDatedThread("2025-08-02T18:00:00"),
+      ],
+      now,
+    );
+
+    expect(
+      groups.map((group) => ({
+        label: group.label,
+        startIndex: group.startIndex,
+        count: group.threads.length,
+      })),
+    ).toEqual([
+      { label: "Today", startIndex: 0, count: 2 },
+      { label: "Yesterday", startIndex: 2, count: 1 },
+      { label: "August", startIndex: 3, count: 2 },
+    ]);
+  });
+
+  it("dates a thread by its latest message", () => {
+    const thread = {
+      messages: [
+        { internalDate: "2025-08-01T09:00:00" },
+        { internalDate: "2025-09-05T09:00:00" },
+      ],
+    };
+
+    expect(groupThreadsByDate([thread], now)[0].label).toBe("Today");
+  });
+
+  it("starts a new group when the list is not date-ordered", () => {
+    const groups = groupThreadsByDate(
+      [
+        createDatedThread("2025-09-05T11:00:00"),
+        createDatedThread("2025-09-04T11:00:00"),
+        createDatedThread("2025-09-05T09:00:00"),
+      ],
+      now,
+    );
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Today",
+      "Yesterday",
+      "Today",
+    ]);
+  });
+});
+
+function createDatedThread(internalDate: string) {
+  return { messages: [{ internalDate }] };
+}
 
 function createBox({
   top,

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -342,6 +342,27 @@ describe("groupThreadsByDate", () => {
     expect(groupThreadsByDate([thread], now)[0].label).toBe("Today");
   });
 
+  it("gives undated threads no heading instead of dating them now", () => {
+    const groups = groupThreadsByDate(
+      [
+        createDatedThread("2025-09-05T11:00:00"),
+        { messages: [{ internalDate: undefined }] },
+        { messages: [{ internalDate: "not-a-date" }] },
+      ],
+      now,
+    );
+
+    expect(
+      groups.map((group) => ({
+        label: group.label,
+        count: group.threads.length,
+      })),
+    ).toEqual([
+      { label: "Today", count: 1 },
+      { label: null, count: 2 },
+    ]);
+  });
+
   it("starts a new group when the list is not date-ordered", () => {
     const groups = groupThreadsByDate(
       [

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -1,4 +1,5 @@
-import { formatDateGroupLabel, internalDateToDate } from "@/utils/date";
+import { formatDateGroupLabel } from "@/utils/date";
+import { getThreadTimestamp } from "@/utils/threads/sort";
 
 export const THREAD_PREFETCH_REMAINING = 8;
 export const THREAD_SCROLL_PADDING_PX = 8;
@@ -136,19 +137,24 @@ export function scrollElementIntoContainer(
 /**
  * Splits a date-ordered list into consecutive runs that share a date heading,
  * keeping each thread's position in the flat list so selection and focus stay
- * index-addressed.
+ * index-addressed. Runs are dated with the same timestamp the list is sorted
+ * by, so a heading can never disagree with where its rows sit; undated threads
+ * get no heading rather than a fabricated one.
  */
 export function groupThreadsByDate<
   T extends { messages: Array<{ internalDate?: string | null }> },
 >(threads: T[], now?: Date) {
-  const groups: { label: string; startIndex: number; threads: T[] }[] = [];
+  const groups: {
+    label: string | null;
+    startIndex: number;
+    threads: T[];
+  }[] = [];
 
   threads.forEach((thread, index) => {
-    const message = thread.messages.at(-1);
-    const label = formatDateGroupLabel(
-      internalDateToDate(message?.internalDate),
-      now,
-    );
+    const timestamp = getThreadTimestamp(thread);
+    const label = timestamp
+      ? formatDateGroupLabel(new Date(timestamp), now)
+      : null;
 
     const openGroup = groups.at(-1);
     if (openGroup?.label === label) openGroup.threads.push(thread);

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.ts
@@ -1,3 +1,5 @@
+import { formatDateGroupLabel, internalDateToDate } from "@/utils/date";
+
 export const THREAD_PREFETCH_REMAINING = 8;
 export const THREAD_SCROLL_PADDING_PX = 8;
 export const THREAD_LOAD_MORE_ROOT_MARGIN = "400px 0px";
@@ -129,4 +131,29 @@ export function scrollElementIntoContainer(
   } else if (bottomOverflow > 0) {
     container.scrollTop += bottomOverflow;
   }
+}
+
+/**
+ * Splits a date-ordered list into consecutive runs that share a date heading,
+ * keeping each thread's position in the flat list so selection and focus stay
+ * index-addressed.
+ */
+export function groupThreadsByDate<
+  T extends { messages: Array<{ internalDate?: string | null }> },
+>(threads: T[], now?: Date) {
+  const groups: { label: string; startIndex: number; threads: T[] }[] = [];
+
+  threads.forEach((thread, index) => {
+    const message = thread.messages.at(-1);
+    const label = formatDateGroupLabel(
+      internalDateToDate(message?.internalDate),
+      now,
+    );
+
+    const openGroup = groups.at(-1);
+    if (openGroup?.label === label) openGroup.threads.push(thread);
+    else groups.push({ label, startIndex: index, threads: [thread] });
+  });
+
+  return groups;
 }

--- a/apps/web/utils/date.test.ts
+++ b/apps/web/utils/date.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatDateGroupLabel,
   getElapsedBusinessDaysForDisplay,
   formatInUserTimezone,
   formatTimeInUserTimezone,
@@ -254,5 +255,40 @@ describe("business day elapsed helpers", () => {
         timezone: "UTC",
       }),
     ).toBe(3);
+  });
+});
+
+describe("formatDateGroupLabel", () => {
+  const now = new Date("2025-09-05T12:00:00");
+
+  it.each([
+    { name: "today", date: "2025-09-05T09:30:00", expected: "Today" },
+    { name: "yesterday", date: "2025-09-04T23:59:00", expected: "Yesterday" },
+    {
+      name: "an earlier day this month",
+      date: "2025-09-01T08:00:00",
+      expected: "September 1st",
+    },
+    {
+      name: "a day last month",
+      date: "2025-08-22T08:00:00",
+      expected: "August",
+    },
+    {
+      name: "a day in a previous year",
+      date: "2024-08-22T08:00:00",
+      expected: "August 2024",
+    },
+  ])("labels $name", ({ date, expected }) => {
+    expect(formatDateGroupLabel(new Date(date), now)).toBe(expected);
+  });
+
+  it("labels yesterday even when it falls in the previous month", () => {
+    expect(
+      formatDateGroupLabel(
+        new Date("2025-08-31T22:00:00"),
+        new Date("2025-09-01T09:00:00"),
+      ),
+    ).toBe("Yesterday");
   });
 });

--- a/apps/web/utils/date.ts
+++ b/apps/web/utils/date.ts
@@ -1,6 +1,10 @@
 import { format } from "date-fns/format";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
+import { isSameDay } from "date-fns/isSameDay";
+import { isSameMonth } from "date-fns/isSameMonth";
+import { isSameYear } from "date-fns/isSameYear";
 import { isWeekend } from "date-fns/isWeekend";
+import { subDays } from "date-fns/subDays";
 import { TZDate } from "@date-fns/tz";
 import { createScopedLogger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
@@ -54,6 +58,20 @@ export function formatShortDate(
   });
 
   return options.lowercase ? formattedDate : formattedDate.toUpperCase();
+}
+
+/**
+ * Labels a date for grouping an email list into sections.
+ * - Today and yesterday get their own sections.
+ * - Other days in the current month are labelled by day (e.g. "September 5th").
+ * - Earlier dates are labelled by month (e.g. "August", or "August 2024").
+ */
+export function formatDateGroupLabel(date: Date, now: Date = new Date()) {
+  if (isSameDay(date, now)) return "Today";
+  if (isSameDay(date, subDays(now, 1))) return "Yesterday";
+  if (isSameMonth(date, now)) return format(date, "MMMM do");
+  if (isSameYear(date, now)) return format(date, "MMMM");
+  return format(date, "MMMM yyyy");
 }
 
 export function dateToSeconds(date: Date) {

--- a/apps/web/utils/threads/sort.ts
+++ b/apps/web/utils/threads/sort.ts
@@ -1,7 +1,9 @@
 import { internalDateToDate } from "@/utils/date";
-import type { ThreadListItem } from "@/utils/threads/load";
 
-export function getThreadTimestamp(thread: Pick<ThreadListItem, "messages">) {
+/** Undated threads collapse to 0 so they sort to the end of a list. */
+export function getThreadTimestamp(thread: {
+  messages: Array<{ internalDate?: string | null }>;
+}) {
   return (
     internalDateToDate(thread.messages.at(-1)?.internalDate, {
       fallbackToNow: false,


### PR DESCRIPTION
Splits the mail list into date sections so long lists are easier to scan.

- Headings are Today, Yesterday, day of month for earlier days in the current month (e.g. "September 5th"), then month, then month and year for older mail.
- Grouping runs over consecutive threads and keeps each row's flat index, so selection, range select, and J/K focus are unchanged.
- Each run renders as an ARIA group inside the existing conversation listbox; headings scroll with the content rather than sticking, so the keyboard cursor is never hidden behind one.
- Covered by unit tests for the label and grouping helpers; the emulated Playwright mail navigation, triage, and command palette specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email threads are grouped under date-based headings such as Today, Yesterday, and month names.
  * Date headings adjust for current-month, previous-month, and prior-year messages.
  * Grouping refreshes automatically at local midnight to keep labels current.

* **Bug Fixes**
  * Date grouping reflects each thread’s most recent message, including non-date-ordered lists.
  * Threads without valid dates no longer receive misleading date headings.

* **Tests**
  * Added coverage for date labels, month boundaries, year transitions, and thread grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->