### PR TITLE
fix(desktop): restore Windows menu and title bar

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,6 +1,6 @@
 # Desktop app
 
-Electron shell around the hosted Inbox Zero web app. There is no backend in this package: the window loads the same Next.js origin a browser does.
+Electron shell for the hosted Inbox Zero web app.
 
 ## Run
 
@@ -16,11 +16,7 @@ Against a local web app:
 INBOX_ZERO_APP_URL=http://localhost:3000 pnpm --filter @inboxzero/desktop dev
 ```
 
-Sign-in opens the system browser, then returns through `inboxzero://` and `/api/mobile-auth/exchange-code`. Google and Microsoft OAuth are not completed inside the Electron window.
-
-The window remembers the last in-app page (stored in `userData/last-app-url`) and restores it on launch instead of going through `/login` redirects. On macOS, closing the window hides it so reopening from the dock is instant; quit with Cmd+Q.
-
-The web app defaults `DESKTOP_AUTH_ORIGIN` to `inboxzero://`, the same scheme as mobile. Override that only if the desktop protocol scheme changes.
+Sign-in uses the system browser and returns through `inboxzero://`. The web app's `DESKTOP_AUTH_ORIGIN` defaults to this scheme.
 
 ## Package
 
@@ -29,13 +25,11 @@ pnpm --filter @inboxzero/desktop dist:mac
 pnpm --filter @inboxzero/desktop dist:win
 ```
 
-Installers land in `apps/desktop/release/`. Use `pnpm dev` for unsigned local testing; packaged macOS builds require the Developer ID certificate configured below.
-
-The Mac app is distributed directly as a signed and notarized DMG/ZIP. It is not a Mac App Store build, so it does not use Apple's App Sandbox or Mac App Store update and payment policies.
+Installers land in `apps/desktop/release/`. macOS packaging requires a Developer ID certificate and notarization credentials.
 
 ## Release
 
-Push a `desktop-v*` tag or run the **Desktop Release** workflow. That builds macOS (dmg/zip, arm64 + x64) and Windows (NSIS, x64 + arm64) and can publish a GitHub Release.
+Push a `desktop-v*` tag to build and publish a release, or run the [Desktop Release workflow](../../.github/workflows/desktop-release.yml) manually with optional publishing. It packages macOS (DMG/ZIP) and Windows (NSIS) for arm64 and x64.
 
 The macOS release requires these GitHub secrets:
 
@@ -44,6 +38,4 @@ The macOS release requires these GitHub secrets:
 
 Windows signing uses `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` for the Authenticode `.p12`.
 
-`electron-builder.yml` keeps `mac.notarize` enabled. App Store Connect API credentials are also accepted by Apple's notarization service; using them here does not make the output a Mac App Store build.
-
-Packaged apps check `https://github.com/elie222/inbox-zero/releases/download/desktop-updates` for `latest-mac.yml` / `latest.yml`. That feed is a stable GitHub release; the installers stay on `desktop-v*` releases.
+Auto-update metadata (`latest-mac.yml` / `latest.yml`) is published to the `desktop-updates` release; installers stay on `desktop-v*` releases.

