### PR TITLE
mail: Soften the dark theme to charcoal

### DIFF
--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -156,9 +156,25 @@ jobs:
           fi
           public_base_url="https://${S3_BUCKET}.${S3_ENDPOINT#https://}/playwright"
           gallery_url="$public_base_url/prs/$PR_NUMBER/index.html"
+          review_path="$GITHUB_WORKSPACE/.tmp/playwright-dashboard/screenshots/review.json"
+          if [[ ! -f "$review_path" ]]; then
+            echo "Missing Playwright review manifest at $review_path." >&2
+            exit 1
+          fi
+          changed_paths_file="$(mktemp)"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > "$changed_paths_file"
           marker="<!-- inbox-zero-playwright-screenshots -->"
-          body="$(printf '%s\n### Playwright screenshots\n[Open screenshot gallery](%s) · [Dashboard](%s/index.html) · [CI run](%s)\n\nUpdated for commit `%s`.' \
-            "$marker" "$gallery_url" "$public_base_url" "$RUN_URL" "${SHA:0:7}")"
+          body="$(
+            PLAYWRIGHT_GALLERY_URL="$gallery_url" \
+            PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
+            PLAYWRIGHT_RUN_URL="$RUN_URL" \
+            PLAYWRIGHT_SHA="$SHA" \
+              pnpm -F inbox-zero-ai exec tsx scripts/build-playwright-pr-comment.ts \
+                "$review_path" \
+                "$changed_paths_file"
+          )"
           comment_id="$(gh api --paginate --slurp \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
             jq -r --arg marker "$marker" \

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -161,10 +161,13 @@ jobs:
             echo "Missing Playwright review manifest at $review_path." >&2
             exit 1
           fi
+          # Compare against the run's exact commit so a push that lands mid-step
+          # cannot swap in a newer head's file list.
+          base_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .base.sha)"
           changed_paths_file="$(mktemp)"
           gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
-            --jq '.[].filename' > "$changed_paths_file"
+            "repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${SHA}?per_page=100" \
+            --jq '.files[].filename' > "$changed_paths_file"
           marker="<!-- inbox-zero-playwright-screenshots -->"
           body="$(
             PLAYWRIGHT_GALLERY_URL="$gallery_url" \

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -80,6 +80,11 @@ failure also retains its trace and video.
 After each pull request run, a trusted follow-up workflow publishes a
 screenshot-only gallery, compares its checkpoints with the latest successful
 `main` run, and adds or updates a pull request comment with the gallery link.
+The comment also embeds the frames most worth a look: failure captures, new
+checkpoints, changed checkpoints from specs the pull request touched, and the
+changed checkpoints with the largest share of differing pixels against `main`.
+Hash comparison alone flags most captures as changed because of timestamps and
+other drift, so the pixel ranking is what surfaces real visual changes.
 The full HTML report stays private to the GitHub Actions artifact for pull
 requests because it was generated from contributor-controlled code. Successful
 and failed `main` runs also publish the full report and visual history to the

--- a/apps/web/scripts/build-playwright-pr-comment.ts
+++ b/apps/web/scripts/build-playwright-pr-comment.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import {
+  buildPlaywrightPrComment,
+  type PlaywrightPrCommentScreenshot,
+} from "./playwright-pr-comment";
+
+const [reviewPath, changedPathsPath] = process.argv.slice(2);
+
+if (!reviewPath || !changedPathsPath) {
+  throw new Error(
+    "Usage: build-playwright-pr-comment <review-json-path> <changed-paths-file>",
+  );
+}
+
+buildComment(reviewPath, changedPathsPath);
+
+async function buildComment(reviewFile: string, changedPathsFile: string) {
+  const review = JSON.parse(await readFile(reviewFile, "utf8")) as {
+    screenshots?: PlaywrightPrCommentScreenshot[];
+    screenshotsUrl?: string;
+  };
+  if (!Array.isArray(review.screenshots)) {
+    throw new Error("review.json must include a screenshots array");
+  }
+  if (!isHttpsUrl(review.screenshotsUrl)) {
+    throw new Error("review.json must include an https screenshotsUrl");
+  }
+
+  const changedPaths = (await readFile(changedPathsFile, "utf8"))
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  process.stdout.write(
+    `${buildPlaywrightPrComment({
+      changedPaths,
+      dashboardUrl: getRequiredHttpsEnvironmentVariable(
+        "PLAYWRIGHT_DASHBOARD_URL",
+      ),
+      galleryUrl: getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_GALLERY_URL"),
+      runUrl: getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_RUN_URL"),
+      screenshots: review.screenshots,
+      screenshotsUrl: review.screenshotsUrl,
+      sha: getRequiredEnvironmentVariable("PLAYWRIGHT_SHA"),
+    })}\n`,
+  );
+}
+
+function getRequiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getRequiredHttpsEnvironmentVariable(name: string): string {
+  const value = getRequiredEnvironmentVariable(name);
+  if (!isHttpsUrl(value)) throw new Error(`${name} must use HTTPS`);
+  return value;
+}
+
+function isHttpsUrl(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    URL.canParse(value) &&
+    new URL(value).protocol === "https:"
+  );
+}

--- a/apps/web/scripts/generate-playwright-report-dashboard.ts
+++ b/apps/web/scripts/generate-playwright-report-dashboard.ts
@@ -274,34 +274,37 @@ async function measureDifferences(
       galleryFileName(index, screenshot.source),
     ]),
   );
