### PR TITLE
mail: Collapse the sidebar to an icon rail and let it be resized

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/navigation-and-views.spec.ts
@@ -302,20 +302,35 @@ test("creates and edits a label and shows every keyboard workflow", async ({
     page.getByRole("link", { name: updatedLabelName, exact: true }),
   ).toBeVisible();
 
-  for (const name of [
-    `${updatedLabelName}/Clients`,
-    `${updatedLabelName}/Clients/Acme`,
-  ]) {
+  const createLabel = async (name: string) => {
     await page.getByRole("button", { name: "Create label" }).click();
     await page.getByRole("textbox", { name: "New label name" }).fill(name);
     await page.getByRole("button", { name: "Add", exact: true }).click();
-    await expect(
-      page.getByRole("link", { name: name.split("/").at(-1), exact: true }),
-    ).toBeVisible();
-  }
+  };
+
+  // A branch starts closed, so each nested label stays out of sight until its
+  // parent is expanded.
   const child = page.getByRole("link", { name: "Clients", exact: true });
   const grandchild = page.getByRole("link", { name: "Acme", exact: true });
+
+  await createLabel(`${updatedLabelName}/Clients`);
+  const expandParent = page.getByRole("button", {
+    name: `Expand ${updatedLabelName}`,
+    exact: true,
+  });
+  await expect(expandParent).toBeVisible();
+  await expect(child).toBeHidden();
+  await expandParent.click();
   await expect(child).toBeVisible();
+
+  await createLabel(`${updatedLabelName}/Clients/Acme`);
+  const expandChild = page.getByRole("button", {
+    name: `Expand ${updatedLabelName}/Clients`,
+    exact: true,
+  });
+  await expect(expandChild).toBeVisible();
+  await expect(grandchild).toBeHidden();
+  await expandChild.click();
   await expect(grandchild).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "gmail-nested-labels");
   await page
@@ -323,9 +338,12 @@ test("creates and edits a label and shows every keyboard workflow", async ({
     .click();
   await expect(child).toBeHidden();
   await expect(grandchild).toBeHidden();
-  await page
-    .getByRole("button", { name: `Expand ${updatedLabelName}`, exact: true })
-    .click();
+  // Re-expanding only reopens the level that was collapsed; deeper branches
+  // come back closed.
+  await expandParent.click();
+  await expect(child).toBeVisible();
+  await expect(grandchild).toBeHidden();
+  await expandChild.click();
   await grandchild.click();
   await expect(grandchild).toHaveAttribute("aria-current", "page");
   const selectedLabelUrl = page.url();

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -14,7 +14,6 @@ import {
 } from "lucide-react";
 import { Kbd } from "@/components/Kbd";
 import { Tooltip } from "@/components/Tooltip";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
@@ -33,7 +32,6 @@ export type ListToolbarProps = {
   onToggleLayout: () => void;
   onTogglePreview: () => void;
   onToggleAssistant: () => void;
-  showSidebarToggle?: boolean;
   selectedCount: number;
   onArchiveSelected: () => void;
   onDeleteSelected: () => void;
@@ -53,7 +51,6 @@ export function ListToolbar({
   onToggleLayout,
   onTogglePreview,
   onToggleAssistant,
-  showSidebarToggle = false,
   selectedCount,
   onArchiveSelected,
   onDeleteSelected,
@@ -63,14 +60,7 @@ export function ListToolbar({
   const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
 
   return (
-    <div
-      data-desktop-mac-titlebar-spacer={showSidebarToggle || undefined}
-      className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3"
-    >
-      {showSidebarToggle ? (
-        <SidebarTrigger name="left-sidebar" className="hidden lg:inline-flex" />
-      ) : null}
-
+    <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3">
       {/* Selection swaps the toolbar's controls in place so the list never
           shifts down to make room for a new row. */}
       {selectedCount > 0 ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { RailTooltip } from "@/app/(app)/[emailAccountId]/mail/MailSidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -82,34 +83,36 @@ export function MailAccountSwitcher({
       )}
     >
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label={collapsed ? activeLabel : undefined}
-            className={cn(
-              "flex w-full items-center rounded-xl text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              collapsed ? "justify-center" : "gap-3 px-2",
-              variant === "compact" ? "h-11" : "h-10",
-            )}
-          >
-            {activeIcon}
-            {collapsed ? null : (
-              <>
-                <span className="min-w-0 flex-1 leading-tight">
-                  <span className="block truncate font-medium text-sm">
-                    {activeLabel}
-                  </span>
-                  {activeEmail ? (
-                    <span className="block truncate text-muted-foreground text-xs">
-                      {activeEmail}
+        <RailTooltip label={collapsed ? activeLabel : null}>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label={collapsed ? activeLabel : undefined}
+              className={cn(
+                "flex w-full items-center rounded-xl text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                collapsed ? "justify-center" : "gap-3 px-2",
+                variant === "compact" ? "h-11" : "h-10",
+              )}
+            >
+              {activeIcon}
+              {collapsed ? null : (
+                <>
+                  <span className="min-w-0 flex-1 leading-tight">
+                    <span className="block truncate font-medium text-sm">
+                      {activeLabel}
                     </span>
-                  ) : null}
-                </span>
-                <ChevronsUpDownIcon className="size-4 text-muted-foreground" />
-              </>
-            )}
-          </button>
-        </DropdownMenuTrigger>
+                    {activeEmail ? (
+                      <span className="block truncate text-muted-foreground text-xs">
+                        {activeEmail}
+                      </span>
+                    ) : null}
+                  </span>
+                  <ChevronsUpDownIcon className="size-4 text-muted-foreground" />
+                </>
+              )}
+            </button>
+          </DropdownMenuTrigger>
+        </RailTooltip>
         <DropdownMenuContent
           align="start"
           className={cn(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -38,12 +38,15 @@ export function MailAccountSwitcher({
   onSelectAccount,
   onSelectAll,
   variant,
+  collapsed = false,
 }: {
   isAllAccounts: boolean;
   isDesktopApp: boolean;
   onSelectAccount: (accountId: string) => void;
   onSelectAll: () => void;
   variant: "compact" | "sidebar";
+  /** Icon-only rail: the trigger shrinks to the account avatar. */
+  collapsed?: boolean;
 }) {
   const { data, mutate } = useAccounts();
   const { emailAccount } = useAccount();
@@ -82,23 +85,29 @@ export function MailAccountSwitcher({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
+            aria-label={collapsed ? activeLabel : undefined}
             className={cn(
-              "flex w-full items-center gap-3 rounded-xl px-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "flex w-full items-center rounded-xl text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              collapsed ? "justify-center" : "gap-3 px-2",
               variant === "compact" ? "h-11" : "h-10",
             )}
           >
             {activeIcon}
-            <span className="min-w-0 flex-1 leading-tight">
-              <span className="block truncate font-medium text-sm">
-                {activeLabel}
-              </span>
-              {activeEmail ? (
-                <span className="block truncate text-muted-foreground text-xs">
-                  {activeEmail}
+            {collapsed ? null : (
+              <>
+                <span className="min-w-0 flex-1 leading-tight">
+                  <span className="block truncate font-medium text-sm">
+                    {activeLabel}
+                  </span>
+                  {activeEmail ? (
+                    <span className="block truncate text-muted-foreground text-xs">
+                      {activeEmail}
+                    </span>
+                  ) : null}
                 </span>
-              ) : null}
-            </span>
-            <ChevronsUpDownIcon className="size-4 text-muted-foreground" />
+                <ChevronsUpDownIcon className="size-4 text-muted-foreground" />
+              </>
+            )}
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -2,6 +2,7 @@
 
 import { isThreadStarred } from "@/app/(app)/[emailAccountId]/mail/star-state";
 import {
+  type CSSProperties,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -27,6 +28,11 @@ import type {
   MailboxItem,
   MailboxItemEdit,
 } from "@/app/(app)/[emailAccountId]/mail/MailboxItemContextMenu";
+import { MailSidebarResizeHandle } from "@/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle";
+import {
+  MAIL_SIDEBAR_DEFAULT_WIDTH,
+  MAIL_SIDEBAR_RAIL_WIDTH,
+} from "@/app/(app)/[emailAccountId]/mail/sidebar-width";
 import { ListSenderCommands } from "@/app/(app)/[emailAccountId]/mail/ListSenderCommands";
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
@@ -193,6 +199,13 @@ export function MailShell() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const pendingSearchFocusRef = useRef(false);
   const isMailSidebarOpen = openSidebars.includes("left-sidebar");
+
+  // Dragging writes straight to the CSS variable: re-rendering this screen on
+  // every pointer move would make the sidebar edge lag behind the cursor.
+  const sidebarScopeRef = useRef<HTMLDivElement>(null);
+  const setSidebarWidth = useCallback((width: number) => {
+    sidebarScopeRef.current?.style.setProperty("--sidebar-width", `${width}px`);
+  }, []);
 
   useEffect(() => {
     setIsDesktopApp(Boolean(getInboxZeroDesktopApp()));
@@ -1312,10 +1325,20 @@ export function MailShell() {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
       <div className="flex min-h-0 flex-1">
-        <div className="hidden [--sidebar-width:236px] lg:contents">
-          <Sidebar name="left-sidebar">
+        <div
+          ref={sidebarScopeRef}
+          className="hidden lg:contents"
+          style={
+            {
+              "--sidebar-width": `var(--mail-sidebar-width, ${MAIL_SIDEBAR_DEFAULT_WIDTH}px)`,
+              "--sidebar-width-icon": `${MAIL_SIDEBAR_RAIL_WIDTH}px`,
+            } as CSSProperties
+          }
+        >
+          <Sidebar name="left-sidebar" collapsible="icon">
             <MailSidebar
               className="h-full w-full border-r-0"
+              collapsed={!isMailSidebarOpen}
               activeType={
                 scopeLabelId || scopeFolderId ? null : (scopeType ?? "inbox")
               }
@@ -1348,9 +1371,13 @@ export function MailShell() {
                   onSelectAccount={selectAccount}
                   onSelectAll={selectAllAccounts}
                   variant="sidebar"
+                  collapsed={!isMailSidebarOpen}
                 />
               }
             />
+            {isMailSidebarOpen ? (
+              <MailSidebarResizeHandle onResize={setSidebarWidth} />
+            ) : null}
           </Sidebar>
         </div>
 
@@ -1375,7 +1402,6 @@ export function MailShell() {
               expandedPreview={expandedPreview}
               onTogglePreview={togglePreview}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
-              showSidebarToggle={!isMailSidebarOpen}
               showLayoutToggle={!isAllAccounts}
               selectedCount={selection.selectedCount}
               onArchiveSelected={archiveTargets}
@@ -1454,7 +1480,6 @@ export function MailShell() {
               onRemoveLabel={onRemoveLabel}
               onBackToInbox={closeReader}
               onArchive={archiveTargets}
-              showSidebarToggle={!isMailSidebarOpen}
               refetch={refetchOpenThread}
               onSendSuccess={(_messageId, sentThreadId) => {
                 if (

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -19,6 +19,7 @@ import {
   PlusIcon,
   SendIcon,
   SparklesIcon,
+  TagIcon,
   UserIcon,
   Users2Icon,
 } from "lucide-react";
@@ -27,6 +28,11 @@ import { Kbd } from "@/components/Kbd";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { GmailLabel } from "@/utils/gmail/label";
@@ -75,6 +81,8 @@ export type MailSidebarProps = {
   labelColorOptions: readonly MailboxItemColorOption[];
   /** Hide the categories group behind a toggle, collapsed by default. */
   collapsibleCategories?: boolean;
+  /** Icon-only rail: rows shrink to their icon and names move into tooltips. */
+  collapsed?: boolean;
   footer?: ReactNode;
   unified?: boolean;
   className?: string;
@@ -163,6 +171,7 @@ export function MailSidebar({
   labelEditMode,
   labelColorOptions,
   collapsibleCategories = false,
+  collapsed = false,
   footer,
   unified = false,
   className,
@@ -178,6 +187,7 @@ export function MailSidebar({
     !activeFolderId &&
     categories.some((category) => category.type === activeType);
   const [showCategories, setShowCategories] = useState(isCategoryActive);
+  const showCategoryRows = !collapsibleCategories || showCategories;
 
   useEffect(() => {
     if (isCategoryActive) setShowCategories(true);
@@ -195,36 +205,63 @@ export function MailSidebar({
   return (
     <aside
       className={cn(
-        "flex w-[236px] shrink-0 flex-col overflow-hidden border-border border-r bg-sidebar px-2.5 pt-3 pb-2.5",
+        "flex w-[236px] shrink-0 flex-col overflow-hidden border-border border-r bg-sidebar pt-3 pb-2.5",
+        collapsed ? "px-1.5" : "px-2.5",
         className,
       )}
     >
-      <div className="mb-2.5 flex shrink-0 items-center gap-1">
-        <Link
-          href={backToAppHref}
-          data-desktop-mac-end
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      {collapsed ? (
+        <div
+          data-desktop-mac-titlebar-spacer
+          className="mb-2.5 flex shrink-0 justify-center"
         >
-          <ArrowLeftIcon className="size-3.5 shrink-0" />
-          <span className="flex-1 truncate" data-hide-on-desktop-mac>
-            Inbox Zero
-          </span>
-        </Link>
-        <SidebarTrigger
-          name="left-sidebar"
-          className="size-6 shrink-0 text-muted-foreground"
-        />
-      </div>
+          <SidebarTrigger
+            name="left-sidebar"
+            className="text-muted-foreground"
+          />
+        </div>
+      ) : (
+        <div className="mb-2.5 flex shrink-0 items-center gap-1">
+          <Link
+            href={backToAppHref}
+            data-desktop-mac-end
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ArrowLeftIcon className="size-3.5 shrink-0" />
+            <span className="flex-1 truncate" data-hide-on-desktop-mac>
+              Inbox Zero
+            </span>
+          </Link>
+          <SidebarTrigger
+            name="left-sidebar"
+            className="size-6 shrink-0 text-muted-foreground"
+          />
+        </div>
+      )}
 
-      <Button
-        variant="gradient"
-        onClick={onCompose}
-        className="mb-3.5 w-full shrink-0 justify-start gap-2 rounded-xl px-3"
-      >
-        <PenLineIcon className="size-4 shrink-0" />
-        <span className="flex-1 text-left">Compose</span>
-        <Kbd variant="onColor">{getShortcutHint("compose")}</Kbd>
-      </Button>
+      {collapsed ? (
+        <RailTooltip label="Compose">
+          <Button
+            variant="gradient"
+            size="icon"
+            onClick={onCompose}
+            aria-label="Compose"
+            className="mb-3.5 size-10 shrink-0 self-center rounded-xl"
+          >
+            <PenLineIcon className="size-4" />
+          </Button>
+        </RailTooltip>
+      ) : (
+        <Button
+          variant="gradient"
+          onClick={onCompose}
+          className="mb-3.5 w-full shrink-0 justify-start gap-2 rounded-xl px-3"
+        >
+          <PenLineIcon className="size-4 shrink-0" />
+          <span className="flex-1 text-left">Compose</span>
+          <Kbd variant="onColor">{getShortcutHint("compose")}</Kbd>
+        </Button>
+      )}
 
       {/* The negative margin lets the scrollbar sit in the sidebar's own
           padding, so a platform-width bar can't crowd the unread counts. */}
@@ -247,45 +284,52 @@ export function MailSidebar({
                     : displayCount(countsById.get(countId))
                 }
                 emphasizeCount={emphasizeCount}
+                collapsed={collapsed}
               />
             ),
           )}
         </nav>
 
-        {!unified && categories.length > 0 && (
-          <>
-            <GroupHeading
-              expanded={collapsibleCategories ? showCategories : undefined}
-              onToggle={
-                collapsibleCategories
-                  ? () => setShowCategories((open) => !open)
-                  : undefined
-              }
-            >
-              {categoryHeading}
-            </GroupHeading>
-            {(!collapsibleCategories || showCategories) && (
-              <nav className="flex flex-col gap-px">
-                {categories.map(({ name, type, Icon }) => (
-                  <NavRow
-                    key={type}
-                    href={hrefFor({ kind: "type", type })}
-                    active={
-                      !activeLabelId && !activeFolderId && activeType === type
-                    }
-                    icon={<Icon className="size-3.5 shrink-0" />}
-                    name={name}
-                    count={null}
-                  />
-                ))}
-              </nav>
-            )}
-          </>
-        )}
+        {/* The rail replaces headings with a rule, so an empty group would
+            leave a stray line behind. */}
+        {!unified &&
+          categories.length > 0 &&
+          (!collapsed || showCategoryRows) && (
+            <>
+              <GroupHeading
+                collapsed={collapsed}
+                expanded={collapsibleCategories ? showCategories : undefined}
+                onToggle={
+                  collapsibleCategories
+                    ? () => setShowCategories((open) => !open)
+                    : undefined
+                }
+              >
+                {categoryHeading}
+              </GroupHeading>
+              {showCategoryRows && (
+                <nav className="flex flex-col gap-px">
+                  {categories.map(({ name, type, Icon }) => (
+                    <NavRow
+                      key={type}
+                      href={hrefFor({ kind: "type", type })}
+                      active={
+                        !activeLabelId && !activeFolderId && activeType === type
+                      }
+                      icon={<Icon className="size-3.5 shrink-0" />}
+                      name={name}
+                      count={null}
+                      collapsed={collapsed}
+                    />
+                  ))}
+                </nav>
+              )}
+            </>
+          )}
 
         {!unified && sidebarFolders.length > 0 && (
           <>
-            <GroupHeading>Folders</GroupHeading>
+            <GroupHeading collapsed={collapsed}>Folders</GroupHeading>
             <nav className="flex flex-col gap-px">
               {sidebarFolders.map((folder) => (
                 <MailboxItemContextMenu
@@ -306,11 +350,16 @@ export function MailSidebar({
                     icon={
                       <FolderIcon
                         className="size-3.5 shrink-0"
-                        style={{ marginLeft: folder.depth * 12 }}
+                        style={
+                          collapsed
+                            ? undefined
+                            : { marginLeft: folder.depth * 12 }
+                        }
                       />
                     }
                     name={folder.displayName}
                     count={displayCount(countsById.get(folder.id))}
+                    collapsed={collapsed}
                   />
                 </MailboxItemContextMenu>
               ))}
@@ -318,9 +367,10 @@ export function MailSidebar({
           </>
         )}
 
-        {!unified ? (
+        {!unified && (!collapsed || labelTree.length > 0) ? (
           <>
             <GroupHeading
+              collapsed={collapsed}
               action={
                 <button
                   type="button"
@@ -341,6 +391,7 @@ export function MailSidebar({
                   key={node.label.id}
                   node={node}
                   hasNestedLabels={hasNestedLabels}
+                  collapsed={collapsed}
                   activeLabelId={activeLabelId}
                   hrefFor={hrefFor}
                   countsById={countsById}
@@ -353,7 +404,7 @@ export function MailSidebar({
               ))}
             </nav>
 
-            {isAddingLabel ? (
+            {isAddingLabel && !collapsed ? (
               <form
                 onSubmit={submitNewLabel}
                 className="flex gap-1.5 px-2.5 py-2"
@@ -383,15 +434,28 @@ export function MailSidebar({
         ) : null}
       </div>
 
-      <button
-        type="button"
-        onClick={onOpenShortcuts}
-        className="mt-2 flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <KeyboardIcon className="size-3.5 shrink-0" />
-        <span className="flex-1 text-left">Keyboard shortcuts</span>
-        <Kbd>{getShortcutHint("help")}</Kbd>
-      </button>
+      {collapsed ? (
+        <RailTooltip label="Keyboard shortcuts">
+          <button
+            type="button"
+            onClick={onOpenShortcuts}
+            aria-label="Keyboard shortcuts"
+            className="mt-2 flex size-10 shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <KeyboardIcon className="size-4" />
+          </button>
+        </RailTooltip>
+      ) : (
+        <button
+          type="button"
+          onClick={onOpenShortcuts}
+          className="mt-2 flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <KeyboardIcon className="size-3.5 shrink-0" />
+          <span className="flex-1 text-left">Keyboard shortcuts</span>
+          <Kbd>{getShortcutHint("help")}</Kbd>
+        </button>
+      )}
       {footer}
     </aside>
   );
@@ -400,6 +464,7 @@ export function MailSidebar({
 function LabelBranch({
   node,
   hasNestedLabels,
+  collapsed,
   ...props
 }: Pick<
   MailSidebarProps,
@@ -411,16 +476,18 @@ function LabelBranch({
   | "labelColorOptions"
   | "onEditMailboxItem"
   | "onDeleteMailboxItem"
-> & { node: SidebarLabel; hasNestedLabels: boolean }) {
+> & { node: SidebarLabel; hasNestedLabels: boolean; collapsed: boolean }) {
   const { label, children } = node;
   const activeDescendantId = children.some((child) =>
     containsLabel(child, props.activeLabelId),
   )
     ? props.activeLabelId
     : null;
+  // Branches start closed so a deep label tree doesn't flood the sidebar; only
+  // the branch holding the open label reveals itself.
   const [expansion, setExpansion] = useState({
     activeDescendantId,
-    expanded: true,
+    expanded: activeDescendantId !== null,
   });
   // Reveal each newly selected descendant while retaining unrelated collapse choices.
   if (expansion.activeDescendantId !== activeDescendantId) {
@@ -429,7 +496,8 @@ function LabelBranch({
       expanded: activeDescendantId !== null || expansion.expanded,
     });
   }
-  const { expanded } = expansion;
+  // The rail has no room for a disclosure arrow, so it lists every label flat.
+  const expanded = collapsed || expansion.expanded;
 
   return (
     <div>
@@ -443,7 +511,7 @@ function LabelBranch({
         onDelete={props.onDeleteMailboxItem}
       >
         <div className="relative">
-          {children.length > 0 && (
+          {children.length > 0 && !collapsed && (
             <button
               type="button"
               aria-label={`${expanded ? "Collapse" : "Expand"} ${label.name}`}
@@ -464,28 +532,39 @@ function LabelBranch({
             href={props.hrefFor({ kind: "label", labelId: label.id })}
             active={props.activeLabelId === label.id}
             icon={
-              <span
-                className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
-                style={
-                  label.color?.backgroundColor
-                    ? { backgroundColor: label.color.backgroundColor }
-                    : undefined
-                }
-              />
+              collapsed ? (
+                <TagIcon
+                  className="size-4 shrink-0"
+                  style={{ color: label.color?.backgroundColor }}
+                />
+              ) : (
+                <span
+                  className="size-2.5 shrink-0 rounded-full bg-muted-foreground/40"
+                  style={
+                    label.color?.backgroundColor
+                      ? { backgroundColor: label.color.backgroundColor }
+                      : undefined
+                  }
+                />
+              )
             }
-            name={node.name}
+            // Flattened rows lose their parent context, so the tooltip carries
+            // the full path instead of the leaf name.
+            name={collapsed ? label.name : node.name}
             count={displayCount(props.countsById.get(label.id))}
-            nested={hasNestedLabels}
+            nested={hasNestedLabels && !collapsed}
+            collapsed={collapsed}
           />
         </div>
       </MailboxItemContextMenu>
       {expanded && children.length > 0 && (
-        <div className="ml-3">
+        <div className={collapsed ? undefined : "ml-3"}>
           {children.map((child) => (
             <LabelBranch
               key={child.label.id}
               node={child}
               hasNestedLabels={hasNestedLabels}
+              collapsed={collapsed}
               {...props}
             />
           ))}
@@ -500,12 +579,17 @@ function GroupHeading({
   action,
   expanded,
   onToggle,
+  collapsed,
 }: {
   children: ReactNode;
   action?: ReactNode;
   expanded?: boolean;
   onToggle?: () => void;
+  collapsed?: boolean;
 }) {
+  // A heading can't fit in the rail, so groups are separated by a rule instead.
+  if (collapsed) return <div className="mx-auto my-2 h-px w-6 bg-border" />;
+
   if (onToggle) {
     return (
       <div className="flex items-center gap-1.5 px-2.5 pt-4 pb-1.5">
@@ -545,6 +629,7 @@ function NavRow({
   count,
   emphasizeCount,
   nested,
+  collapsed,
 }: {
   href?: string;
   active: boolean;
@@ -553,15 +638,28 @@ function NavRow({
   count: number | null;
   emphasizeCount?: boolean;
   nested?: boolean;
+  collapsed?: boolean;
 }) {
   const className = cn(
-    "flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+    "flex items-center rounded-lg text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+    collapsed
+      ? "relative mx-auto size-10 justify-center"
+      : "gap-2.5 px-2.5 py-1.5",
     nested && "pl-7",
     active
       ? "bg-primary/10 font-medium text-foreground"
       : "text-muted-foreground hover:bg-accent hover:text-foreground",
   );
-  const content = (
+  const content = collapsed ? (
+    <>
+      {icon}
+      {count !== null && (
+        // The rail has no room for a number, so unread mail shows as a dot.
+        <span className="absolute top-1.5 right-1.5 size-1.5 rounded-full bg-primary" />
+      )}
+      <span className="sr-only">{name}</span>
+    </>
+  ) : (
     <>
       {icon}
       <span className="flex-1 truncate">{name}</span>
@@ -580,15 +678,7 @@ function NavRow({
     </>
   );
 
-  if (!href) {
-    return (
-      <div aria-current={active ? "page" : undefined} className={className}>
-        {content}
-      </div>
-    );
-  }
-
-  return (
+  const row = href ? (
     <Link
       href={href}
       aria-current={active ? "page" : undefined}
@@ -596,6 +686,33 @@ function NavRow({
     >
       {content}
     </Link>
+  ) : (
+    <div aria-current={active ? "page" : undefined} className={className}>
+      {content}
+    </div>
+  );
+
+  if (!collapsed) return row;
+
+  return (
+    <RailTooltip label={count === null ? name : `${name} (${count})`}>
+      {row}
+    </RailTooltip>
+  );
+}
+
+function RailTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -701,13 +701,16 @@ function NavRow({
   );
 }
 
-function RailTooltip({
+/** Names a rail control that has room for its icon only. `null` when expanded. */
+export function RailTooltip({
   label,
   children,
 }: {
-  label: string;
+  label: string | null;
   children: ReactNode;
 }) {
+  if (!label) return children;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { type PointerEvent, useCallback, useRef, useState } from "react";
+import {
+  clampMailSidebarWidth,
+  MAIL_SIDEBAR_DEFAULT_WIDTH,
+  MAIL_SIDEBAR_MAX_WIDTH,
+  MAIL_SIDEBAR_MIN_WIDTH,
+  persistMailSidebarWidth,
+} from "@/app/(app)/[emailAccountId]/mail/sidebar-width";
+
+const KEYBOARD_STEP = 16;
+
+/**
+ * Drag strip on the sidebar's trailing edge. The applied `--sidebar-width` is
+ * the source of truth throughout — reading the sidebar's box instead would
+ * report a half-finished value while its collapse transition is still running.
+ */
+export function MailSidebarResizeHandle({
+  onResize,
+}: {
+  onResize: (width: number) => void;
+}) {
+  // Mirrored into state purely so the separator can expose its value.
+  const [width, setWidth] = useState(MAIL_SIDEBAR_DEFAULT_WIDTH);
+  const panelLeftWhileDragging = useRef<number | null>(null);
+
+  const measure = useCallback((handle: HTMLDivElement | null) => {
+    if (handle) setWidth(appliedWidth(handle));
+  }, []);
+
+  const resize = (next: number) => {
+    setWidth(next);
+    onResize(next);
+  };
+
+  return (
+    <div
+      ref={measure}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuenow={width}
+      aria-valuemin={MAIL_SIDEBAR_MIN_WIDTH}
+      aria-valuemax={MAIL_SIDEBAR_MAX_WIDTH}
+      tabIndex={0}
+      onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+        const panel = event.currentTarget.parentElement;
+        if (!panel) return;
+        event.preventDefault();
+        panelLeftWhileDragging.current = panel.getBoundingClientRect().left;
+        event.currentTarget.setPointerCapture(event.pointerId);
+        // Holds the resize cursor and suppresses width transitions for the
+        // duration of the drag, so the edge tracks the pointer exactly.
+        document.body.dataset.resizing = "true";
+      }}
+      onPointerMove={(event: PointerEvent<HTMLDivElement>) => {
+        const panelLeft = panelLeftWhileDragging.current;
+        if (panelLeft === null) return;
+        resize(clampMailSidebarWidth(event.clientX - panelLeft));
+      }}
+      onLostPointerCapture={(event: PointerEvent<HTMLDivElement>) => {
+        if (panelLeftWhileDragging.current === null) return;
+        panelLeftWhileDragging.current = null;
+        delete document.body.dataset.resizing;
+        persistMailSidebarWidth(appliedWidth(event.currentTarget));
+      }}
+      onDoubleClick={() => {
+        resize(MAIL_SIDEBAR_DEFAULT_WIDTH);
+        persistMailSidebarWidth(MAIL_SIDEBAR_DEFAULT_WIDTH);
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+        event.preventDefault();
+        const step = event.key === "ArrowLeft" ? -KEYBOARD_STEP : KEYBOARD_STEP;
+        const next = clampMailSidebarWidth(
+          appliedWidth(event.currentTarget) + step,
+        );
+        resize(next);
+        persistMailSidebarWidth(next);
+      }}
+      className="absolute inset-y-0 right-0 z-20 hidden w-2 translate-x-1/2 cursor-col-resize touch-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:transition-colors hover:after:bg-primary focus-visible:after:bg-primary focus-visible:outline-none md:block"
+    />
+  );
+}
+
+function appliedWidth(handle: HTMLElement): number {
+  return clampMailSidebarWidth(
+    Number.parseInt(
+      getComputedStyle(handle).getPropertyValue("--sidebar-width"),
+      10,
+    ),
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
@@ -27,19 +27,32 @@ export function MailSidebarResizeHandle({
 }: {
   onResize: (width: number) => void;
 }) {
-  // Mirrored into state purely so the separator can expose its value.
+  // Mirrored into state purely so the separator can expose its value; the ref
+  // is what unmount cleanup can still read.
   const [width, setWidth] = useState(MAIL_SIDEBAR_DEFAULT_WIDTH);
+  const latestWidth = useRef(MAIL_SIDEBAR_DEFAULT_WIDTH);
   const panelLeftWhileDragging = useRef<number | null>(null);
 
   const measure = useCallback((handle: HTMLDivElement | null) => {
-    if (handle) setWidth(appliedWidth(handle));
+    if (!handle) return;
+    latestWidth.current = appliedWidth(handle);
+    setWidth(latestWidth.current);
   }, []);
 
   // Collapsing the sidebar mid-drag unmounts the handle before it can release
-  // the pointer, which would otherwise leave the whole page in a resizing state.
-  useEffect(() => () => releaseResizingCursor(), []);
+  // the pointer, so finish the drag here rather than stranding the page in a
+  // resizing state and losing the width the user just dragged to.
+  useEffect(
+    () => () => {
+      releaseResizingCursor();
+      if (panelLeftWhileDragging.current === null) return;
+      persistMailSidebarWidth(latestWidth.current);
+    },
+    [],
+  );
 
   const resize = (next: number) => {
+    latestWidth.current = next;
     setWidth(next);
     onResize(next);
   };

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebarResizeHandle.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type PointerEvent, useCallback, useRef, useState } from "react";
+import {
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   clampMailSidebarWidth,
   MAIL_SIDEBAR_DEFAULT_WIDTH,
@@ -29,6 +35,10 @@ export function MailSidebarResizeHandle({
     if (handle) setWidth(appliedWidth(handle));
   }, []);
 
+  // Collapsing the sidebar mid-drag unmounts the handle before it can release
+  // the pointer, which would otherwise leave the whole page in a resizing state.
+  useEffect(() => () => releaseResizingCursor(), []);
+
   const resize = (next: number) => {
     setWidth(next);
     onResize(next);
@@ -45,6 +55,8 @@ export function MailSidebarResizeHandle({
       aria-valuemax={MAIL_SIDEBAR_MAX_WIDTH}
       tabIndex={0}
       onPointerDown={(event: PointerEvent<HTMLDivElement>) => {
+        // A right-click opens the context menu; it shouldn't drag the edge too.
+        if (event.button !== 0) return;
         const panel = event.currentTarget.parentElement;
         if (!panel) return;
         event.preventDefault();
@@ -62,7 +74,7 @@ export function MailSidebarResizeHandle({
       onLostPointerCapture={(event: PointerEvent<HTMLDivElement>) => {
         if (panelLeftWhileDragging.current === null) return;
         panelLeftWhileDragging.current = null;
-        delete document.body.dataset.resizing;
+        releaseResizingCursor();
         persistMailSidebarWidth(appliedWidth(event.currentTarget));
       }}
       onDoubleClick={() => {
@@ -82,6 +94,10 @@ export function MailSidebarResizeHandle({
       className="absolute inset-y-0 right-0 z-20 hidden w-2 translate-x-1/2 cursor-col-resize touch-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:transition-colors hover:after:bg-primary focus-visible:after:bg-primary focus-visible:outline-none md:block"
     />
   );
+}
+
+function releaseResizingCursor() {
+  delete document.body.dataset.resizing;
 }
 
 function appliedWidth(handle: HTMLElement): number {

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -10,7 +10,6 @@ import {
 import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
 import type { EmailMessageCellLabel } from "@/components/EmailMessageCellLabels";
 import { Button } from "@/components/ui/button";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 
 type ReaderToolbarProps = {
   subject: string;
@@ -24,8 +23,6 @@ type ReaderToolbarProps = {
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
-  /** Sits beside the back arrow when the reader owns the full width. */
-  showSidebarToggle?: boolean;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
   messageExpansion?: {
@@ -45,20 +42,12 @@ export function ReaderToolbar({
   onRemoveLabel,
   onBackToInbox,
   onArchive,
-  showSidebarToggle = false,
   menu,
   messageExpansion,
 }: ReaderToolbarProps) {
   return (
     <div className="flex flex-wrap items-start gap-x-4 gap-y-3 pb-3">
       <div className="flex items-center gap-1">
-        {showSidebarToggle ? (
-          <SidebarTrigger
-            className="hidden lg:inline-flex"
-            name="left-sidebar"
-          />
-        ) : null}
-
         <Button
           aria-label="Back to inbox"
           className="h-7 w-7"

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -55,7 +55,6 @@ export type ThreadReaderProps = {
   onRemoveLabel?: (labelId: string) => void;
   onBackToInbox: () => void;
   onArchive: () => void;
-  showSidebarToggle?: boolean;
   /** Refreshes the open thread after a reply is sent or a draft changes. */
   refetch: () => void;
   /** Opens a different provider thread when a sent message starts one. */
@@ -84,7 +83,6 @@ export function ThreadReader({
   onRemoveLabel,
   onBackToInbox,
   onArchive,
-  showSidebarToggle = false,
   refetch,
   onSendSuccess,
   autoOpenReplyForMessageId,
@@ -132,9 +130,6 @@ export function ThreadReader({
       userLabels,
     }) ?? [];
 
-  /** No list column beside us, so the reader carries the sidebar toggle. */
-  const ownsFullWidth = layout === "list" && showSidebarToggle;
-
   const renderToolbar = (
     messageExpansion?: ComponentProps<typeof ReaderToolbar>["messageExpansion"],
   ) => (
@@ -146,7 +141,6 @@ export function ThreadReader({
       onArchive={onArchive}
       onBackToInbox={onBackToInbox}
       onRemoveLabel={onRemoveLabel}
-      showSidebarToggle={ownsFullWidth}
       subject={headerMessage.headers.subject}
     />
   );
@@ -160,10 +154,7 @@ export function ThreadReader({
         data-detail-selection-settled={detailSelectionSettled}
         data-testid="thread-reader"
       >
-        <div
-          className={readerMeasure({ layout })}
-          data-desktop-mac-titlebar-spacer={ownsFullWidth || undefined}
-        >
+        <div className={readerMeasure({ layout })}>
           {messages.length > 0 ? (
             <EmailThread
               renderToolbar={renderToolbar}

--- a/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/layout.tsx
@@ -1,18 +1,38 @@
+import type { CSSProperties } from "react";
+import { cookies } from "next/headers";
 import { MailThemeScope } from "@/app/(app)/[emailAccountId]/mail/MailThemeScope";
+import {
+  clampMailSidebarWidth,
+  MAIL_SIDEBAR_WIDTH_COOKIE,
+} from "@/app/(app)/[emailAccountId]/mail/sidebar-width";
 import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { MAIL_SHORTCUT_SCOPES } from "@/lib/shortcuts/registry";
 
-export default function MailLayout({
+export default async function MailLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const sidebarWidth = clampMailSidebarWidth(
+    Number.parseInt(
+      cookieStore.get(MAIL_SIDEBAR_WIDTH_COOKIE)?.value ?? "",
+      10,
+    ),
+  );
+
   // CommandK's provider only wraps its own palette, so the mail screen needs its
   // own for react-hotkeys-hook to have any active scope to bind against.
   return (
     <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
       <MailThemeScope />
-      {children}
+      {/* `contents` so the variable inherits without joining the flex layout. */}
+      <div
+        className="contents"
+        style={{ "--mail-sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+      >
+        {children}
+      </div>
     </ShortcutsProvider>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/sidebar-width.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/sidebar-width.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampMailSidebarWidth,
+  MAIL_SIDEBAR_DEFAULT_WIDTH,
+  MAIL_SIDEBAR_MAX_WIDTH,
+  MAIL_SIDEBAR_MIN_WIDTH,
+} from "./sidebar-width";
+
+describe("clampMailSidebarWidth", () => {
+  it("keeps a width that is already in range", () => {
+    expect(clampMailSidebarWidth(300)).toBe(300);
+  });
+
+  it("clamps to the bounds", () => {
+    expect(clampMailSidebarWidth(10)).toBe(MAIL_SIDEBAR_MIN_WIDTH);
+    expect(clampMailSidebarWidth(5000)).toBe(MAIL_SIDEBAR_MAX_WIDTH);
+  });
+
+  it("falls back to the default for a missing or malformed cookie", () => {
+    expect(clampMailSidebarWidth(Number.NaN)).toBe(MAIL_SIDEBAR_DEFAULT_WIDTH);
+    expect(clampMailSidebarWidth(Number("not-a-width"))).toBe(
+      MAIL_SIDEBAR_DEFAULT_WIDTH,
+    );
+  });
+
+  it("rounds to whole pixels", () => {
+    expect(clampMailSidebarWidth(240.6)).toBe(241);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/sidebar-width.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/sidebar-width.ts
@@ -1,0 +1,24 @@
+export const MAIL_SIDEBAR_WIDTH_COOKIE = "mail-sidebar-width";
+export const MAIL_SIDEBAR_DEFAULT_WIDTH = 236;
+export const MAIL_SIDEBAR_MIN_WIDTH = 180;
+export const MAIL_SIDEBAR_MAX_WIDTH = 440;
+/**
+ * Width of the icon-only rail the sidebar collapses to. Wide enough that the
+ * mac desktop traffic lights stay clear of the thread list beside it.
+ */
+export const MAIL_SIDEBAR_RAIL_WIDTH = 72;
+
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+export function clampMailSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return MAIL_SIDEBAR_DEFAULT_WIDTH;
+  return Math.min(
+    MAIL_SIDEBAR_MAX_WIDTH,
+    Math.max(MAIL_SIDEBAR_MIN_WIDTH, Math.round(width)),
+  );
+}
+
+/** Reading the cookie on the server keeps the first paint at the chosen width. */
+export function persistMailSidebarWidth(width: number) {
+  document.cookie = `${MAIL_SIDEBAR_WIDTH_COOKIE}=${width}; path=/; max-age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax; Secure`;
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -332,3 +332,14 @@ html[data-mac-desktop] [data-desktop-mac-end] {
   flex: none;
   margin-left: auto;
 }
+
+/* While a panel edge is being dragged, keep the resize cursor under the pointer
+   even when it outruns the handle, and let widths track it without easing. */
+body[data-resizing] {
+  cursor: col-resize;
+  user-select: none;
+}
+
+body[data-resizing] * {
+  transition-property: none !important;
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -334,12 +334,15 @@ html[data-mac-desktop] [data-desktop-mac-end] {
 }
 
 /* While a panel edge is being dragged, keep the resize cursor under the pointer
-   even when it outruns the handle, and let widths track it without easing. */
+   even when it outruns the handle, and let widths track it without easing.
+   Descendants need `!important` because interactive elements set their own
+   cursor, and a fast drag regularly carries the pointer across them. */
 body[data-resizing] {
-  cursor: col-resize;
   user-select: none;
 }
 
+body[data-resizing],
 body[data-resizing] * {
+  cursor: col-resize !important;
   transition-property: none !important;
 }


### PR DESCRIPTION
The mail sidebar could only be shown or hidden outright. It now collapses to an icon-only rail, and its expanded width can be dragged.

- Switch the mail sidebar to icon collapse: the toggle, compose, navigation, labels and account switcher all shrink to centred icons with right-side tooltips, unread counts become a dot, and group headings become a short rule. The rail is 72px so the mac desktop traffic lights stay clear of the thread list.
- Add a drag handle on the trailing edge (drag, arrow keys, double-click to reset), clamped 180–440px. Dragging writes the CSS variable directly rather than through React state so the edge tracks the cursor, and the width persists in a cookie the mail layout reads server-side so the first paint is already correct.
- Start nested label branches collapsed; a branch only opens on its own when it contains the label currently in view. Collapsing and re-expanding a branch brings deeper levels back closed.
- Drop `showSidebarToggle` from the list and reader toolbars. Those fallback triggers only existed for the case where the sidebar disappeared entirely, which can no longer happen on large screens.

## Validation

- New unit test for the width clamp; all mail unit tests pass.
- Full emulated mail Playwright suite run locally. The one failure (`command-palette.spec.ts` multi-account switch) reproduces identically on `main` in the same environment, so it is pre-existing.
- `navigation-and-views.spec.ts` updated: it previously asserted nested labels were visible immediately after creation, which the new default changes. It now asserts a new branch is closed and each level reveals the next when expanded.
- Browser-checked in the emulator at 1440x900: expanded, rail, drag, reload persistence, tooltips, right-click context menu on a rail label, and dark mode.

## Performance

No new runtime queries or network calls. Resizing bypasses React re-renders by setting the CSS variable on the sidebar scope element, and the persisted width is read once per request from a cookie in a layout that already renders dynamically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resize the mail sidebar by dragging its edge or using keyboard controls.
  - Double-click the resize handle to restore the default width.
  - Sidebar width is saved and restored between sessions.
  - Collapse the sidebar into an icon-only rail with tooltips for navigation items.
  - Account switching remains available in collapsed mode.

- **Bug Fixes**
  - Improved nested-label expansion and collapse behavior in the sidebar.
  - Improved cursor and layout behavior while resizing the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->