### PR TITLE
mail: Report pre-send rejections as failed instead of uncertain delivery

### DIFF
--- a/apps/web/utils/email/durable-email-send.test.ts
+++ b/apps/web/utils/email/durable-email-send.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import { EmailSendOperationStatus } from "@/generated/prisma/enums";
+import { SafeError } from "@/utils/error";
+import { executeDurableEmailSend } from "./durable-email-send";
+
+vi.mock("@/utils/prisma");
+
+const input = {
+  mutationId: "7f0c3b9e-2c1d-4d6e-9b2a-1f0e5d4c3b2a",
+  queuedAt: Date.now(),
+  threadId: "thread",
+  messageIds: ["message"],
+  email: {
+    to: "person@example.com",
+    subject: "Reply",
+    messageHtml: "<p>Hello</p>",
+  },
+};
+
+describe("executeDurableEmailSend", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    prisma.emailSendOperation.findUnique.mockResolvedValue(null);
+    prisma.emailSendOperation.create.mockImplementation((async ({
+      data,
+    }: {
+      data: { payloadHash: string };
+    }) => ({
+      id: "operation",
+      status: EmailSendOperationStatus.PROCESSING,
+      ...data,
+    })) as never);
+  });
+
+  it("rejects a pre-send failure with its message and releases the operation", async () => {
+    const provider = createMockEmailProvider({
+      sendEmailWithHtml: vi
+        .fn()
+        .mockRejectedValue(new SafeError("Email sending is disabled.")),
+    });
+
+    const outcome = await executeDurableEmailSend({
+      emailAccountId: "account",
+      getEmailProvider: async () => provider,
+      input,
+      provider: "google",
+    });
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      error: "Email sending is disabled.",
+    });
+    expect(prisma.emailSendOperation.deleteMany).toHaveBeenCalledWith({
+      where: { id: "operation" },
+    });
+    expect(prisma.emailSendOperation.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps unexplained provider failures uncertain", async () => {
+    const provider = createMockEmailProvider({
+      sendEmailWithHtml: vi.fn().mockRejectedValue(new Error("socket hang up")),
+    });
+
+    const outcome = await executeDurableEmailSend({
+      emailAccountId: "account",
+      getEmailProvider: async () => provider,
+      input,
+      provider: "google",
+    });
+
+    expect(outcome).toEqual({ status: "uncertain" });
+    expect(prisma.emailSendOperation.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "operation",
+        status: EmailSendOperationStatus.PROCESSING,
+      },
+      data: { status: EmailSendOperationStatus.UNCERTAIN },
+    });
+    expect(prisma.emailSendOperation.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/email/durable-email-send.ts
+++ b/apps/web/utils/email/durable-email-send.ts
@@ -4,6 +4,7 @@ import { classifyEmailAccountProviderIssue } from "@/utils/email/provider-health
 import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
 import type { EmailProvider } from "@/utils/email/types";
 import { MAIL_MUTATION_RETRY_WINDOW_MS } from "@/utils/email-cache/policy";
+import { SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import type { DurableEmailSendBody } from "./durable-email-send.validation";
@@ -94,6 +95,17 @@ export async function executeDurableEmailSend({
         where: { id: existing.id },
       });
       return { status: "blocked_auth" as const };
+    }
+    // Providers throw SafeError for checks that run before anything is sent,
+    // so the outcome is known and the operation can be retried later.
+    if (error instanceof SafeError) {
+      await prisma.emailSendOperation.deleteMany({
+        where: { id: existing.id },
+      });
+      return {
+        status: "rejected" as const,
+        error: error.safeMessage ?? error.message,
+      };
     }
     await prisma.emailSendOperation.updateMany({
       where: { id: existing.id, status: EmailSendOperationStatus.PROCESSING },

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -27,6 +27,7 @@ import { buildThreadingHeaders } from "@/utils/email/threading";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
 import { getMessage } from "@/utils/gmail/message";
 import { getDraftIdForMessage } from "@/utils/gmail/draft";
+import { SafeError } from "@/utils/error";
 import { GmailLabel } from "@/utils/gmail/label";
 import { convertNewlinesToBr, textToHtmlParagraphs } from "@/utils/string";
 import {
@@ -118,13 +119,13 @@ export async function sendEmailWithHtml(
     const message = await getMessage(replyToEmail.messageId, gmail, "metadata");
     if (message.labelIds?.includes(GmailLabel.DRAFT)) {
       if (message.labelIds.includes(GmailLabel.SENT)) {
-        throw new Error(
+        throw new SafeError(
           "This draft is already marked as sent. Reopen the thread before sending.",
         );
       }
       const draftId = await getDraftIdForMessage(gmail, replyToEmail.messageId);
       if (!draftId) {
-        throw new Error(
+        throw new SafeError(
           "The draft changed or is no longer available. Reopen the thread before sending.",
         );
       }

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -23,6 +23,32 @@ describe("sendEmailWithHtml", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects a reply without a recipient before creating the reply draft", async () => {
+    const api = vi.fn(() => {
+      throw new Error("Graph should not be called");
+    });
+    const client = createMockOutlookClient(api);
+
+    await expect(
+      sendEmailWithHtml(
+        client,
+        {
+          to: "",
+          subject: "Re: Subject",
+          messageHtml: "<p>Hello</p>",
+          replyToEmail: {
+            threadId: "thread-1",
+            headerMessageId: "<message-1@example.com>",
+            messageId: "message-1",
+          },
+        },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow("Recipient address is required");
+
+    expect(api).not.toHaveBeenCalled();
+  });
+
   it("parses formatted recipients when sending a new draft", async () => {
     const draftPost = vi.fn(
       async () =>

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -16,6 +16,7 @@ import {
   withMicrosoftGraphWriteRetry,
 } from "@/utils/microsoft/retry";
 import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
+import { SafeError } from "@/utils/error";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
 import { uploadResumableChunks } from "@/utils/microsoft/upload-session";
 import type { Logger } from "@/utils/logger";
@@ -44,7 +45,8 @@ export async function sendEmailWithHtml(
   }
 
   const toRecipients = buildGraphRecipients(body.to);
-  if (!toRecipients?.length) throw new Error("Recipient address is required");
+  if (!toRecipients?.length)
+    throw new SafeError("Recipient address is required");
   const ccRecipients = buildGraphRecipients(body.cc);
   const bccRecipients = buildGraphRecipients(body.bcc);
   const replyToRecipients = buildGraphRecipients(body.replyTo);

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -38,15 +38,16 @@ export async function sendEmailWithHtml(
 ): Promise<SentEmailResult> {
   ensureEmailSendingEnabled();
 
+  const toRecipients = buildGraphRecipients(body.to);
+  if (!toRecipients?.length)
+    throw new SafeError("Recipient address is required");
+
   // For replies with a message ID, use createReply for proper threading
   // Microsoft Graph's sendMail doesn't support In-Reply-To/References headers
   if (body.replyToEmail?.messageId) {
     return sendReplyUsingCreateReply(client, body, logger);
   }
 
-  const toRecipients = buildGraphRecipients(body.to);
-  if (!toRecipients?.length)
-    throw new SafeError("Recipient address is required");
   const ccRecipients = buildGraphRecipients(body.cc);
   const bccRecipients = buildGraphRecipients(body.bcc);
   const replyToRecipients = buildGraphRecipients(body.replyTo);


### PR DESCRIPTION
When a provider send throws before anything is transmitted, the durable send path treated it like any unknown failure and marked the operation uncertain, so the composer showed "Delivery uncertain, check Sent" for cases where nothing was sent. This surfaced locally when the email sending kill switch was off.

- `executeDurableEmailSend` now treats a `SafeError` from the provider as a known pre-send rejection: it releases the operation so the send can be retried and returns `rejected` with the error message, which the composer shows as "Reply could not be sent" with the reason
- The Gmail stale-draft checks and the Outlook missing-recipient check now throw `SafeError`, matching the existing sending kill switch
- Adds a unit test covering the rejected and uncertain outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email sending error handling for invalid recipients and unavailable or already-sent drafts.
  * Invalid reply recipients are rejected before any message is created or sent.
  * Expected send failures now return a clear rejected result and clean up the pending operation.
  * Unexpected provider failures are marked as uncertain so their status can be reviewed accurately.

* **Tests**
  * Added coverage for rejected and uncertain email delivery outcomes, recipient validation, operation status updates, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->