### PR TITLE
mail: Unify account search and split controls

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/search.spec.ts
@@ -2,46 +2,60 @@ import { expect } from "@playwright/test";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
-test("searches the mailbox and clears back to the inbox", async ({ page }) => {
-  const { conversations } = await openMail(page);
-  const options = conversations.getByRole("option");
-  await expect(options.first()).toBeVisible();
-
-  const matching = conversationWithSubject(
+for (const accountScope of ["single", "all"] as const) {
+  test(`${accountScope}: searches the mailbox and clears back to the inbox`, async ({
     page,
-    conversations,
-    "Archive Action Message",
-  );
-  const nonMatching = conversationWithSubject(
+  }) => {
+    const { conversations, emailAccountId } = await openMail(page);
+    if (accountScope === "all")
+      await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    const options = conversations.getByRole("option");
+    await expect(options.first()).toBeVisible();
+
+    const matching = conversationWithSubject(
+      page,
+      conversations,
+      "Archive Action Message",
+    );
+    const nonMatching = conversationWithSubject(
+      page,
+      conversations,
+      "Keyboard Navigation Message",
+    );
+    await expect(matching).toBeVisible();
+    await expect(nonMatching).toBeVisible();
+
+    const searchInput = page.getByPlaceholder("Search mail");
+    await searchInput.fill("Archive Action");
+    await searchInput.press("Enter");
+
+    await expect(page).toHaveURL(/[?&]q=/);
+    expect(new URL(page.url()).searchParams.get("q")).toBe("Archive Action");
+    await expect(matching).toBeVisible();
+    await expect(nonMatching).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Clear search" }).click();
+    await expect(page).not.toHaveURL(/[?&]q=/);
+    await expect(matching).toBeVisible();
+    await expect(nonMatching).toBeVisible();
+  });
+
+  test(`${accountScope}: slash focuses search and Command K opens commands`, async ({
     page,
-    conversations,
-    "Keyboard Navigation Message",
-  );
-  await expect(matching).toBeVisible();
-  await expect(nonMatching).toBeVisible();
+  }) => {
+    const { emailAccountId } = await openMail(page);
+    if (accountScope === "all")
+      await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    const searchInput = page.getByPlaceholder("Search mail");
+    await expect(searchInput).toBeVisible();
+    await page.getByRole("listbox", { name: "Conversations" }).click();
 
-  const searchInput = page.getByPlaceholder("Search mail");
-  await searchInput.fill("Archive Action");
-  await searchInput.press("Enter");
+    await page.keyboard.press("Slash");
 
-  await expect(page).toHaveURL(/[?&]q=/);
-  expect(new URL(page.url()).searchParams.get("q")).toBe("Archive Action");
-  await expect(matching).toBeVisible();
-  await expect(nonMatching).toHaveCount(0);
-
-  await page.getByRole("button", { name: "Clear search" }).click();
-  await expect(page).not.toHaveURL(/[?&]q=/);
-  await expect(matching).toBeVisible();
-  await expect(nonMatching).toBeVisible();
-});
-
-test("slash focuses the mail search bar", async ({ page }) => {
-  await openMail(page);
-  const searchInput = page.getByPlaceholder("Search mail");
-  await expect(searchInput).toBeVisible();
-  await page.getByRole("listbox", { name: "Conversations" }).click();
-
-  await page.keyboard.press("Slash");
-
-  await expect(searchInput).toBeFocused();
-});
+    await expect(searchInput).toBeFocused();
+    await page.keyboard.press(
+      `${process.platform === "darwin" ? "Meta" : "Control"}+k`,
+    );
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+}

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -146,3 +146,73 @@ test("organizes split choices and manages all rule labels", async ({
   await page.getByRole("option", { name: "Remove all" }).click();
   await expect(calendarSplit).toHaveCount(0);
 });
+
+for (const accountScope of ["single", "all"] as const) {
+  test(`${accountScope}: creates and removes splits without selecting them`, async ({
+    page,
+    request,
+  }) => {
+    const { emailAccountId } = await openMail(page);
+    if (accountScope === "all")
+      await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    await page.getByRole("button", { name: "New split" }).click();
+    await page
+      .getByRole("option", { name: "Project Alpha", exact: true })
+      .click();
+    const split = page.getByRole("button", {
+      name: "Project Alpha",
+      exact: true,
+    });
+    await expect(split).toBeVisible();
+    await page
+      .getByRole("button", { name: "Remove the Project Alpha split" })
+      .click();
+    await expect(split).toHaveCount(0);
+
+    for (const name of ["All", "Unread"] as const) {
+      await page
+        .getByRole("button", { name: `Remove the ${name} split` })
+        .click();
+      await expect
+        .poll(async () => {
+          const response = await request.get("/api/mail/settings", {
+            headers: { "X-Email-Account-ID": emailAccountId },
+          });
+          return (await response.json()).hiddenBuiltInSplits;
+        })
+        .toEqual(name === "All" ? ["all"] : ["all", "unread"]);
+      await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
+        0,
+      );
+    }
+    await page.reload();
+    await expect(page.getByRole("button", { name: "New split" })).toBeVisible();
+    for (const name of ["All", "Unread"]) {
+      await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
+        0,
+      );
+      await page.getByRole("button", { name: "New split" }).click();
+      await page.getByRole("option", { name, exact: true }).click();
+      await expect
+        .poll(async () => {
+          const response = await request.get("/api/mail/settings", {
+            headers: { "X-Email-Account-ID": emailAccountId },
+          });
+          return (await response.json()).hiddenBuiltInSplits;
+        })
+        .toEqual(name === "All" ? ["unread"] : []);
+      await expect(
+        page.getByRole("button", { name, exact: true }),
+      ).toBeVisible();
+    }
+    await page.reload();
+    await expect(
+      page.getByRole("listbox", { name: "Conversations" }),
+    ).toBeVisible();
+    for (const name of ["All", "Unread"]) {
+      await expect(
+        page.getByRole("button", { name, exact: true }),
+      ).toBeVisible();
+    }
+  });
+}

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -179,9 +179,9 @@ for (const accountScope of ["single", "all"] as const) {
           const response = await request.get("/api/mail/settings", {
             headers: { "X-Email-Account-ID": emailAccountId },
           });
-          return (await response.json()).hiddenBuiltInSplits;
+          return new Set((await response.json()).hiddenBuiltInSplits);
         })
