### PR TITLE
fix: show platform-specific account shortcut modifiers

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/account-selection.spec.ts
@@ -35,17 +35,36 @@ test("chooses which accounts appear in All Accounts", async ({
         inboxZeroDesktop: { startAuth: async () => {} },
       });
     });
-    await page.reload();
-    await page
-      .getByRole("button", { name: /playwright-test\+/i })
-      .last()
-      .click();
-    await expect(page.getByRole("menu").locator("kbd")).toHaveText([
-      "⌘/Ctrl+0",
-      "⌘/Ctrl+1",
-      "⌘/Ctrl+2",
-    ]);
-    await capturePlaywrightCheckpoint(page, testInfo, "account-shortcuts");
+    for (const { userAgent, modifier, checkpoint } of [
+      {
+        userAgent: "Macintosh",
+        modifier: "⌘",
+        checkpoint: "account-shortcuts-mac",
+      },
+      {
+        userAgent: "Windows NT 10.0",
+        modifier: "Ctrl+",
+        checkpoint: "account-shortcuts-windows",
+      },
+    ]) {
+      await page.reload();
+      await page.evaluate((userAgent) => {
+        Object.defineProperty(navigator, "userAgent", {
+          configurable: true,
+          get: () => userAgent,
+        });
+      }, userAgent);
+      await page
+        .getByRole("button", { name: /playwright-test\+/i })
+        .last()
+        .click();
+      await expect(page.getByRole("menu").locator("kbd")).toHaveText([
+        `${modifier}0`,
+        `${modifier}1`,
+        `${modifier}2`,
+      ]);
+      await capturePlaywrightCheckpoint(page, testInfo, checkpoint);
+    }
 
     await chooseAccountsMenuItem.click();
 

--- a/apps/web/lib/shortcuts/registry.test.ts
+++ b/apps/web/lib/shortcuts/registry.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertNoShortcutConflicts,
   buildShortcutPaletteCommands,
@@ -17,6 +17,9 @@ import {
 } from "./registry";
 
 describe("shortcut registry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it("gives every key a single owner", () => {
     expect(findShortcutConflicts(SHORTCUTS)).toEqual([]);
   });
@@ -68,16 +71,27 @@ describe("shortcut registry", () => {
     expect(formatShortcutKeys(getShortcut("discardDraft"))).toBe("⌘⇧,");
     expect(formatShortcutKeys(getShortcut("backToApp"))).toBe("G A");
     expect(formatShortcutKeys(getShortcut("delete"))).toBe("#");
-    expect(formatShortcutKeys(getShortcut("switchAccount"))).toBe("⌘/Ctrl+1–9");
-    expect(formatShortcutKeys(getShortcut("switchAllAccounts"))).toBe(
-      "⌘/Ctrl+0",
-    );
     expect(formatShortcutKeys(getShortcut("markUnread"))).toBe("U");
     expect(formatShortcutKeys(getShortcut("move"))).toBe("V");
     expect(formatShortcutKeys(getShortcut("toggleLayout"))).toBe("⇧V");
     expect(formatShortcutKeys(getShortcut("markSpam"))).toBe("!");
     expect(formatShortcutKeys(getShortcut("openExternal"))).toBe("G G");
     expect(formatShortcutKeys(getShortcut("forward"))).toBe("F");
+  });
+
+  it.each([
+    ["Macintosh", "⌘", "⌘"],
+    ["Windows NT 10.0", "Ctrl+", "Ctrl"],
+    ["X11; Linux x86_64", "Ctrl+", "Ctrl"],
+  ])("shows the account modifier for %s", (userAgent, hint, label) => {
+    vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+
+    expect(formatShortcutKeys(getShortcut("switchAccount"))).toBe(`${hint}1–9`);
+    expect(formatShortcutKeys(getShortcut("switchAllAccounts"))).toBe(
+      `${hint}0`,
+    );
+    expect(getShortcutKeyLabels("switchAccount")).toEqual([label, "1–9"]);
+    expect(getShortcutKeyLabels("switchAllAccounts")).toEqual([label, "0"]);
   });
 
   it("splits keys into one spelled-out label per block", () => {

--- a/apps/web/lib/shortcuts/registry.ts
+++ b/apps/web/lib/shortcuts/registry.ts
@@ -489,9 +489,7 @@ export function getShortcutKeyLabels(id: ShortcutId): string[] {
   return binding
     .split(SEQUENCE_SPLIT_KEY)
     .flatMap((step) => step.split("+"))
-    .map(
-      (token) => KEY_WORDS[token] ?? KEY_SYMBOLS[token] ?? token.toUpperCase(),
-    );
+    .map((token) => formatKeyToken(token, true));
 }
 
 /** Feeds ⌘K: an entry appears once its handler is registered. */
@@ -638,7 +636,6 @@ if (process.env.NODE_ENV === "production") {
 
 const KEY_SYMBOLS: Record<string, string> = {
   mod: "⌘",
-  modorctrl: "⌘/Ctrl+",
   meta: "⌘",
   ctrl: "⌃",
   alt: "⌥",
@@ -656,7 +653,6 @@ const KEY_SYMBOLS: Record<string, string> = {
 
 /** Overrides `KEY_SYMBOLS` where a word reads better than a symbol. */
 const KEY_WORDS: Record<string, string> = {
-  modorctrl: "⌘/ctrl",
   ctrl: "ctrl",
   alt: "option",
   shift: "shift",
@@ -673,10 +669,27 @@ function formatKey(key: string): string {
     .map((step) =>
       step
         .split("+")
-        .map((token) => KEY_SYMBOLS[token] ?? token.toUpperCase())
+        .map((token) => formatKeyToken(token))
         .join(""),
     )
     .join(" ");
+}
+
+function formatKeyToken(token: string, spelledOut = false): string {
+  if (token === "modorctrl") {
+    const isMac =
+      typeof window === "undefined" ||
+      /Mac|iPhone|iPod|iPad/.test(window.navigator.userAgent);
+
+    if (isMac) return "⌘";
+    return spelledOut ? "Ctrl" : "Ctrl+";
+  }
+
+  return (
+    (spelledOut ? KEY_WORDS[token] : undefined) ??
+    KEY_SYMBOLS[token] ??
+    token.toUpperCase()
+  );
 }
 
 function addOwner(


### PR DESCRIPTION
Account-switching hints show both Command and Control even though the active modifier depends on the operating system. Show Command on Mac and Control on Windows/Linux in the account menu and shortcut help.

Validated with 27 shortcut unit tests, the focused emulated account-selection browser test, inspected Mac and Windows screenshots, and Biome checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut labels now automatically adapt to the user’s platform.
  * macOS displays the Command symbol (⌘), while Windows and Linux display the appropriate Ctrl-based shortcut format.

* **Bug Fixes**
  * Corrected account-switching shortcut labels so they consistently reflect the active platform across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->