### PR TITLE
mail: Restore offline inbox loading and desktop recovery

### DIFF
--- a/apps/desktop/src/load-recovery.test.ts
+++ b/apps/desktop/src/load-recovery.test.ts
@@ -147,4 +147,24 @@ describe("desktop load recovery", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(contents.loadURL).not.toHaveBeenCalled();
   });
+
+  it("recovers the current mailbox after client-side navigation", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    const currentUrl = `${origin}/account-2/mail?type=archive`;
+    contents.emit("did-start-navigation", {
+      url: currentUrl,
+      isSameDocument: true,
+      isMainFrame: true,
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(contents.loadURL).not.toHaveBeenCalled();
+    contents.emit("render-process-gone", {}, { reason: "crashed" });
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(contents.loadURL).toHaveBeenLastCalledWith(currentUrl);
+  });
 });

--- a/apps/desktop/src/load-recovery.test.ts
+++ b/apps/desktop/src/load-recovery.test.ts
@@ -1,0 +1,150 @@
+import { EventEmitter } from "node:events";
+import type { WebContents } from "electron";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installDesktopLoadRecovery } from "./load-recovery";
+
+const origin = "https://app.example.com";
+const mailUrl = `${origin}/account-1/mail`;
+
+function makeContents() {
+  return Object.assign(new EventEmitter(), {
+    loadURL: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    isDestroyed: () => false,
+    getURL: () => mailUrl,
+  });
+}
+
+describe("desktop load recovery", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("shows recovery for a failed main page and automatically retries", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("did-fail-load", {}, -106, "Disconnected", mailUrl, true);
+    expect(contents.loadURL).toHaveBeenCalledWith(
+      expect.stringContaining("data:text/html"),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(contents.loadURL).toHaveBeenLastCalledWith(mailUrl);
+  });
+
+  it("keeps retrying when Chromium finishes its error document after a failed load", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("did-start-navigation", {
+      url: mailUrl,
+      isSameDocument: false,
+      isMainFrame: true,
+    });
+    contents.emit("did-fail-load", {}, -106, "Disconnected", mailUrl, true);
+    contents.emit("did-finish-load");
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(contents.loadURL).toHaveBeenLastCalledWith(mailUrl);
+  });
+
+  it("replaces a stalled navigation with recovery instead of waiting minutes", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("did-start-navigation", {
+      url: mailUrl,
+      isSameDocument: false,
+      isMainFrame: true,
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(contents.stop).toHaveBeenCalledOnce();
+    expect(contents.loadURL).toHaveBeenCalledWith(
+      expect.stringContaining("data:text/html"),
+    );
+  });
+
+  it("does not interrupt a loaded inbox for failed images or aborted navigations", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit(
+      "did-fail-load",
+      {},
+      -106,
+      "Disconnected",
+      `${origin}/image.png`,
+      false,
+    );
+    contents.emit("did-fail-load", {}, -3, "Aborted", mailUrl, true);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(contents.loadURL).not.toHaveBeenCalled();
+  });
+
+  it("stops recovery after the app finishes loading", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("did-fail-load", {}, -106, "Disconnected", mailUrl, true);
+    contents.emit("did-start-navigation", {
+      url: mailUrl,
+      isSameDocument: false,
+      isMainFrame: true,
+    });
+    contents.emit("did-finish-load");
+    contents.loadURL.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(contents.loadURL).not.toHaveBeenCalled();
+  });
+
+  it("retries immediately when the recovery page is reloaded", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("did-fail-load", {}, -106, "Disconnected", mailUrl, true);
+    const recoveryUrl = contents.loadURL.mock.calls[0][0];
+    const navigation = {
+      url: recoveryUrl,
+      isMainFrame: true,
+      isSameDocument: false,
+    };
+    contents.emit("did-start-navigation", navigation);
+    contents.loadURL.mockClear();
+    contents.emit("did-start-navigation", navigation);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(contents.loadURL).toHaveBeenCalledExactlyOnceWith(mailUrl);
+  });
+
+  it("recovers a crashed renderer and cancels timers when the window closes", async () => {
+    const contents = makeContents();
+    installDesktopLoadRecovery(
+      contents as unknown as WebContents,
+      origin,
+      () => mailUrl,
+    );
+    contents.emit("render-process-gone", {}, { reason: "crashed" });
+    expect(contents.loadURL).toHaveBeenCalledWith(
+      expect.stringContaining("data:text/html"),
+    );
+    contents.emit("destroyed");
+    contents.loadURL.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(contents.loadURL).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/load-recovery.ts
+++ b/apps/desktop/src/load-recovery.ts
@@ -1,0 +1,106 @@
+import type { WebContents } from "electron";
+
+export function installDesktopLoadRecovery(
+  contents: WebContents,
+  appOrigin: string,
+  getStartUrl: () => string,
+) {
+  let targetUrl = getStartUrl();
+  let showingRecovery = false;
+  let loadingRecoveryPage = false;
+  let loadTimeout: ReturnType<typeof setTimeout> | undefined;
+  let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  function cancelTimers() {
+    clearTimeout(loadTimeout);
+    clearTimeout(retryTimeout);
+    loadTimeout = undefined;
+    retryTimeout = undefined;
+  }
+
+  function showRecovery() {
+    if (contents.isDestroyed()) return;
+    cancelTimers();
+    showingRecovery = true;
+    loadingRecoveryPage = true;
+    contents.loadURL(getDesktopRecoveryPage(targetUrl)).catch(() => {});
+    retryTimeout = setTimeout(() => {
+      if (!contents.isDestroyed()) contents.loadURL(targetUrl).catch(() => {});
+    }, 10_000);
+  }
+
+  contents.on(
+    "did-start-navigation",
+    ({ url, isSameDocument, isMainFrame }) => {
+      if (!isMainFrame || isSameDocument || !isAppUrl(url, appOrigin)) return;
+      targetUrl = url;
+      cancelTimers();
+      loadTimeout = setTimeout(() => {
+        contents.stop();
+        showRecovery();
+      }, 15_000);
+    },
+  );
+  contents.on(
+    "did-fail-load",
+    (_event, code, _description, url, isMainFrame) => {
+      // Chromium aborts superseded navigations; images and iframes must never
+      // replace an otherwise usable inbox with the recovery screen.
+      if (!isMainFrame || code === -3 || !isAppUrl(url, appOrigin)) return;
+      targetUrl = url;
+      showRecovery();
+    },
+  );
+  contents.on("did-finish-load", () => {
+    // Chromium also finishes its error document after did-fail-load.
+    if (loadTimeout === undefined || !isAppUrl(contents.getURL(), appOrigin))
+      return;
+    showingRecovery = false;
+    cancelTimers();
+  });
+  contents.on("render-process-gone", showRecovery);
+  contents.once("destroyed", cancelTimers);
+
+  // Reloading the local recovery page from View > Reload should retry the app.
+  contents.on("did-start-navigation", ({ url, isMainFrame }) => {
+    if (!showingRecovery || !isMainFrame || !url.startsWith("data:text/html"))
+      return;
+    if (loadingRecoveryPage) {
+      loadingRecoveryPage = false;
+      return;
+    }
+    cancelTimers();
+    retryTimeout = setTimeout(() => {
+      if (!contents.isDestroyed()) contents.loadURL(targetUrl).catch(() => {});
+    }, 0);
+  });
+}
+
+export function getDesktopRecoveryPage(targetUrl: string) {
+  const href = targetUrl
+    .replace(/&/gu, "&amp;")
+    .replace(/"/gu, "&quot;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;");
+  return `data:text/html;charset=utf-8,${encodeURIComponent(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+<title>Inbox Zero</title><style>
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #fafafa; color: #18181b; font: 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+main { max-width: 420px; padding: 40px; text-align: center; }
+h1 { font-size: 24px; letter-spacing: -.5px; } p { color: #52525b; line-height: 1.6; }
+a { display: inline-block; margin: 16px 0; padding: 12px 24px; background: #18181b; color: white; border-radius: 8px; text-decoration: none; }
+small { display: block; color: #71717a; }
+</style></head><body><main><h1>Connecting to Inbox Zero</h1>
+<p>We couldn't load your mailbox. Check your connection. We'll retry automatically.</p>
+<a href="${href}">Retry now</a><small>You can also use View → Reload.</small>
+</main></body></html>`)}`;
+}
+
+function isAppUrl(url: string, origin: string) {
+  try {
+    return new URL(url).origin === origin;
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/load-recovery.ts
+++ b/apps/desktop/src/load-recovery.ts
@@ -24,9 +24,7 @@ export function installDesktopLoadRecovery(
     showingRecovery = true;
     loadingRecoveryPage = true;
     contents.loadURL(getDesktopRecoveryPage(targetUrl)).catch(() => {});
-    retryTimeout = setTimeout(() => {
-      if (!contents.isDestroyed()) contents.loadURL(targetUrl).catch(() => {});
-    }, 10_000);
+    retryTimeout = setTimeout(retryLoad, 10_000);
   }
 
   contents.on(
@@ -70,13 +68,15 @@ export function installDesktopLoadRecovery(
       return;
     }
     cancelTimers();
-    retryTimeout = setTimeout(() => {
-      if (!contents.isDestroyed()) contents.loadURL(targetUrl).catch(() => {});
-    }, 0);
+    retryTimeout = setTimeout(retryLoad, 0);
   });
+
+  function retryLoad() {
+    if (!contents.isDestroyed()) contents.loadURL(targetUrl).catch(() => {});
+  }
 }
 
-export function getDesktopRecoveryPage(targetUrl: string) {
+function getDesktopRecoveryPage(targetUrl: string) {
   const href = targetUrl
     .replace(/&/gu, "&amp;")
     .replace(/"/gu, "&quot;")

--- a/apps/desktop/src/load-recovery.ts
+++ b/apps/desktop/src/load-recovery.ts
@@ -30,8 +30,9 @@ export function installDesktopLoadRecovery(
   contents.on(
     "did-start-navigation",
     ({ url, isSameDocument, isMainFrame }) => {
-      if (!isMainFrame || isSameDocument || !isAppUrl(url, appOrigin)) return;
+      if (!isMainFrame || !isAppUrl(url, appOrigin)) return;
       targetUrl = url;
+      if (isSameDocument) return;
       cancelTimers();
       loadTimeout = setTimeout(() => {
         contents.stop();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -11,6 +11,7 @@ import {
   type Session,
   type WebContents,
 } from "electron";
+import { installDesktopLoadRecovery } from "./load-recovery";
 import { configureDesktopApplicationMenu } from "./application-menu";
 import {
   checkForDesktopUpdatesManually,
@@ -170,7 +171,8 @@ function createMainWindow() {
   applyNavigationPolicy(mainWindow.webContents);
   applyDesktopWindowDragRegion(mainWindow.webContents);
   trackLastAppUrl(mainWindow.webContents);
-  mainWindow.loadURL(getStartUrl()).catch(showSignInError);
+  installDesktopLoadRecovery(mainWindow.webContents, appOrigin, getStartUrl);
+  mainWindow.loadURL(getStartUrl()).catch(() => {});
 }
 
 function getStartUrl(): string {
@@ -189,6 +191,8 @@ function trackLastAppUrl(contents: WebContents) {
 }
 
 function persistLastAppUrl(url: string) {
+  // Local load recovery must not erase the last mailbox to restore.
+  if (url.startsWith("data:") || url === "about:blank") return;
   const file = path.join(app.getPath("userData"), LAST_APP_URL_FILE);
   try {
     if (shouldPersistDesktopUrl(url, appOrigin)) {
@@ -225,7 +229,7 @@ function applyDesktopWindowDragRegion(contents: WebContents) {
 function applyNavigationPolicy(contents: WebContents) {
   contents.setWindowOpenHandler(({ url }) => {
     if (isAllowedDesktopNavigation(url, appOrigin)) {
-      contents.loadURL(url).catch(showSignInError);
+      contents.loadURL(url).catch(() => {});
     } else {
       openExternal(url).catch(showSignInError);
     }
@@ -271,7 +275,7 @@ async function handleAuthCallbackUrl(url: string) {
       callback.code,
       callback.state,
     );
-    await window.loadURL(consumePostAuthUrl());
+    await window.loadURL(consumePostAuthUrl()).catch(() => {});
   } catch (error) {
     showSignInError(error);
   }

--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -36,6 +36,11 @@
     "app/(app)/[emailAccountId]/mail/MailboxItemContextMenu.tsx",
     "app/(app)/[emailAccountId]/mail/ShortcutsDialog.tsx"
   ],
+  "offline-loading.spec.ts": [
+    "app/sw.ts",
+    "providers/GlobalProviders.tsx",
+    "utils/offline/clear-mail-cache.ts"
+  ],
   "offline-outbox.spec.ts": [
     "app/(app)/MailMutationOutboxManager.tsx",
     "utils/email-cache/mail-mutations.ts",

--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -1,0 +1,144 @@
+import { build } from "esbuild";
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { expect } from "@playwright/test";
+import { test } from "../playwright-test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+// The emulated suite runs Next in development. Install the real worker with
+// the assets loaded by this page in place of the production precache manifest.
+test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
+  page,
+  context,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  await expect(
+    conversationWithSubject(page, conversations, "Archive Action Message"),
+  ).toBeVisible();
+  const assets = await page.evaluate(() =>
+    performance
+      .getEntriesByType("resource")
+      .map((entry) => entry.name)
+      .filter(
+        (url) =>
+          new URL(url).origin === location.origin &&
+          new URL(url).pathname.startsWith("/_next/static/"),
+      ),
+  );
+  const workerName = `sw-offline-test-${process.pid}.js`;
+  const workerFile = path.resolve("public", workerName);
+  try {
+    await build({
+      entryPoints: ["app/sw.ts"],
+      bundle: true,
+      define: {
+        "process.env.NODE_ENV": JSON.stringify("production"),
+        "self.__SW_MANIFEST": JSON.stringify(
+          [...new Set(assets)].map((url) => ({ url, revision: null })),
+        ),
+      },
+      outfile: workerFile,
+    });
+
+    await page.evaluate(async (name) => {
+      await navigator.serviceWorker.register(`/${name}`, { scope: "/" });
+      await navigator.serviceWorker.ready;
+      if (!navigator.serviceWorker.controller) {
+        await new Promise<void>((resolve) =>
+          navigator.serviceWorker.addEventListener(
+            "controllerchange",
+            () => resolve(),
+            { once: true },
+          ),
+        );
+      }
+      navigator.serviceWorker.controller?.postMessage({
+        type: "inbox-zero:save-offline-mail",
+      });
+    }, workerName);
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const name = (await caches.keys()).find((name) =>
+            name.startsWith("inbox-zero:offline-mail:"),
+          );
+          if (!name) return false;
+          const cache = await caches.open(name);
+          return (
+            Boolean(await cache.match(location.origin + location.pathname)) &&
+            Boolean(
+              await cache.match(`${location.origin}/api/user/email-accounts`),
+            )
+          );
+        }),
+      )
+      .toBe(true);
+
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
+    await expect(
+      page.getByRole("listbox", { name: "Conversations" }),
+    ).toBeVisible();
+    await expect(
+      conversationWithSubject(
+        page,
+        page.getByRole("listbox", { name: "Conversations" }),
+        "Archive Action Message",
+      ),
+    ).toBeVisible();
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "mail-after-real-offline-reload",
+    );
+
+    await context.setOffline(false);
+    await page.reload();
+    await expect(
+      conversationWithSubject(
+        page,
+        page.getByRole("listbox", { name: "Conversations" }),
+        "Archive Action Message",
+      ),
+    ).toBeVisible();
+    await capturePlaywrightCheckpoint(page, testInfo, "mail-after-reconnect");
+
+    const signOutStatus = await page.evaluate(async () => {
+      const response = await fetch("/api/auth/sign-out", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      return response.status;
+    });
+    expect(signOutStatus).toBe(200);
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const names = (await caches.keys()).filter((name) =>
+            name.startsWith("inbox-zero:offline-mail:"),
+          );
+          const entries = await Promise.all(
+            names.map(
+              async (name) => (await (await caches.open(name)).keys()).length,
+            ),
+          );
+          return entries.reduce((count, size) => count + size, 0);
+        }),
+      )
+      .toBe(0);
+  } finally {
+    await context.setOffline(false);
+    await page
+      .evaluate(async () => {
+        await Promise.all(
+          (await navigator.serviceWorker.getRegistrations()).map(
+            (registration) => registration.unregister(),
+          ),
+        );
+      })
+      .catch(() => {});
+    await rm(workerFile, { force: true });
+  }
+});

--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -77,15 +77,9 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
 
     await context.setOffline(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
+    await expect(conversations).toBeVisible();
     await expect(
-      page.getByRole("listbox", { name: "Conversations" }),
-    ).toBeVisible();
-    await expect(
-      conversationWithSubject(
-        page,
-        page.getByRole("listbox", { name: "Conversations" }),
-        "Archive Action Message",
-      ),
+      conversationWithSubject(page, conversations, "Archive Action Message"),
     ).toBeVisible();
     await capturePlaywrightCheckpoint(
       page,
@@ -96,11 +90,7 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     await context.setOffline(false);
     await page.reload();
     await expect(
-      conversationWithSubject(
-        page,
-        page.getByRole("listbox", { name: "Conversations" }),
-        "Archive Action Message",
-      ),
+      conversationWithSubject(page, conversations, "Archive Action Message"),
     ).toBeVisible();
     await capturePlaywrightCheckpoint(page, testInfo, "mail-after-reconnect");
 

--- a/apps/web/app/(app)/accounts/page.tsx
+++ b/apps/web/app/(app)/accounts/page.tsx
@@ -39,6 +39,7 @@ import {
   SCOPES as MICROSOFT_EMAIL_SCOPES,
 } from "@/utils/outlook/scopes";
 import { MICROSOFT_DRIVE_SCOPES } from "@/utils/drive/scopes";
+import { clearOfflineMailCache } from "@/utils/offline/clear-mail-cache";
 import { clearEmailCacheForAccount } from "@/utils/email-cache/database";
 import { clearPersistedSwrCacheForAccount } from "@/utils/swr-persistence";
 
@@ -164,6 +165,7 @@ function AccountOptionsDropdown({
       } else {
         clearEmailCacheForAccount(emailAccount.id).catch(() => {});
         clearPersistedSwrCacheForAccount(emailAccount.id);
+        await clearOfflineMailCache();
       }
     },
     onError: (error) => {

--- a/apps/web/app/sw.ts
+++ b/apps/web/app/sw.ts
@@ -1,4 +1,11 @@
 import { Serwist, type PrecacheEntry, type SerwistGlobalConfig } from "serwist";
+import {
+  CLEAR_OFFLINE_MAIL,
+  SAVE_OFFLINE_MAIL,
+  OFFLINE_MAIL_CACHE_PREFIX,
+  createOfflineMailCache,
+  matchesOfflineMailRequest,
+} from "../utils/offline/mail-cache";
 
 // This declares the value of `injectionPoint` to TypeScript.
 // `injectionPoint` is the string that will be replaced by the
@@ -12,12 +19,100 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
+// An old document must not outlive the precached JavaScript it references.
+const manifest = self.__SW_MANIFEST;
+const cacheNamePromise = crypto.subtle
+  .digest("SHA-256", new TextEncoder().encode(JSON.stringify(manifest ?? [])))
+  .then(
+    (hash) =>
+      `${OFFLINE_MAIL_CACHE_PREFIX}${Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, "0")).join("")}`,
+  );
+const mailCachePromise = cacheNamePromise.then((cacheName) =>
+  createOfflineMailCache({ origin: self.location.origin, cacheName }),
+);
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    cacheNamePromise.then(async (currentCache) => {
+      await Promise.all(
+        (await caches.keys())
+          .filter(
+            (name) =>
+              name.startsWith(OFFLINE_MAIL_CACHE_PREFIX) &&
+              name !== currentCache,
+          )
+          .map((name) => caches.delete(name)),
+      );
+    }),
+  );
+});
+
+self.addEventListener("message", (event) => {
+  if (
+    event.data?.type !== CLEAR_OFFLINE_MAIL &&
+    event.data?.type !== SAVE_OFFLINE_MAIL
+  )
+    return;
+  event.waitUntil(
+    (async () => {
+      if (!event.source || !("id" in event.source)) return;
+      const client = await self.clients.get(event.source.id);
+      if (!client || new URL(client.url).origin !== self.location.origin)
+        return;
+      const cache = await mailCachePromise;
+      if (event.data.type === CLEAR_OFFLINE_MAIL) {
+        await cache.clear();
+        event.ports[0]?.postMessage({ ok: true });
+      } else {
+        await cache.save(client.url, (promise) => event.waitUntil(promise));
+      }
+    })().catch(() => {}),
+  );
+});
+
 const serwist = new Serwist({
-  precacheEntries: self.__SW_MANIFEST,
+  precacheEntries: manifest,
   skipWaiting: true,
   clientsClaim: true,
-  navigationPreload: true,
-  runtimeCaching: [], // caching disabled
+  navigationPreload: false,
+  runtimeCaching: [
+    {
+      matcher: ({ request }) =>
+        matchesOfflineMailRequest(request, self.location.origin),
+      handler: async ({ request, event }) =>
+        (await mailCachePromise).handle(request, (promise) =>
+          event.waitUntil(promise),
+        ),
+    },
+    {
+      matcher: ({ request, url }) =>
+        url.origin === self.location.origin &&
+        request.mode === "navigate" &&
+        ["/login", "/welcome-redirect", "/connect-mailbox"].includes(
+          url.pathname,
+        ),
+      handler: async ({ request }) => {
+        await (await mailCachePromise).clear();
+        return fetch(request);
+      },
+    },
+    {
+      method: "POST",
+      matcher: ({ url }) =>
+        url.origin === self.location.origin &&
+        (url.pathname.startsWith("/api/auth/") ||
+          url.pathname === "/api/mobile-auth/exchange-code"),
+      handler: async ({ request }) => {
+        const cache = await mailCachePromise;
+        await cache.clear();
+        try {
+          return await fetch(request);
+        } finally {
+          await cache.clear();
+        }
+      },
+    },
+  ],
   disableDevLogs: process.env.NODE_ENV === "production",
 });
 

--- a/apps/web/app/sw.ts
+++ b/apps/web/app/sw.ts
@@ -5,6 +5,7 @@ import {
   OFFLINE_MAIL_CACHE_PREFIX,
   createOfflineMailCache,
   matchesOfflineMailRequest,
+  clearsOfflineMailOnGet,
 } from "../utils/offline/mail-cache";
 
 // This declares the value of `injectionPoint` to TypeScript.
@@ -85,12 +86,8 @@ const serwist = new Serwist({
         ),
     },
     {
-      matcher: ({ request, url }) =>
-        url.origin === self.location.origin &&
-        request.mode === "navigate" &&
-        ["/login", "/welcome-redirect", "/connect-mailbox"].includes(
-          url.pathname,
-        ),
+      matcher: ({ request }) =>
+        clearsOfflineMailOnGet(request, self.location.origin),
       handler: async ({ request }) => {
         await (await mailCachePromise).clear();
         return fetch(request);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -54,7 +54,12 @@ const nextConfig: NextConfig = {
                 // Playwright already isolates feature groups in short-lived
                 // dev servers. Restarting one mid-test aborts active requests.
                 ...(playwrightRunId
-                  ? { devMemoryThresholdRestart: false }
+                  ? {
+                      devMemoryThresholdRestart: false,
+                      // Offline tests must hydrate without Next's dev-only
+                      // WebSocket debug stream, just like a production build.
+                      reactDebugChannel: false,
+                    }
                   : {}),
               }
             : {}),

--- a/apps/web/providers/GlobalProviders.tsx
+++ b/apps/web/providers/GlobalProviders.tsx
@@ -2,6 +2,11 @@
 
 import type React from "react";
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import {
+  SAVE_OFFLINE_MAIL,
+  isOfflineMailPath,
+} from "@/utils/offline/mail-cache";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { SerwistProvider, useSerwist } from "@serwist/next/react";
 import { toast } from "sonner";
@@ -31,9 +36,10 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
 
 // SerwistProvider's own register drops the promise, so the failures that come
 // with crawlers, webviews and private browsing surface as unhandled rejections.
-// The worker is precache-only, so swallowing them is safe.
+// Registration failures must not interrupt the online app.
 function ManageServiceWorker() {
   const { serwist } = useSerwist();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!serwist) return;
@@ -43,7 +49,14 @@ function ManageServiceWorker() {
     let lastCheckedAt: number | null = null;
     let registration: ServiceWorkerRegistration | undefined;
 
+    const saveOfflineMail = () => {
+      saveOfflineMailPage(
+        navigator.serviceWorker.controller ?? registration?.active,
+      );
+    };
+
     const notifyAboutUpdate = () => {
+      saveOfflineMail();
       if (hadController && isDesktopApp) {
         toast.info("Update available", {
           action: {
@@ -73,6 +86,7 @@ function ManageServiceWorker() {
       }
 
       lastCheckedAt = now;
+      saveOfflineMail();
       try {
         registration ??= await navigator.serviceWorker.getRegistration();
         await registration?.update();
@@ -92,6 +106,7 @@ function ManageServiceWorker() {
       .register()
       .then((serviceWorkerRegistration) => {
         registration ??= serviceWorkerRegistration;
+        saveOfflineMail();
         return checkForUpdate();
       })
       .catch(() => {});
@@ -106,5 +121,20 @@ function ManageServiceWorker() {
     };
   }, [serwist]);
 
+  useEffect(() => {
+    if (!serwist || !pathname || !isOfflineMailPath(pathname)) return;
+    saveOfflineMailPage(navigator.serviceWorker.controller);
+  }, [serwist, pathname]);
+
   return null;
+}
+
+function saveOfflineMailPage(worker: ServiceWorker | null | undefined) {
+  if (
+    !isOfflineMailPath(window.location.pathname) ||
+    !navigator.onLine ||
+    document.visibilityState !== "visible"
+  )
+    return;
+  worker?.postMessage({ type: SAVE_OFFLINE_MAIL });
 }

--- a/apps/web/serwist.config.mjs
+++ b/apps/web/serwist.config.mjs
@@ -2,7 +2,7 @@
 import { serwist } from "@serwist/next/config";
 
 // Built by `serwist build` after `next build` (see the build scripts).
-// The service worker is precache-only; runtime caching is disabled in app/sw.ts.
+// Static assets are precached; app/sw.ts also keeps an offline mailbox shell.
 export default serwist({
   swSrc: "app/sw.ts",
   swDest: "public/sw.js",

--- a/apps/web/utils/offline/clear-mail-cache.ts
+++ b/apps/web/utils/offline/clear-mail-cache.ts
@@ -1,0 +1,35 @@
+import { CLEAR_OFFLINE_MAIL, OFFLINE_MAIL_CACHE_PREFIX } from "./mail-cache";
+
+export async function clearOfflineMailCache() {
+  if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      const worker = navigator.serviceWorker.controller ?? registration?.active;
+      if (worker) {
+        await new Promise<void>((resolve) => {
+          const channel = new MessageChannel();
+          const finish = () => {
+            clearTimeout(timeout);
+            channel.port1.close();
+            resolve();
+          };
+          const timeout = setTimeout(finish, 3000);
+          channel.port1.onmessage = finish;
+          worker.postMessage({ type: CLEAR_OFFLINE_MAIL }, [channel.port2]);
+        });
+      }
+    } catch {
+      // A stopped worker must not prevent logout; clear its disk cache below.
+    }
+  }
+  if (typeof caches === "undefined") return;
+  try {
+    await Promise.all(
+      (await caches.keys())
+        .filter((name) => name.startsWith(OFFLINE_MAIL_CACHE_PREFIX))
+        .map((name) => caches.delete(name)),
+    );
+  } catch {
+    // Cache Storage can be unavailable in private browsing.
+  }
+}

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOfflineMailCache,
+  matchesOfflineMailRequest,
+} from "./mail-cache";
+
+const origin = "https://app.example.com";
+const mailUrl = `${origin}/account-1/mail`;
+
+// Cache Storage is the browser boundary; requests and responses remain real.
+function createStorage() {
+  const entries = new Map<string, Response>();
+  return {
+    match: async (key: string) => entries.get(key)?.clone(),
+    put: async (key: string, response: Response) => {
+      entries.set(key, response.clone());
+    },
+    delete: async (key: string | Request) =>
+      entries.delete(typeof key === "string" ? key : key.url),
+    keys: async () => [...entries.keys()].map((key) => new Request(key)),
+  };
+}
+
+function html(body = "Saved mailbox") {
+  return new Response(body, { headers: { "content-type": "text/html" } });
+}
+
+function documentRequest(url = mailUrl) {
+  const request = new Request(url);
+  Object.defineProperty(request, "mode", { value: "navigate" });
+  return request;
+}
+
+describe("offline mail cache", () => {
+  let storage: ReturnType<typeof createStorage>;
+  let pending: Promise<unknown>[];
+  const network = vi.fn<typeof fetch>();
+  const waitUntil = (promise: Promise<unknown>) => pending.push(promise);
+  const makeCache = () => createOfflineMailCache({ origin, cacheName: "test" });
+
+  beforeEach(() => {
+    storage = createStorage();
+    pending = [];
+    network.mockReset();
+    vi.stubGlobal("fetch", network);
+    vi.stubGlobal("caches", { open: async () => storage });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens a previously visited mailbox when the actual network fails", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    // A new worker instance must restore the disk cache too.
+    const response = await makeCache().handle(documentRequest(), waitUntil);
+    expect(await response.text()).toBe("Saved mailbox");
+  });
+
+  it("uses saved mail within three seconds when the network hangs", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    vi.useFakeTimers();
+    network.mockImplementation(() => new Promise(() => {}));
+    const response = cache.handle(documentRequest(), waitUntil);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(await (await response).text()).toBe("Saved mailbox");
+  });
+
+  it("uses saved mail when response headers arrive but the page body stalls", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    vi.useFakeTimers();
+    network.mockResolvedValueOnce(
+      new Response(new ReadableStream(), {
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const response = cache.handle(documentRequest(), waitUntil);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(await (await response).text()).toBe("Saved mailbox");
+  });
+
+  it("bounds a stalled request even when there is no saved mailbox", async () => {
+    vi.useFakeTimers();
+    network.mockImplementation(
+      (_request, options) =>
+        new Promise((_resolve, reject) => {
+          const signal = options?.signal;
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    const result = expect(
+      makeCache().handle(documentRequest(), waitUntil),
+    ).rejects.toThrow("Mailbox request timed out");
+    await vi.advanceTimersByTimeAsync(15_000);
+    await result;
+    await Promise.all(pending);
+  });
+
+  it("coalesces simultaneous saves and permits refreshing again later", async () => {
+    const cache = makeCache();
+    network.mockImplementation(async (request) =>
+      new URL((request as Request).url).pathname.includes("/api/")
+        ? Response.json({ emailAccounts: [] })
+        : html(),
+    );
+    await Promise.all([
+      cache.save(mailUrl, waitUntil),
+      cache.save(`${mailUrl}?type=archive`, waitUntil),
+    ]);
+    await Promise.all(pending);
+    expect(network).toHaveBeenCalledTimes(2);
+    await cache.save(mailUrl, waitUntil);
+    await Promise.all(pending);
+    expect(network).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not fetch account metadata if logout interrupts saving the document", async () => {
+    const cache = makeCache();
+    let complete!: (response: Response) => void;
+    network.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const saving = cache.save(mailUrl, waitUntil);
+    await cache.clear();
+    complete(html());
+    await saving;
+    await Promise.all(pending);
+    expect(network).toHaveBeenCalledOnce();
+  });
+
+  it("preserves mailbox views without mixing accounts or caching RSC payloads", () => {
+    expect(
+      matchesOfflineMailRequest(
+        documentRequest(`${mailUrl}?type=archive`),
+        origin,
+      ),
+    ).toBe(true);
+    expect(
+      matchesOfflineMailRequest(
+        new Request(mailUrl, { headers: { RSC: "1" } }),
+        origin,
+      ),
+    ).toBe(false);
+    expect(
+      matchesOfflineMailRequest(documentRequest(`${origin}/login`), origin),
+    ).toBe(false);
+    expect(
+      matchesOfflineMailRequest(
+        documentRequest("https://other.example.com/account-1/mail"),
+        origin,
+      ),
+    ).toBe(false);
+  });
+
+  it("restores account metadata but never caches arbitrary API responses", async () => {
+    const cache = makeCache();
+    const request = new Request(`${origin}/api/user/email-accounts`);
+    network.mockResolvedValueOnce(
+      Response.json({ emailAccounts: [{ id: "account-1" }] }),
+    );
+    await cache.handle(request, waitUntil);
+    await Promise.all(pending);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    expect(await (await cache.handle(request, waitUntil)).json()).toEqual({
+      emailAccounts: [{ id: "account-1" }],
+    });
+    expect(
+      matchesOfflineMailRequest(new Request(`${origin}/api/threads`), origin),
+    ).toBe(false);
+    expect(
+      matchesOfflineMailRequest(
+        new Request(`${origin}/api/auth/get-session`),
+        origin,
+      ),
+    ).toBe(false);
+  });
+
+  it("never substitutes cached content for an authentication failure", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    network.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    expect((await cache.handle(documentRequest(), waitUntil)).status).toBe(401);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    await expect(cache.handle(documentRequest(), waitUntil)).rejects.toThrow();
+  });
+
+  it("does not let a stale authentication failure erase a newer mailbox", async () => {
+    const cache = makeCache();
+    let complete!: (response: Response) => void;
+    network.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const oldRequest = cache.handle(documentRequest(), waitUntil);
+    await cache.clear();
+    network.mockResolvedValueOnce(html("New session mailbox"));
+    await cache.handle(documentRequest(), waitUntil);
+    complete(new Response(null, { status: 401 }));
+    await oldRequest;
+    await Promise.all(pending);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    expect(
+      await (await cache.handle(documentRequest(), waitUntil)).text(),
+    ).toBe("New session mailbox");
+  });
+
+  it("does not keep login redirects as a saved mailbox", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    const login = html("Sign in");
+    Object.defineProperties(login, {
+      redirected: { value: true },
+      url: { value: `${origin}/login` },
+    });
+    network.mockResolvedValueOnce(login);
+    await cache.handle(documentRequest(), waitUntil);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    await expect(cache.handle(documentRequest(), waitUntil)).rejects.toThrow();
+  });
+
+  it("clears saved pages and prevents an in-flight response restoring them after logout", async () => {
+    const cache = makeCache();
+    let complete!: (response: Response) => void;
+    network.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const loading = cache.handle(documentRequest(), waitUntil);
+    await cache.clear();
+    complete(html());
+    await loading;
+    await Promise.all(pending);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    await expect(
+      makeCache().handle(documentRequest(), waitUntil),
+    ).rejects.toThrow();
+  });
+
+  it("never serves another account's document", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    await expect(
+      cache.handle(documentRequest(`${origin}/account-2/mail`), waitUntil),
+    ).rejects.toThrow();
+  });
+
+  it("still returns live mail when local storage fails", async () => {
+    vi.stubGlobal("caches", {
+      open: async () => {
+        throw new Error("Storage unavailable");
+      },
+    });
+    network.mockResolvedValue(html("Live mailbox"));
+    expect(
+      await (await makeCache().handle(documentRequest(), waitUntil)).text(),
+    ).toBe("Live mailbox");
+    await Promise.all(pending);
+  });
+});

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -332,6 +332,25 @@ describe("offline mail cache", () => {
     expect(await (await storage.match(mailUrl))?.text()).toBe("New mailbox");
   });
 
+  it("keeps slow saves coalesced after returning a cached fallback", async () => {
+    vi.useFakeTimers();
+    const cache = makeCache();
+    await storage.put(mailUrl, html("Saved mailbox"));
+    const liveResponse = Promise.withResolvers<Response>();
+    network.mockReturnValueOnce(liveResponse.promise);
+    network.mockResolvedValue(Response.json({ emailAccounts: [] }));
+    const firstSave = cache.save(mailUrl, waitUntil);
+    await vi.advanceTimersByTimeAsync(6000);
+    const secondSave = cache.save(mailUrl, waitUntil);
+    expect(secondSave).toBe(firstSave);
+    liveResponse.resolve(html("Refreshed mailbox"));
+    await Promise.all([firstSave, secondSave]);
+    expect(await (await storage.match(mailUrl))?.text()).toBe(
+      "Refreshed mailbox",
+    );
+    expect(network).toHaveBeenCalledTimes(2);
+  });
+
   it("still returns live mail when local storage fails", async () => {
     vi.stubGlobal("caches", {
       open: async () => {

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createOfflineMailCache,
   matchesOfflineMailRequest,
+  clearsOfflineMailOnGet,
 } from "./mail-cache";
 
 const origin = "https://app.example.com";
@@ -167,6 +168,33 @@ describe("offline mail cache", () => {
     ).toBe(false);
   });
 
+  it("clears offline mail on SSO entry and callbacks without clearing it for session reads", () => {
+    for (const path of [
+      "/api/sso/signin",
+      "/api/auth/sso/callback/provider",
+      "/api/auth/sso/saml2/callback/provider",
+    ]) {
+      expect(
+        clearsOfflineMailOnGet(new Request(`${origin}${path}`), origin),
+      ).toBe(true);
+    }
+    expect(
+      clearsOfflineMailOnGet(
+        new Request(`${origin}/api/auth/get-session`),
+        origin,
+      ),
+    ).toBe(false);
+    expect(
+      clearsOfflineMailOnGet(
+        new Request("https://other.example.com/api/sso/signin"),
+        origin,
+      ),
+    ).toBe(false);
+    expect(
+      clearsOfflineMailOnGet(documentRequest(`${origin}/login`), origin),
+    ).toBe(true);
+  });
+
   it("restores account metadata but never caches arbitrary API responses", async () => {
     const cache = makeCache();
     const request = new Request(`${origin}/api/user/email-accounts`);
@@ -268,6 +296,40 @@ describe("offline mail cache", () => {
     await expect(
       cache.handle(documentRequest(`${origin}/account-2/mail`), waitUntil),
     ).rejects.toThrow();
+  });
+
+  it("does not cache requests that begin while logout is deleting pages", async () => {
+    const cache = makeCache();
+    const deletion = Promise.withResolvers<Request[]>();
+    vi.spyOn(storage, "keys").mockReturnValueOnce(deletion.promise);
+    const clearing = cache.clear();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    deletion.resolve([]);
+    await clearing;
+    await Promise.all(pending);
+    expect(await storage.match(mailUrl)).toBeUndefined();
+  });
+
+  it("allows a fresh save after clearing an unfinished save", async () => {
+    const cache = makeCache();
+    const oldResponse = Promise.withResolvers<Response>();
+    const newResponse = Promise.withResolvers<Response>();
+    network.mockReturnValueOnce(oldResponse.promise);
+    const oldSave = cache.save(mailUrl, waitUntil);
+    await cache.clear();
+    network.mockReturnValueOnce(newResponse.promise);
+    const newSave = cache.save(mailUrl, waitUntil);
+    expect(network).toHaveBeenCalledTimes(2);
+    oldResponse.resolve(html("Old mailbox"));
+    await oldSave;
+    const sameSave = cache.save(mailUrl, waitUntil);
+    expect(sameSave).toBe(newSave);
+    network.mockResolvedValueOnce(Response.json({ emailAccounts: [] }));
+    newResponse.resolve(html("New mailbox"));
+    await newSave;
+    await Promise.all(pending);
+    expect(await (await storage.match(mailUrl))?.text()).toBe("New mailbox");
   });
 
   it("still returns live mail when local storage fails", async () => {

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -137,13 +137,18 @@ export function createOfflineMailCache({
     const existing = saves.get(key);
     if (existing) return existing;
     const startedAtGeneration = generation;
+    const backgroundWork: Promise<unknown>[] = [];
+    const trackWork: WaitUntil = (promise) => {
+      backgroundWork.push(promise);
+      waitUntil(promise);
+    };
     const saving = (async () => {
       const response = await handle(
         new Request(url, {
           credentials: "include",
           headers: { Accept: "text/html" },
         }),
-        waitUntil,
+        trackWork,
       );
       if (
         response.status !== 200 ||
@@ -155,9 +160,12 @@ export function createOfflineMailCache({
         new Request(`${origin}${ACCOUNT_PATH}`, {
           credentials: "include",
         }),
-        waitUntil,
+        trackWork,
       );
-    })().finally(() => {
+    })().finally(async () => {
+      // A cached fallback can return while the live refresh is still running.
+      await Promise.all(backgroundWork);
+      await writes;
       if (saves.get(key) === saving) saves.delete(key);
     });
     saves.set(key, saving);

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -16,6 +16,7 @@ export function createOfflineMailCache({
   cacheName: string;
 }) {
   let generation = 0;
+  let activeClears = 0;
   let writes: Promise<unknown> = Promise.resolve();
   const saves = new Map<string, Promise<void>>();
 
@@ -28,13 +29,19 @@ export function createOfflineMailCache({
 
   async function clear() {
     generation++;
-    await queueWrite(async (cache) => {
-      await Promise.all((await cache.keys()).map((key) => cache.delete(key)));
-    });
+    activeClears++;
+    saves.clear();
+    try {
+      await queueWrite(async (cache) => {
+        await Promise.all((await cache.keys()).map((key) => cache.delete(key)));
+      });
+    } finally {
+      activeClears--;
+    }
   }
 
   async function handle(request: Request, waitUntil: WaitUntil) {
-    const startedAtGeneration = generation;
+    const startedAtGeneration = activeClears ? undefined : generation;
     const url = new URL(request.url);
     // Mail's query parameters select client-side views of the same account.
     const key = `${origin}${url.pathname}`;
@@ -120,7 +127,11 @@ export function createOfflineMailCache({
 
   function save(url: string, waitUntil: WaitUntil): Promise<void> {
     const parsed = new URL(url);
-    if (parsed.origin !== origin || !isOfflineMailPath(parsed.pathname))
+    if (
+      activeClears ||
+      parsed.origin !== origin ||
+      !isOfflineMailPath(parsed.pathname)
+    )
       return Promise.resolve();
     const key = parsed.pathname;
     const existing = saves.get(key);
@@ -146,7 +157,9 @@ export function createOfflineMailCache({
         }),
         waitUntil,
       );
-    })().finally(() => saves.delete(key));
+    })().finally(() => {
+      if (saves.get(key) === saving) saves.delete(key);
+    });
     saves.set(key, saving);
     return saving;
   }
@@ -166,4 +179,17 @@ export function matchesOfflineMailRequest(request: Request, origin: string) {
 
 export function isOfflineMailPath(pathname: string) {
   return MAIL_PATH.test(pathname);
+}
+
+export function clearsOfflineMailOnGet(request: Request, origin: string) {
+  const url = new URL(request.url);
+  if (request.method !== "GET" || url.origin !== origin) return false;
+  return (
+    url.pathname === "/api/sso/signin" ||
+    url.pathname.startsWith("/api/auth/sso/") ||
+    (request.mode === "navigate" &&
+      ["/login", "/welcome-redirect", "/connect-mailbox"].includes(
+        url.pathname,
+      ))
+  );
 }

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -1,0 +1,169 @@
+const MAIL_PATH = /^\/[^/]+\/mail\/?$/u;
+const ACCOUNT_PATH = "/api/user/email-accounts";
+export const OFFLINE_MAIL_CACHE_PREFIX = "inbox-zero:offline-mail:";
+export const CLEAR_OFFLINE_MAIL = "inbox-zero:clear-offline-mail";
+export const SAVE_OFFLINE_MAIL = "inbox-zero:save-offline-mail";
+
+type WaitUntil = (promise: Promise<unknown>) => void;
+
+// Documents and account metadata let the existing IndexedDB mailbox open
+// without a server. API mutations and authentication always use the network.
+export function createOfflineMailCache({
+  origin,
+  cacheName,
+}: {
+  origin: string;
+  cacheName: string;
+}) {
+  let generation = 0;
+  let writes: Promise<unknown> = Promise.resolve();
+  const saves = new Map<string, Promise<void>>();
+
+  function queueWrite(operation: (cache: Cache) => Promise<unknown>) {
+    writes = writes
+      .then(async () => operation(await caches.open(cacheName)))
+      .catch(() => {});
+    return writes;
+  }
+
+  async function clear() {
+    generation++;
+    await queueWrite(async (cache) => {
+      await Promise.all((await cache.keys()).map((key) => cache.delete(key)));
+    });
+  }
+
+  async function handle(request: Request, waitUntil: WaitUntil) {
+    const startedAtGeneration = generation;
+    const url = new URL(request.url);
+    // Mail's query parameters select client-side views of the same account.
+    const key = `${origin}${url.pathname}`;
+    const isDocument = isOfflineMailPath(url.pathname);
+    const controller = new AbortController();
+    const abortRequest = () => controller.abort(request.signal.reason);
+    request.signal.addEventListener("abort", abortRequest, { once: true });
+    if (request.signal.aborted) abortRequest();
+    const networkTimeout = setTimeout(() => {
+      controller.abort(new Error("Mailbox request timed out"));
+    }, 15_000);
+    const cached = async () => {
+      if (startedAtGeneration !== generation) return;
+      try {
+        await writes;
+        const response = await (await caches.open(cacheName)).match(key);
+        return startedAtGeneration === generation ? response : undefined;
+      } catch {
+        return;
+      }
+    };
+    const network = (async () => {
+      const response = await fetch(request, { signal: controller.signal });
+      const responsePath = response.url
+        ? new URL(response.url).pathname
+        : url.pathname;
+      if (
+        response.status === 401 ||
+        response.status === 403 ||
+        (isDocument && response.redirected && responsePath !== url.pathname)
+      ) {
+        if (startedAtGeneration === generation) await clear();
+        return response;
+      }
+      if (response.status >= 500) {
+        return (await cached()) ?? response;
+      }
+      const contentType = response.headers.get("content-type") ?? "";
+      if (
+        response.status === 200 &&
+        contentType.includes(isDocument ? "text/html" : "application/json") &&
+        startedAtGeneration === generation
+      ) {
+        // Headers can arrive while the streamed HTML stalls indefinitely.
+        // Keep the timeout active until the document is actually readable.
+        await response.clone().arrayBuffer();
+        const copy = response.clone();
+        waitUntil(
+          queueWrite(async (cache) => {
+            // Logout can happen while opening Cache Storage or writing another entry.
+            if (startedAtGeneration === generation) await cache.put(key, copy);
+          }),
+        );
+      }
+      return response;
+    })().finally(() => {
+      clearTimeout(networkTimeout);
+      request.signal.removeEventListener("abort", abortRequest);
+    });
+    // Keep a late successful response alive to refresh the offline copy, even
+    // after the timeout has already returned the saved document.
+    waitUntil(network.catch(() => {}));
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const fallback = new Promise<Response>((resolve) => {
+      timeout = setTimeout(async () => {
+        const response = await cached();
+        if (response) resolve(response);
+      }, 3000);
+    });
+    try {
+      return await Promise.race([
+        network.catch(async (error: unknown) => {
+          const response = await cached();
+          if (response) return response;
+          throw error;
+        }),
+        fallback,
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  function save(url: string, waitUntil: WaitUntil): Promise<void> {
+    const parsed = new URL(url);
+    if (parsed.origin !== origin || !isOfflineMailPath(parsed.pathname))
+      return Promise.resolve();
+    const key = parsed.pathname;
+    const existing = saves.get(key);
+    if (existing) return existing;
+    const startedAtGeneration = generation;
+    const saving = (async () => {
+      const response = await handle(
+        new Request(url, {
+          credentials: "include",
+          headers: { Accept: "text/html" },
+        }),
+        waitUntil,
+      );
+      if (
+        response.status !== 200 ||
+        response.redirected ||
+        startedAtGeneration !== generation
+      )
+        return;
+      await handle(
+        new Request(`${origin}${ACCOUNT_PATH}`, {
+          credentials: "include",
+        }),
+        waitUntil,
+      );
+    })().finally(() => saves.delete(key));
+    saves.set(key, saving);
+    return saving;
+  }
+
+  return { handle, clear, save };
+}
+
+export function matchesOfflineMailRequest(request: Request, origin: string) {
+  const url = new URL(request.url);
+  if (request.method !== "GET" || url.origin !== origin) return false;
+  if (request.headers.has("RSC")) return false;
+  return (
+    (request.mode === "navigate" && isOfflineMailPath(url.pathname)) ||
+    (url.pathname === ACCOUNT_PATH && !url.search)
+  );
+}
+
+export function isOfflineMailPath(pathname: string) {
+  return MAIL_PATH.test(pathname);
+}

--- a/apps/web/utils/user.ts
+++ b/apps/web/utils/user.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { clearOfflineMailCache } from "@/utils/offline/clear-mail-cache";
 import { signOut } from "@/utils/auth-client";
 import { clearLastEmailAccountAction } from "@/utils/actions/email-account-cookie";
 import { redirectToSafeUrl } from "@/utils/redirect";
@@ -9,7 +10,7 @@ import { clearPersistedSwrCache } from "@/utils/swr-persistence";
 export async function logOut(callbackUrl?: string) {
   clearLastEmailAccountAction();
   clearPersistedSwrCache();
-  await clearEmailCache();
+  await Promise.all([clearEmailCache(), clearOfflineMailCache()]);
 
   await signOut({
     fetchOptions: {


### PR DESCRIPTION
Previously cached emails could remain inaccessible when the desktop app needed to reload its document over an unavailable or stalled connection. Cache the mailbox shell and account metadata so saved mail can reopen offline, and show a local recovery screen with manual and automatic retry when desktop loading fails or stalls.

- Scope cached documents to mailbox routes and build versions; clear them on sign-out, authentication changes, and account removal, including in-flight cache writes.
- Bound network waits and preserve the last mailbox URL during desktop recovery.
- Add regression coverage for offline reload, reconnect, sign-out, stalled responses, cache isolation, and desktop retry behavior.

Validation: 98 focused unit tests, a real browser offline/reconnect/sign-out scenario, Electron recovery smoke checks, and repository lint passed. Inspected browser and desktop screenshots. Confirmed the browser regression fails with the original service worker and passes with the fix. Desktop typechecking remains blocked by existing errors in unchanged test and update-feed files.

CI: build, unit tests, and the offline browser regression passed. The split-tabs browser job passed on retry after its initial run exceeded the existing eight-minute workflow limit. Automated reviews passed.

Performance: cache priming adds coalesced document and account-metadata requests using existing routes, with no schema changes. Mailbox responses are buffered before use so incomplete documents cannot replace the working page; cached fallback starts after three seconds and network attempts are bounded to fifteen seconds.
