### PR TITLE
fix: include the member's own rules when picking an org rule copy name

### DIFF
--- a/apps/web/utils/organizations/rules.test.ts
+++ b/apps/web/utils/organizations/rules.test.ts
@@ -328,6 +328,13 @@ describe("syncOrganizationRuleToMembers", () => {
     >;
     expect(retryData.name).toBe("Invoices (2)");
     expect(retryData.organizationRuleId).toBe("org-rule-1");
+
+    // The conflicting rule is the member's own (no organizationRuleId); a
+    // plain `not` filter would exclude it and keep retrying the taken name.
+    const takenNamesWhere = prisma.rule.findMany.mock.calls[0]?.[0]?.where;
+    expect(takenNamesWhere?.OR).toEqual(
+      expect.arrayContaining([{ organizationRuleId: null }]),
+    );
   });
 });
 

--- a/apps/web/utils/organizations/rules.ts
+++ b/apps/web/utils/organizations/rules.ts
@@ -509,11 +509,16 @@ async function availableRuleName({
   desiredName: string;
   excludeOrganizationRuleId: string;
 }): Promise<string> {
+  // `not` never matches NULL, so the member's own rules (no organizationRuleId)
+  // have to be included explicitly - they are the usual source of the conflict.
   const rules = await prisma.rule.findMany({
     where: {
       emailAccountId,
       name: { startsWith: desiredName },
-      NOT: { organizationRuleId: excludeOrganizationRuleId },
+      OR: [
+        { organizationRuleId: null },
+        { organizationRuleId: { not: excludeOrganizationRuleId } },
+      ],
     },
     select: { name: true },
   });


### PR DESCRIPTION
## Summary

When an organization rule is copied to a member whose mailbox already has a rule with the same name, `materializeMemberRuleCopy` retries with a suffixed name from `availableRuleName`. That helper excluded copies of the same org rule with `NOT: { organizationRuleId }`, but Prisma's `not` never matches `NULL` — and the member's own rules (built-in system rules in particular) have no `organizationRuleId`. So the conflicting rule was never counted as taken, every retry proposed the same name, and after five attempts the copy was created as `Name (<organizationRuleId>)`.

Reproduced on a self-hosted instance where each member had built-in *FYI*, *Marketing* and *Receipt* rules and the org defined rules of the same names: every copy ended up as e.g. `Marketing (cmtre34g7004b01o1oyiwr5ui)`. The equivalent SQL (`NOT ("organizationRuleId" = 'x')`) returns zero rows for the built-in rule.

Include rules with a `NULL` `organizationRuleId` explicitly, so the first retry lands on `Name (2)` as intended.

## Test plan

- [x] `utils/organizations/rules.test.ts` (24 tests) passes; the existing conflict test now also asserts that the taken-names query includes the member's own rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule name conflict detection to account for personal rules.
  * Organization rule synchronization now avoids selecting names that conflict with existing personal rules.
* **Tests**
  * Added coverage verifying that conflicting personal rules are included when checking available names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->