### PR TITLE
mail: Add slash shortcut to focus search

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
@@ -34,3 +34,14 @@ test("searches the mailbox and clears back to the inbox", async ({ page }) => {
   await expect(matching).toBeVisible();
   await expect(nonMatching).toBeVisible();
 });
+
+test("slash focuses the mail search bar", async ({ page }) => {
+  await openMail(page);
+  const searchInput = page.getByPlaceholder("Search mail");
+  await expect(searchInput).toBeVisible();
+  await page.getByRole("listbox", { name: "Conversations" }).click();
+
+  await page.keyboard.press("Slash");
+
+  await expect(searchInput).toBeFocused();
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, type RefObject } from "react";
 import {
   ArchiveIcon,
   ColumnsIcon,
@@ -27,6 +27,8 @@ export type ListToolbarProps = {
   searchQuery?: string;
   /** When provided, the toolbar shows a real mail search input. */
   onSearch?: (query: string) => void;
+  /** Lets `/` focus the mail search field from the shortcut handler. */
+  searchInputRef?: RefObject<HTMLInputElement | null>;
   onOpenSearch: () => void;
   onToggleLayout: () => void;
   onTogglePreview: () => void;
@@ -46,6 +48,7 @@ export function ListToolbar({
   expandedPreview,
   searchQuery = "",
   onSearch,
+  searchInputRef,
   onOpenSearch,
   onToggleLayout,
   onTogglePreview,
@@ -129,7 +132,11 @@ export function ListToolbar({
           </Tooltip>
         </>
       ) : onSearch ? (
-        <MailSearchInput searchQuery={searchQuery} onSearch={onSearch} />
+        <MailSearchInput
+          searchQuery={searchQuery}
+          onSearch={onSearch}
+          inputRef={searchInputRef}
+        />
       ) : (
         // Opens the command palette rather than searching mail — combined
         // inboxes can't search across accounts yet, so promising search we
@@ -204,11 +211,14 @@ export function ListToolbar({
 function MailSearchInput({
   searchQuery,
   onSearch,
+  inputRef: inputRefProp,
 }: {
   searchQuery: string;
   onSearch: (query: string) => void;
+  inputRef?: RefObject<HTMLInputElement | null>;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const localRef = useRef<HTMLInputElement>(null);
+  const inputRef = inputRefProp ?? localRef;
 
   return (
     <form
@@ -221,7 +231,7 @@ function MailSearchInput({
         event.preventDefault();
         onSearch(inputRef.current?.value.trim() ?? "");
       }}
-      className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors focus-within:border-[hsl(var(--border-strong))] focus-within:bg-background hover:border-[hsl(var(--border-strong))]"
+      className="group flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors focus-within:border-[hsl(var(--border-strong))] focus-within:bg-background hover:border-[hsl(var(--border-strong))]"
     >
       <SearchIcon className="size-3.5 shrink-0" />
       <input
@@ -250,7 +260,11 @@ function MailSearchInput({
         >
           <XIcon className="size-3.5" />
         </button>
-      ) : null}
+      ) : (
+        <Kbd className="pointer-events-none shrink-0 group-focus-within:invisible">
+          {getShortcutHint("search")}
+        </Kbd>
+      )}
     </form>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -184,6 +185,8 @@ export function MailShell() {
     mode: "reply" | "forward";
     threadKey: string;
   } | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const pendingSearchFocusRef = useRef(false);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
 
   useEffect(() => {
@@ -1003,8 +1006,36 @@ export function MailShell() {
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
       togglePreview,
       help: () => setIsHelpOpen(true),
+      search: isMailOverlayOpen
+        ? undefined
+        : () => {
+            if (isAllAccounts) {
+              setPaletteOpen(true);
+              return;
+            }
+            if (selection.hasSelection) selection.clear();
+            if (layout === "list" && openThreadId) closeReader();
+            pendingSearchFocusRef.current = true;
+            const input = searchInputRef.current;
+            if (input) {
+              pendingSearchFocusRef.current = false;
+              input.focus();
+              input.select();
+            }
+          },
     };
   })();
+
+  useLayoutEffect(() => {
+    // The search field remounts when selection clears or the list returns, so
+    // consume a pending `/` focus after whichever commit actually rendered it.
+    if (!pendingSearchFocusRef.current) return;
+    const input = searchInputRef.current;
+    if (!input) return;
+    pendingSearchFocusRef.current = false;
+    input.focus();
+    input.select();
+  });
 
   useShortcuts(handlers, { isDesktopApp });
 
@@ -1303,6 +1334,7 @@ export function MailShell() {
               layout={layout}
               searchQuery={searchQuery ?? ""}
               onSearch={isAllAccounts ? undefined : setSearch}
+              searchInputRef={searchInputRef}
               onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
               expandedPreview={expandedPreview}

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -58,6 +58,7 @@ describe("shortcut registry", () => {
   it("renders keys the way the help dialog and palette show them", () => {
     expect(formatShortcutKeys(getShortcut("next"))).toBe("J / ↓");
     expect(formatShortcutKeys(getShortcut("commandPalette"))).toBe("⌘K");
+    expect(formatShortcutKeys(getShortcut("search"))).toBe("/");
     expect(formatShortcutKeys(getShortcut("selectAll"))).toBe("⌘A");
     expect(formatShortcutKeys(getShortcut("send"))).toBe("⌘↵");
     expect(formatShortcutKeys(getShortcut("sendAndMarkDone"))).toBe("⌘⇧↵");

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -165,6 +165,13 @@ const SHORTCUT_DEFINITIONS = [
     allowWhileTyping: true,
   },
   {
+    id: "search",
+    keys: ["/"],
+    scope: "mail",
+    group: "Navigate",
+    label: "Search",
+  },
+  {
     id: "select",
     keys: ["x"],
     scope: "mail",

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -24,6 +24,29 @@ describe("useShortcuts", () => {
     expect(snooze).toHaveBeenCalledOnce();
   });
 
+  it("runs the search shortcut for slash", () => {
+    const search = vi.fn();
+    renderShortcuts({ search });
+
+    const event = press({ key: "/", code: "Slash" });
+
+    expect(search).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves slash to the field while the user is typing", () => {
+    const search = vi.fn();
+    renderShortcuts({ search });
+
+    const event = press(
+      { key: "/", code: "Slash" },
+      screen.getByRole("textbox"),
+    );
+
+    expect(search).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("leaves mail shortcuts inert outside the mail scope", () => {
     const archive = vi.fn();
     const commandPalette = vi.fn();
@@ -137,7 +160,8 @@ describe("useShortcuts", () => {
     const backToList = vi.fn();
     const open = vi.fn();
     const nextSplit = vi.fn();
-    renderShortcuts({ backToList, nextSplit, open });
+    const search = vi.fn();
+    renderShortcuts({ backToList, nextSplit, open, search });
 
     const mailEvent = press({ key: "Tab", code: "Tab" });
     const mailOpenEvent = press({ key: "Enter", code: "Enter" });
@@ -153,15 +177,21 @@ describe("useShortcuts", () => {
       { key: "Escape", code: "Escape" },
       screen.getByRole("button", { name: "Dialog action" }),
     );
+    const dialogSearchEvent = press(
+      { key: "/", code: "Slash" },
+      screen.getByRole("button", { name: "Dialog action" }),
+    );
 
     expect(nextSplit).toHaveBeenCalledOnce();
     expect(open).toHaveBeenCalledOnce();
     expect(backToList).not.toHaveBeenCalled();
+    expect(search).not.toHaveBeenCalled();
     expect(mailEvent.defaultPrevented).toBe(true);
     expect(mailOpenEvent.defaultPrevented).toBe(true);
     expect(dialogTabEvent.defaultPrevented).toBe(false);
     expect(dialogOpenEvent.defaultPrevented).toBe(false);
     expect(dialogEscapeEvent.defaultPrevented).toBe(false);
+    expect(dialogSearchEvent.defaultPrevented).toBe(false);
   });
 
   it("ignores modified presses of a plain shortcut", () => {

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -201,7 +201,7 @@ function resolveTarget(
   }
   if (
     target?.type === "entry" &&
-    ["backToList", "open", "nextSplit"].includes(target.entry.id) &&
+    ["backToList", "open", "nextSplit", "search"].includes(target.entry.id) &&
     event.target instanceof Element &&
     event.target.closest('[role="dialog"]')
   ) {


### PR DESCRIPTION
## Summary
- Bind `/` on the mail screen to focus the search bar so users can jump to search without reaching for the mouse
- Open the command palette from `/` in combined inbox, where cross-account search is not available yet
- Leave `/` as a normal character while typing or when a dialog has focus

## Test plan
- [ ] Open mail and press `/` — the search field should focus
- [ ] Type a query and submit — search still works as before
- [ ] Press `/` while already in an input or dialog — it should type `/` instead of stealing focus
- [ ] Combined inbox: `/` should open the command palette
- [ ] Open the `?` shortcut help and confirm Search is listed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `/` keyboard shortcut to quickly focus mail search while viewing a conversation list.
  - Displays the search shortcut hint when the search field is inactive.
  - In all-accounts view, `/` opens the command palette instead.

- **Bug Fixes**
  - Search shortcuts no longer activate while typing in text fields or interacting with dialogs.
  - Search focus is preserved correctly when the mail view reloads or remounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->