-  return Promise.all(
-    screenshots.map(async (screenshot) => {
-      const baselineFileName = baselineFileNames.get(screenshot.source);
-      if (screenshot.comparison !== "changed" || !baselineFileName) {
-        return screenshot;
-      }
-      const baselineFile = path.join(
-        baselineImagesPath,
-        path.basename(baselineFileName),
+  // Sequential on purpose: a full suite decodes hundreds of image pairs and
+  // holding them all at once would exhaust the runner's memory.
+  const measured: PlaywrightScreenshot[] = [];
+  for (const screenshot of screenshots) {
+    const baselineFileName = baselineFileNames.get(screenshot.source);
+    if (screenshot.comparison !== "changed" || !baselineFileName) {
+      measured.push(screenshot);
+      continue;
+    }
+    const baselineFile = path.join(
+      baselineImagesPath,
+      path.basename(baselineFileName),
+    );
+    try {
+      const baselineImage = await readFile(baselineFile);
+      validatePngScreenshot(baselineImage, baselineFile);
+      measured.push({
+        ...screenshot,
+        difference: measureScreenshotDifference(
+          await readFile(path.join(outputPath, screenshot.fileName)),
+          baselineImage,
+        ),
+      });
+    } catch (error) {
+      console.warn(
+        `Skipping visual difference for ${screenshot.source}: ${error instanceof Error ? error.message : String(error)}`,
       );
-      try {
-        const baselineImage = await readFile(baselineFile);
-        validatePngScreenshot(baselineImage, baselineFile);
-        return {
-          ...screenshot,
-          difference: measureScreenshotDifference(
-            await readFile(path.join(outputPath, screenshot.fileName)),
-            baselineImage,
-          ),
-        };
-      } catch (error) {
-        console.warn(
-          `Skipping visual difference for ${screenshot.source}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        return screenshot;
-      }
-    }),
-  );
+      measured.push(screenshot);
+    }
+  }
+  return measured;
 }
 
 function titleFromFileName(fileName: string): string {

--- a/apps/web/scripts/generate-playwright-report-dashboard.ts
+++ b/apps/web/scripts/generate-playwright-report-dashboard.ts
@@ -10,18 +10,21 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import {
+  MAX_PNG_SCREENSHOT_BYTES,
+  validatePngScreenshot,
+} from "./png-validation";
+import {
   compareScreenshotsWithBaseline,
   createScreenshotManifest,
+  galleryFileName,
+  isScreenshotManifest,
   type PlaywrightScreenshot,
   renderPlaywrightDashboard,
   renderScreenshotGallery,
   shouldPublishStableMainBaseline,
   updatePlaywrightHistory,
 } from "./playwright-report-dashboard";
-import {
-  MAX_PNG_SCREENSHOT_BYTES,
-  validatePngScreenshot,
-} from "./png-validation";
+import { measureScreenshotDifference } from "./playwright-screenshot-diff";
 
 const [
   historyPath,
@@ -29,6 +32,7 @@ const [
   testResultsPath,
   galleryPath,
   baselineManifestPath,
+  baselineImagesPath,
 ] = process.argv.slice(2);
 const MAX_SCREENSHOT_COUNT = 500;
 const MAX_TOTAL_SCREENSHOT_BYTES = 100 * 1024 * 1024;
@@ -48,11 +52,16 @@ async function generateDashboard() {
     testResultsPath,
     galleryPath,
   );
+  const baseline = await readOptionalJson(baselineManifestPath);
   const comparison = compareScreenshotsWithBaseline(
     collectedScreenshots,
-    await readOptionalJson(baselineManifestPath),
+    baseline,
   );
-  const screenshots = comparison.screenshots;
+  const screenshots = await measureDifferences(
+    comparison.screenshots,
+    baseline,
+    galleryPath,
+  );
   const createdAt = new Date().toISOString();
   const dashboardUrl = getRequiredEnvironmentVariable(
     "PLAYWRIGHT_DASHBOARD_URL",
@@ -98,6 +107,36 @@ async function generateDashboard() {
   await writeFile(
     path.join(galleryPath, "manifest.json"),
     `${JSON.stringify(createScreenshotManifest(screenshots, runIdentity), null, 2)}\n`,
+  );
+  // Consumed by the pull request comment step, which runs after publication.
+  await writeFile(
+    path.join(galleryPath, "review.json"),
+    `${JSON.stringify(
+      {
+        screenshots: screenshots.map(
+          ({
+            captureType,
+            comparison,
+            difference,
+            fileName,
+            source,
+            testId,
+            title,
+          }) => ({
+            captureType,
+            comparison,
+            difference,
+            fileName,
+            source,
+            testId,
+            title,
+          }),
+        ),
+        screenshotsUrl,
+      },
+      null,
+      2,
+    )}\n`,
   );
   await writeFile(
     path.join(galleryPath, "publish-stable-baseline"),
@@ -169,11 +208,11 @@ async function collectScreenshots(
     const screenshot = await readFile(file);
     validatePngScreenshot(screenshot, file);
     const source = path.relative(resultsPath, file);
-    const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
-    await copyFile(file, path.join(imagePath, fileName));
+    const fileName = galleryFileName(index, source);
+    await copyFile(file, path.join(outputPath, fileName));
     screenshots.push({
       captureType: isFailureCapture(file) ? "failure" : "checkpoint",
-      fileName: `images/${fileName}`,
+      fileName,
       hash: createHash("sha256").update(screenshot).digest("hex"),
       source,
       testId: testIdFromSource(source),
@@ -221,8 +260,48 @@ async function findPngFiles(
   return files.flat();
 }
 
-function sanitizeFileName(fileName: string): string {
-  return fileName.replaceAll(/[^a-zA-Z0-9._-]/g, "-");
+async function measureDifferences(
+  screenshots: PlaywrightScreenshot[],
+  baseline: unknown,
+  outputPath: string,
+): Promise<PlaywrightScreenshot[]> {
+  if (!baselineImagesPath || !isScreenshotManifest(baseline)) {
+    return screenshots;
+  }
+  const baselineFileNames = new Map(
+    baseline.screenshots.map((screenshot, index) => [
+      screenshot.source,
+      galleryFileName(index, screenshot.source),
+    ]),
+  );
+  return Promise.all(
+    screenshots.map(async (screenshot) => {
+      const baselineFileName = baselineFileNames.get(screenshot.source);
+      if (screenshot.comparison !== "changed" || !baselineFileName) {
+        return screenshot;
+      }
+      const baselineFile = path.join(
+        baselineImagesPath,
+        path.basename(baselineFileName),
+      );
+      try {
+        const baselineImage = await readFile(baselineFile);
+        validatePngScreenshot(baselineImage, baselineFile);
+        return {
+          ...screenshot,
+          difference: measureScreenshotDifference(
+            await readFile(path.join(outputPath, screenshot.fileName)),
+            baselineImage,
+          ),
+        };
+      } catch (error) {
+        console.warn(
+          `Skipping visual difference for ${screenshot.source}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return screenshot;
+      }
+    }),
+  );
 }
 
 function titleFromFileName(fileName: string): string {

--- a/apps/web/scripts/playwright-pr-comment.test.ts
+++ b/apps/web/scripts/playwright-pr-comment.test.ts
@@ -196,6 +196,25 @@ describe("buildPlaywrightPrComment", () => {
     );
     expect(comment).not.toContain("![");
   });
+
+  it("says when changed captures could not be measured against main", () => {
+    const comment = buildPlaywrightPrComment({
+      ...links,
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/001-final-state.png",
+          source: "mail_ssearch.spec.ts/search/final-state.png",
+          title: "final state",
+        }),
+      ],
+    });
+
+    expect(comment).toContain(
+      "1 changed captures could not be measured against main; review them in the gallery.",
+    );
+  });
 });
 
 function screenshot(

--- a/apps/web/scripts/playwright-pr-comment.test.ts
+++ b/apps/web/scripts/playwright-pr-comment.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlaywrightPrComment,
+  PLAYWRIGHT_PR_COMMENT_MARKER,
+  type PlaywrightPrCommentScreenshot,
+  selectPlaywrightPrFrames,
+} from "./playwright-pr-comment";
+
+describe("selectPlaywrightPrFrames", () => {
+  it("orders failures, new checkpoints, changed specs, then the largest visual changes", () => {
+    const selection = selectPlaywrightPrFrames({
+      changedPaths: [
+        "apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts",
+        "apps/web/styles/globals.css",
+      ],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          difference: 0.35,
+          fileName: "images/001-dark-mode.png",
+          source: "mail_stheme.spec.ts/theme-dark/dark-mode.png",
+          title: "dark mode",
+        }),
+        screenshot({
+          comparison: "changed",
+          difference: 0.004,
+          fileName: "images/002-final-state.png",
+          source: "mail_ssearch.spec.ts/search/final-state.png",
+          title: "search drift",
+        }),
+        screenshot({
+          comparison: "changed",
+          difference: 0.01,
+          fileName: "images/003-split-tabs.png",
+          source: "mail_ssplit-tabs.spec.ts/split/tabs.png",
+          title: "split tabs",
+        }),
+        screenshot({
+          comparison: "new",
+          fileName: "images/004-new-checkpoint.png",
+          source: "mail_sstarring.spec.ts/star/new-checkpoint.png",
+          title: "new checkpoint",
+        }),
+        screenshot({
+          captureType: "failure",
+          comparison: "unavailable",
+          fileName: "images/005-test-failed-1.png",
+          source: "mail_ssearch.spec.ts/search/test-failed-1.png",
+          title: "test failed 1",
+        }),
+        screenshot({
+          comparison: "changed",
+          difference: 0.6,
+          fileName: "images/006-reader.png",
+          source: "mail_sreader-visuals.spec.ts/reader/reader.png",
+          title: "reader",
+        }),
+      ],
+    });
+
+    expect(
+      selection.frames.map((frame) => [frame.title, frame.reason]),
+    ).toEqual([
+      ["test failed 1", "failed"],
+      ["new checkpoint", "new"],
+      ["split tabs", "spec changed"],
+      ["reader", "visual change"],
+      ["dark mode", "visual change"],
+    ]);
+    expect(selection.omittedCount).toBe(0);
+  });
+
+  it("does not list a frame twice and reports how many were cut by the limit", () => {
+    const selection = selectPlaywrightPrFrames({
+      changedPaths: [
+        "apps/web/__tests__/playwright/emulated/mail/theme.spec.ts",
+      ],
+      limit: 2,
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          difference: 0.5,
+          fileName: "images/001-dark.png",
+          source: "mail_stheme.spec.ts/theme/dark.png",
+          title: "dark",
+        }),
+        screenshot({
+          comparison: "changed",
+          difference: 0.4,
+          fileName: "images/002-light.png",
+          source: "mail_stheme.spec.ts/theme/light.png",
+          title: "light",
+        }),
+        screenshot({
+          comparison: "changed",
+          difference: 0.3,
+          fileName: "images/003-reader.png",
+          source: "mail_sreader-visuals.spec.ts/reader/reader.png",
+          title: "reader",
+        }),
+      ],
+    });
+
+    expect(selection.frames.map((frame) => frame.title)).toEqual([
+      "dark",
+      "light",
+    ]);
+    expect(selection.omittedCount).toBe(1);
+  });
+});
+
+describe("buildPlaywrightPrComment", () => {
+  const links = {
+    dashboardUrl: "https://example.com/playwright/index.html",
+    galleryUrl: "https://example.com/playwright/prs/42/index.html",
+    runUrl: "https://github.com/example/repo/actions/runs/1",
+    screenshotsUrl:
+      "https://example.com/playwright/runs/1-1/screenshots/index.html",
+    sha: "0123456789abcdef",
+  };
+
+  it("embeds the selected frames with their spec path and reason", () => {
+    const comment = buildPlaywrightPrComment({
+      ...links,
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          difference: 0.412,
+          fileName: "images/001-Mail-in-dark-mode.png",
+          source: "mail_stheme.spec.ts/theme-dark/Mail-in-dark-mode.png",
+          title: "Mail in dark mode",
+        }),
+        screenshot({
+          comparison: "unchanged",
+          fileName: "images/002-final-state.png",
+          source: "mail_ssearch.spec.ts/search/final-state.png",
+          title: "final state",
+        }),
+      ],
+    });
+
+    expect(comment.startsWith(PLAYWRIGHT_PR_COMMENT_MARKER)).toBe(true);
+    expect(comment).toContain(
+      "2 screenshots captured: 0 new, 1 changed, 1 unchanged compared with main.",
+    );
+    expect(comment).toContain(
+      "**Mail in dark mode** · mail/theme.spec.ts · 41% of pixels differ from main",
+    );
+    expect(comment).toContain(
+      "![Mail in dark mode](https://example.com/playwright/runs/1-1/screenshots/images/001-Mail-in-dark-mode.png)",
+    );
+    expect(comment).toContain(`[Open screenshot gallery](${links.galleryUrl})`);
+    expect(comment).toContain("Updated for commit `0123456`.");
+  });
+
+  it("explains when no baseline exists and escapes markdown in titles", () => {
+    const comment = buildPlaywrightPrComment({
+      ...links,
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          captureType: "failure",
+          comparison: "unavailable",
+          fileName: "images/001-test-failed-1.png",
+          source: "mail_ssearch.spec.ts/[search]_x/test-failed-1.png",
+          title: "test failed [1]",
+        }),
+      ],
+    });
+
+    expect(comment).toContain(
+      "1 screenshots captured, 1 failure captures. No main baseline was available for comparison.",
+    );
+    expect(comment).toContain("**test failed \\[1\\]** · mail/search.spec.ts");
+    expect(comment).toContain("![test failed \\[1\\]](");
+  });
+
+  it("points at the gallery when nothing stands out", () => {
+    const comment = buildPlaywrightPrComment({
+      ...links,
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          difference: 0.001,
+          fileName: "images/001-final-state.png",
+          source: "mail_ssearch.spec.ts/search/final-state.png",
+          title: "final state",
+        }),
+      ],
+    });
+
+    expect(comment).toContain(
+      "Nothing stood out against main; browse every capture in the gallery.",
+    );
+    expect(comment).not.toContain("![");
+  });
+});
+
+function screenshot(
+  overrides: Partial<PlaywrightPrCommentScreenshot> &
+    Pick<PlaywrightPrCommentScreenshot, "fileName" | "source" | "title">,
+): PlaywrightPrCommentScreenshot {
+  return {
+    captureType: "checkpoint",
+    comparison: "unchanged",
+    testId: overrides.source.split("/").slice(0, -1).join(" / "),
+    ...overrides,
+  };
+}

