### PR TITLE
fix: refresh label name from provider when a rule is saved with a label ID

### DIFF
--- a/apps/web/utils/label/resolve-label.test.ts
+++ b/apps/web/utils/label/resolve-label.test.ts
@@ -44,8 +44,30 @@ describe("resolveLabelNameAndId", () => {
     expect(mockEmailProvider.getLabelByName).toHaveBeenCalledWith("My Label");
   });
 
-  it("should return both when both provided", async () => {
-    const mockEmailProvider = {} as EmailProvider;
+  it("should take the provider's name when both provided", async () => {
+    const mockEmailProvider = {
+      getLabelById: vi
+        .fn()
+        .mockResolvedValue({ id: "Label_123", name: "Current Name" }),
+    } as unknown as EmailProvider;
+
+    const result = await resolveLabelNameAndId({
+      emailProvider: mockEmailProvider,
+      label: "Stale Name",
+      labelId: "Label_123",
+    });
+
+    expect(result).toEqual({
+      label: "Current Name",
+      labelId: "Label_123",
+    });
+    expect(mockEmailProvider.getLabelById).toHaveBeenCalledWith("Label_123");
+  });
+
+  it("should keep the given name when the ID lookup finds nothing", async () => {
+    const mockEmailProvider = {
+      getLabelById: vi.fn().mockResolvedValue(null),
+    } as unknown as EmailProvider;
 
     const result = await resolveLabelNameAndId({
       emailProvider: mockEmailProvider,
@@ -57,6 +79,41 @@ describe("resolveLabelNameAndId", () => {
       label: "My Label",
       labelId: "Label_123",
     });
+  });
+
+  it("should keep the given name when the ID lookup fails", async () => {
+    const mockEmailProvider = {
+      getLabelById: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as EmailProvider;
+
+    const result = await resolveLabelNameAndId({
+      emailProvider: mockEmailProvider,
+      label: "My Label",
+      labelId: "Label_123",
+    });
+
+    expect(result).toEqual({
+      label: "My Label",
+      labelId: "Label_123",
+    });
+  });
+
+  it("should not look up a template even when an ID is provided", async () => {
+    const mockEmailProvider = {
+      getLabelById: vi.fn(),
+    } as unknown as EmailProvider;
+
+    const result = await resolveLabelNameAndId({
+      emailProvider: mockEmailProvider,
+      label: "{{pick a label}}",
+      labelId: "Label_123",
+    });
+
+    expect(result).toEqual({
+      label: "{{pick a label}}",
+      labelId: "Label_123",
+    });
+    expect(mockEmailProvider.getLabelById).not.toHaveBeenCalled();
   });
 
   it("should handle templates with complex expressions", async () => {

--- a/apps/web/utils/label/resolve-label.ts
+++ b/apps/web/utils/label/resolve-label.ts
@@ -8,7 +8,8 @@ const logger = createScopedLogger("resolve-label");
  * Resolves label name and ID pairing for a label action.
  * - If only label name is provided, looks up the labelId (creates if not found)
  * - If only labelId is provided, looks up the label name
- * - If both are provided, returns both
+ * - If both are provided, keeps the ID and refreshes the name from the provider
+ *   (the UI only updates the ID when a different label is picked)
  * - Returns null for both if lookup fails
  * - Skips resolution for AI templates (strings containing {{...}})
  */
@@ -21,7 +22,17 @@ export async function resolveLabelNameAndId({
   label?: string | null;
   labelId?: string | null;
 }): Promise<{ label: string | null; labelId: string | null }> {
-  // If we have both, return them
+  // The ID is the source of truth. A name given alongside it may be stale
+  // (label picker changed only the ID), so take the provider's name.
+  if (label && labelId && !hasVariables(label)) {
+    try {
+      const foundLabel = await emailProvider.getLabelById(labelId);
+      return { label: foundLabel?.name ?? label, labelId };
+    } catch {
+      return { label, labelId };
+    }
+  }
+
   if (label && labelId) {
     return { label, labelId };
   }


### PR DESCRIPTION
## Summary

When a rule is saved, `resolveLabelNameAndId` returned the given name and ID unchanged if both were present. The label picker only updates the label *ID* when a different label is chosen (`LabelCombobox.onChangeValue` receives the id), so the previously stored name was persisted alongside the new ID. The ID was applied correctly, but `ExecutedAction.label` — and therefore rule history — showed the old label name.

The ID is the source of truth, so look the name up by ID on save. Keep the given name if the lookup fails or returns nothing; templates are still skipped.

## Test plan

- [x] `resolve-label.test.ts`: provider name wins when both are given; given name kept on null / error; templates never looked up.
- [x] Existing `rule.test.ts` and `actions/rule.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Label names now stay synchronized with the latest provider data when a label ID is supplied.
  - If the label lookup fails or no matching label is found, the provided name and ID are preserved.
  - Template labels continue to bypass provider lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->