--- a/apps/desktop/src/application-menu.test.ts
+++ b/apps/desktop/src/application-menu.test.ts
@@ -1,0 +1,47 @@
+import type { MenuItemConstructorOptions } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { configureDesktopApplicationMenu } from "./application-menu";
+
+const { app, Menu } = vi.hoisted(() => ({
+  app: {
+    getVersion: vi.fn(() => "0.2.0"),
+    setAboutPanelOptions: vi.fn(),
+    showAboutPanel: vi.fn(),
+  },
+  Menu: {
+    buildFromTemplate: vi.fn(
+      (template: MenuItemConstructorOptions[]) => template,
+    ),
+    setApplicationMenu: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({ app, Menu }));
+
+describe("desktop application menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lets Windows users check for updates and view the installed version", () => {
+    const checkForUpdates = vi.fn();
+    configureDesktopApplicationMenu(checkForUpdates, "win32");
+
+    const template = Menu.buildFromTemplate.mock.results[0].value;
+    expect(Menu.setApplicationMenu).toHaveBeenCalledWith(template);
+    const help = template.find((item) => item.role === "help");
+    const submenu = help?.submenu as MenuItemConstructorOptions[];
+    const update = submenu.find((item) => item.label === "Check for Updates…");
+    expect(update?.click).toBe(checkForUpdates);
+
+    const about = submenu.find((item) => item.label === "About Inbox Zero");
+    expect(about?.click).toEqual(expect.any(Function));
+    about?.click?.({} as never, {} as never, {} as never);
+
+    expect(app.setAboutPanelOptions).toHaveBeenCalledWith({
+      applicationName: "Inbox Zero",
+      applicationVersion: "0.2.0",
+    });
+    expect(app.showAboutPanel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/application-menu.ts
+++ b/apps/desktop/src/application-menu.ts
@@ -6,7 +6,10 @@ export function configureDesktopApplicationMenu(
   checkForUpdates: () => void,
   platform = process.platform,
 ) {
-  app.setAboutPanelOptions({ applicationName: PRODUCT_NAME });
+  app.setAboutPanelOptions({
+    applicationName: PRODUCT_NAME,
+    applicationVersion: app.getVersion(),
+  });
 
   const checkForUpdatesItem: MenuItemConstructorOptions = {
     label: "Check for Updates…",
@@ -42,7 +45,14 @@ export function configureDesktopApplicationMenu(
       : [
           {
             role: "help",
-            submenu: [checkForUpdatesItem],
+            submenu: [
+              checkForUpdatesItem,
+              { type: "separator" },
+              {
+                label: `About ${PRODUCT_NAME}`,
+                click: () => app.showAboutPanel(),
+              },
+            ],
           } satisfies MenuItemConstructorOptions,
         ]),
   ];

--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -146,20 +146,16 @@ describe("desktop shell helpers", () => {
     ).toBe("https://www.getinboxzero.com/evil.test");
   });
 
-  it("uses a light hidden title bar so the native chrome matches the web app", () => {
+  it("uses platform-appropriate title bars and menu visibility", () => {
     expect(getDesktopWindowChrome("darwin")).toEqual({
       backgroundColor: "#ffffff",
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 16, y: 18 },
     });
-    expect(getDesktopWindowChrome("win32")).toMatchObject({
+    expect(getDesktopWindowChrome("win32")).toEqual({
+      autoHideMenuBar: false,
       backgroundColor: "#ffffff",
-      titleBarStyle: "hidden",
-      titleBarOverlay: {
-        color: "#ffffff",
-        height: 36,
-        symbolColor: "#0f172a",
-      },
+      titleBarStyle: "default",
     });
     expect(getDesktopWindowChrome("linux")).toEqual({
       autoHideMenuBar: true,

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -207,12 +207,7 @@ export const DESKTOP_MAC_HIDE_ATTRIBUTE = "data-hide-on-desktop-mac";
 export function getDesktopWindowChrome(platform = process.platform): {
   autoHideMenuBar?: boolean;
   backgroundColor: string;
-  titleBarOverlay?: {
-    color: string;
-    height: number;
-    symbolColor: string;
-  };
-  titleBarStyle?: "hidden" | "hiddenInset";
+  titleBarStyle?: "default" | "hiddenInset";
   trafficLightPosition?: { x: number; y: number };
 } {
   if (platform === "darwin") {
@@ -225,13 +220,9 @@ export function getDesktopWindowChrome(platform = process.platform): {
 
   if (platform === "win32") {
     return {
+      autoHideMenuBar: false,
       backgroundColor: DESKTOP_WINDOW_BACKGROUND,
-      titleBarOverlay: {
-        color: DESKTOP_WINDOW_BACKGROUND,
-        height: 36,
-        symbolColor: "#0f172a",
-      },
-      titleBarStyle: "hidden",
+      titleBarStyle: "default",
     };
   }
 


### PR DESCRIPTION
Restore the standard Windows title bar and keep the application menu visible so users can move the window and access update checks. Add Help → About Inbox Zero with the installed version, and trim the desktop README to developer essentials.

- Validation: all 35 desktop tests pass; Biome and whitespace checks pass.
- Native Windows menu appearance and dragging still need a Windows QA pass.
- Performance: window/menu configuration only; no additional network or database calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an About option to the desktop Help menu on non-macOS platforms.
  - The About panel now displays the product name and application version.

- **UI Updates**
  - Windows desktop windows now use the standard title bar and keep the application menu visible.

- **Documentation**
  - Updated desktop sign-in, packaging, release, and auto-update documentation with current guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->