-        .toEqual(name === "All" ? ["all"] : ["all", "unread"]);
+        .toEqual(new Set(name === "All" ? ["all"] : ["all", "unread"]));
       await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
         0,
       );
@@ -199,9 +199,9 @@ for (const accountScope of ["single", "all"] as const) {
           const response = await request.get("/api/mail/settings", {
             headers: { "X-Email-Account-ID": emailAccountId },
           });
-          return (await response.json()).hiddenBuiltInSplits;
+          return new Set((await response.json()).hiddenBuiltInSplits);
         })
-        .toEqual(name === "All" ? ["unread"] : []);
+        .toEqual(new Set(name === "All" ? ["unread"] : []));
       await expect(
         page.getByRole("button", { name, exact: true }),
       ).toBeVisible();

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -153,8 +153,9 @@ for (const accountScope of ["single", "all"] as const) {
     request,
   }) => {
     const { emailAccountId } = await openMail(page);
-    if (accountScope === "all")
+    if (accountScope === "all") {
       await page.goto(`/${emailAccountId}/mail?accountScope=all`);
+    }
     await page.getByRole("button", { name: "New split" }).click();
     await page
       .getByRole("option", { name: "Project Alpha", exact: true })

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -23,13 +23,11 @@ export type ListToolbarProps = {
   layout: MailLayoutMode;
   showLayoutToggle?: boolean;
   expandedPreview: boolean;
-  /** Committed search query. Only meaningful when `onSearch` is provided. */
-  searchQuery?: string;
-  /** When provided, the toolbar shows a real mail search input. */
-  onSearch?: (query: string) => void;
+  /** Committed search query. */
+  searchQuery: string;
+  onSearch: (query: string) => void;
   /** Lets `/` focus the mail search field from the shortcut handler. */
   searchInputRef?: RefObject<HTMLInputElement | null>;
-  onOpenSearch: () => void;
   onToggleLayout: () => void;
   onTogglePreview: () => void;
   onToggleAssistant: () => void;
@@ -49,7 +47,6 @@ export function ListToolbar({
   searchQuery = "",
   onSearch,
   searchInputRef,
-  onOpenSearch,
   onToggleLayout,
   onTogglePreview,
   onToggleAssistant,
@@ -131,27 +128,12 @@ export function ListToolbar({
             </button>
           </Tooltip>
         </>
-      ) : onSearch ? (
+      ) : (
         <MailSearchInput
           searchQuery={searchQuery}
           onSearch={onSearch}
           inputRef={searchInputRef}
         />
-      ) : (
-        // Opens the command palette rather than searching mail — combined
-        // inboxes can't search across accounts yet, so promising search we
-        // don't have would mislead.
-        <button
-          type="button"
-          onClick={onOpenSearch}
-          className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-sidebar px-2.5 text-muted-foreground text-sm transition-colors hover:border-[hsl(var(--border-strong))] hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <SearchIcon className="size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1 truncate text-left">
-            Search or jump to…
-          </span>
-          <Kbd>{getShortcutHint("commandPalette")}</Kbd>
-        </button>
       )}
 
       {selectedCount === 0 ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -31,7 +31,6 @@ import { ListSenderCommands } from "@/app/(app)/[emailAccountId]/mail/ListSender
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
-import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type {
   NewSplitDraft,
   NewSplitOption,
@@ -63,7 +62,7 @@ import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { Sidebar, useSidebar } from "@/components/ui/sidebar";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import {
   commandPaletteOpenAtom,
   mailCommandContextAtom,
@@ -120,8 +119,7 @@ import { getEmailTerminology } from "@/utils/terminology";
 import { GMAIL_LABEL_COLORS } from "@/utils/gmail/label-colors";
 import { OUTLOOK_CATEGORY_COLORS } from "@/utils/outlook/category-colors";
 
-// Always present, never deletable. Everything else is a saved split. They carry
-// a kind so built-ins and saved splits resolve through one mapping.
+// Built-in and saved splits resolve through the same query mapping.
 const BUILT_IN_SPLITS = [
   { id: "all", name: "All", kind: MailSplitKind.INBOX, value: null },
   { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD, value: null },
@@ -152,7 +150,7 @@ export function MailShell() {
   const { onOpen: openCompose } = useComposeModal();
   const { setInput: setChatInput } = useChat();
   const { state: openSidebars, toggleSidebar } = useSidebar();
-  const [isPaletteOpen, setPaletteOpen] = useAtom(commandPaletteOpenAtom);
+  const isPaletteOpen = useAtomValue(commandPaletteOpenAtom);
   const senderCommandContext = useAtomValue(senderCommandContextAtom);
   const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
@@ -290,8 +288,7 @@ export function MailShell() {
   }, [scopeFolderId, scopeLabelId, scopeType]);
   const isScoped = !isAllAccounts && scopeQuery !== null;
 
-  // Combined inboxes can't search across accounts, so search is single-account.
-  const searchQuery = isAllAccounts ? null : searchParam?.trim() || null;
+  const searchQuery = searchParam?.trim() || null;
   const setSearch = useCallback(
     (value: string) => setSearchParam(value.trim() || null),
     [setSearchParam],
@@ -302,25 +299,29 @@ export function MailShell() {
     [settings?.splits, userLabels],
   );
 
-  const splits: MailSplitTab[] = useMemo(() => {
-    const builtInSplits = BUILT_IN_SPLITS.map((split) => ({
-      id: split.id,
-      name: split.name,
-      deletable: false,
-    }));
-    return [
-      ...builtInSplits,
-      ...(isAllAccounts ? combinedLabelSplits : (settings?.splits ?? [])).map(
-        (split) => ({
-          id: split.id,
-          name: split.name,
-          deletable: true,
-        }),
-      ),
-    ];
-  }, [combinedLabelSplits, isAllAccounts, settings?.splits]);
-  const displayedActiveSplitId =
-    splits.find((split) => split.id === activeSplitId)?.id ?? "all";
+  const splits = useMemo(() => {
+    const builtInSplits = BUILT_IN_SPLITS.filter(
+      (split) => !settings?.hiddenBuiltInSplits.includes(split.id),
+    );
+    const savedSplits = (settings?.splits ?? []).filter(
+      (split) =>
+        !isAllAccounts ||
+        split.kind === MailSplitKind.INBOX ||
+        split.kind === MailSplitKind.UNREAD ||
+        combinedLabelSplits.some((portable) => portable.id === split.id),
+    );
+    return [...builtInSplits, ...savedSplits];
+  }, [
+    combinedLabelSplits,
+    isAllAccounts,
+    settings?.splits,
+    settings?.hiddenBuiltInSplits,
+  ]);
+  const activeSplit =
+    splits.find((split) => split.id === activeSplitId) ??
+    splits[0] ??
+    BUILT_IN_SPLITS[0];
+  const displayedActiveSplitId = activeSplit.id;
   const activeCombinedLabelName = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
   )?.labelName;
@@ -352,13 +353,8 @@ export function MailShell() {
     if (searchQuery) return { q: searchQuery };
     if (scopeQuery) return scopeQuery;
 
-    const active =
-      settings?.splits?.find((split) => split.id === activeSplitId) ??
-      BUILT_IN_SPLITS.find((split) => split.id === activeSplitId) ??
-      BUILT_IN_SPLITS[0];
-
-    return mailSplitToThreadsQuery(active);
-  }, [searchQuery, scopeQuery, activeSplitId, settings?.splits]);
+    return mailSplitToThreadsQuery(activeSplit);
+  }, [searchQuery, scopeQuery, activeSplit]);
 
   const accountThreadState = useMailThreads({
     emailAccountId,
@@ -369,8 +365,9 @@ export function MailShell() {
     accounts: combinedAccounts,
     emailAccountId,
     enabled: isAllAccounts,
-    isUnread: displayedActiveSplitId === "unread",
-    labelName: activeCombinedLabelName,
+    isUnread: !searchQuery && activeSplit.kind === MailSplitKind.UNREAD,
+    labelName: searchQuery ? undefined : activeCombinedLabelName,
+    searchQuery: searchQuery ?? undefined,
   });
   const { labelsByAccount } = combinedThreadState;
   const { threads, isLoading, error, hasMore, isLoadingMore, loadMore } =
@@ -1044,10 +1041,6 @@ export function MailShell() {
       search: isMailOverlayOpen
         ? undefined
         : () => {
-            if (isAllAccounts) {
-              setPaletteOpen(true);
-              return;
-            }
             if (selection.hasSelection) selection.clear();
             if (layout === "list" && openThreadId) closeReader();
             pendingSearchFocusRef.current = true;
@@ -1079,14 +1072,14 @@ export function MailShell() {
     : "category";
   const newSplitOptions: NewSplitOption[] = useMemo(
     () => [
-      {
-        id: "state:unread",
-        name: "Unread",
-        kind: MailSplitKind.UNREAD,
-        value: null,
-        group: "state",
-      },
-      ...categories.map((category) => ({
+      ...BUILT_IN_SPLITS.filter((split) =>
+        settings?.hiddenBuiltInSplits.includes(split.id),
+      ).map((split) => ({
+        ...split,
+        id: `state:${split.id}`,
+        group: "state" as const,
+      })),
+      ...(isAllAccounts ? [] : categories).map((category) => ({
         id: `category:${category.type}`,
         name: category.name,
         kind: MailSplitKind.CATEGORY,
@@ -1101,11 +1094,28 @@ export function MailShell() {
         group: "label" as const,
       })),
     ],
-    [categories, categoryGroup, visibleLabels],
+    [
+      categories,
+      categoryGroup,
+      visibleLabels,
+      isAllAccounts,
+      settings?.hiddenBuiltInSplits,
+    ],
   );
 
   const onCreateSplit = useCallback(
     async (draft: NewSplitDraft) => {
+      const builtIn = BUILT_IN_SPLITS.find(
+        (split) => split.kind === draft.kind,
+      );
+      if (builtIn) {
+        updatePreferences({
+          hiddenBuiltInSplits: (settings?.hiddenBuiltInSplits ?? []).filter(
+            (id) => id !== builtIn.id,
+          ),
+        });
+        return;
+      }
       const result = await createMailSplitAction(emailAccountId, draft);
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
@@ -1113,7 +1123,12 @@ export function MailShell() {
       }
       mutateSettings();
     },
-    [emailAccountId, mutateSettings],
+    [
+      emailAccountId,
+      mutateSettings,
+      settings?.hiddenBuiltInSplits,
+      updatePreferences,
+    ],
   );
 
   const onCreateSplitFromPrompt = useCallback(
@@ -1142,6 +1157,15 @@ export function MailShell() {
 
   const onDeleteSplit = useCallback(
     async (splitId: string) => {
+      const builtIn = BUILT_IN_SPLITS.find((split) => split.id === splitId);
+      if (builtIn) {
+        updatePreferences({
+          hiddenBuiltInSplits: [
+            ...new Set([...(settings?.hiddenBuiltInSplits ?? []), builtIn.id]),
+          ],
+        });
+        return;
+      }
       if (activeSplitId === splitId) setActiveSplitId("all");
       const result = await deleteMailSplitAction(emailAccountId, {
         id: splitId,
@@ -1152,7 +1176,14 @@ export function MailShell() {
       }
       mutateSettings();
     },
-    [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
+    [
+      emailAccountId,
+      mutateSettings,
+      activeSplitId,
+      setActiveSplitId,
+      settings?.hiddenBuiltInSplits,
+      updatePreferences,
+    ],
   );
 
   const onSetDefaultSplits = useCallback(
@@ -1368,9 +1399,8 @@ export function MailShell() {
             <ListToolbar
               layout={layout}
               searchQuery={searchQuery ?? ""}
-              onSearch={isAllAccounts ? undefined : setSearch}
+              onSearch={setSearch}
               searchInputRef={searchInputRef}
-              onOpenSearch={() => setPaletteOpen(true)}
               onToggleLayout={toggleLayout}
               expandedPreview={expandedPreview}
               onTogglePreview={togglePreview}
@@ -1395,7 +1425,6 @@ export function MailShell() {
                 canAddDefaultSplits={canAddDefaultSplits}
                 canRemoveDefaultSplits={canRemoveDefaultSplits}
                 onSetDefaultSplits={onSetDefaultSplits}
-                canCreateSplits={!isAllAccounts}
               />
             )}
             {isAllAccounts && combinedThreadState.failedAccountIds.length ? (
@@ -1426,7 +1455,7 @@ export function MailShell() {
                 onLoadMore={loadMore}
                 listKey={
                   isAllAccounts
-                    ? `all-accounts:${displayedActiveSplitId}`
+                    ? `all-accounts:${searchQuery ?? displayedActiveSplitId}`
                     : JSON.stringify(query)
                 }
               />

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -116,14 +116,9 @@ import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions
 import type { LabelCount } from "@/app/api/labels/counts/route";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getEmailTerminology } from "@/utils/terminology";
+import { BUILT_IN_SPLITS } from "@/utils/mail/built-in-splits";
 import { GMAIL_LABEL_COLORS } from "@/utils/gmail/label-colors";
 import { OUTLOOK_CATEGORY_COLORS } from "@/utils/outlook/category-colors";
-
-// Built-in and saved splits resolve through the same query mapping.
-const BUILT_IN_SPLITS = [
-  { id: "all", name: "All", kind: MailSplitKind.INBOX, value: null },
-  { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD, value: null },
-] as const;
 
 // Module-level so an "empty" reader doesn't hand children a new array each render.
 const NO_MESSAGES: ThreadMessage[] = [];
@@ -301,7 +296,7 @@ export function MailShell() {
 
   const splits = useMemo(() => {
     const builtInSplits = BUILT_IN_SPLITS.filter(
-      (split) => !settings?.hiddenBuiltInSplits.includes(split.id),
+      (split) => !settings?.hiddenBuiltInSplits?.includes(split.id),
     );
     const savedSplits = (settings?.splits ?? []).filter(
       (split) =>
@@ -1073,7 +1068,7 @@ export function MailShell() {
   const newSplitOptions: NewSplitOption[] = useMemo(
     () => [
       ...BUILT_IN_SPLITS.filter((split) =>
-        settings?.hiddenBuiltInSplits.includes(split.id),
+        settings?.hiddenBuiltInSplits?.includes(split.id),
       ).map((split) => ({
         ...split,
         id: `state:${split.id}`,
@@ -1105,17 +1100,6 @@ export function MailShell() {
 
   const onCreateSplit = useCallback(
     async (draft: NewSplitDraft) => {
-      const builtIn = BUILT_IN_SPLITS.find(
-        (split) => split.kind === draft.kind,
-      );
-      if (builtIn) {
-        updatePreferences({
-          hiddenBuiltInSplits: (settings?.hiddenBuiltInSplits ?? []).filter(
-            (id) => id !== builtIn.id,
-          ),
-        });
-        return;
-      }
       const result = await createMailSplitAction(emailAccountId, draft);
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
@@ -1123,12 +1107,7 @@ export function MailShell() {
       }
       mutateSettings();
     },
-    [
-      emailAccountId,
-      mutateSettings,
-      settings?.hiddenBuiltInSplits,
-      updatePreferences,
-    ],
+    [emailAccountId, mutateSettings],
   );
 
   const onCreateSplitFromPrompt = useCallback(

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -12,8 +12,6 @@ import { cn } from "@/utils";
 export type MailSplitTab = {
   id: string;
   name: string;
-  /** Built-in splits (e.g. All) can't be removed. */
-  deletable: boolean;
 };
 
 export type SplitTabsProps = {
@@ -27,8 +25,6 @@ export type SplitTabsProps = {
   canAddDefaultSplits: boolean;
   canRemoveDefaultSplits: boolean;
   onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
-  /** Split creation stays account-scoped, so it is hidden in All accounts. */
-  canCreateSplits: boolean;
   className?: string;
 };
 
@@ -43,7 +39,6 @@ export function SplitTabs({
   canAddDefaultSplits,
   canRemoveDefaultSplits,
   onSetDefaultSplits,
-  canCreateSplits,
   className,
 }: SplitTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
@@ -98,30 +93,26 @@ export function SplitTabs({
             >
               {split.name}
             </button>
-            {active && split.deletable && (
-              <button
-                type="button"
-                onClick={() => onDelete(split.id)}
-                aria-label={`Remove the ${split.name} split`}
-                className="rounded-full p-0.5 text-primary/60 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <XIcon className="size-3" />
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => onDelete(split.id)}
+              aria-label={`Remove the ${split.name} split`}
+              className="rounded-full p-0.5 text-muted-foreground hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <XIcon className="size-3" />
+            </button>
           </div>
         );
       })}
 
-      {canCreateSplits && (
-        <NewSplitPopover
-          options={newSplitOptions}
-          onCreate={onCreateSplit}
-          onCreateFromPrompt={onCreateSplitFromPrompt}
-          canAddDefaultSplits={canAddDefaultSplits}
-          canRemoveDefaultSplits={canRemoveDefaultSplits}
-          onSetDefaultSplits={onSetDefaultSplits}
-        />
-      )}
+      <NewSplitPopover
+        options={newSplitOptions}
+        onCreate={onCreateSplit}
+        onCreateFromPrompt={onCreateSplitFromPrompt}
+        canAddDefaultSplits={canAddDefaultSplits}
+        canRemoveDefaultSplits={canRemoveDefaultSplits}
+        onSetDefaultSplits={onSetDefaultSplits}
+      />
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -60,6 +60,53 @@ describe("useCombinedMailThreads", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps search results separate from synced inbox threads and other searches", async () => {
+    mailbox.read.mockResolvedValue({
+      threads: [createUnreadThread("account-1", "inbox-only")],
+    });
+    const fetcher = vi.fn(async (key: string) => ({
+      threads: [
+        createUnreadThread(
+          "account-1",
+          new URL(key, "http://localhost").searchParams.get("q")!,
+        ),
+      ],
+      failedAccountIds: [],
+      labelsByAccount: {},
+      nextPageToken: null,
+    }));
+    const { result, rerender, unmount } = renderHook(
+      ({ searchQuery }) =>
+        useCombinedMailThreads({
+          accounts: ACCOUNTS,
+          emailAccountId: "account-1",
+          enabled: true,
+          isUnread: false,
+          searchQuery,
+        }),
+      {
+        initialProps: { searchQuery: "first" },
+        wrapper: createWrapper(fetcher),
+      },
+    );
+    try {
+      await waitFor(() =>
+        expect(result.current.threads.map((thread) => thread.id)).toEqual([
+          "first",
+        ]),
+      );
+      rerender({ searchQuery: "second" });
+      await waitFor(() =>
+        expect(result.current.threads.map((thread) => thread.id)).toEqual([
+          "second",
+        ]),
+      );
+      expect(mailbox.read).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+    }
+  });
+
   it("does not revive an archived thread when returning to a cached combined split", async () => {
     const clock = vi.spyOn(Date, "now").mockReturnValue(100);
     const fetcher = vi.fn().mockImplementation(async () => ({

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -64,17 +64,16 @@ describe("useCombinedMailThreads", () => {
     mailbox.read.mockResolvedValue({
       threads: [createUnreadThread("account-1", "inbox-only")],
     });
-    const fetcher = vi.fn(async (key: string) => ({
-      threads: [
-        createUnreadThread(
-          "account-1",
-          new URL(key, "http://localhost").searchParams.get("q")!,
-        ),
-      ],
-      failedAccountIds: [],
-      labelsByAccount: {},
-      nextPageToken: null,
-    }));
+    const fetcher = vi.fn(async (key: string) => {
+      const query = new URL(key, "http://localhost").searchParams.get("q");
+      if (query === null) throw new Error("Expected a search query");
+      return {
+        threads: [createUnreadThread("account-1", query)],
+        failedAccountIds: [],
+        labelsByAccount: {},
+        nextPageToken: null,
+      };
+    });
     const { result, rerender, unmount } = renderHook(
       ({ searchQuery }) =>
         useCombinedMailThreads({

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -56,12 +56,14 @@ export function useCombinedMailThreads({
   enabled,
   isUnread,
   labelName,
+  searchQuery,
 }: {
   accounts: CombinedThread["account"][];
   emailAccountId: string;
   enabled: boolean;
   isUnread: boolean;
   labelName?: string;
+  searchQuery?: string;
 }) {
   const accountIdentity = useMemo(
     () =>
@@ -82,8 +84,9 @@ export function useCombinedMailThreads({
         accountIdentity,
         isUnread: isUnread || undefined,
         labelName,
+        q: searchQuery,
       }),
-    [accountIdentity, isUnread, labelName],
+    [accountIdentity, isUnread, labelName, searchQuery],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
   const { fetcher } = useSWRConfig();
@@ -97,11 +100,12 @@ export function useCombinedMailThreads({
         limit: COMBINED_PAGE_SIZE,
         isUnread: isUnread || undefined,
         labelName,
+        q: searchQuery,
         cursor: pageIndex > 0 ? previousPageData?.nextPageToken : undefined,
       });
       return `/api/threads/all?${params.toString()}`;
     },
-    [accountIdentity, enabled, isUnread, labelName],
+    [accountIdentity, enabled, isUnread, labelName, searchQuery],
   );
   const fetchCombinedPage = useCallback(
     async (key: string) => {
@@ -176,7 +180,7 @@ export function useCombinedMailThreads({
   }, [emailAccountId, enabled, viewIdentity, viewKey]);
 
   useEffect(() => {
-    if (!enabled || !accountIdentity || labelName) return;
+    if (!enabled || !accountIdentity || labelName || searchQuery) return;
     let cancelled = false;
     const accountIds = new Set(
       accountsRef.current.map((account) => account.id),
@@ -209,6 +213,7 @@ export function useCombinedMailThreads({
     enabled,
     isUnread,
     labelName,
+    searchQuery,
     localSnapshotLimit,
     viewIdentity,
   ]);

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
+import { hiddenBuiltInSplitsSchema } from "@/utils/actions/mail-split.validation";
 import { getDefaultMailSplitDraftsForAccount } from "@/utils/mail/default-splits.server";
 
 export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
@@ -12,6 +13,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
       select: {
         mailLayout: true,
         mailExpandedPreview: true,
+        mailHiddenBuiltInSplits: true,
         mailSplits: {
           // createdAt breaks ties so tab order can't shuffle between requests
           orderBy: [{ order: "asc" }, { createdAt: "asc" }],
@@ -31,6 +33,9 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
   return {
     layout: emailAccount?.mailLayout ?? null,
     expandedPreview: emailAccount?.mailExpandedPreview ?? false,
+    hiddenBuiltInSplits: hiddenBuiltInSplitsSchema.parse(
+      emailAccount?.mailHiddenBuiltInSplits ?? [],
+    ),
     splits: emailAccount?.mailSplits ?? [],
     defaultSplits,
   };

--- a/apps/web/app/api/threads/all/route.test.ts
+++ b/apps/web/app/api/threads/all/route.test.ts
@@ -116,6 +116,23 @@ describe("GET /api/threads/all", () => {
     });
   });
 
+  it("searches every included mailbox without inbox or split restrictions", async () => {
+    getConnectedEmailAccountsMock.mockResolvedValue([
+      { id: "account-1", email: "first@example.com", provider: "google" },
+      { id: "account-2", email: "second@example.com", provider: "microsoft" },
+    ]);
+    await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads/all?q=invoice&isUnread=true&labelName=Missing",
+      ),
+      {} as never,
+    );
+    expect(loadThreadsMock).toHaveBeenCalledTimes(2);
+    for (const [args] of loadThreadsMock.mock.calls) {
+      expect(args.query).toEqual({ q: "invoice", limit: 20 });
+    }
+  });
+
   it("rejects an unsafe provider cursor before loading threads", async () => {
     const cursor = Buffer.from(
       JSON.stringify({

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -10,6 +10,7 @@ import { threadsQuery } from "@/utils/threads/validation";
 export const maxDuration = 30;
 
 const querySchema = z.object({
+  q: threadsQuery.shape.q,
   cursor: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
   labelName: z.string().trim().min(1).max(255).optional(),
@@ -24,7 +25,7 @@ export type GetAllThreadsResponse = Awaited<
 >;
 
 export const GET = withAuth("threads/all", async (request) => {
-  const { cursor, limit, isUnread, labelName } = querySchema.parse(
+  const { cursor, limit, isUnread, labelName, q } = querySchema.parse(
     Object.fromEntries(new URL(request.url).searchParams),
   );
   const accounts = await getConnectedEmailAccounts({
@@ -43,7 +44,7 @@ export const GET = withAuth("threads/all", async (request) => {
         provider: account.provider,
         logger,
       });
-      if (labelName) {
+      if (labelName && !q) {
         const labels = await emailProvider.getLabels();
         const normalizedLabelName = labelName.toLowerCase();
         const matchingLabel = labels.find(
@@ -69,8 +70,7 @@ export const GET = withAuth("threads/all", async (request) => {
       const [loaded, labels] = await Promise.all([
         loadThreads({
           query: threadsQuery.parse({
-            type: "inbox",
-            isUnread,
+            ...(q ? { q } : { type: "inbox", isUnread }),
             limit,
             nextPageToken: pageToken,
           }),

--- a/apps/web/prisma/migrations/20260907140000_add_hidden_mail_splits/migration.sql
+++ b/apps/web/prisma/migrations/20260907140000_add_hidden_mail_splits/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "EmailAccount" ADD COLUMN "mailHiddenBuiltInSplits" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -160,6 +160,7 @@ model EmailAccount {
 
   mailLayout          MailLayout @default(LIST)
   mailExpandedPreview Boolean    @default(false)
+  mailHiddenBuiltInSplits String[] @default([])
 
   includeInAllAccounts Boolean @default(true)
 

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -216,6 +216,21 @@ describe("mail split actions", () => {
     expect(result?.serverError).toBe("You can only have 12 splits.");
   });
 
+  it("persists and restores hidden built-in splits", async () => {
+    for (const hiddenBuiltInSplits of [["all", "unread"], []] as (
+      | "all"
+      | "unread"
+    )[][]) {
+      await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
+        hiddenBuiltInSplits,
+      });
+      expect(prisma.emailAccount.update).toHaveBeenLastCalledWith({
+        where: { id: EMAIL_ACCOUNT_ID },
+        data: { mailHiddenBuiltInSplits: hiddenBuiltInSplits },
+      });
+    }
+  });
+
   it("persists the selected mail layout", async () => {
     await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
       layout: MailLayout.SPLIT,

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -57,9 +57,9 @@ describe("mail split actions", () => {
       id: "split-1",
       createdAt: new Date(),
       updatedAt: new Date(),
-      name: "Unread",
-      kind: MailSplitKind.UNREAD,
-      value: null,
+      name: "Receipts",
+      kind: MailSplitKind.LABEL,
+      value: "label-1",
       order: 0,
       emailAccountId: EMAIL_ACCOUNT_ID,
     };
@@ -69,9 +69,9 @@ describe("mail split actions", () => {
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Unread",
-      kind: MailSplitKind.UNREAD,
-      value: null,
+      name: "Receipts",
+      kind: MailSplitKind.LABEL,
+      value: "label-1",
     });
 
     expect(result?.data).toEqual({ split });
@@ -91,8 +91,8 @@ describe("mail split actions", () => {
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Later",
-      kind: MailSplitKind.UNREAD,
-      value: null,
+      kind: MailSplitKind.LABEL,
+      value: "label-1",
     });
 
     expect(result?.serverError).toBe("You can only have 12 splits.");
@@ -105,24 +105,24 @@ describe("mail split actions", () => {
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Unread",
-      kind: MailSplitKind.UNREAD,
-      value: null,
+      name: "Receipts",
+      kind: MailSplitKind.LABEL,
+      value: "label-1",
     });
 
-    expect(result?.serverError).toBe('You already have a "Unread" split.');
+    expect(result?.serverError).toBe('You already have a "Receipts" split.');
   });
 
   it("handles a duplicate-name constraint race with a safe error", async () => {
     prisma.$transaction.mockRejectedValue(createDuplicateNameError());
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Unread",
-      kind: MailSplitKind.UNREAD,
-      value: null,
+      name: "Receipts",
+      kind: MailSplitKind.LABEL,
+      value: "label-1",
     });
 
-    expect(result?.serverError).toBe('You already have a "Unread" split.');
+    expect(result?.serverError).toBe('You already have a "Receipts" split.');
   });
 
   it("creates the split the AI matched from a description", async () => {
@@ -162,6 +162,42 @@ describe("mail split actions", () => {
         ],
       }),
     );
+  });
+
+  it.each([
+    { id: "all", name: "All", kind: MailSplitKind.INBOX },
+    { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD },
+  ])("restores $name through manual and AI creation without saving a duplicate", async (builtIn) => {
+    prisma.$executeRaw.mockResolvedValue(1);
+    vi.mocked(aiPromptToSplit).mockResolvedValue({
+      reasoning: "Matches the built-in filter",
+      optionId: `state:${builtIn.id}`,
+      name: builtIn.name,
+    });
+    const draft = { name: builtIn.name, kind: builtIn.kind, value: null };
+    const manual = await createMailSplitAction(EMAIL_ACCOUNT_ID, draft);
+    const described = await createMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
+      prompt: "restore the filter",
+      options: [{ ...draft, id: `state:${builtIn.id}` }],
+    });
+    for (const result of [manual, described]) {
+      expect(result?.data?.split).toEqual({ ...builtIn, value: null });
+    }
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+    expect(prisma.$executeRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining("array_remove")]),
+      builtIn.id,
+      EMAIL_ACCOUNT_ID,
+    );
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate hidden split IDs before writing preferences", async () => {
+    const result = await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
+      hiddenBuiltInSplits: ["all", "all"],
+    });
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
   });
 
   it("returns a user-safe error when the AI response isn't one of the options", async () => {

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -120,12 +120,15 @@ export const updateMailPreferencesAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId },
-      parsedInput: { layout, expandedPreview },
+      parsedInput: { layout, expandedPreview, hiddenBuiltInSplits },
     }) => {
       await prisma.emailAccount.update({
         where: { id: emailAccountId },
         data: {
           ...(layout === undefined ? {} : { mailLayout: layout }),
+          ...(hiddenBuiltInSplits === undefined
+            ? {}
+            : { mailHiddenBuiltInSplits: hiddenBuiltInSplits }),
           ...(expandedPreview === undefined
             ? {}
             : { mailExpandedPreview: expandedPreview }),

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -17,6 +17,7 @@ import {
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { lockMailSplits } from "@/utils/mail/split-lock";
+import { BUILT_IN_SPLITS } from "@/utils/mail/built-in-splits";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import {
   getDefaultMailSplitDraftsForAccount,
@@ -139,7 +140,18 @@ export const updateMailPreferencesAction = actionClient
 
 async function createMailSplitOrThrow(
   data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">,
-): Promise<MailSplit> {
+) {
+  const builtIn = BUILT_IN_SPLITS.find((split) => split.kind === data.kind);
+  if (builtIn) {
+    await prisma.$executeRaw`
+      UPDATE "EmailAccount"
+      SET "mailHiddenBuiltInSplits" = array_remove("mailHiddenBuiltInSplits", ${builtIn.id}),
+          "updatedAt" = NOW()
+      WHERE id = ${data.emailAccountId}
+    `;
+    return builtIn;
+  }
+
   try {
     const result = await createMailSplit(data);
 

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -55,7 +55,10 @@ export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
 export const hiddenBuiltInSplitsSchema = z
   .array(z.enum(["all", "unread"]))
-  .max(2);
+  .max(2)
+  .refine((ids) => new Set(ids).size === ids.length, {
+    message: "Hidden split IDs must be unique",
+  });
 
 export const updateMailPreferencesBody = z
   .object({

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -53,10 +53,15 @@ export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
 export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
+export const hiddenBuiltInSplitsSchema = z
+  .array(z.enum(["all", "unread"]))
+  .max(2);
+
 export const updateMailPreferencesBody = z
   .object({
     layout: z.nativeEnum(MailLayout).optional(),
     expandedPreview: z.boolean().optional(),
+    hiddenBuiltInSplits: hiddenBuiltInSplitsSchema.optional(),
   })
   // Every field is optional so a caller can update one preference without
   // restating the others, which would otherwise also accept an empty update.

--- a/apps/web/utils/mail/built-in-splits.ts
+++ b/apps/web/utils/mail/built-in-splits.ts
@@ -1,0 +1,6 @@
+import { MailSplitKind } from "@/generated/prisma/enums";
+
+export const BUILT_IN_SPLITS = [
+  { id: "all", name: "All", kind: MailSplitKind.INBOX, value: null },
+  { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD, value: null },
+] as const;


### PR DESCRIPTION
Mail search and split controls now behave consistently in individual and combined account views. Every split exposes a remove control, and built-in tab visibility persists across reloads.

- Use `/` for mail search and Command-K for the command palette in both modes.
- Enable combined mailbox search and label split creation through shared controls and query mapping.
- Add a database migration for hiding and restoring built-in splits, with shared server-side restoration for manual and AI creation.
- Validation: 40 focused unit tests and 9 browser scenarios passed; screenshots inspected. Migration verified against an isolated test database.

Performance: combined search queries each included account through the existing paginated loader. Split visibility uses the existing settings read and preference write; no new background polling is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search is available directly in combined, all-account mailbox views.
  - Combined mailbox results update based on the entered search query.
  - Built-in “All” and “Unread” splits can be hidden and restored.
  - Mail split controls support creating, removing, and restoring splits.

- **Improvements**
  - The mail search field is always visible in the mailbox toolbar.
  - Pressing `/` focuses search, while `Meta/Control+K` opens the commands dialog.
  - Split preferences persist across reloads and account scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->