### PR TITLE
fix: prevent duplicate email branding and footer scoring penalties

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.test.ts
@@ -11,6 +11,7 @@ const { mockEnv } = vi.hoisted(() => ({
 
 vi.mock("@/env", () => ({
   env: {
+    NEXT_PUBLIC_BRAND_NAME: "Inbox Zero",
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
     NEXT_PUBLIC_EMAIL_SEND_ENABLED: true,
     NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: true,

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -85,7 +85,7 @@ import type {
 } from "@/utils/email-cache/reply-drafts";
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
-import { stripReferralSignature } from "@/utils/referral/signature";
+import { stripBrandingSignatures } from "@/utils/referral/signature";
 import { renderSentWithFooterHtml } from "@/utils/email/sent-with-footer";
 import { getActionErrorMessage } from "@/utils/error";
 import { redirectToSafeUrl } from "@/utils/redirect";
@@ -309,7 +309,7 @@ function ComposeEmailFormContent({
         draft: {
           ...draft,
           editableHtml: sentWithFooterHtml
-            ? stripReferralSignature(parsedDraft.body.innerHTML)
+            ? stripBrandingSignatures(parsedDraft.body.innerHTML)
             : parsedDraft.body.innerHTML,
         },
         preservedBlocks,
@@ -327,7 +327,7 @@ function ComposeEmailFormContent({
     const draft = {
       ...preparedDraft,
       editableHtml: sentWithFooterHtml
-        ? stripReferralSignature(preparedDraft.editableHtml)
+        ? stripBrandingSignatures(preparedDraft.editableHtml)
         : preparedDraft.editableHtml,
       signatureHtml: [preparedDraft.signatureHtml, sentWithFooterHtml]
         .filter(Boolean)

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -85,6 +85,7 @@ import type {
 } from "@/utils/email-cache/reply-drafts";
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
+import { stripReferralSignature } from "@/utils/referral/signature";
 import { renderSentWithFooterHtml } from "@/utils/email/sent-with-footer";
 import { getActionErrorMessage } from "@/utils/error";
 import { redirectToSafeUrl } from "@/utils/redirect";
@@ -305,7 +306,12 @@ function ComposeEmailFormContent({
         }
       }
       return {
-        draft: { ...draft, editableHtml: parsedDraft.body.innerHTML },
+        draft: {
+          ...draft,
+          editableHtml: sentWithFooterHtml
+            ? stripReferralSignature(parsedDraft.body.innerHTML)
+            : parsedDraft.body.innerHTML,
+        },
         preservedBlocks,
       };
     }
@@ -320,6 +326,9 @@ function ComposeEmailFormContent({
     // removed with it, without introducing another block in the composer.
     const draft = {
       ...preparedDraft,
+      editableHtml: sentWithFooterHtml
+        ? stripReferralSignature(preparedDraft.editableHtml)
+        : preparedDraft.editableHtml,
       signatureHtml: [preparedDraft.signatureHtml, sentWithFooterHtml]
         .filter(Boolean)
         .join("<br>"),

--- a/apps/web/utils/actions/admin.test.ts
+++ b/apps/web/utils/actions/admin.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/utils/auth", () => ({
 }));
 vi.mock("@/env", () => ({
   env: {
+    NEXT_PUBLIC_BRAND_NAME: "Inbox Zero",
     ADMINS: ["admin@example.com"],
     NODE_ENV: "test",
   },

--- a/apps/web/utils/follow-up/generate-draft.test.ts
+++ b/apps/web/utils/follow-up/generate-draft.test.ts
@@ -7,6 +7,7 @@ import { aiDraftFollowUp } from "@/utils/ai/reply/draft-follow-up";
 
 const { envMock } = vi.hoisted(() => ({
   envMock: {
+    NEXT_PUBLIC_BRAND_NAME: "Inbox Zero",
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
     NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE: true,
   },

--- a/apps/web/utils/referral/signature.test.ts
+++ b/apps/web/utils/referral/signature.test.ts
@@ -23,6 +23,10 @@ describe("branding signatures", () => {
   it.each([
     "The report was sent with Inbox Zero sync enabled.",
     "Drafted by Inbox Zero is the footer text.",
+    "Drafted byInbox Zero",
+    "Sent withInbox Zero",
+    "Example > Sent with Inbox Zero",
+    "Sent with Inbox Zero < example",
     "<p>The report was sent with Inbox Zero sync enabled.</p>",
   ])("preserves branding phrases within authored text: %s", (body) => {
     expect(stripBrandingSignatures(body)).toBe(body);

--- a/apps/web/utils/referral/signature.test.ts
+++ b/apps/web/utils/referral/signature.test.ts
@@ -20,6 +20,14 @@ describe("referral signatures", () => {
 });
 
 describe("branding signatures", () => {
+  it.each([
+    "The report was sent with Inbox Zero sync enabled.",
+    "Drafted by Inbox Zero is the footer text.",
+    "<p>The report was sent with Inbox Zero sync enabled.</p>",
+  ])("preserves branding phrases within authored text: %s", (body) => {
+    expect(stripBrandingSignatures(body)).toBe(body);
+  });
+
   it("removes both HTML footers from a draft body", () => {
     const body = "<p>Thanks for the update.</p>";
     expect(
@@ -32,9 +40,7 @@ describe("branding signatures", () => {
   it("does not consume later content through malformed links", () => {
     const fragments = "Drafted by Inbox Zero [https:// ".repeat(10_000);
     const anchorFragments = "Sent with <a href=broken ".repeat(10_000);
-    expect(stripBrandingSignatures(fragments)).toBe(
-      " [https:// ".repeat(10_000).trim(),
-    );
+    expect(stripBrandingSignatures(fragments)).toBe(fragments.trim());
     expect(stripBrandingSignatures(anchorFragments)).toBe(
       anchorFragments.trim(),
     );

--- a/apps/web/utils/referral/signature.test.ts
+++ b/apps/web/utils/referral/signature.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   hasReferralSignature,
   stripReferralSignature,
+  stripBrandingSignatures,
 } from "@/utils/referral/signature";
 
 describe("referral signatures", () => {
@@ -12,7 +13,30 @@ describe("referral signatures", () => {
 
     expect(stripReferralSignature(html)).toBe(`${body}${signature}<div></div>`);
     expect(hasReferralSignature(html)).toBe(true);
+    // Repeated detection must not depend on the global regex lastIndex.
     expect(hasReferralSignature(html)).toBe(true);
     expect(hasReferralSignature(stripReferralSignature(html))).toBe(false);
+  });
+});
+
+describe("branding signatures", () => {
+  it("removes both HTML footers from a draft body", () => {
+    const body = "<p>Thanks for the update.</p>";
+    expect(
+      stripBrandingSignatures(
+        `${body}<div>Drafted by <a href="https://example.com">Inbox Zero</a>.</div><div>Sent with <a href="https://example.com">Inbox Zero</a></div>`,
+      ),
+    ).toBe(`${body}<div></div><div></div>`);
+  });
+
+  it("does not consume later content through malformed links", () => {
+    const fragments = "Drafted by Inbox Zero [https:// ".repeat(10_000);
+    const anchorFragments = "Sent with <a href=broken ".repeat(10_000);
+    expect(stripBrandingSignatures(fragments)).toBe(
+      " [https:// ".repeat(10_000).trim(),
+    );
+    expect(stripBrandingSignatures(anchorFragments)).toBe(
+      anchorFragments.trim(),
+    );
   });
 });

--- a/apps/web/utils/referral/signature.test.ts
+++ b/apps/web/utils/referral/signature.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasReferralSignature,
+  stripReferralSignature,
+} from "@/utils/referral/signature";
+
+describe("referral signatures", () => {
+  it("removes drafted branding without altering reply links or personal signatures", () => {
+    const body = '<p>See <a href="https://example.com">the update</a>.</p>';
+    const signature = "<p>Best,<br>Sender</p>";
+    const html = `${body}${signature}<div>Drafted by <a href="https://example.com/?ref=test">Inbox Zero</a>.</div>`;
+
+    expect(stripReferralSignature(html)).toBe(`${body}${signature}<div></div>`);
+    expect(hasReferralSignature(html)).toBe(true);
+    expect(hasReferralSignature(html)).toBe(true);
+    expect(hasReferralSignature(stripReferralSignature(html))).toBe(false);
+  });
+});

--- a/apps/web/utils/referral/signature.test.ts
+++ b/apps/web/utils/referral/signature.test.ts
@@ -26,6 +26,7 @@ describe("branding signatures", () => {
     "Drafted byInbox Zero",
     "Sent withInbox Zero",
     "Example > Sent with Inbox Zero",
+    "Contact <sender@example.com> Sent with Inbox Zero",
     "Sent with Inbox Zero < example",
     "<p>The report was sent with Inbox Zero sync enabled.</p>",
   ])("preserves branding phrases within authored text: %s", (body) => {

--- a/apps/web/utils/referral/signature.ts
+++ b/apps/web/utils/referral/signature.ts
@@ -1,21 +1,40 @@
+import { BRAND_NAME } from "@/utils/branding";
+
 const REFERRAL_SIGNATURE_PREFIX = "Drafted by";
 const REFERRAL_SIGNATURE_PRODUCT = "Inbox Zero";
 
-const REFERRAL_SIGNATURE_PATTERN = new RegExp(
-  `\\s*${escapeRegExp(REFERRAL_SIGNATURE_PREFIX)}\\s*(?:<a\\b[^>]*>)?${escapeRegExp(REFERRAL_SIGNATURE_PRODUCT)}(?:</a>)?\\.?\\s*`,
-  "i",
+const REFERRAL_SIGNATURE_PATTERN = createSignaturePattern(
+  REFERRAL_SIGNATURE_PREFIX,
+  REFERRAL_SIGNATURE_PRODUCT,
 );
+const SENT_WITH_SIGNATURE_PATTERN = createSignaturePattern(
+  "Sent with",
+  BRAND_NAME,
+);
+
+export function stripBrandingSignatures(value: string) {
+  return stripReferralSignature(value)
+    .replace(SENT_WITH_SIGNATURE_PATTERN, "")
+    .trim();
+}
 
 export function renderReferralSignatureHtml(referralLink: string) {
   return `${REFERRAL_SIGNATURE_PREFIX} <a href="${referralLink}">${REFERRAL_SIGNATURE_PRODUCT}</a>.`;
 }
 
 export function hasReferralSignature(value: string) {
-  return REFERRAL_SIGNATURE_PATTERN.test(value);
+  return value.search(REFERRAL_SIGNATURE_PATTERN) !== -1;
 }
 
 export function stripReferralSignature(value: string) {
   return value.replace(REFERRAL_SIGNATURE_PATTERN, "").trim();
+}
+
+function createSignaturePattern(prefix: string, product: string) {
+  return new RegExp(
+    `${escapeRegExp(prefix)}\\s*(?:<a\\b[^>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]]+\\])?\\.?`,
+    "gi",
+  );
 }
 
 function escapeRegExp(value: string) {

--- a/apps/web/utils/referral/signature.ts
+++ b/apps/web/utils/referral/signature.ts
@@ -32,7 +32,7 @@ export function stripReferralSignature(value: string) {
 
 function createSignaturePattern(prefix: string, product: string) {
   return new RegExp(
-    `${escapeRegExp(prefix)}\\s*(?:<a\\b[^<>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]\\s]+\\])?\\.?`,
+    `(?<=^|[\\r\\n>])[^\\S\\r\\n]*${escapeRegExp(prefix)}\\s*(?:<a\\b[^<>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]\\s]+\\])?\\.?(?=[^\\S\\r\\n]*(?:$|[\\r\\n<]))`,
     "gi",
   );
 }

--- a/apps/web/utils/referral/signature.ts
+++ b/apps/web/utils/referral/signature.ts
@@ -32,7 +32,7 @@ export function stripReferralSignature(value: string) {
 
 function createSignaturePattern(prefix: string, product: string) {
   return new RegExp(
-    `${escapeRegExp(prefix)}\\s*(?:<a\\b[^>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]]+\\])?\\.?`,
+    `${escapeRegExp(prefix)}\\s*(?:<a\\b[^<>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]\\s]+\\])?\\.?`,
     "gi",
   );
 }

--- a/apps/web/utils/referral/signature.ts
+++ b/apps/web/utils/referral/signature.ts
@@ -3,18 +3,18 @@ import { BRAND_NAME } from "@/utils/branding";
 const REFERRAL_SIGNATURE_PREFIX = "Drafted by";
 const REFERRAL_SIGNATURE_PRODUCT = "Inbox Zero";
 
-const REFERRAL_SIGNATURE_PATTERN = createSignaturePattern(
+const REFERRAL_SIGNATURE_PATTERN = createSignaturePatterns(
   REFERRAL_SIGNATURE_PREFIX,
   REFERRAL_SIGNATURE_PRODUCT,
 );
-const SENT_WITH_SIGNATURE_PATTERN = createSignaturePattern(
+const SENT_WITH_SIGNATURE_PATTERN = createSignaturePatterns(
   "Sent with",
   BRAND_NAME,
 );
 
 export function stripBrandingSignatures(value: string) {
   return stripReferralSignature(value)
-    .replace(SENT_WITH_SIGNATURE_PATTERN, "")
+    .replace(getSignaturePattern(value, SENT_WITH_SIGNATURE_PATTERN), "")
     .trim();
 }
 
@@ -23,18 +23,36 @@ export function renderReferralSignatureHtml(referralLink: string) {
 }
 
 export function hasReferralSignature(value: string) {
-  return value.search(REFERRAL_SIGNATURE_PATTERN) !== -1;
+  return (
+    value.search(getSignaturePattern(value, REFERRAL_SIGNATURE_PATTERN)) !== -1
+  );
 }
 
 export function stripReferralSignature(value: string) {
-  return value.replace(REFERRAL_SIGNATURE_PATTERN, "").trim();
+  return value
+    .replace(getSignaturePattern(value, REFERRAL_SIGNATURE_PATTERN), "")
+    .trim();
 }
 
-function createSignaturePattern(prefix: string, product: string) {
-  return new RegExp(
-    `(?<=^|[\\r\\n>])[^\\S\\r\\n]*${escapeRegExp(prefix)}\\s*(?:<a\\b[^<>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]\\s]+\\])?\\.?(?=[^\\S\\r\\n]*(?:$|[\\r\\n<]))`,
-    "gi",
-  );
+function getSignaturePattern(
+  value: string,
+  patterns: { text: RegExp; html: RegExp },
+) {
+  return /<\/?[a-z][^<>]*>/i.test(value) ? patterns.html : patterns.text;
+}
+
+function createSignaturePatterns(prefix: string, product: string) {
+  const signature = `${escapeRegExp(prefix)}\\s+(?:<a\\b[^<>]*>)?${escapeRegExp(product)}(?:</a>)?(?:\\s*\\[https?://[^\\]\\s]+\\])?\\.?`;
+  return {
+    text: new RegExp(
+      `(?<=^|[\\r\\n])[^\\S\\r\\n]*${signature}(?=[^\\S\\r\\n]*(?:$|[\\r\\n]))`,
+      "gi",
+    ),
+    html: new RegExp(
+      `(?<=^|[\\r\\n>])[^\\S\\r\\n]*${signature}(?=[^\\S\\r\\n]*(?:$|[\\r\\n<]))`,
+      "gi",
+    ),
+  };
 }
 
 function escapeRegExp(value: string) {

--- a/apps/web/utils/referral/signature.ts
+++ b/apps/web/utils/referral/signature.ts
@@ -38,7 +38,9 @@ function getSignaturePattern(
   value: string,
   patterns: { text: RegExp; html: RegExp },
 ) {
-  return /<\/?[a-z][^<>]*>/i.test(value) ? patterns.html : patterns.text;
+  return /<\/?(?:html|body|div|p|br|span|a)(?:\s[^<>]*|\/?)>/i.test(value)
+    ? patterns.html
+    : patterns.text;
 }
 
 function createSignaturePatterns(prefix: string, product: string) {

--- a/apps/web/utils/reply-tracker/draft-similarity.test.ts
+++ b/apps/web/utils/reply-tracker/draft-similarity.test.ts
@@ -3,6 +3,29 @@ import type { ParsedMessage } from "@/utils/types";
 import { getDraftSendLogSimilarityFields } from "./draft-similarity";
 
 describe("getDraftSendLogSimilarityFields", () => {
+  it.each([
+    "",
+    "Sent with Inbox Zero",
+    "Drafted by Inbox Zero.\n\nSent with Inbox Zero",
+  ])("ignores branding changes in recorded scores: %s", (footer) => {
+    const body = "Thanks for the update.";
+    const sentText = `${body}\n\n${footer}`;
+    const fields = getDraftSendLogSimilarityFields({
+      draftText: `${body}\n\nDrafted by Inbox Zero.`,
+      sentMessage: createParsedMessage(sentText),
+      sentText,
+      draftExists: false,
+      sentMessageRepliesToSource: true,
+    });
+    expect(fields.bodySimilarityScore).toBe(1);
+    expect(fields.similarityMetadata.draft.comparableBodyLength).toBe(
+      body.length,
+    );
+    expect(fields.similarityMetadata.sent.comparableBodyLength).toBe(
+      body.length,
+    );
+  });
+
   it("records normalized reply lengths without signatures or quoted content", () => {
     const accountSignature = [
       "Sender Name",

--- a/apps/web/utils/reply-tracker/draft-similarity.ts
+++ b/apps/web/utils/reply-tracker/draft-similarity.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "@/generated/prisma/client";
 import type { ParsedMessage } from "@/utils/types";
-import { stripReferralSignature } from "@/utils/referral/signature";
+import { stripBrandingSignatures } from "@/utils/referral/signature";
 import { calculateSimilarityDetails } from "@/utils/similarity-score";
 
 const BODY_SIMILARITY_STATUS = {
@@ -80,8 +80,8 @@ function getBodySimilarityResult({
   accountSignature?: string | null;
 }): BodySimilarityResult {
   const selectedBodySource = getSelectedProviderBodySource(sentMessage);
-  const comparableDraftText = stripReferralSignature(draftText ?? "");
-  const comparableSentText = stripReferralSignature(sentText ?? "");
+  const comparableDraftText = stripBrandingSignatures(draftText ?? "");
+  const comparableSentText = stripBrandingSignatures(sentText ?? "");
   const base = {
     comparableDraftLength: comparableDraftText.length,
     comparableSentLength: comparableSentText.length,

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -95,6 +95,7 @@ vi.mock("@/utils/ai/knowledge/extract-from-email-history", () => ({
 
 vi.mock("@/env", () => ({
   env: {
+    NEXT_PUBLIC_BRAND_NAME: "Inbox Zero",
     NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE: false,
   },
 }));

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -487,3 +487,21 @@ On Mon, Jan 1, 2024 wrote:
     });
   });
 });
+
+describe("branding footer normalization", () => {
+  it.each([
+    "Drafted by Inbox Zero.",
+    "Sent with Inbox Zero",
+    'Drafted by <a href="https://example.com/?ref=test">Inbox Zero</a>.',
+    "Sent with Inbox Zero [https://example.com/?ref=test]",
+    "Drafted by Inbox Zero [https://example.com/?ref=test].",
+    "Drafted by Inbox Zero.\n\nSent with Inbox Zero",
+  ])("ignores adding or deleting %s", (footer) => {
+    const body = "Thanks for the update.";
+    expect(calculateSimilarity(`${body}\n\n${footer}`, body)).toBe(1);
+    expect(calculateSimilarity(body, `${body}\n\n${footer}`)).toBe(1);
+    expect(
+      calculateSimilarity(`${body}\n\n${footer}`, "A different reply."),
+    ).toBeLessThan(1);
+  });
+});

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -1,3 +1,4 @@
+import { stripBrandingSignatures } from "@/utils/referral/signature";
 import he from "he";
 import * as stringSimilarity from "string-similarity";
 import {
@@ -52,7 +53,7 @@ function normalizeForOutlook(content: string, stripSignature = false): string {
   const withoutSignature = stripSignature
     ? stripPlainTextSignature(withoutForwardedContent)
     : withoutForwardedContent;
-  return withoutSignature.toLowerCase().trim();
+  return stripBrandingSignatures(withoutSignature).toLowerCase().trim();
 }
 
 /**
@@ -101,7 +102,7 @@ function normalizeForGmail(content: string, stripSignature = false): string {
   const withoutSignature = stripSignature
     ? stripPlainTextSignature(withoutForwardedContent)
     : withoutForwardedContent;
-  return withoutSignature.toLowerCase().trim();
+  return stripBrandingSignatures(withoutSignature).toLowerCase().trim();
 }
 
 /**


### PR DESCRIPTION
Remove drafted branding from the editable reply when the email client adds its sent footer, and exclude branding footers from draft similarity scores.

- Handle HTML and plain-text footers, including referral links, while preserving reply content and personal signatures.
- Validation: 176 focused tests passed; formatting and diff checks passed.
- CI unit-test shards, build, and compose-and-reply browser tests passed; browser screenshots were inspected.