--- a/apps/web/scripts/playwright-pr-comment.ts
+++ b/apps/web/scripts/playwright-pr-comment.ts
@@ -112,10 +112,18 @@ export function buildPlaywrightPrComment(input: {
     summarizeScreenshots(input.screenshots),
   ];
 
+  const unmeasuredChanges = input.screenshots.filter(
+    (screenshot) =>
+      screenshot.captureType === "checkpoint" &&
+      screenshot.comparison === "changed" &&
+      screenshot.difference === undefined,
+  ).length;
   if (frames.length === 0) {
     lines.push(
       "",
-      "Nothing stood out against main; browse every capture in the gallery.",
+      unmeasuredChanges > 0
+        ? `${unmeasuredChanges} changed captures could not be measured against main; review them in the gallery.`
+        : "Nothing stood out against main; browse every capture in the gallery.",
     );
   } else {
     lines.push("", "#### Frames to review");

--- a/apps/web/scripts/playwright-pr-comment.ts
+++ b/apps/web/scripts/playwright-pr-comment.ts
@@ -1,0 +1,188 @@
+import {
+  getPlaywrightSpecPathFromTargetName,
+  getPlaywrightTargetName,
+} from "../utils/playwright/emulated-suite-targets.mjs";
+import type { PlaywrightScreenshot } from "./playwright-report-dashboard";
+
+export const PLAYWRIGHT_PR_COMMENT_MARKER =
+  "<!-- inbox-zero-playwright-screenshots -->";
+export const PLAYWRIGHT_PR_COMMENT_FRAME_LIMIT = 6;
+// Timestamps, avatars, and other run-to-run drift move far fewer pixels than
+// this, so anything above it is a change worth a reviewer's glance.
+export const PLAYWRIGHT_PR_COMMENT_MIN_DIFFERENCE = 0.02;
+
+const EMULATED_SPEC_PATTERN =
+  /^apps\/web\/(__tests__\/playwright\/emulated\/.+\.spec\.ts)$/;
+
+export type PlaywrightPrCommentScreenshot = Pick<
+  PlaywrightScreenshot,
+  | "captureType"
+  | "comparison"
+  | "difference"
+  | "fileName"
+  | "source"
+  | "testId"
+  | "title"
+>;
+
+export type PlaywrightPrFrame = PlaywrightPrCommentScreenshot & {
+  reason: "failed" | "new" | "spec changed" | "visual change";
+};
+
+export function selectPlaywrightPrFrames(input: {
+  changedPaths: readonly string[];
+  limit?: number;
+  minDifference?: number;
+  screenshots: readonly PlaywrightPrCommentScreenshot[];
+}): { frames: PlaywrightPrFrame[]; omittedCount: number } {
+  const limit = input.limit ?? PLAYWRIGHT_PR_COMMENT_FRAME_LIMIT;
+  const minDifference =
+    input.minDifference ?? PLAYWRIGHT_PR_COMMENT_MIN_DIFFERENCE;
+  const changedTargets = new Set(
+    input.changedPaths
+      .map((changedPath) => EMULATED_SPEC_PATTERN.exec(changedPath)?.[1])
+      .filter((specPath): specPath is string => specPath !== undefined)
+      .map(getPlaywrightTargetName),
+  );
+  const checkpoints = input.screenshots.filter(
+    (screenshot) => screenshot.captureType === "checkpoint",
+  );
+  const changed = checkpoints.filter(
+    (screenshot) => screenshot.comparison === "changed",
+  );
+
+  const candidates: PlaywrightPrFrame[] = [
+    ...input.screenshots
+      .filter((screenshot) => screenshot.captureType === "failure")
+      .map((screenshot) => ({ ...screenshot, reason: "failed" as const })),
+    ...checkpoints
+      .filter((screenshot) => screenshot.comparison === "new")
+      .map((screenshot) => ({ ...screenshot, reason: "new" as const })),
+    ...changed
+      .filter((screenshot) =>
+        changedTargets.has(targetNameFromSource(screenshot.source)),
+      )
+      .map((screenshot) => ({
+        ...screenshot,
+        reason: "spec changed" as const,
+      })),
+    ...changed
+      .filter((screenshot) => (screenshot.difference ?? 0) >= minDifference)
+      .sort((left, right) => (right.difference ?? 0) - (left.difference ?? 0))
+      .map((screenshot) => ({
+        ...screenshot,
+        reason: "visual change" as const,
+      })),
+  ];
+
+  const seen = new Set<string>();
+  const frames = candidates.filter((frame) => {
+    if (seen.has(frame.fileName)) return false;
+    seen.add(frame.fileName);
+    return true;
+  });
+  return {
+    frames: frames.slice(0, limit),
+    omittedCount: Math.max(0, frames.length - limit),
+  };
+}
+
+export function buildPlaywrightPrComment(input: {
+  changedPaths: readonly string[];
+  dashboardUrl: string;
+  galleryUrl: string;
+  limit?: number;
+  minDifference?: number;
+  runUrl: string;
+  screenshots: readonly PlaywrightPrCommentScreenshot[];
+  screenshotsUrl: string;
+  sha: string;
+}): string {
+  const { frames, omittedCount } = selectPlaywrightPrFrames(input);
+  const galleryBaseUrl = new URL(".", input.screenshotsUrl);
+  const lines = [
+    PLAYWRIGHT_PR_COMMENT_MARKER,
+    "### Playwright screenshots",
+    [
+      `[Open screenshot gallery](${input.galleryUrl})`,
+      `[Dashboard](${input.dashboardUrl})`,
+      `[CI run](${input.runUrl})`,
+    ].join(" · "),
+    "",
+    summarizeScreenshots(input.screenshots),
+  ];
+
+  if (frames.length === 0) {
+    lines.push(
+      "",
+      "Nothing stood out against main; browse every capture in the gallery.",
+    );
+  } else {
+    lines.push("", "#### Frames to review");
+    for (const frame of frames) {
+      const imageUrl = new URL(frame.fileName, galleryBaseUrl).toString();
+      const title = escapeMarkdown(frame.title);
+      lines.push(
+        "",
+        `**${title}** · ${escapeMarkdown(specPathFromSource(frame.source))} · ${describeReason(frame)}`,
+        "",
+        `![${title}](${imageUrl})`,
+      );
+    }
+    if (omittedCount > 0) {
+      lines.push("", `${omittedCount} more to review in the gallery.`);
+    }
+  }
+
+  lines.push("", `Updated for commit \`${input.sha.slice(0, 7)}\`.`);
+  return lines.join("\n");
+}
+
+function summarizeScreenshots(
+  screenshots: readonly PlaywrightPrCommentScreenshot[],
+): string {
+  const total = screenshots.length;
+  if (total === 0) return "No screenshots were captured.";
+
+  const count = (
+    predicate: (screenshot: PlaywrightPrCommentScreenshot) => boolean,
+  ) => screenshots.filter(predicate).length;
+  const failed = count((screenshot) => screenshot.captureType === "failure");
+  const failureNote = failed > 0 ? `, ${failed} failure captures` : "";
+  const baselineAvailable = screenshots.some(
+    (screenshot) => screenshot.comparison !== "unavailable",
+  );
+  if (!baselineAvailable) {
+    return `${total} screenshots captured${failureNote}. No main baseline was available for comparison.`;
+  }
+  return `${total} screenshots captured: ${count((screenshot) => screenshot.comparison === "new")} new, ${count((screenshot) => screenshot.comparison === "changed")} changed, ${count((screenshot) => screenshot.comparison === "unchanged")} unchanged compared with main${failureNote}.`;
+}
+
+function describeReason(frame: PlaywrightPrFrame): string {
+  switch (frame.reason) {
+    case "failed":
+      return "failed test capture";
+    case "new":
+      return "new checkpoint";
+    case "spec changed":
+      return "spec changed in this PR";
+    case "visual change":
+      return `${Math.round((frame.difference ?? 0) * 100)}% of pixels differ from main`;
+  }
+}
+
+function targetNameFromSource(source: string): string {
+  return source.split(/[\\/]/)[0] ?? source;
+}
+
+function specPathFromSource(source: string): string {
+  return getPlaywrightSpecPathFromTargetName(targetNameFromSource(source));
+}
+
+function escapeMarkdown(value: string): string {
+  const normalized = value.replaceAll(/\s+/g, " ").trim();
+  return (normalized.length > 0 ? normalized : "screenshot").replaceAll(
+    /[\\`*_[\]<>#|]/g,
+    (character) => `\\${character}`,
+  );
+}

--- a/apps/web/scripts/playwright-report-dashboard.ts
+++ b/apps/web/scripts/playwright-report-dashboard.ts
@@ -31,6 +31,8 @@ export type PlaywrightRun = {
 export type PlaywrightScreenshot = {
   captureType: "checkpoint" | "failure";
   comparison: "changed" | "new" | "unavailable" | "unchanged";
+  /** Share of pixels that differ from the main baseline, when both images were available */
+  difference?: number;
   fileName: string;
   hash: string;
   source: string;
@@ -47,8 +49,14 @@ export type PlaywrightScreenshotManifest = {
 
 export type PlaywrightScreenshotMetadata = Omit<
   PlaywrightScreenshot,
-  "comparison" | "fileName"
+  "comparison" | "difference" | "fileName"
 >;
+
+/** Gallery images are numbered in manifest order, so a manifest index maps back to its file. */
+export function galleryFileName(index: number, source: string): string {
+  const baseName = source.split(/[\\/]/).at(-1) ?? source;
+  return `images/${String(index + 1).padStart(3, "0")}-${baseName.replaceAll(/[^a-zA-Z0-9._-]/g, "-")}`;
+}
 
 export function createScreenshotManifest(
   screenshots: PlaywrightScreenshot[],
@@ -414,6 +422,7 @@ export function renderScreenshotGallery(input: {
               <small>${screenshot.captureType === "failure" ? "Automatic failure capture" : "Intentional test checkpoint"} · ${escapeHtml(screenshot.testId)}</small>
               <small title="${escapeHtml(screenshot.source)}">${escapeHtml(screenshot.source)}</small>
               <small>SHA-256 ${escapeHtml(screenshot.hash.slice(0, 12))}</small>
+              ${screenshot.difference === undefined ? "" : `<small>${Math.round(screenshot.difference * 100)}% of pixels differ from main</small>`}
             </span>
           </figcaption>
         </figure>`;
@@ -615,7 +624,7 @@ function isPlaywrightRun(value: unknown): value is PlaywrightRun {
   );
 }
 
-function isScreenshotManifest(
+export function isScreenshotManifest(
   value: unknown,
 ): value is PlaywrightScreenshotManifest {
   if (!value || typeof value !== "object") return false;

--- a/apps/web/scripts/playwright-report-dashboard.ts
+++ b/apps/web/scripts/playwright-report-dashboard.ts
@@ -422,7 +422,7 @@ export function renderScreenshotGallery(input: {
               <small>${screenshot.captureType === "failure" ? "Automatic failure capture" : "Intentional test checkpoint"} · ${escapeHtml(screenshot.testId)}</small>
               <small title="${escapeHtml(screenshot.source)}">${escapeHtml(screenshot.source)}</small>
               <small>SHA-256 ${escapeHtml(screenshot.hash.slice(0, 12))}</small>
-              ${screenshot.difference === undefined ? "" : `<small>${Math.round(screenshot.difference * 100)}% of pixels differ from main</small>`}
+              ${screenshot.difference === undefined ? "" : `<small>${formatDifference(screenshot.difference)} of pixels differ from main</small>`}
             </span>
           </figcaption>
         </figure>`;
@@ -646,6 +646,12 @@ export function isScreenshotManifest(
       );
     })
   );
+}
+
+function formatDifference(difference: number): string {
+  return difference < 0.001
+    ? "<0.1%"
+    : `${Math.round(difference * 1000) / 10}%`;
 }
 
 function isHttpsUrl(value: unknown): value is string {

--- a/apps/web/scripts/playwright-screenshot-diff.test.ts
+++ b/apps/web/scripts/playwright-screenshot-diff.test.ts
@@ -1,0 +1,54 @@
+import { PNG } from "pngjs";
+import { describe, expect, it } from "vitest";
+import { measureScreenshotDifference } from "./playwright-screenshot-diff";
+
+describe("measureScreenshotDifference", () => {
+  it("returns 0 for identical images and ignores sub-threshold noise", () => {
+    const image = solidImage(10, 10, [40, 42, 45, 255]);
+    const noisy = solidImage(10, 10, [44, 38, 49, 255]);
+
+    expect(measureScreenshotDifference(image, image)).toBe(0);
+    expect(measureScreenshotDifference(image, noisy)).toBe(0);
+  });
+
+  it("returns the share of pixels that changed", () => {
+    const baseline = solidImage(10, 10, [255, 255, 255, 255]);
+    const current = solidImage(10, 10, [255, 255, 255, 255], (_x, y) =>
+      y < 4 ? [38, 40, 44, 255] : undefined,
+    );
+
+    expect(measureScreenshotDifference(current, baseline)).toBeCloseTo(0.4);
+  });
+
+  it("treats a size change as fully different", () => {
+    expect(
+      measureScreenshotDifference(
+        solidImage(10, 10, [0, 0, 0, 255]),
+        solidImage(10, 12, [0, 0, 0, 255]),
+      ),
+    ).toBe(1);
+  });
+});
+
+function solidImage(
+  width: number,
+  height: number,
+  color: [number, number, number, number],
+  override?: (
+    x: number,
+    y: number,
+  ) => [number, number, number, number] | undefined,
+): Buffer {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = (y * width + x) * 4;
+      const pixel = override?.(x, y) ?? color;
+      png.data[offset] = pixel[0];
+      png.data[offset + 1] = pixel[1];
+      png.data[offset + 2] = pixel[2];
+      png.data[offset + 3] = pixel[3];
+    }
+  }
+  return PNG.sync.write(png);
+}

--- a/apps/web/scripts/playwright-screenshot-diff.ts
+++ b/apps/web/scripts/playwright-screenshot-diff.ts
@@ -1,0 +1,43 @@
+import { PNG } from "pngjs";
+
+// Anti-aliasing and font hinting jitter stays well under this per-channel delta,
+// so only real pixel changes count toward the difference.
+const CHANNEL_TOLERANCE = 8;
+
+/**
+ * Share of pixels that differ between two PNG screenshots, from 0 to 1.
+ * Screenshots with different dimensions count as fully different.
+ */
+export function measureScreenshotDifference(
+  current: Buffer,
+  baseline: Buffer,
+): number {
+  const currentImage = PNG.sync.read(current);
+  const baselineImage = PNG.sync.read(baseline);
+  if (
+    currentImage.width !== baselineImage.width ||
+    currentImage.height !== baselineImage.height
+  ) {
+    return 1;
+  }
+
+  const pixelCount = currentImage.width * currentImage.height;
+  if (pixelCount === 0) return 0;
+
+  let differingPixels = 0;
+  for (let offset = 0; offset < currentImage.data.length; offset += 4) {
+    if (
+      Math.abs(currentImage.data[offset] - baselineImage.data[offset]) >
+        CHANNEL_TOLERANCE ||
+      Math.abs(currentImage.data[offset + 1] - baselineImage.data[offset + 1]) >
+        CHANNEL_TOLERANCE ||
+      Math.abs(currentImage.data[offset + 2] - baselineImage.data[offset + 2]) >
+        CHANNEL_TOLERANCE ||
+      Math.abs(currentImage.data[offset + 3] - baselineImage.data[offset + 3]) >
+        CHANNEL_TOLERANCE
+    ) {
+      differingPixels += 1;
+    }
+  }
+  return differingPixels / pixelCount;
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -100,7 +100,8 @@
    * Intended to be promoted to `:root` in a follow-up PR, at which point this
    * block and the `data-theme` attribute go away.
    *
-   * Dark mode deliberately has no Mail variant — it inherits `.dark` unchanged.
+   * The dark variant below swaps the near-black app palette for charcoal so
+   * the mail screen reads as one soft surface rather than panels on void.
    */
   :root[data-theme="mail"]:not(.dark) {
     --background: 0 0% 99.2%; /* #FDFDFD */
@@ -141,6 +142,47 @@
     --sidebar-accent-foreground: 0 0% 14.1%;
     --sidebar-border: 0 0% 93.7%;
     --sidebar-ring: 221.2 83.2% 53.3%;
+  }
+
+  :root[data-theme="mail"].dark {
+    --background: 220 7% 16%; /* #262A2D */
+    --foreground: 220 8% 92%; /* #E8EAED */
+
+    --muted: 220 7% 21%; /* #32363B */
+    --muted-foreground: 220 5% 62%; /* #979BA2 */
+
+    --popover: 220 7% 19%; /* #2D3034 */
+    --popover-foreground: 220 8% 92%;
+
+    --card: 220 7% 19%; /* #2D3034 */
+    --card-foreground: 220 8% 92%;
+
+    --border: 220 6% 22%; /* #35383C */
+    --input: 220 6% 22%;
+    --border-strong: 220 6% 28%; /* #43474C */
+
+    --primary: 217.2 91.2% 59.8%; /* #3B82F6 */
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 220 7% 24%; /* #393D42 */
+    --secondary-foreground: 220 8% 85%; /* #D6D8DC */
+
+    --accent: 220 7% 24%; /* #393D42 */
+    --accent-foreground: 220 8% 95%; /* #F1F2F4 */
+
+    --destructive: 0 72% 55%; /* #DF3E3E */
+    --destructive-foreground: 0 0% 100%;
+
+    --ring: 217.2 91.2% 59.8%;
+
+    --sidebar-background: 220 7% 14%; /* #212426 */
+    --sidebar-foreground: 220 6% 80%; /* #C9CBCF */
+    --sidebar-primary: 217.2 91.2% 59.8%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 220 7% 21%; /* #32363B */
+    --sidebar-accent-foreground: 220 8% 95%;
+    --sidebar-border: 220 6% 20%; /* #303339 */
+    --sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -161,8 +161,10 @@
     --input: 220 6% 22%;
     --border-strong: 220 6% 28%; /* #43474C */
 
-    --primary: 217.2 91.2% 59.8%; /* #3B82F6 */
-    --primary-foreground: 0 0% 100%;
+    /* Lighter fills with dark text so both the fill and the tinted text on the
+       charcoal background clear WCAG AA contrast */
+    --primary: 213.1 93.9% 67.8%; /* #60A5FA */
+    --primary-foreground: 220 7% 12%; /* #1C1F22 */
 
     --secondary: 220 7% 24%; /* #393D42 */
     --secondary-foreground: 220 8% 85%; /* #D6D8DC */
@@ -170,19 +172,19 @@
     --accent: 220 7% 24%; /* #393D42 */
     --accent-foreground: 220 8% 95%; /* #F1F2F4 */
 
-    --destructive: 0 72% 55%; /* #DF3E3E */
-    --destructive-foreground: 0 0% 100%;
+    --destructive: 0 90.6% 70.8%; /* #F87171 */
+    --destructive-foreground: 220 7% 12%;
 
-    --ring: 217.2 91.2% 59.8%;
+    --ring: 213.1 93.9% 67.8%;
 
     --sidebar-background: 220 7% 14%; /* #212426 */
     --sidebar-foreground: 220 6% 80%; /* #C9CBCF */
-    --sidebar-primary: 217.2 91.2% 59.8%;
-    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-primary: 213.1 93.9% 67.8%;
+    --sidebar-primary-foreground: 220 7% 12%;
     --sidebar-accent: 220 7% 21%; /* #32363B */
     --sidebar-accent-foreground: 220 8% 95%;
     --sidebar-border: 220 6% 20%; /* #303339 */
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 213.1 93.9% 67.8%;
   }
 }
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -145,45 +145,45 @@
   }
 
   :root[data-theme="mail"].dark {
-    --background: 220 7% 16%; /* #262A2D */
-    --foreground: 220 8% 92%; /* #E8EAED */
+    --background: 220 7% 16%; /* #26282C */
+    --foreground: 220 8% 92%; /* #E9EAEC */
 
-    --muted: 220 7% 21%; /* #32363B */
-    --muted-foreground: 220 5% 62%; /* #979BA2 */
+    --muted: 220 7% 21%; /* #323439 */
+    --muted-foreground: 220 5% 62%; /* #999CA3 */
 
-    --popover: 220 7% 19%; /* #2D3034 */
+    --popover: 220 7% 19%; /* #2D2F34 */
     --popover-foreground: 220 8% 92%;
 
-    --card: 220 7% 19%; /* #2D3034 */
+    --card: 220 7% 19%; /* #2D2F34 */
     --card-foreground: 220 8% 92%;
 
-    --border: 220 6% 22%; /* #35383C */
+    --border: 220 6% 22%; /* #35373B */
     --input: 220 6% 22%;
-    --border-strong: 220 6% 28%; /* #43474C */
+    --border-strong: 220 6% 28%; /* #43464C */
 
     /* Lighter fills with dark text so both the fill and the tinted text on the
        charcoal background clear WCAG AA contrast */
     --primary: 213.1 93.9% 67.8%; /* #60A5FA */
-    --primary-foreground: 220 7% 12%; /* #1C1F22 */
+    --primary-foreground: 220 7% 12%; /* #1C1E21 */
 
-    --secondary: 220 7% 24%; /* #393D42 */
+    --secondary: 220 7% 24%; /* #393C41 */
     --secondary-foreground: 220 8% 85%; /* #D6D8DC */
 
-    --accent: 220 7% 24%; /* #393D42 */
-    --accent-foreground: 220 8% 95%; /* #F1F2F4 */
+    --accent: 220 7% 24%; /* #393C41 */
+    --accent-foreground: 220 8% 95%; /* #F1F2F3 */
 
     --destructive: 0 90.6% 70.8%; /* #F87171 */
     --destructive-foreground: 220 7% 12%;
 
     --ring: 213.1 93.9% 67.8%;
 
-    --sidebar-background: 220 7% 14%; /* #212426 */
+    --sidebar-background: 220 7% 14%; /* #212326 */
     --sidebar-foreground: 220 6% 80%; /* #C9CBCF */
     --sidebar-primary: 213.1 93.9% 67.8%;
     --sidebar-primary-foreground: 220 7% 12%;
-    --sidebar-accent: 220 7% 21%; /* #32363B */
+    --sidebar-accent: 220 7% 21%; /* #323439 */
     --sidebar-accent-foreground: 220 8% 95%;
-    --sidebar-border: 220 6% 20%; /* #303339 */
+    --sidebar-border: 220 6% 20%; /* #303236 */
     --sidebar-ring: 213.1 93.9% 67.8%;
   }
 }

--- a/apps/web/utils/playwright/emulated-suite-targets.d.mts
+++ b/apps/web/utils/playwright/emulated-suite-targets.d.mts
@@ -1,0 +1,8 @@
+export function expandPlaywrightTargets(
+  paths: readonly string[],
+  appRoot: string,
+): Array<{ name: string; path: string }>;
+
+export function getPlaywrightTargetName(specPath: string): string;
+
+export function getPlaywrightSpecPathFromTargetName(targetName: string): string;

--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -7,12 +7,41 @@ export function expandPlaywrightTargets(paths, appRoot) {
     for (const file of getSpecFiles(targetPath, appRoot)) files.add(file);
   }
   return [...files].sort().map((file) => ({
-    name: file
-      .replace(/^__tests__\/playwright\/emulated\//, "")
-      .replaceAll("_", "__")
-      .replaceAll("/", "_s"),
+    name: getPlaywrightTargetName(file),
     path: file,
   }));
+}
+
+/**
+ * Result directories are named after the spec path with `/` encoded as `_s`.
+ * Existing underscores double up first so the encoding stays reversible.
+ */
+export function getPlaywrightTargetName(specPath) {
+  return specPath
+    .replace(/^__tests__\/playwright\/emulated\//, "")
+    .replaceAll("_", "__")
+    .replaceAll("/", "_s");
+}
+
+export function getPlaywrightSpecPathFromTargetName(targetName) {
+  let specPath = "";
+  for (let index = 0; index < targetName.length; index += 1) {
+    if (targetName[index] !== "_") {
+      specPath += targetName[index];
+      continue;
+    }
+    const next = targetName[index + 1];
+    if (next === "_") {
+      specPath += "_";
+      index += 1;
+    } else if (next === "s") {
+      specPath += "/";
+      index += 1;
+    } else {
+      specPath += "_";
+    }
+  }
+  return specPath;
 }
 
 function getSpecFiles(targetPath, appRoot) {

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -2,7 +2,11 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, test } from "vitest";
-import { expandPlaywrightTargets } from "./emulated-suite-targets.mjs";
+import {
+  expandPlaywrightTargets,
+  getPlaywrightSpecPathFromTargetName,
+  getPlaywrightTargetName,
+} from "./emulated-suite-targets.mjs";
 
 const appRoot = mkdtempSync(path.join(os.tmpdir(), "playwright-targets-"));
 afterEach(() => rmSync(appRoot, { recursive: true, force: true }));
@@ -37,4 +41,18 @@ test("isolates every selected spec once, including nested specs and overlapping 
     `${mail}/reply.spec.ts`,
   ]);
   expect(new Set(targets.map((target) => target.name)).size).toBe(6);
+});
+
+test("target names round-trip spec paths that contain underscores", () => {
+  for (const specPath of [
+    "mail/theme.spec.ts",
+    "mail/nested/split_tabs.spec.ts",
+    "auto_s/s_flow.spec.ts",
+  ]) {
+    const targetName = getPlaywrightTargetName(
+      `__tests__/playwright/emulated/${specPath}`,
+    );
+    expect(targetName).not.toContain("/");
+    expect(getPlaywrightSpecPathFromTargetName(targetName)).toBe(specPath);
+  }
 });

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -138,10 +138,14 @@ baseline_images_dir=""
 if [[ -n "${PLAYWRIGHT_PR_NUMBER:-}" && -f "$baseline_manifest_path" ]]; then
   # The baseline images let the generator rank changed screenshots by how much
   # actually moved, which the pull request comment uses to pick frames.
-  baseline_images_run_key="$(jq -r '
+  if ! baseline_images_run_key="$(jq -r '
     if (.id | type == "string") and (.attempt | type == "number")
     then .id + "-" + (.attempt | tostring) else empty end
-  ' "$baseline_manifest_path")"
+  ' "$baseline_manifest_path" 2>"$baseline_error_path")"; then
+    echo "::warning::Could not parse the main screenshot baseline manifest; visual difference ranking will be unavailable."
+    cat "$baseline_error_path"
+    baseline_images_run_key=""
+  fi
   if [[ -n "$baseline_images_run_key" ]]; then
     baseline_images_dir="$dashboard_dir/main-baseline-images"
     if aws s3 sync \

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -134,6 +134,30 @@ if [[ -n "${PLAYWRIGHT_PR_NUMBER:-}" ]]; then
   fi
 fi
 
+baseline_images_dir=""
+if [[ -n "${PLAYWRIGHT_PR_NUMBER:-}" && -f "$baseline_manifest_path" ]]; then
+  # The baseline images let the generator rank changed screenshots by how much
+  # actually moved, which the pull request comment uses to pick frames.
+  baseline_images_run_key="$(jq -r '
+    if (.id | type == "string") and (.attempt | type == "number")
+    then .id + "-" + (.attempt | tostring) else empty end
+  ' "$baseline_manifest_path")"
+  if [[ -n "$baseline_images_run_key" ]]; then
+    baseline_images_dir="$dashboard_dir/main-baseline-images"
+    if aws s3 sync \
+      "$bucket_uri/runs/$baseline_images_run_key/screenshots/images/" \
+      "$baseline_images_dir/" \
+      --endpoint-url "$S3_ENDPOINT" \
+      2>"$baseline_error_path"; then
+      echo "Downloaded the main baseline screenshots for visual comparison."
+    else
+      echo "::warning::Could not download the main baseline screenshots; visual difference ranking will be unavailable."
+      cat "$baseline_error_path"
+      baseline_images_dir=""
+    fi
+  fi
+fi
+
 if [[ -z "${PLAYWRIGHT_PR_NUMBER:-}" && "$PLAYWRIGHT_EVENT" == "push" && "$PLAYWRIGHT_BRANCH" == "main" && "$PLAYWRIGHT_RESULT" == "success" ]]; then
   stable_baseline_missing="false"
   stable_baseline_downloaded="false"
@@ -179,7 +203,8 @@ PLAYWRIGHT_PR_URL="$pull_request_url" \
     "$dashboard_path" \
     "$test_results_dir" \
     "$gallery_dir" \
-    "$baseline_manifest_path"
+    "$baseline_manifest_path" \
+    "$baseline_images_dir"
 
 if [[ "$publish_report" == "true" ]]; then
   aws s3 sync \


### PR DESCRIPTION
The mail screen's dark mode inherited the app-wide near-black palette, so the thread list and reader rendered as flat black panels. This adds a mail-scoped dark palette using charcoal surfaces instead, and makes the Playwright PR comment show the screenshots that matter.

### Mail dark theme

- Add a `:root[data-theme="mail"].dark` token block in `globals.css` alongside the existing light mail palette
- Background, card, popover, muted, accent, border, and sidebar tokens now step through a low-saturation charcoal ramp rather than near-black
- Primary and destructive use lighter fills with dark text so both the fills and the tinted text on charcoal clear WCAG AA contrast
- Verified with an emulated Playwright run: thread list, reader, and compose panel all render on the new surfaces

### Playwright screenshots in PR comments

- The publish workflow now downloads the main baseline images and ranks changed checkpoints by the share of differing pixels
- The PR comment embeds failure captures, new checkpoints, changed checkpoints from specs the PR touched, and the largest visual changes, with a link to the full gallery
- Hash comparison alone flags almost every capture as changed because of timestamps and other drift, so the pixel ranking is what surfaces real changes
- The comment step compares against the run's exact commit, and baseline comparisons run sequentially to keep memory bounded on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
