### PR TITLE
mail: Let a split cover several labels and split search from AI assist

### DIFF
--- a/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
@@ -24,6 +24,7 @@ const OPTIONS = [
   { id: "label:lbl-newsletter", name: "Newsletter", kind: MailSplitKind.LABEL },
   { id: "label:lbl-receipts", name: "Receipts", kind: MailSplitKind.LABEL },
   { id: "label:lbl-github", name: "GitHub", kind: MailSplitKind.LABEL },
+  { id: "label:lbl-invoices", name: "Invoices", kind: MailSplitKind.LABEL },
 ];
 
 describe.runIf(isAiTest)("aiPromptToSplit", () => {
@@ -36,7 +37,7 @@ describe.runIf(isAiTest)("aiPromptToSplit", () => {
         options: OPTIONS,
       });
 
-      expect(result.optionId).toBe("label:lbl-receipts");
+      expect(result.optionIds).toContain("label:lbl-receipts");
       expect(result.name).toBeTruthy();
     },
     TIMEOUT,
@@ -51,7 +52,7 @@ describe.runIf(isAiTest)("aiPromptToSplit", () => {
         options: OPTIONS,
       });
 
-      expect(result.optionId).toBe("state:unread");
+      expect(result.optionIds).toEqual(["state:unread"]);
     },
     TIMEOUT,
   );
@@ -65,7 +66,7 @@ describe.runIf(isAiTest)("aiPromptToSplit", () => {
         options: OPTIONS,
       });
 
-      expect(result.optionId).toBeNull();
+      expect(result.optionIds).toEqual([]);
     },
     TIMEOUT,
   );
@@ -81,7 +82,27 @@ describe.runIf(isAiTest)("aiPromptToSplit", () => {
         options: OPTIONS,
       });
 
-      expect(result.optionId).toBeNull();
+      expect(result.optionIds).toEqual([]);
+    },
+    TIMEOUT,
+  );
+
+  // The failure that motivated multi-label splits: a description spanning two
+  // of the user's labels used to come back as no match at all.
+  it(
+    "returns every label a description spans",
+    async () => {
+      const result = await aiPromptToSplit({
+        emailAccount: getEmailAccount(),
+        prompt: "receipts and invoices",
+        options: OPTIONS,
+      });
+
+      expect(result.optionIds.toSorted()).toEqual([
+        "label:lbl-invoices",
+        "label:lbl-receipts",
+      ]);
+      expect(result.name).toBeTruthy();
     },
     TIMEOUT,
   );

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -129,6 +129,12 @@ describe.skipIf(!RUN_DB_TESTS)(
         defaultSplits,
         enabled: true,
       });
+      const afterEnable = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+        select: { name: true },
+      });
+      expect(afterEnable.map((split) => split.name)).toEqual(["Receipt"]);
+
       await createMailSplit({
         emailAccountId,
         name: "Receipts and invoices",

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -6,7 +6,14 @@ import {
   SystemType,
 } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
-import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
+import {
+  createMailSplit,
+  removeLabelFromMailSplits,
+} from "@/utils/mail/splits.server";
+import {
+  seedDefaultMailSplits,
+  setDefaultMailSplits,
+} from "@/utils/mail/default-splits.server";
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
 
@@ -90,6 +97,82 @@ describe.skipIf(!RUN_DB_TESTS)(
 
       expect(splits).toHaveLength(1);
       expect(splits[0]?.id).toBe("concurrent-saved-split");
+    });
+
+    // The insert goes through raw SQL, so the array parameter needs a real
+    // database to prove it lands as a Postgres text[] rather than a string.
+    test("stores every label of a multi-label split", async () => {
+      const result = await createMailSplit({
+        emailAccountId,
+        name: "Feedback",
+        kind: MailSplitKind.LABEL,
+        values: ["label-users", "label-customers"],
+      });
+
+      expect(result?.status).toBe("created");
+      const saved = await prisma.mailSplit.findFirst({
+        where: { emailAccountId, name: "Feedback" },
+      });
+      expect(saved?.values).toEqual(["label-users", "label-customers"]);
+    });
+
+    test("adds and removes rule-label defaults without touching a widened split", async () => {
+      const defaultSplits = [
+        {
+          name: "Receipt",
+          kind: MailSplitKind.LABEL,
+          values: ["receipt-label"],
+        },
+      ];
+      await setDefaultMailSplits({
+        emailAccountId,
+        defaultSplits,
+        enabled: true,
+      });
+      await createMailSplit({
+        emailAccountId,
+        name: "Receipts and invoices",
+        kind: MailSplitKind.LABEL,
+        values: ["receipt-label", "invoice-label"],
+      });
+
+      await setDefaultMailSplits({
+        emailAccountId,
+        defaultSplits,
+        enabled: false,
+      });
+
+      const remaining = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+      });
+      expect(remaining.map((split) => split.name)).toEqual([
+        "Receipts and invoices",
+      ]);
+    });
+
+    test("narrows splits that share a deleted label and drops the ones left empty", async () => {
+      await createMailSplit({
+        emailAccountId,
+        name: "Feedback",
+        kind: MailSplitKind.LABEL,
+        values: ["gone"],
+      });
+      await createMailSplit({
+        emailAccountId,
+        name: "Feedback and support",
+        kind: MailSplitKind.LABEL,
+        values: ["gone", "kept"],
+      });
+
+      await removeLabelFromMailSplits({ emailAccountId, labelId: "gone" });
+
+      const remaining = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+        select: { name: true, values: true },
+      });
+      expect(remaining).toEqual([
+        { name: "Feedback and support", values: ["kept"] },
+      ]);
     });
   },
 );

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -166,7 +166,7 @@ async function deleteDefaultSplitRule(client: Client, emailAccountId: string) {
     `DELETE FROM "MailSplit"
      WHERE "emailAccountId" = $1
        AND kind = 'LABEL'
-       AND value = $2
+       AND "values" = ARRAY[$2]
        AND name = 'Calendar'`,
     [emailAccountId, DEFAULT_SPLIT_LABEL_ID],
   );

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -46,7 +46,7 @@ test("shows a combined picker and creates a matching split", async ({
   await page.getByRole("button", { name: "New split" }).click();
 
   const search = page.getByRole("combobox", {
-    name: "Search or describe a split",
+    name: "Search labels and categories",
   });
   await expect(
     page.getByRole("option", { name: "Promotions", exact: true }),
@@ -61,17 +61,16 @@ test("shows a combined picker and creates a matching split", async ({
   });
   await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-initial");
 
-  await search.fill("Posts from social networks");
+  await page.getByRole("button", { name: "Describe a split instead" }).click();
   await expect(
-    page.getByRole("option", {
-      name: "Create “Posts from social networks”",
-    }),
+    page.getByRole("textbox", { name: "Describe a split" }),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(
     page,
     testInfo,
     "mail-new-split-description",
   );
+  await page.getByRole("button", { name: "Back to the split list" }).click();
 
   await search.fill("Promotions");
   const promotionsOption = page.getByRole("option", {
@@ -129,22 +128,73 @@ test("organizes split choices and manages all rule labels", async ({
     groupHeadings.findIndex((heading) => heading.startsWith("Categories")),
   );
 
-  await page.getByRole("option", { name: "Add all" }).click();
+  // The bulk controls sit below the list rather than among the label rows.
+  await expect(
+    page.getByRole("option", { name: "Add a tab for each rule label" }),
+  ).toHaveCount(0);
+  await page
+    .getByRole("button", { name: "Add a tab for each rule label" })
+    .click();
   const calendarSplit = page.getByRole("button", {
     name: "Calendar",
     exact: true,
   });
   await expect(calendarSplit).toBeVisible();
   await page.getByRole("button", { name: "New split" }).click();
-  await expect(page.getByRole("option", { name: "Remove all" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Remove the rule label tabs" }),
+  ).toBeVisible();
   await capturePlaywrightCheckpoint(
     page,
     testInfo,
     "mail-rule-label-splits-added",
   );
 
-  await page.getByRole("option", { name: "Remove all" }).click();
+  await page
+    .getByRole("button", { name: "Remove the rule label tabs" })
+    .click();
   await expect(calendarSplit).toHaveCount(0);
+});
+
+test("builds one tab from several labels and names it", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  const extraLabel = `Split Partner ${testInfo.retry}`;
+  await page.getByRole("button", { name: "Create label" }).click();
+  await page.getByRole("textbox", { name: "New label name" }).fill(extraLabel);
+  await page.getByRole("button", { name: "Add", exact: true }).click();
+  await expect(
+    page.getByRole("link", { name: extraLabel, exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "New split" }).click();
+  await page
+    .getByRole("option", { name: "Project Alpha", exact: true })
+    .click();
+  await page.getByRole("option", { name: extraLabel, exact: true }).click();
+
+  const name = page.getByRole("textbox", { name: "Tab name" });
+  await expect(name).toHaveValue(`Project Alpha, ${extraLabel}`);
+  await name.fill("Two labels");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-new-split-multi-label",
+  );
+  await page.getByRole("button", { name: "Add tab for 2 labels" }).click();
+
+  const split = page.getByRole("button", { name: "Two labels", exact: true });
+  await expect(split).toHaveAttribute("aria-current", "true");
+  // Both labels feed one tab, so mail carrying either one shows up in it.
+  await expect(
+    conversationWithSubject(page, conversations, "Project Label Message"),
+  ).toBeVisible();
+
+  await page
+    .getByRole("button", { name: "Remove the Two labels split" })
+    .click();
+  await expect(split).toHaveCount(0);
 });
 
 for (const accountScope of ["single", "all"] as const) {
@@ -160,6 +210,7 @@ for (const accountScope of ["single", "all"] as const) {
     await page
       .getByRole("option", { name: "Project Alpha", exact: true })
       .click();
+    await page.getByRole("button", { name: "Add tab", exact: true }).click();
     const split = page.getByRole("button", {
       name: "Project Alpha",
       exact: true,

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -52,7 +52,7 @@ test("shows a combined picker and creates a matching split", async ({
     page.getByRole("option", { name: "Promotions", exact: true }),
   ).toBeVisible();
   await expect(
-    page.getByRole("option", { name: "Project Alpha", exact: true }),
+    page.getByRole("option", { name: "Project Alpha, not selected" }),
   ).toBeVisible();
   await expect(page.getByText(/Compiling/)).toBeHidden();
   // Keep Next's development indicator out of product screenshots.
@@ -170,9 +170,15 @@ test("builds one tab from several labels and names it", async ({
 
   await page.getByRole("button", { name: "New split" }).click();
   await page
-    .getByRole("option", { name: "Project Alpha", exact: true })
+    .getByRole("option", { name: "Project Alpha, not selected" })
     .click();
-  await page.getByRole("option", { name: extraLabel, exact: true }).click();
+  await page
+    .getByRole("option", { name: `${extraLabel}, not selected` })
+    .click();
+  // The tick is decorative, so the row's name has to carry the state.
+  await expect(
+    page.getByRole("option", { name: "Project Alpha, selected" }),
+  ).toBeVisible();
 
   const name = page.getByRole("textbox", { name: "Tab name" });
   await expect(name).toHaveValue(`Project Alpha, ${extraLabel}`);
@@ -208,7 +214,7 @@ for (const accountScope of ["single", "all"] as const) {
     }
     await page.getByRole("button", { name: "New split" }).click();
     await page
-      .getByRole("option", { name: "Project Alpha", exact: true })
+      .getByRole("option", { name: "Project Alpha, not selected" })
       .click();
     await page.getByRole("button", { name: "Add tab", exact: true }).click();
     const split = page.getByRole("button", {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -95,7 +95,7 @@ import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
 import {
   createMailSplitAction,
-  createMailSplitFromPromptAction,
+  suggestMailSplitAction,
   deleteMailSplitAction,
   setDefaultMailSplitsAction,
   updateMailPreferencesAction,
@@ -330,18 +330,18 @@ export function MailShell() {
     splits[0] ??
     BUILT_IN_SPLITS[0];
   const displayedActiveSplitId = activeSplit.id;
-  const activeCombinedLabelName = combinedLabelSplits.find(
+  const activeCombinedLabelNames = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
-  )?.labelName;
+  )?.labelNames;
   const savedDefaultSplits = useMemo(() => {
     const defaultLabelIds = new Set(
-      (settings?.defaultSplits ?? []).map((split) => split.value),
+      (settings?.defaultSplits ?? []).map((split) => split.values[0]),
     );
     return (settings?.splits ?? []).filter(
       (split) =>
         split.kind === MailSplitKind.LABEL &&
-        split.value &&
-        defaultLabelIds.has(split.value),
+        split.values.length === 1 &&
+        defaultLabelIds.has(split.values[0]),
     );
   }, [settings?.defaultSplits, settings?.splits]);
   const canAddDefaultSplits = (settings?.defaultSplits ?? []).some(
@@ -350,7 +350,8 @@ export function MailShell() {
         (split) =>
           split.name === defaultSplit.name ||
           (split.kind === MailSplitKind.LABEL &&
-            split.value === defaultSplit.value),
+            split.values.length === 1 &&
+            split.values[0] === defaultSplit.values[0]),
       ),
   );
   const canRemoveDefaultSplits = savedDefaultSplits.length > 0;
@@ -374,7 +375,7 @@ export function MailShell() {
     emailAccountId,
     enabled: isAllAccounts,
     isUnread: !searchQuery && activeSplit.kind === MailSplitKind.UNREAD,
-    labelName: searchQuery ? undefined : activeCombinedLabelName,
+    labelNames: searchQuery ? undefined : activeCombinedLabelNames,
     searchQuery: searchQuery ?? undefined,
   });
   const { labelsByAccount } = combinedThreadState;
@@ -1091,14 +1092,14 @@ export function MailShell() {
         id: `category:${category.type}`,
         name: category.name,
         kind: MailSplitKind.CATEGORY,
-        value: category.type,
+        values: [category.type],
         group: categoryGroup,
       })),
       ...visibleLabels.map((label) => ({
         id: `label:${label.id}`,
         name: label.name,
         kind: MailSplitKind.LABEL,
-        value: label.id,
+        values: [label.id],
         group: "label" as const,
       })),
     ],
@@ -1116,35 +1117,35 @@ export function MailShell() {
       const result = await createMailSplitAction(emailAccountId, draft);
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
-        return;
-      }
-      mutateSettings();
-    },
-    [emailAccountId, mutateSettings],
-  );
-
-  const onCreateSplitFromPrompt = useCallback(
-    async (prompt: string) => {
-      const result = await createMailSplitFromPromptAction(emailAccountId, {
-        prompt,
-        options: newSplitOptions.map(({ id, name, kind, value }) => ({
-          id,
-          name,
-          kind,
-          value,
-        })),
-      });
-      if (result?.serverError || result?.validationErrors) {
-        toast.error(getActionErrorMessage(result));
         return false;
       }
       await mutateSettings();
-      // Jump to the new tab so the user immediately sees what the AI matched.
+      // Jump to the new tab so its mail is what the user sees next.
       const split = result?.data?.split;
       if (split) setActiveSplitId(split.id);
       return true;
     },
-    [emailAccountId, newSplitOptions, mutateSettings, setActiveSplitId],
+    [emailAccountId, mutateSettings, setActiveSplitId],
+  );
+
+  const onSuggestSplit = useCallback(
+    async (prompt: string) => {
+      const result = await suggestMailSplitAction(emailAccountId, {
+        prompt,
+        options: newSplitOptions.map(({ id, name, kind, values }) => ({
+          id,
+          name,
+          kind,
+          values,
+        })),
+      });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return null;
+      }
+      return result?.data ?? null;
+    },
+    [emailAccountId, newSplitOptions],
   );
 
   const onDeleteSplit = useCallback(
@@ -1266,7 +1267,7 @@ export function MailShell() {
           (split) =>
             split.id === activeSplitId &&
             split.kind === MailSplitKind.LABEL &&
-            split.value === item.id,
+            split.values.includes(item.id),
         );
       if (isActive) {
         await Promise.all([
@@ -1426,7 +1427,7 @@ export function MailShell() {
                 onDelete={onDeleteSplit}
                 newSplitOptions={newSplitOptions}
                 onCreateSplit={onCreateSplit}
-                onCreateSplitFromPrompt={onCreateSplitFromPrompt}
+                onSuggestSplit={onSuggestSplit}
                 canAddDefaultSplits={canAddDefaultSplits}
                 canRemoveDefaultSplits={canRemoveDefaultSplits}
                 onSetDefaultSplits={onSetDefaultSplits}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1267,7 +1267,9 @@ export function MailShell() {
           (split) =>
             split.id === activeSplitId &&
             split.kind === MailSplitKind.LABEL &&
-            split.values.includes(item.id),
+            // A wider split survives the delete with its remaining labels.
+            split.values.length === 1 &&
+            split.values[0] === item.id,
         );
       if (isActive) {
         await Promise.all([

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -109,11 +109,18 @@ export function NewSplitPopover({
   };
 
   const toggleOption = (option: NewSplitOption) => {
+    setNote(null);
     if (selectedIds.includes(option.id)) {
       const next = selectedIds.filter((id) => id !== option.id);
       setSelectedIds(next);
       if (!next.length) setNameOverride(null);
-      setNote(null);
+      return;
+    }
+    // Only labels stack. Picking one while a read state or category is held
+    // replaces it, because that pair has no query.
+    if (selected.some((held) => held.kind !== MailSplitKind.LABEL)) {
+      setSelectedIds([option.id]);
+      setNameOverride(null);
       return;
     }
     if (selectedIds.length >= MAX_SPLIT_LABELS) {
@@ -121,7 +128,6 @@ export function NewSplitPopover({
       return;
     }
     setSelectedIds([...selectedIds, option.id]);
-    setNote(null);
   };
 
   const createSplit = async (draft: NewSplitDraft) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -280,10 +280,19 @@ export function NewSplitPopover({
                     <CommandGroup key={group} heading={title}>
                       {groupOptions.map((option) => {
                         const isLabel = option.kind === MailSplitKind.LABEL;
+                        const isSelected = selectedIds.includes(option.id);
                         return (
                           <CommandItem
                             key={option.id}
                             value={option.id}
+                            // cmdk owns aria-selected for its own highlight, so
+                            // the tick's meaning has to reach screen readers
+                            // through the accessible name instead.
+                            aria-label={
+                              isLabel
+                                ? `${option.name}, ${isSelected ? "selected" : "not selected"}`
+                                : undefined
+                            }
                             keywords={
                               title ? [option.name, title] : [option.name]
                             }
@@ -303,7 +312,7 @@ export function NewSplitPopover({
                               <div
                                 className={cn(
                                   "flex size-3.5 items-center justify-center rounded-sm border border-primary",
-                                  selectedIds.includes(option.id)
+                                  isSelected
                                     ? "bg-primary text-primary-foreground"
                                     : "opacity-50 [&_svg]:invisible",
                                 )}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -108,7 +108,7 @@ export function NewSplitPopover({
     setNote(null);
   };
 
-  const toggleLabel = (option: NewSplitOption) => {
+  const toggleOption = (option: NewSplitOption) => {
     if (selectedIds.includes(option.id)) {
       const next = selectedIds.filter((id) => id !== option.id);
       setSelectedIds(next);
@@ -134,10 +134,12 @@ export function NewSplitPopover({
     }
   };
 
+  // Several options only combine when they are all labels; a read state or a
+  // category is always on its own, so the first pick decides the kind.
   const createFromSelection = () =>
     createSplit({
       name: name.trim().slice(0, 60),
-      kind: MailSplitKind.LABEL,
+      kind: selected[0]?.kind ?? MailSplitKind.LABEL,
       values: selected.flatMap((option) => option.values),
     });
 
@@ -157,20 +159,12 @@ export function NewSplitPopover({
       const [first] = matched;
       if (!first) return;
 
-      // Only labels combine, so a read state or category is added outright.
+      // Only labels combine, so a read state or category stands alone. Either
+      // way the picker shows the match for the user to confirm or change.
       const labels = matched.filter(
         (option) => option.kind === MailSplitKind.LABEL,
       );
-      if (!labels.length) {
-        await createSplit({
-          name: (suggestion.name || first.name).slice(0, 60),
-          kind: first.kind,
-          values: first.values,
-        });
-        return;
-      }
-
-      setSelectedIds(labels.map((option) => option.id));
+      setSelectedIds(labels.length ? labels.map((o) => o.id) : [first.id]);
       setNameOverride(suggestion.name);
       setIsDescribing(false);
       setPrompt("");
@@ -279,8 +273,12 @@ export function NewSplitPopover({
                   return (
                     <CommandGroup key={group} heading={title}>
                       {groupOptions.map((option) => {
-                        const isLabel = option.kind === MailSplitKind.LABEL;
                         const isSelected = selectedIds.includes(option.id);
+                        // Labels are picked a few at a time. Anything else adds
+                        // its tab on the spot, unless the AI already put it in
+                        // the selection, where clicking takes it back out.
+                        const isToggle =
+                          option.kind === MailSplitKind.LABEL || isSelected;
                         return (
                           <CommandItem
                             key={option.id}
@@ -289,7 +287,7 @@ export function NewSplitPopover({
                             // the tick's meaning has to reach screen readers
                             // through the accessible name instead.
                             aria-label={
-                              isLabel
+                              isToggle
                                 ? `${option.name}, ${isSelected ? "selected" : "not selected"}`
                                 : undefined
                             }
@@ -297,8 +295,8 @@ export function NewSplitPopover({
                               title ? [option.name, title] : [option.name]
                             }
                             onSelect={() =>
-                              isLabel
-                                ? toggleLabel(option)
+                              isToggle
+                                ? toggleOption(option)
                                 : createSplit({
                                     name: option.name,
                                     kind: option.kind,
@@ -308,7 +306,7 @@ export function NewSplitPopover({
                             disabled={isBusy}
                             className="gap-2 text-xs"
                           >
-                            {isLabel && (
+                            {isToggle && (
                               <div
                                 className={cn(
                                   "flex size-3.5 items-center justify-center rounded-sm border border-primary",

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitPopover.tsx
@@ -1,20 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { Loader2Icon, PlusIcon, SparklesIcon } from "lucide-react";
-import type { MailSplitKind } from "@/generated/prisma/enums";
+import { useMemo, useState } from "react";
+import { ArrowLeftIcon, CheckIcon, PlusIcon, SparklesIcon } from "lucide-react";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import { Button } from "@/components/ui/button";
 import {
   Command,
+  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
+import { cn } from "@/utils";
 
 export type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
 
@@ -23,22 +28,28 @@ export type NewSplitOption = {
   id: string;
   name: string;
   kind: MailSplitKind;
-  /** Label id or category key the split filters on. `null` for ALL/UNREAD. */
-  value: string | null;
+  /** Label ids or the category key the split filters on. Empty for ALL/UNREAD. */
+  values: string[];
   group: NewSplitOptionGroup;
 };
 
 export type NewSplitDraft = {
   name: string;
   kind: MailSplitKind;
-  value: string | null;
+  values: string[];
+};
+
+export type NewSplitSuggestion = {
+  optionIds: string[];
+  name: string | null;
+  reasoning: string;
 };
 
 export type NewSplitPopoverProps = {
   options: NewSplitOption[];
-  onCreate: (draft: NewSplitDraft) => void;
-  /** Resolves a free-text description into a split. Returns whether it succeeded. */
-  onCreateFromPrompt: (prompt: string) => Promise<boolean>;
+  onCreate: (draft: NewSplitDraft) => Promise<boolean>;
+  /** Resolves a free-text description into a selection of the options above. */
+  onSuggest: (prompt: string) => Promise<NewSplitSuggestion | null>;
   canAddDefaultSplits: boolean;
   canRemoveDefaultSplits: boolean;
   onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
@@ -54,67 +65,127 @@ const GROUPS = [
   title?: string;
 }[];
 
+const DESCRIBE_EXAMPLES = ["Mail I still owe a reply", "Invoices and receipts"];
+
+const FOOTER_BUTTON_CLASS =
+  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
 export function NewSplitPopover({
   options,
   onCreate,
-  onCreateFromPrompt,
+  onSuggest,
   canAddDefaultSplits,
   canRemoveDefaultSplits,
   onSetDefaultSplits,
 }: NewSplitPopoverProps) {
   const [open, setOpen] = useState(false);
+  const [isDescribing, setIsDescribing] = useState(false);
   const [prompt, setPrompt] = useState("");
-  const [isCreating, setIsCreating] = useState(false);
-  const [isUpdatingDefaults, setIsUpdatingDefaults] = useState(false);
-  const isBusy = isCreating || isUpdatingDefaults;
-  const trimmedPrompt = prompt.trim();
-  const normalizedPrompt = trimmedPrompt.toLowerCase();
-  const hasMatchingOption =
-    options.some((option) => {
-      const groupTitle = GROUPS.find(
-        ({ group }) => group === option.group,
-      )?.title;
-      return `${option.name} ${groupTitle ?? ""}`
-        .toLowerCase()
-        .includes(normalizedPrompt);
-    }) ||
-    (canAddDefaultSplits && "add all labels".includes(normalizedPrompt)) ||
-    (canRemoveDefaultSplits && "remove all labels".includes(normalizedPrompt));
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [nameOverride, setNameOverride] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [isSuggesting, setIsSuggesting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const optionsById = useMemo(
+    () => new Map(options.map((option) => [option.id, option])),
+    [options],
+  );
+  const selected = selectedIds.flatMap((id) => {
+    const option = optionsById.get(id);
+    return option ? [option] : [];
+  });
+  const name = nameOverride ?? selected.map((option) => option.name).join(", ");
+  const isBusy = isSuggesting || isSaving;
 
   const changeOpen = (next: boolean) => {
     setOpen(next);
-    if (!next) setPrompt("");
+    if (next) return;
+    setIsDescribing(false);
+    setPrompt("");
+    setSelectedIds([]);
+    setNameOverride(null);
+    setNote(null);
   };
 
-  const createFromPrompt = async () => {
-    if (!trimmedPrompt || isBusy) return;
-    setIsCreating(true);
+  const toggleLabel = (option: NewSplitOption) => {
+    if (selectedIds.includes(option.id)) {
+      const next = selectedIds.filter((id) => id !== option.id);
+      setSelectedIds(next);
+      if (!next.length) setNameOverride(null);
+      setNote(null);
+      return;
+    }
+    if (selectedIds.length >= MAX_SPLIT_LABELS) {
+      setNote(`A tab can cover up to ${MAX_SPLIT_LABELS} labels.`);
+      return;
+    }
+    setSelectedIds([...selectedIds, option.id]);
+    setNote(null);
+  };
+
+  const createSplit = async (draft: NewSplitDraft) => {
+    if (isBusy) return;
+    setIsSaving(true);
     try {
-      const created = await onCreateFromPrompt(trimmedPrompt);
-      if (created) changeOpen(false);
+      if (await onCreate(draft)) changeOpen(false);
     } finally {
-      setIsCreating(false);
+      setIsSaving(false);
     }
   };
 
-  const createFromOption = (option: NewSplitOption) => {
-    if (isBusy) return;
-    onCreate({
-      name: option.name,
-      kind: option.kind,
-      value: option.value,
+  const createFromSelection = () =>
+    createSplit({
+      name: name.trim().slice(0, 60),
+      kind: MailSplitKind.LABEL,
+      values: selected.flatMap((option) => option.values),
     });
-    changeOpen(false);
+
+  const suggest = async () => {
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt || isBusy) return;
+    setIsSuggesting(true);
+    try {
+      const suggestion = await onSuggest(trimmedPrompt);
+      if (!suggestion) return;
+      setNote(suggestion.reasoning);
+
+      const matched = suggestion.optionIds.flatMap((id) => {
+        const option = optionsById.get(id);
+        return option ? [option] : [];
+      });
+      const [first] = matched;
+      if (!first) return;
+
+      // Only labels combine, so a read state or category is added outright.
+      const labels = matched.filter(
+        (option) => option.kind === MailSplitKind.LABEL,
+      );
+      if (!labels.length) {
+        await createSplit({
+          name: (suggestion.name || first.name).slice(0, 60),
+          kind: first.kind,
+          values: first.values,
+        });
+        return;
+      }
+
+      setSelectedIds(labels.map((option) => option.id));
+      setNameOverride(suggestion.name);
+      setIsDescribing(false);
+      setPrompt("");
+    } finally {
+      setIsSuggesting(false);
+    }
   };
 
   const updateDefaultSplits = async (enabled: boolean) => {
     if (isBusy) return;
-    setIsUpdatingDefaults(true);
+    setIsSaving(true);
     try {
-      const updated = await onSetDefaultSplits(enabled);
-      if (updated) changeOpen(false);
+      if (await onSetDefaultSplits(enabled)) changeOpen(false);
     } finally {
-      setIsUpdatingDefaults(false);
+      setIsSaving(false);
     }
   };
 
@@ -126,89 +197,199 @@ export function NewSplitPopover({
       >
         <PlusIcon className="size-3.5" />
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-72 p-0 text-foreground">
-        <Command filter={filterByName}>
-          <CommandInput
-            value={prompt}
-            onValueChange={setPrompt}
-            placeholder="Search or describe a split"
-            aria-label="Search or describe a split"
-            maxLength={300}
-            disabled={isBusy}
-            className="h-9 text-xs"
-          />
-          <CommandList className="max-h-56">
-            {trimmedPrompt && !hasMatchingOption && (
-              <CommandGroup forceMount>
-                <CommandItem
-                  forceMount
-                  value={`create:${trimmedPrompt}`}
-                  onSelect={createFromPrompt}
+      <PopoverContent align="start" className="w-80 p-0 text-foreground">
+        {isDescribing ? (
+          <div className="space-y-3 p-3">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setIsDescribing(false);
+                  setNote(null);
+                }}
+                aria-label="Back to the split list"
+                className="rounded p-0.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <ArrowLeftIcon className="size-3.5" />
+              </button>
+              <span className="font-medium text-xs">Describe a split</span>
+            </div>
+            <p className="text-muted-foreground text-xs">
+              We pick the labels that match. You can change them before the tab
+              is added.
+            </p>
+            <Input
+              autoFocus
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                suggest();
+              }}
+              placeholder="Anything from customers"
+              aria-label="Describe a split"
+              maxLength={300}
+              disabled={isBusy}
+              className="h-8 text-xs"
+            />
+            <div className="flex flex-wrap gap-1">
+              {DESCRIBE_EXAMPLES.map((example) => (
+                <button
+                  key={example}
+                  type="button"
+                  onClick={() => setPrompt(example)}
                   disabled={isBusy}
-                  className="gap-2 text-xs"
+                  className="rounded-full bg-accent px-2 py-0.5 text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
-                  {isCreating ? (
-                    <Loader2Icon className="size-3.5 animate-spin text-muted-foreground" />
-                  ) : (
-                    <SparklesIcon className="size-3.5 text-muted-foreground" />
-                  )}
-                  <span className="truncate">
-                    Create &ldquo;{trimmedPrompt}&rdquo;
-                  </span>
-                </CommandItem>
-              </CommandGroup>
+                  {example}
+                </button>
+              ))}
+            </div>
+            {note && <p className="text-muted-foreground text-xs">{note}</p>}
+            <Button
+              size="sm"
+              className="w-full"
+              onClick={suggest}
+              disabled={!prompt.trim() || isBusy}
+              loading={isSuggesting}
+            >
+              Find matching labels
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Command filter={filterByName}>
+              <CommandInput
+                placeholder="Search labels and categories"
+                aria-label="Search labels and categories"
+                disabled={isBusy}
+                className="h-9 text-xs"
+              />
+              <CommandList className="max-h-56">
+                <CommandEmpty className="py-4 text-center text-muted-foreground text-xs">
+                  No labels or categories match.
+                </CommandEmpty>
+                {GROUPS.map(({ group, title }) => {
+                  const groupOptions = options.filter(
+                    (option) => option.group === group,
+                  );
+                  if (!groupOptions.length) return null;
+
+                  return (
+                    <CommandGroup key={group} heading={title}>
+                      {groupOptions.map((option) => {
+                        const isLabel = option.kind === MailSplitKind.LABEL;
+                        return (
+                          <CommandItem
+                            key={option.id}
+                            value={option.id}
+                            keywords={
+                              title ? [option.name, title] : [option.name]
+                            }
+                            onSelect={() =>
+                              isLabel
+                                ? toggleLabel(option)
+                                : createSplit({
+                                    name: option.name,
+                                    kind: option.kind,
+                                    values: option.values,
+                                  })
+                            }
+                            disabled={isBusy}
+                            className="gap-2 text-xs"
+                          >
+                            {isLabel && (
+                              <div
+                                className={cn(
+                                  "flex size-3.5 items-center justify-center rounded-sm border border-primary",
+                                  selectedIds.includes(option.id)
+                                    ? "bg-primary text-primary-foreground"
+                                    : "opacity-50 [&_svg]:invisible",
+                                )}
+                              >
+                                <CheckIcon className="size-3" />
+                              </div>
+                            )}
+                            <span className="truncate">{option.name}</span>
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  );
+                })}
+              </CommandList>
+            </Command>
+
+            <div className="border-border border-t p-1">
+              <button
+                type="button"
+                onClick={() => {
+                  setIsDescribing(true);
+                  setNote(null);
+                }}
+                disabled={isBusy}
+                className={`${FOOTER_BUTTON_CLASS} text-primary`}
+              >
+                <SparklesIcon className="size-3.5" />
+                Describe a split instead
+              </button>
+              {canAddDefaultSplits && (
+                <button
+                  type="button"
+                  onClick={() => updateDefaultSplits(true)}
+                  disabled={isBusy}
+                  className={`${FOOTER_BUTTON_CLASS} text-muted-foreground hover:text-foreground`}
+                >
+                  Add a tab for each rule label
+                </button>
+              )}
+              {canRemoveDefaultSplits && (
+                <button
+                  type="button"
+                  onClick={() => updateDefaultSplits(false)}
+                  disabled={isBusy}
+                  className={`${FOOTER_BUTTON_CLASS} text-muted-foreground hover:text-foreground`}
+                >
+                  Remove the rule label tabs
+                </button>
+              )}
+            </div>
+
+            {selected.length > 0 && (
+              <div className="space-y-2 border-border border-t p-3">
+                {note && (
+                  <p className="text-muted-foreground text-xs">{note}</p>
+                )}
+                <Input
+                  value={name}
+                  onChange={(event) => setNameOverride(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") return;
+                    event.preventDefault();
+                    createFromSelection();
+                  }}
+                  placeholder="Tab name"
+                  aria-label="Tab name"
+                  maxLength={60}
+                  disabled={isBusy}
+                  className="h-8 text-xs"
+                />
+                <Button
+                  size="sm"
+                  className="w-full"
+                  onClick={createFromSelection}
+                  disabled={!name.trim() || isBusy}
+                  loading={isSaving}
+                >
+                  {selected.length === 1
+                    ? "Add tab"
+                    : `Add tab for ${selected.length} labels`}
+                </Button>
+              </div>
             )}
-
-            {GROUPS.map(({ group, title }) => {
-              const groupOptions = options.filter(
-                (option) => option.group === group,
-              );
-              const showDefaultControls =
-                group === "label" &&
-                (canAddDefaultSplits || canRemoveDefaultSplits);
-              if (!groupOptions.length && !showDefaultControls) return null;
-
-              return (
-                <CommandGroup key={group} heading={title}>
-                  {canAddDefaultSplits && group === "label" && (
-                    <CommandItem
-                      value="default-labels:add"
-                      keywords={["Add all", "Labels"]}
-                      onSelect={() => updateDefaultSplits(true)}
-                      disabled={isBusy}
-                      className="text-primary text-xs"
-                    >
-                      Add all
-                    </CommandItem>
-                  )}
-                  {canRemoveDefaultSplits && group === "label" && (
-                    <CommandItem
-                      value="default-labels:remove"
-                      keywords={["Remove all", "Labels"]}
-                      onSelect={() => updateDefaultSplits(false)}
-                      disabled={isBusy}
-                      className="text-primary text-xs"
-                    >
-                      Remove all
-                    </CommandItem>
-                  )}
-                  {groupOptions.map((option) => (
-                    <CommandItem
-                      key={option.id}
-                      value={option.id}
-                      keywords={title ? [option.name, title] : [option.name]}
-                      onSelect={() => createFromOption(option)}
-                      disabled={isBusy}
-                      className="text-xs"
-                    >
-                      {option.name}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              );
-            })}
-          </CommandList>
-        </Command>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -6,6 +6,7 @@ import {
   type NewSplitDraft,
   type NewSplitOption,
   NewSplitPopover,
+  type NewSplitSuggestion,
 } from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
 import { cn } from "@/utils";
 
@@ -20,8 +21,8 @@ export type SplitTabsProps = {
   onSelect: (splitId: string) => void;
   onDelete: (splitId: string) => void;
   newSplitOptions: NewSplitOption[];
-  onCreateSplit: (draft: NewSplitDraft) => void;
-  onCreateSplitFromPrompt: (prompt: string) => Promise<boolean>;
+  onCreateSplit: (draft: NewSplitDraft) => Promise<boolean>;
+  onSuggestSplit: (prompt: string) => Promise<NewSplitSuggestion | null>;
   canAddDefaultSplits: boolean;
   canRemoveDefaultSplits: boolean;
   onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
@@ -35,7 +36,7 @@ export function SplitTabs({
   onDelete,
   newSplitOptions,
   onCreateSplit,
-  onCreateSplitFromPrompt,
+  onSuggestSplit,
   canAddDefaultSplits,
   canRemoveDefaultSplits,
   onSetDefaultSplits,
@@ -108,7 +109,7 @@ export function SplitTabs({
       <NewSplitPopover
         options={newSplitOptions}
         onCreate={onCreateSplit}
-        onCreateFromPrompt={onCreateSplitFromPrompt}
+        onSuggest={onSuggestSplit}
         canAddDefaultSplits={canAddDefaultSplits}
         canRemoveDefaultSplits={canRemoveDefaultSplits}
         onSetDefaultSplits={onSetDefaultSplits}

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.test.tsx
@@ -402,7 +402,7 @@ describe("useCombinedMailThreads", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it("loads a named-label view without mixing in the generic inbox snapshot", async () => {
+  it("loads a multi-label view without mixing in the generic inbox snapshot", async () => {
     const fetcher = vi.fn(() =>
       Promise.resolve({
         failedAccountIds: [],
@@ -419,7 +419,7 @@ describe("useCombinedMailThreads", () => {
           emailAccountId: "account-1",
           enabled: true,
           isUnread: false,
-          labelName: "Receipts & orders",
+          labelNames: ["Receipts & orders", "Invoices"],
         }),
       { wrapper: createWrapper(fetcher) },
     );
@@ -430,7 +430,9 @@ describe("useCombinedMailThreads", () => {
       ]),
     );
     expect(fetcher).toHaveBeenCalledWith(
-      expect.stringContaining("labelName=Receipts+%26+orders"),
+      expect.stringContaining(
+        "labelNames=Receipts+%26+orders&labelNames=Invoices",
+      ),
     );
     expect(mailbox.read).not.toHaveBeenCalled();
   });

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -55,14 +55,14 @@ export function useCombinedMailThreads({
   emailAccountId,
   enabled,
   isUnread,
-  labelName,
+  labelNames,
   searchQuery,
 }: {
   accounts: CombinedThread["account"][];
   emailAccountId: string;
   enabled: boolean;
   isUnread: boolean;
-  labelName?: string;
+  labelNames?: string[];
   searchQuery?: string;
 }) {
   const accountIdentity = useMemo(
@@ -77,16 +77,17 @@ export function useCombinedMailThreads({
     () => accounts.map((account) => account.id),
     [accounts],
   );
+  const labelIdentity = labelNames?.length ? labelNames.join("\n") : undefined;
   const viewKey = useMemo(
     () =>
       createThreadListCacheKey({
         scope: "combined",
         accountIdentity,
         isUnread: isUnread || undefined,
-        labelName,
+        labelIdentity,
         q: searchQuery,
       }),
-    [accountIdentity, isUnread, labelName, searchQuery],
+    [accountIdentity, isUnread, labelIdentity, searchQuery],
   );
   const viewIdentity = `${emailAccountId}:${accountIdentity}:${viewKey}`;
   const { fetcher } = useSWRConfig();
@@ -99,13 +100,17 @@ export function useCombinedMailThreads({
         accountSet: accountIdentity,
         limit: COMBINED_PAGE_SIZE,
         isUnread: isUnread || undefined,
-        labelName,
         q: searchQuery,
         cursor: pageIndex > 0 ? previousPageData?.nextPageToken : undefined,
       });
+      // Repeated params rather than a joined value, because a label name may
+      // itself contain whatever separator we would pick.
+      for (const labelName of labelIdentity?.split("\n") ?? []) {
+        params.append("labelNames", labelName);
+      }
       return `/api/threads/all?${params.toString()}`;
     },
-    [accountIdentity, enabled, isUnread, labelName, searchQuery],
+    [accountIdentity, enabled, isUnread, labelIdentity, searchQuery],
   );
   const fetchCombinedPage = useCallback(
     async (key: string) => {
@@ -180,7 +185,7 @@ export function useCombinedMailThreads({
   }, [emailAccountId, enabled, viewIdentity, viewKey]);
 
   useEffect(() => {
-    if (!enabled || !accountIdentity || labelName || searchQuery) return;
+    if (!enabled || !accountIdentity || labelIdentity || searchQuery) return;
     let cancelled = false;
     const accountIds = new Set(
       accountsRef.current.map((account) => account.id),
@@ -212,7 +217,7 @@ export function useCombinedMailThreads({
     accountIdentity,
     enabled,
     isUnread,
-    labelName,
+    labelIdentity,
     searchQuery,
     localSnapshotLimit,
     viewIdentity,

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts
@@ -77,7 +77,10 @@ export function useCombinedMailThreads({
     () => accounts.map((account) => account.id),
     [accounts],
   );
-  const labelIdentity = labelNames?.length ? labelNames.join("\n") : undefined;
+  // JSON rather than a delimiter, because a label name can contain anything.
+  const labelIdentity = labelNames?.length
+    ? JSON.stringify(labelNames)
+    : undefined;
   const viewKey = useMemo(
     () =>
       createThreadListCacheKey({
@@ -105,7 +108,7 @@ export function useCombinedMailThreads({
       });
       // Repeated params rather than a joined value, because a label name may
       // itself contain whatever separator we would pick.
-      for (const labelName of labelIdentity?.split("\n") ?? []) {
+      for (const labelName of labelIdentity ? JSON.parse(labelIdentity) : []) {
         params.append("labelNames", labelName);
       }
       return `/api/threads/all?${params.toString()}`;

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -21,7 +21,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
             id: true,
             name: true,
             kind: true,
-            value: true,
+            values: true,
             order: true,
           },
         },

--- a/apps/web/app/api/threads/all/route.test.ts
+++ b/apps/web/app/api/threads/all/route.test.ts
@@ -136,11 +136,11 @@ describe("GET /api/threads/all", () => {
   it("rejects an unsafe provider cursor before loading threads", async () => {
     const cursor = Buffer.from(
       JSON.stringify({
-        version: 2,
-        accounts: {
+        version: 3,
+        sources: {
           "account-1": {
             pageToken: "https://example.com/messages",
-            consumedThreadIds: [],
+            consumedIds: [],
             done: false,
           },
         },
@@ -215,7 +215,7 @@ describe("GET /api/threads/all", () => {
 
     await GET(
       new NextRequest(
-        "http://localhost:3000/api/threads/all?labelName=Receipts",
+        "http://localhost:3000/api/threads/all?labelNames=Receipts",
       ),
       {} as never,
     );
@@ -239,6 +239,62 @@ describe("GET /api/threads/all", () => {
     );
     expect(loadThreadsMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ emailAccountId: "account-3" }),
+    );
+  });
+
+  it("asks each account for whichever of a split's labels it has", async () => {
+    getConnectedEmailAccountsMock.mockResolvedValue([
+      {
+        id: "account-1",
+        email: "first@example.com",
+        name: "First",
+        image: null,
+        provider: "google",
+      },
+      {
+        id: "account-2",
+        email: "second@example.com",
+        name: "Second",
+        image: null,
+        provider: "google",
+      },
+    ]);
+    createEmailProviderMock.mockImplementation(
+      async ({ emailAccountId }: { emailAccountId: string }) => ({
+        name: "google",
+        getLabels: vi.fn().mockResolvedValue(
+          emailAccountId === "account-1"
+            ? [
+                { id: "users", name: "User feedback", type: "user" },
+                { id: "customers", name: "Customer feedback", type: "user" },
+              ]
+            : [{ id: "only-users", name: "User feedback", type: "user" }],
+        ),
+      }),
+    );
+
+    await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads/all?labelNames=User+feedback&labelNames=Customer+feedback",
+      ),
+      {} as never,
+    );
+
+    expect(loadThreadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        query: expect.objectContaining({
+          labelIds: ["INBOX"],
+          anyLabelIds: ["users", "customers"],
+        }),
+      }),
+    );
+    // The second account only has one of the labels, so it stays a plain query.
+    expect(loadThreadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-2",
+        query: expect.objectContaining({ labelIds: ["only-users", "INBOX"] }),
+      }),
     );
   });
 });

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -6,6 +6,7 @@ import { withAuth } from "@/utils/middleware";
 import { loadCombinedThreads } from "@/utils/threads/load-combined";
 import { loadThreads, toListThreads } from "@/utils/threads/load";
 import { threadsQuery } from "@/utils/threads/validation";
+import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 
 export const maxDuration = 30;
 
@@ -13,7 +14,8 @@ const querySchema = z.object({
   q: threadsQuery.shape.q,
   cursor: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
-  labelName: z.string().trim().min(1).max(255).optional(),
+  // A split can cover several labels, and each account resolves them by name.
+  labelNames: z.array(z.string().trim().min(1).max(255)).max(MAX_SPLIT_LABELS),
   isUnread: z
     .enum(["true", "false"])
     .transform((value) => value === "true")
@@ -25,9 +27,11 @@ export type GetAllThreadsResponse = Awaited<
 >;
 
 export const GET = withAuth("threads/all", async (request) => {
-  const { cursor, limit, isUnread, labelName, q } = querySchema.parse(
-    Object.fromEntries(new URL(request.url).searchParams),
-  );
+  const { searchParams } = new URL(request.url);
+  const { cursor, limit, isUnread, labelNames, q } = querySchema.parse({
+    ...Object.fromEntries(searchParams),
+    labelNames: searchParams.getAll("labelNames"),
+  });
   const accounts = await getConnectedEmailAccounts({
     userId: request.auth.userId,
     includeInAllAccounts: true,
@@ -44,19 +48,24 @@ export const GET = withAuth("threads/all", async (request) => {
         provider: account.provider,
         logger,
       });
-      if (labelName && !q) {
+      if (labelNames.length && !q) {
         const labels = await emailProvider.getLabels();
-        const normalizedLabelName = labelName.toLowerCase();
-        const matchingLabel = labels.find(
-          (label) => label.name.trim().toLowerCase() === normalizedLabelName,
+        const wanted = new Set(
+          labelNames.map((labelName) => labelName.toLowerCase()),
         );
-        if (!matchingLabel) {
+        const matchingLabelIds = labels
+          .filter((label) => wanted.has(label.name.trim().toLowerCase()))
+          .map((label) => label.id);
+        // An account missing every one of the split's labels contributes nothing.
+        if (!matchingLabelIds.length) {
           return { threads: [], nextPageToken: null, labels };
         }
 
         const loaded = await loadThreads({
           query: threadsQuery.parse({
-            labelIds: [matchingLabel.id, "INBOX"],
+            ...(matchingLabelIds.length === 1
+              ? { labelIds: [matchingLabelIds[0], "INBOX"] }
+              : { labelIds: ["INBOX"], anyLabelIds: matchingLabelIds }),
             limit,
             nextPageToken: pageToken,
           }),

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -20,11 +20,14 @@ export const GET = withEmailProvider(
     const nextPageToken = searchParams.get("nextPageToken");
     const q = searchParams.get("q");
     const labelId = searchParams.get("labelId");
-    const labelIds = searchParams
-      .getAll("labelIds")
-      .flatMap((value) => value.split(","))
-      .map((labelId) => labelId.trim())
-      .filter(Boolean);
+    const readLabelIds = (key: string) =>
+      searchParams
+        .getAll(key)
+        .flatMap((value) => value.split(","))
+        .map((labelId) => labelId.trim())
+        .filter(Boolean);
+    const labelIds = readLabelIds("labelIds");
+    const anyLabelIds = readLabelIds("anyLabelIds");
     const after = searchParams.get("after");
     const before = searchParams.get("before");
     const isUnread = searchParams.get("isUnread");
@@ -40,6 +43,7 @@ export const GET = withEmailProvider(
       q,
       labelId,
       labelIds: labelIds.length ? labelIds : undefined,
+      anyLabelIds: anyLabelIds.length ? anyLabelIds : undefined,
       after,
       before,
       isUnread,

--- a/apps/web/prisma/migrations/20260907190000_mail_split_multi_value/migration.sql
+++ b/apps/web/prisma/migrations/20260907190000_mail_split_multi_value/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "MailSplit" ADD COLUMN "values" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+UPDATE "MailSplit" SET "values" = ARRAY["value"] WHERE "value" IS NOT NULL;
+
+ALTER TABLE "MailSplit" DROP COLUMN "value";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -240,8 +240,9 @@ model EmailAccount {
   @@index([watchEmailsSubscriptionHistory(ops: JsonbPathOps)], type: Gin)
 }
 
-// A saved filter shown as a tab above the mail list. `value` holds the label id for
-// LABEL splits and the provider category for CATEGORY splits; it is unused for INBOX/UNREAD.
+// A saved filter shown as a tab above the mail list. `values` holds one or more label
+// ids for LABEL splits and a single provider category for CATEGORY splits; it is empty
+// for INBOX/UNREAD.
 model MailSplit {
   id        String        @id @default(cuid())
   createdAt DateTime      @default(now())

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -248,7 +248,8 @@ model MailSplit {
   updatedAt DateTime      @updatedAt
   name      String
   kind      MailSplitKind
-  value     String?
+  /// Label ids for LABEL splits (one or more), the category for CATEGORY splits, empty otherwise.
+  values    String[]      @default([])
   order     Int
 
   emailAccountId String

--- a/apps/web/utils/actions/mail-mailbox-item.test.ts
+++ b/apps/web/utils/actions/mail-mailbox-item.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
-import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   deleteMailboxItemAction,
@@ -142,29 +141,24 @@ describe("mailbox item actions", () => {
     expect(result?.serverError).toBeUndefined();
     expect(method).toHaveBeenCalledWith(`${kind}-1`);
     if (kind === "label") {
-      // Splits keep their other labels; only ones left empty are removed.
+      // One statement, so splits keep their other labels and only the ones
+      // this label emptied are deleted.
       expect(prisma.$executeRaw).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.stringContaining("array_remove")]),
+        expect.arrayContaining([
+          expect.stringContaining("array_remove"),
+          expect.stringContaining("DELETE FROM"),
+        ]),
         "label-1",
         EMAIL_ACCOUNT_ID,
         "label-1",
       );
-      expect(prisma.mailSplit.deleteMany).toHaveBeenCalledWith({
-        where: {
-          emailAccountId: EMAIL_ACCOUNT_ID,
-          kind: MailSplitKind.LABEL,
-          values: { isEmpty: true },
-        },
-      });
     } else {
-      expect(prisma.mailSplit.deleteMany).not.toHaveBeenCalled();
+      expect(prisma.$executeRaw).not.toHaveBeenCalled();
     }
   });
 
   it("retries saved-view cleanup after a successful provider deletion", async () => {
-    prisma.$transaction.mockRejectedValueOnce(
-      new Error("Database unavailable"),
-    );
+    prisma.$executeRaw.mockRejectedValueOnce(new Error("Database unavailable"));
 
     const firstResult = await deleteMailboxItemAction(EMAIL_ACCOUNT_ID, {
       kind: "label",
@@ -180,7 +174,7 @@ describe("mailbox item actions", () => {
     );
     expect(retryResult?.serverError).toBeUndefined();
     expect(mockDeleteLabel).toHaveBeenCalledTimes(2);
-    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
   });
 
   it("keeps saved views when provider deletion fails", async () => {
@@ -194,7 +188,7 @@ describe("mailbox item actions", () => {
     expect(result?.serverError).toBe(
       "Failed to delete label. Please try again.",
     );
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
   });
 
   it("rejects folder mutations for non-Outlook accounts", async () => {

--- a/apps/web/utils/actions/mail-mailbox-item.test.ts
+++ b/apps/web/utils/actions/mail-mailbox-item.test.ts
@@ -142,11 +142,18 @@ describe("mailbox item actions", () => {
     expect(result?.serverError).toBeUndefined();
     expect(method).toHaveBeenCalledWith(`${kind}-1`);
     if (kind === "label") {
+      // Splits keep their other labels; only ones left empty are removed.
+      expect(prisma.$executeRaw).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.stringContaining("array_remove")]),
+        "label-1",
+        EMAIL_ACCOUNT_ID,
+        "label-1",
+      );
       expect(prisma.mailSplit.deleteMany).toHaveBeenCalledWith({
         where: {
           emailAccountId: EMAIL_ACCOUNT_ID,
           kind: MailSplitKind.LABEL,
-          value: "label-1",
+          values: { isEmpty: true },
         },
       });
     } else {
@@ -155,7 +162,7 @@ describe("mailbox item actions", () => {
   });
 
   it("retries saved-view cleanup after a successful provider deletion", async () => {
-    prisma.mailSplit.deleteMany.mockRejectedValueOnce(
+    prisma.$transaction.mockRejectedValueOnce(
       new Error("Database unavailable"),
     );
 
@@ -173,7 +180,7 @@ describe("mailbox item actions", () => {
     );
     expect(retryResult?.serverError).toBeUndefined();
     expect(mockDeleteLabel).toHaveBeenCalledTimes(2);
-    expect(prisma.mailSplit.deleteMany).toHaveBeenCalledTimes(2);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
   });
 
   it("keeps saved views when provider deletion fails", async () => {
@@ -187,7 +194,7 @@ describe("mailbox item actions", () => {
     expect(result?.serverError).toBe(
       "Failed to delete label. Please try again.",
     );
-    expect(prisma.mailSplit.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("rejects folder mutations for non-Outlook accounts", async () => {

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -9,9 +9,9 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import {
   createMailSplitAction,
-  createMailSplitFromPromptAction,
   renameMailSplitAction,
   setDefaultMailSplitsAction,
+  suggestMailSplitAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
@@ -33,13 +33,19 @@ const PROMPT_OPTIONS = [
     id: "state:unread",
     name: "Unread",
     kind: MailSplitKind.UNREAD,
-    value: null,
+    values: [],
   },
   {
     id: "label:label-1",
     name: "Receipts",
     kind: MailSplitKind.LABEL,
-    value: "label-1",
+    values: ["label-1"],
+  },
+  {
+    id: "label:label-2",
+    name: "Invoices",
+    kind: MailSplitKind.LABEL,
+    values: ["label-2"],
   },
 ];
 
@@ -59,7 +65,7 @@ describe("mail split actions", () => {
       updatedAt: new Date(),
       name: "Receipts",
       kind: MailSplitKind.LABEL,
-      value: "label-1",
+      values: ["label-1"],
       order: 0,
       emailAccountId: EMAIL_ACCOUNT_ID,
     };
@@ -71,7 +77,7 @@ describe("mail split actions", () => {
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Receipts",
       kind: MailSplitKind.LABEL,
-      value: "label-1",
+      values: ["label-1"],
     });
 
     expect(result?.data).toEqual({ split });
@@ -92,7 +98,7 @@ describe("mail split actions", () => {
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Later",
       kind: MailSplitKind.LABEL,
-      value: "label-1",
+      values: ["label-1"],
     });
 
     expect(result?.serverError).toBe("You can only have 12 splits.");
@@ -107,7 +113,7 @@ describe("mail split actions", () => {
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Receipts",
       kind: MailSplitKind.LABEL,
-      value: "label-1",
+      values: ["label-1"],
     });
 
     expect(result?.serverError).toBe('You already have a "Receipts" split.');
@@ -119,71 +125,71 @@ describe("mail split actions", () => {
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Receipts",
       kind: MailSplitKind.LABEL,
-      value: "label-1",
+      values: ["label-1"],
     });
 
     expect(result?.serverError).toBe('You already have a "Receipts" split.');
   });
 
-  it("creates the split the AI matched from a description", async () => {
+  it("returns the matched options for the picker instead of creating a split", async () => {
     vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Receipts filters for what the user described",
-      optionId: "label:label-1",
-      name: "Receipts",
+      reasoning: "Receipts and Invoices both cover billing mail",
+      optionIds: ["label:label-1", "label:label-2"],
+      name: "Billing",
     });
-    const split = {
-      id: "split-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      name: "Receipts",
-      kind: MailSplitKind.LABEL,
-      value: "label-1",
-      order: 0,
-      emailAccountId: EMAIL_ACCOUNT_ID,
-    };
-    prisma.$transaction.mockResolvedValue([
-      [{ locked: true }],
-      [{ status: "created", ...split }],
-    ] as never);
 
-    const result = await createMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
-      prompt: "my receipts",
+    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
+      prompt: "receipts and invoices",
       options: PROMPT_OPTIONS,
     });
 
-    expect(result?.data).toEqual({ split });
+    expect(result?.data).toEqual({
+      optionIds: ["label:label-1", "label:label-2"],
+      name: "Billing",
+      reasoning: "Receipts and Invoices both cover billing mail",
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
     // Label ids are stripped before the prompt; the AI only sees id/name/kind.
     expect(aiPromptToSplit).toHaveBeenCalledWith(
       expect.objectContaining({
-        prompt: "my receipts",
+        prompt: "receipts and invoices",
         options: [
           { id: "state:unread", name: "Unread", kind: MailSplitKind.UNREAD },
           { id: "label:label-1", name: "Receipts", kind: MailSplitKind.LABEL },
+          { id: "label:label-2", name: "Invoices", kind: MailSplitKind.LABEL },
         ],
       }),
     );
   });
 
+  it("keeps only the first option when the AI mixes a state with labels", async () => {
+    vi.mocked(aiPromptToSplit).mockResolvedValue({
+      reasoning: "Unread receipts",
+      optionIds: ["state:unread", "label:label-1"],
+      name: "Unread receipts",
+    });
+
+    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
+      prompt: "unread receipts",
+      options: PROMPT_OPTIONS,
+    });
+
+    expect(result?.data?.optionIds).toEqual(["state:unread"]);
+  });
+
   it.each([
     { id: "all", name: "All", kind: MailSplitKind.INBOX },
     { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD },
-  ])("restores $name through manual and AI creation without saving a duplicate", async (builtIn) => {
+  ])("restores the hidden $name tab instead of saving a duplicate", async (builtIn) => {
     prisma.$executeRaw.mockResolvedValue(1);
-    vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Matches the built-in filter",
-      optionId: `state:${builtIn.id}`,
+
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: builtIn.name,
+      kind: builtIn.kind,
+      values: [],
     });
-    const draft = { name: builtIn.name, kind: builtIn.kind, value: null };
-    const manual = await createMailSplitAction(EMAIL_ACCOUNT_ID, draft);
-    const described = await createMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
-      prompt: "restore the filter",
-      options: [{ ...draft, id: `state:${builtIn.id}` }],
-    });
-    for (const result of [manual, described]) {
-      expect(result?.data?.split).toEqual({ ...builtIn, value: null });
-    }
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+
+    expect(result?.data?.split).toEqual({ ...builtIn, values: [] });
     expect(prisma.$executeRaw).toHaveBeenCalledWith(
       expect.arrayContaining([expect.stringContaining("array_remove")]),
       builtIn.id,
@@ -200,21 +206,23 @@ describe("mail split actions", () => {
     expect(prisma.emailAccount.update).not.toHaveBeenCalled();
   });
 
-  it("returns a user-safe error when the AI response isn't one of the options", async () => {
+  it("drops options the AI invented rather than passing them to the picker", async () => {
     vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Invented an option that does not exist",
-      optionId: "label:made-up",
+      reasoning: "Nothing here covers mail from a specific person",
+      optionIds: ["label:made-up"],
       name: "Boss",
     });
 
-    const result = await createMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
+    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
       prompt: "emails from my boss",
       options: PROMPT_OPTIONS,
     });
 
-    expect(result?.serverError).toBe(
-      "Couldn't match that to a label or category. Try different wording, or pick one from the list.",
-    );
+    expect(result?.data).toEqual({
+      optionIds: [],
+      name: "Boss",
+      reasoning: "Nothing here covers mail from a specific person",
+    });
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -78,12 +78,17 @@ export const suggestMailSplitAction = actionClient
         ? matched
         : matched.slice(0, 1);
 
+      const optionIds = [...new Set(selected.map((option) => option.id))];
+      const capped = optionIds.slice(0, MAX_SPLIT_LABELS);
+
       return {
-        optionIds: [...new Set(selected.map((option) => option.id))].slice(
-          0,
-          MAX_SPLIT_LABELS,
-        ),
-        name: suggestion.name?.trim().slice(0, 60) || null,
+        optionIds: capped,
+        // A name describing more labels than the split ends up with would lie
+        // about the tab, so a truncated match falls back to the label names.
+        name:
+          capped.length === optionIds.length
+            ? suggestion.name?.trim().slice(0, 60) || null
+            : null,
         reasoning: suggestion.reasoning,
       };
     },

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -1,24 +1,28 @@
 "use server";
 
-import { randomUUID } from "node:crypto";
 import type { MailSplit } from "@/generated/prisma/client";
+import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import {
   createMailSplitBody,
-  createMailSplitFromPromptBody,
   deleteMailSplitBody,
   renameMailSplitBody,
   setDefaultMailSplitsBody,
+  suggestMailSplitBody,
   updateMailPreferencesBody,
 } from "@/utils/actions/mail-split.validation";
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { lockMailSplits } from "@/utils/mail/split-lock";
+import { createMailSplit } from "@/utils/mail/splits.server";
 import { BUILT_IN_SPLITS } from "@/utils/mail/built-in-splits";
-import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
+import {
+  MAX_MAIL_SPLITS,
+  MAX_SPLIT_LABELS,
+} from "@/utils/mail/split-constants";
 import {
   getDefaultMailSplitDraftsForAccount,
   setDefaultMailSplits,
@@ -28,45 +32,60 @@ export const createMailSplitAction = actionClient
   .metadata({ name: "createMailSplit" })
   .inputSchema(createMailSplitBody)
   .action(
-    async ({ ctx: { emailAccountId }, parsedInput: { name, kind, value } }) => {
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { name, kind, values },
+    }) => {
       const split = await createMailSplitOrThrow({
         emailAccountId,
         name,
         kind,
-        value: value ?? null,
+        values,
       });
       return { split };
     },
   );
 
-export const createMailSplitFromPromptAction = actionClient
-  .metadata({ name: "createMailSplitFromPrompt" })
-  .inputSchema(createMailSplitFromPromptBody)
+/**
+ * Resolves a description into a selection of the account's own filters. It
+ * deliberately stops short of creating the split so the picker can show what
+ * was matched and let the user adjust it first.
+ */
+export const suggestMailSplitAction = actionClient
+  .metadata({ name: "suggestMailSplit" })
+  .inputSchema(suggestMailSplitBody)
   .action(
     async ({ ctx: { emailAccountId }, parsedInput: { prompt, options } }) => {
       const emailAccount = await getEmailAccountWithAi({ emailAccountId });
       if (!emailAccount) throw new SafeError("Email account not found");
 
-      const match = await aiPromptToSplit({
+      const suggestion = await aiPromptToSplit({
         emailAccount,
         prompt,
         options: options.map(({ id, name, kind }) => ({ id, name, kind })),
       });
 
-      const option = options.find((o) => o.id === match.optionId);
-      if (!option) {
-        throw new SafeError(
-          "Couldn't match that to a label or category. Try different wording, or pick one from the list.",
-        );
-      }
-
-      const split = await createMailSplitOrThrow({
-        emailAccountId,
-        name: (match.name?.trim() || option.name).slice(0, 60),
-        kind: option.kind,
-        value: option.value ?? null,
+      const optionsById = new Map(options.map((option) => [option.id, option]));
+      const matched = suggestion.optionIds.flatMap((optionId) => {
+        const option = optionsById.get(optionId);
+        return option ? [option] : [];
       });
-      return { split };
+      // Only labels stack into one query, so a mixed pick collapses to the
+      // first option rather than producing a split we cannot run.
+      const selected = matched.every(
+        (option) => option.kind === MailSplitKind.LABEL,
+      )
+        ? matched
+        : matched.slice(0, 1);
+
+      return {
+        optionIds: [...new Set(selected.map((option) => option.id))].slice(
+          0,
+          MAX_SPLIT_LABELS,
+        ),
+        name: suggestion.name?.trim().slice(0, 60) || null,
+        reasoning: suggestion.reasoning,
+      };
     },
   );
 
@@ -139,7 +158,7 @@ export const updateMailPreferencesAction = actionClient
   );
 
 async function createMailSplitOrThrow(
-  data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">,
+  data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "values">,
 ) {
   const builtIn = BUILT_IN_SPLITS.find((split) => split.kind === data.kind);
   if (builtIn) {
@@ -173,70 +192,4 @@ async function createMailSplitOrThrow(
     }
     throw error;
   }
-}
-
-type CreateMailSplitResult =
-  | ({ status: "created" } & MailSplit)
-  | { status: "duplicate" | "limit" };
-
-async function createMailSplit({
-  emailAccountId,
-  name,
-  kind,
-  value,
-}: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "value">) {
-  const [, results] = await prisma.$transaction([
-    lockMailSplits(emailAccountId),
-    prisma.$queryRaw<CreateMailSplitResult[]>`
-      WITH split_state AS (
-        SELECT
-          COUNT(*)::integer AS count,
-          COALESCE(MAX("order"), -1)::integer + 1 AS next_order,
-          EXISTS (
-            SELECT 1
-            FROM "MailSplit"
-            WHERE "emailAccountId" = ${emailAccountId}
-              AND "name" = ${name}
-          ) AS name_exists
-        FROM "MailSplit"
-        WHERE "emailAccountId" = ${emailAccountId}
-      ),
-      inserted AS (
-        INSERT INTO "MailSplit" (
-          "id",
-          "createdAt",
-          "updatedAt",
-          "name",
-          "kind",
-          "value",
-          "order",
-          "emailAccountId"
-        )
-        SELECT
-          ${randomUUID()},
-          CURRENT_TIMESTAMP,
-          CURRENT_TIMESTAMP,
-          ${name},
-          ${kind}::"MailSplitKind",
-          ${value},
-          split_state.next_order,
-          ${emailAccountId}
-        FROM split_state
-        WHERE split_state.count < ${MAX_MAIL_SPLITS}
-          AND NOT split_state.name_exists
-        RETURNING *
-      )
-      SELECT
-        CASE
-          WHEN inserted."id" IS NOT NULL THEN 'created'
-          WHEN split_state.name_exists THEN 'duplicate'
-          ELSE 'limit'
-        END AS status,
-        inserted.*
-      FROM split_state
-      LEFT JOIN inserted ON TRUE
-    `,
-  ]);
-
-  return results[0];
 }

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,45 +1,51 @@
 import { z } from "zod";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 
-// LABEL splits carry a provider label id; CATEGORY splits carry a provider category
-// (e.g. CATEGORY_PERSONAL). INBOX and UNREAD need no value.
-const requiresValue = (kind: MailSplitKind) =>
-  kind === MailSplitKind.LABEL || kind === MailSplitKind.CATEGORY;
+// LABEL splits carry one or more provider label ids; CATEGORY splits carry a
+// single provider category (e.g. CATEGORY_PERSONAL). INBOX and UNREAD carry none.
+const kindAndValues = {
+  kind: z.nativeEnum(MailSplitKind),
+  values: z.array(z.string().trim().min(1)).max(MAX_SPLIT_LABELS),
+};
+const hasValidValues = ({
+  kind,
+  values,
+}: {
+  kind: MailSplitKind;
+  values: string[];
+}) => {
+  if (kind === MailSplitKind.LABEL) return values.length >= 1;
+  if (kind === MailSplitKind.CATEGORY) return values.length === 1;
+  return values.length === 0;
+};
+const valuesError = {
+  message:
+    "Label splits need at least one label, category splits exactly one category",
+  path: ["values"],
+};
 
 export const createMailSplitBody = z
-  .object({
-    name: z.string().trim().min(1).max(60),
-    kind: z.nativeEnum(MailSplitKind),
-    value: z.string().trim().min(1).nullish(),
-  })
-  .refine((data) => !requiresValue(data.kind) || !!data.value, {
-    message: "Label and category splits need a value",
-    path: ["value"],
-  });
+  .object({ name: z.string().trim().min(1).max(60), ...kindAndValues })
+  .refine(hasValidValues, valuesError);
 export type CreateMailSplitBody = z.infer<typeof createMailSplitBody>;
 
 // The client sends the account's available options (labels, categories, states)
 // so the server doesn't have to re-fetch them from the provider; the AI only
-// ever picks one of these, so a made-up option can't produce a split.
+// ever picks from these, so a made-up option can't reach the UI.
 const splitPromptOption = z
   .object({
     id: z.string().min(1),
     name: z.string().trim().min(1),
-    kind: z.nativeEnum(MailSplitKind),
-    value: z.string().trim().min(1).nullish(),
+    ...kindAndValues,
   })
-  .refine((data) => !requiresValue(data.kind) || !!data.value, {
-    message: "Label and category splits need a value",
-    path: ["value"],
-  });
+  .refine(hasValidValues, valuesError);
 
-export const createMailSplitFromPromptBody = z.object({
+export const suggestMailSplitBody = z.object({
   prompt: z.string().trim().min(1).max(300),
   options: z.array(splitPromptOption).min(1).max(500),
 });
-export type CreateMailSplitFromPromptBody = z.infer<
-  typeof createMailSplitFromPromptBody
->;
+export type SuggestMailSplitBody = z.infer<typeof suggestMailSplitBody>;
 
 export const renameMailSplitBody = z.object({
   id: z.string(),

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import prisma from "@/utils/prisma";
+import { removeLabelFromMailSplits } from "@/utils/mail/splits.server";
 import { sendEmailBody } from "@/utils/types/mail";
 import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
@@ -18,7 +19,6 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
-import { MailSplitKind } from "@/generated/prisma/enums";
 import { isGmailLabelColor } from "@/utils/gmail/label-colors";
 import { getOutlookCategoryPreset } from "@/utils/outlook/category-colors";
 import { markTrackedDraftDeleted } from "@/utils/ai/draft-cleanup";
@@ -335,13 +335,7 @@ export const deleteMailboxItemAction = actionClient
           await emailProvider.deleteFolder(id);
         } else {
           await emailProvider.deleteLabel(id);
-          await prisma.mailSplit.deleteMany({
-            where: {
-              emailAccountId,
-              kind: MailSplitKind.LABEL,
-              value: id,
-            },
-          });
+          await removeLabelFromMailSplits({ emailAccountId, labelId: id });
         }
       } catch (error) {
         logger.error("Failed to delete mailbox item", { error, kind });

--- a/apps/web/utils/ai/split/prompt-to-split.ts
+++ b/apps/web/utils/ai/split/prompt-to-split.ts
@@ -3,6 +3,7 @@ import { MailSplitKind } from "@/generated/prisma/enums";
 import { createGenerateObject } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
+import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 
 export type SplitPromptOption = {
   id: string;
@@ -14,19 +15,18 @@ const promptToSplitSchema = z.object({
   reasoning: z
     .string()
     .describe(
-      "One short sentence: which option filters for what the user described, or why none of them does",
+      "One short sentence naming the options you picked and why, or why none of them fit. Shown to the user.",
     ),
-  optionId: z
-    .string()
-    .nullable()
+  optionIds: z
+    .array(z.string())
     .describe(
-      "The id of the option that filters for what the user described, or null when no option does",
+      `Ids of every option the split should cover, at most ${MAX_SPLIT_LABELS}. Empty when nothing fits. More than one id is only allowed for label options, and means the split shows mail carrying any of those labels.`,
     ),
   name: z
     .string()
     .nullable()
     .describe(
-      "A short tab name for the split, at most three words. Null when optionId is null.",
+      "A short tab name covering everything the split shows, at most three words. Null when optionIds is empty.",
     ),
 });
 export type PromptToSplitResult = z.infer<typeof promptToSplitSchema>;
@@ -40,15 +40,18 @@ export async function aiPromptToSplit({
   prompt: string;
   options: SplitPromptOption[];
 }): Promise<PromptToSplitResult> {
-  const system = `You match a user's description of an inbox split to one of their existing mail filters.
+  const system = `You match a user's description of an inbox split to their existing mail filters.
 
 A split is a tab in the mail client that shows a filtered slice of the inbox. Each option is one available filter: a read state, a provider category, or one of the user's labels. You cannot create new filters; you can only pick from the options given.
 
 Instructions:
-- Pick an option only when its filter means the same thing as the user's description. Match by meaning, in any language, not only exact wording.
-- If the description is narrower than an option's filter, return null. Example: the user asks for "emails from my bank" and the closest option is a broad "Personal" category — that tab would mostly show unrelated mail, so it is not a match.
-- If no option fits, return null for optionId. A sender, person, or topic that no option covers must return null. Never pick a loosely related option just to return something.
-- The name must describe everything the matched option shows: use the matched option's own name unless the user's wording describes that same filter more clearly. Never name the split after only a subset of what it will contain.`;
+- Pick an option only when its filter means the same thing as part of what the user described. Match by meaning, in any language, not only exact wording.
+- A description that covers several of the user's labels should return every matching label id, up to ${MAX_SPLIT_LABELS} of them. The split then shows mail carrying any of them. Example: "invoices and receipts" returns both label ids when both labels exist.
+- Only label options can be combined. Read states and categories are exclusive: return exactly one id when you pick one.
+- If the description is narrower than an option's filter, leave that option out. Example: the user asks for "emails from my bank" and the closest option is a broad "Personal" category — that tab would mostly show unrelated mail, so it is not a match.
+- Return an empty list rather than a loose match. A sender, person, or topic that no option covers has no match.
+- The name must describe everything the picked options show together. Never name the split after only a subset of what it will contain.
+- The reasoning is shown to the user, so say which options you picked, or say plainly that none of their labels or categories cover the description.`;
 
   const userPrompt = `<options>
 ${options.map((option) => `- id: ${option.id} | name: ${option.name} | type: ${kindLabel(option.kind)}`).join("\n")}

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -516,6 +516,14 @@ function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {
     return false;
   }
   if (
+    query.anyLabelIds?.length &&
+    !messages.some((message) =>
+      query.anyLabelIds?.some((labelId) => message.labelIds?.includes(labelId)),
+    )
+  ) {
+    return false;
+  }
+  if (
     query.folderId &&
     !messages.some((message) => message.parentFolderId === query.folderId)
   ) {

--- a/apps/web/utils/mail/built-in-splits.ts
+++ b/apps/web/utils/mail/built-in-splits.ts
@@ -1,6 +1,16 @@
 import { MailSplitKind } from "@/generated/prisma/enums";
 
 export const BUILT_IN_SPLITS = [
-  { id: "all", name: "All", kind: MailSplitKind.INBOX, value: null },
-  { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD, value: null },
+  {
+    id: "all",
+    name: "All",
+    kind: MailSplitKind.INBOX,
+    values: [] as string[],
+  },
+  {
+    id: "unread",
+    name: "Unread",
+    kind: MailSplitKind.UNREAD,
+    values: [] as string[],
+  },
 ] as const;

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -65,7 +65,7 @@ describe("seedDefaultMailSplits", () => {
       {
         name: "Receipt",
         kind: MailSplitKind.LABEL,
-        value: "receipt-label",
+        values: ["receipt-label"],
       },
     ]);
     expect(prisma.rule.findMany).toHaveBeenCalledWith({
@@ -93,12 +93,12 @@ describe("seedDefaultMailSplits", () => {
         {
           name: "Receipt",
           kind: MailSplitKind.LABEL,
-          value: "receipt-label",
+          values: ["receipt-label"],
         },
         {
           name: "Newsletter",
           kind: MailSplitKind.LABEL,
-          value: "newsletter-label",
+          values: ["newsletter-label"],
         },
       ],
       enabled: false,
@@ -108,7 +108,10 @@ describe("seedDefaultMailSplits", () => {
       where: {
         emailAccountId: "account-id",
         kind: MailSplitKind.LABEL,
-        value: { in: ["receipt-label", "newsletter-label"] },
+        OR: [
+          { values: { equals: ["receipt-label"] } },
+          { values: { equals: ["newsletter-label"] } },
+        ],
       },
     });
   });
@@ -126,12 +129,12 @@ describe("seedDefaultMailSplits", () => {
           {
             name: "Receipt",
             kind: MailSplitKind.LABEL,
-            value: "receipt-label",
+            values: ["receipt-label"],
           },
           {
             name: "Newsletter",
             kind: MailSplitKind.LABEL,
-            value: "newsletter-label",
+            values: ["newsletter-label"],
           },
         ],
         enabled: true,

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -49,7 +49,7 @@ export async function seedDefaultMailSplits({
         "updatedAt",
         "name",
         "kind",
-        "value",
+        "values",
         "order",
         "emailAccountId"
       )
@@ -59,14 +59,14 @@ export async function seedDefaultMailSplits({
         CURRENT_TIMESTAMP,
         defaults."name",
         defaults."kind"::"MailSplitKind",
-        defaults."value",
+        defaults."values",
         defaults."order",
         ${emailAccountId}
       FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb) AS defaults(
         "id" text,
         "name" text,
         "kind" text,
-        "value" text,
+        "values" text[],
         "order" integer
       )
       WHERE NOT EXISTS (
@@ -97,7 +97,10 @@ export async function setDefaultMailSplits({
         where: {
           emailAccountId,
           kind: MailSplitKind.LABEL,
-          value: { in: defaultSplits.map((split) => split.value) },
+          // Exact match so a split the user widened to more labels survives.
+          OR: defaultSplits.map((split) => ({
+            values: { equals: split.values },
+          })),
         },
       }),
     ]);
@@ -128,7 +131,7 @@ export async function setDefaultMailSplits({
           "id" text,
           "name" text,
           "kind" text,
-          "value" text,
+          "values" text[],
           "order" integer
         )
         WHERE NOT EXISTS (
@@ -139,7 +142,7 @@ export async function setDefaultMailSplits({
               existing."name" = defaults."name"
               OR (
                 existing."kind" = 'LABEL'::"MailSplitKind"
-                AND existing."value" = defaults."value"
+                AND existing."values" = defaults."values"
               )
             )
         )
@@ -152,7 +155,7 @@ export async function setDefaultMailSplits({
           "updatedAt",
           "name",
           "kind",
-          "value",
+          "values",
           "order",
           "emailAccountId"
         )
@@ -162,7 +165,7 @@ export async function setDefaultMailSplits({
           CURRENT_TIMESTAMP,
           missing_defaults."name",
           missing_defaults."kind"::"MailSplitKind",
-          missing_defaults."value",
+          missing_defaults."values",
           split_state.next_order + missing_defaults.offset,
           ${emailAccountId}
         FROM missing_defaults

--- a/apps/web/utils/mail/default-splits.test.ts
+++ b/apps/web/utils/mail/default-splits.test.ts
@@ -20,17 +20,17 @@ describe("getDefaultMailSplitDrafts", () => {
       {
         name: "To Reply",
         kind: MailSplitKind.LABEL,
-        value: "reply-label",
+        values: ["reply-label"],
       },
       {
         name: "Newsletter",
         kind: MailSplitKind.LABEL,
-        value: "newsletter-label",
+        values: ["newsletter-label"],
       },
       {
         name: "Receipt",
         kind: MailSplitKind.LABEL,
-        value: "receipt-label",
+        values: ["receipt-label"],
       },
     ]);
   });
@@ -53,7 +53,7 @@ describe("getDefaultMailSplitDrafts", () => {
       {
         name: "Notification",
         kind: MailSplitKind.LABEL,
-        value: "notification-label",
+        values: ["notification-label"],
       },
     ]);
   });

--- a/apps/web/utils/mail/default-splits.ts
+++ b/apps/web/utils/mail/default-splits.ts
@@ -39,7 +39,7 @@ export function getDefaultMailSplitDrafts(rules: RuleForDefaultSplit[]) {
           {
             name: getRuleLabel(systemType),
             kind: MailSplitKind.LABEL,
-            value: labelId,
+            values: [labelId],
           },
         ]
       : [];

--- a/apps/web/utils/mail/split-constants.ts
+++ b/apps/web/utils/mail/split-constants.ts
@@ -1,1 +1,7 @@
 export const MAX_MAIL_SPLITS = 12;
+
+/**
+ * One provider query runs per label and each carries its own page token, so a
+ * wider split would both fan out and grow the pagination cursor without bound.
+ */
+export const MAX_SPLIT_LABELS = 5;

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -7,9 +7,9 @@ import {
 
 function split(
   kind: MailSplitKind,
-  value: string | null = null,
+  ...values: string[]
 ): Parameters<typeof mailSplitToThreadsQuery>[0] {
-  return { id: "split-1", name: "Test split", kind, value };
+  return { id: "split-1", name: "Test split", kind, values };
 }
 
 describe("mailSplitToThreadsQuery", () => {
@@ -49,6 +49,14 @@ describe("mailSplitToThreadsQuery", () => {
     ).toEqual({ type: "inbox", inboxSection });
   });
 
+  it("merges a multi-label split into one inbox query", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split(MailSplitKind.LABEL, "Label_42", "Label_43"),
+      ),
+    ).toEqual({ labelIds: ["INBOX"], anyLabelIds: ["Label_42", "Label_43"] });
+  });
+
   it.each([
     MailSplitKind.LABEL,
     MailSplitKind.CATEGORY,
@@ -71,12 +79,31 @@ describe("getPortableLabelSplits", () => {
         [labelSplit, split(MailSplitKind.CATEGORY, "CATEGORY_UPDATES")],
         { "source-label-id": { name: "Receipts" } },
       ),
-    ).toEqual([{ ...labelSplit, labelName: "Receipts" }]);
+    ).toEqual([{ ...labelSplit, labelNames: ["Receipts"] }]);
   });
 
   it("omits label splits whose source label no longer exists", () => {
     expect(
       getPortableLabelSplits([split(MailSplitKind.LABEL, "missing-label")], {}),
+    ).toEqual([]);
+  });
+
+  it("carries every label name of a multi-label split", () => {
+    const labelSplit = split(MailSplitKind.LABEL, "one", "two");
+
+    expect(
+      getPortableLabelSplits([labelSplit], {
+        one: { name: "One" },
+        two: { name: "Two" },
+      }),
+    ).toEqual([{ ...labelSplit, labelNames: ["One", "Two"] }]);
+  });
+
+  it("omits a multi-label split when one of its labels is gone", () => {
+    expect(
+      getPortableLabelSplits([split(MailSplitKind.LABEL, "one", "missing")], {
+        one: { name: "One" },
+      }),
     ).toEqual([]);
   });
 });

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -61,7 +61,7 @@ export function getPortableLabelSplits(
       const labelName = labelsById[labelId]?.name.trim();
       return labelName ? [labelName] : [];
     });
-    return labelNames.length === split.values.length
+    return labelNames.length && labelNames.length === split.values.length
       ? [{ ...split, labelNames }]
       : [];
   });

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -6,10 +6,10 @@ export type MailSplit = {
   id: string;
   name: string;
   kind: MailSplitKind;
-  value: string | null;
+  values: string[];
 };
 
-export type PortableLabelSplit = MailSplit & { labelName: string };
+export type PortableLabelSplit = MailSplit & { labelNames: string[] };
 
 /**
  * Every split is its own server query. Filtering a paginated list client-side would
@@ -21,16 +21,21 @@ export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
       return { type: "inbox" };
     case MailSplitKind.UNREAD:
       return { type: "inbox", isUnread: true };
-    case MailSplitKind.LABEL:
-      if (!split.value) throw new Error(`Split "${split.name}" has no label`);
-      return { labelIds: [split.value, "INBOX"] };
-    case MailSplitKind.CATEGORY:
-      if (!split.value)
-        throw new Error(`Split "${split.name}" has no category`);
-      if (isOutlookInboxSection(split.value)) {
-        return mailTypeToThreadsQuery(split.value);
+    case MailSplitKind.LABEL: {
+      if (!split.values.length)
+        throw new Error(`Split "${split.name}" has no label`);
+      if (split.values.length === 1)
+        return { labelIds: [split.values[0], "INBOX"] };
+      return { labelIds: ["INBOX"], anyLabelIds: split.values };
+    }
+    case MailSplitKind.CATEGORY: {
+      const [category] = split.values;
+      if (!category) throw new Error(`Split "${split.name}" has no category`);
+      if (isOutlookInboxSection(category)) {
+        return mailTypeToThreadsQuery(category);
       }
-      return { labelIds: [split.value, "INBOX"] };
+      return { labelIds: [category, "INBOX"] };
+    }
   }
 }
 
@@ -41,13 +46,23 @@ export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
   return { type };
 }
 
+/**
+ * Splits the combined mailbox can run. It matches by label name because each
+ * account has its own label ids, so a split whose labels no longer resolve is
+ * dropped rather than silently run against fewer labels.
+ */
 export function getPortableLabelSplits(
   splits: MailSplit[],
   labelsById: Record<string, { name: string }>,
 ): PortableLabelSplit[] {
   return splits.flatMap((split) => {
-    if (split.kind !== MailSplitKind.LABEL || !split.value) return [];
-    const labelName = labelsById[split.value]?.name.trim();
-    return labelName ? [{ ...split, labelName }] : [];
+    if (split.kind !== MailSplitKind.LABEL) return [];
+    const labelNames = split.values.flatMap((labelId) => {
+      const labelName = labelsById[labelId]?.name.trim();
+      return labelName ? [labelName] : [];
+    });
+    return labelNames.length === split.values.length
+      ? [{ ...split, labelNames }]
+      : [];
   });
 }

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+import type { MailSplit } from "@/generated/prisma/client";
+import { MailSplitKind } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import { lockMailSplits } from "@/utils/mail/split-lock";
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
+
+export type CreateMailSplitResult =
+  | ({ status: "created" } & MailSplit)
+  | { status: "duplicate" | "limit" };
+
+/**
+ * Inserts a split only if the account is under its limit and the name is free,
+ * so two concurrent creates can't race past either check.
+ */
+export async function createMailSplit({
+  emailAccountId,
+  name,
+  kind,
+  values,
+}: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "values">) {
+  const [, results] = await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$queryRaw<CreateMailSplitResult[]>`
+      WITH split_state AS (
+        SELECT
+          COUNT(*)::integer AS count,
+          COALESCE(MAX("order"), -1)::integer + 1 AS next_order,
+          EXISTS (
+            SELECT 1
+            FROM "MailSplit"
+            WHERE "emailAccountId" = ${emailAccountId}
+              AND "name" = ${name}
+          ) AS name_exists
+        FROM "MailSplit"
+        WHERE "emailAccountId" = ${emailAccountId}
+      ),
+      inserted AS (
+        INSERT INTO "MailSplit" (
+          "id",
+          "createdAt",
+          "updatedAt",
+          "name",
+          "kind",
+          "values",
+          "order",
+          "emailAccountId"
+        )
+        SELECT
+          ${randomUUID()},
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP,
+          ${name},
+          ${kind}::"MailSplitKind",
+          ${values},
+          split_state.next_order,
+          ${emailAccountId}
+        FROM split_state
+        WHERE split_state.count < ${MAX_MAIL_SPLITS}
+          AND NOT split_state.name_exists
+        RETURNING *
+      )
+      SELECT
+        CASE
+          WHEN inserted."id" IS NOT NULL THEN 'created'
+          WHEN split_state.name_exists THEN 'duplicate'
+          ELSE 'limit'
+        END AS status,
+        inserted.*
+      FROM split_state
+      LEFT JOIN inserted ON TRUE
+    `,
+  ]);
+
+  return results[0];
+}
+
+/**
+ * Keeps splits usable after a label is deleted: wider splits carry on without
+ * it, and a split it was the only label of has nothing left to show.
+ */
+export async function removeLabelFromMailSplits({
+  emailAccountId,
+  labelId,
+}: {
+  emailAccountId: string;
+  labelId: string;
+}) {
+  await prisma.$transaction([
+    prisma.$executeRaw`
+      UPDATE "MailSplit"
+      SET "values" = array_remove("values", ${labelId}),
+          "updatedAt" = NOW()
+      WHERE "emailAccountId" = ${emailAccountId}
+        AND "kind" = 'LABEL'::"MailSplitKind"
+        AND ${labelId} = ANY("values")
+    `,
+    prisma.mailSplit.deleteMany({
+      where: {
+        emailAccountId,
+        kind: MailSplitKind.LABEL,
+        values: { isEmpty: true },
+      },
+    }),
+  ]);
+}

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import type { MailSplit } from "@/generated/prisma/client";
-import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { lockMailSplits } from "@/utils/mail/split-lock";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
@@ -86,21 +85,21 @@ export async function removeLabelFromMailSplits({
   emailAccountId: string;
   labelId: string;
 }) {
-  await prisma.$transaction([
-    prisma.$executeRaw`
+  // One statement so only the rows this label emptied are deleted, rather than
+  // every empty split the account happens to have.
+  await prisma.$executeRaw`
+    WITH narrowed AS (
       UPDATE "MailSplit"
       SET "values" = array_remove("values", ${labelId}),
           "updatedAt" = NOW()
       WHERE "emailAccountId" = ${emailAccountId}
         AND "kind" = 'LABEL'::"MailSplitKind"
         AND ${labelId} = ANY("values")
-    `,
-    prisma.mailSplit.deleteMany({
-      where: {
-        emailAccountId,
-        kind: MailSplitKind.LABEL,
-        values: { isEmpty: true },
-      },
-    }),
-  ]);
+      RETURNING "id", "values"
+    )
+    DELETE FROM "MailSplit"
+    WHERE "id" IN (
+      SELECT "id" FROM narrowed WHERE cardinality("values") = 0
+    )
+  `;
 }

--- a/apps/web/utils/threads/load-combined.test.ts
+++ b/apps/web/utils/threads/load-combined.test.ts
@@ -122,6 +122,47 @@ describe("loadCombinedThreads", () => {
     );
   });
 
+  it("resumes a cursor written before the shared merge shipped", async () => {
+    const legacyCursor = Buffer.from(
+      JSON.stringify({
+        version: 2,
+        accounts: {
+          "account-1": {
+            pageToken: "account-1-next",
+            consumedThreadIds: ["already-served"],
+            done: false,
+          },
+          "account-2": { pageToken: null, consumedThreadIds: [], done: true },
+        },
+      }),
+    ).toString("base64url");
+    const loadPage = vi.fn(async ({ account }: { account: Account }) => ({
+      threads: [
+        thread("already-served", "2026-08-13T10:00:00.000Z"),
+        thread(`${account.id}-next-row`, "2026-08-12T10:00:00.000Z"),
+      ],
+      nextPageToken: null,
+    }));
+
+    const result = await loadCombinedThreads({
+      accounts: [account("account-1"), account("account-2")],
+      cursor: legacyCursor,
+      limit: 20,
+      loadPage,
+      logger,
+    });
+
+    // The exhausted account stays exhausted and the other one keeps its token,
+    // rather than both restarting and re-serving rows the user already has.
+    expect(loadPage).toHaveBeenCalledTimes(1);
+    expect(loadPage).toHaveBeenCalledWith(
+      expect.objectContaining({ pageToken: "account-1-next" }),
+    );
+    expect(result.threads.map((item) => item.id)).toEqual([
+      "account-1-next-row",
+    ]);
+  });
+
   it("returns successful accounts when another mailbox fails", async () => {
     const result = await loadCombinedThreads({
       accounts: [account("working"), account("failed")],

--- a/apps/web/utils/threads/load-combined.ts
+++ b/apps/web/utils/threads/load-combined.ts
@@ -1,20 +1,10 @@
 import type { Logger } from "@/utils/logger";
-import { mapWithConcurrency } from "@/utils/async";
 import type { EmailLabel, EmailLabels } from "@/providers/email-label-types";
 import type { ThreadListItem } from "@/utils/threads/load";
+import { mergePaginatedSources } from "@/utils/threads/merge-paginated-sources";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 
 const ACCOUNT_CONCURRENCY = 4;
-const INITIAL_ACCOUNT_CURSOR: AccountCursorState = {
-  pageToken: null,
-  consumedThreadIds: [],
-  done: false,
-};
-const DONE_ACCOUNT_CURSOR: AccountCursorState = {
-  pageToken: null,
-  consumedThreadIds: [],
-  done: true,
-};
 
 export type CombinedThreadsAccount = {
   id: string;
@@ -22,17 +12,6 @@ export type CombinedThreadsAccount = {
   name: string | null;
   image: string | null;
   provider: string;
-};
-
-type AccountCursorState = {
-  pageToken: string | null;
-  consumedThreadIds: string[];
-  done: boolean;
-};
-
-type CombinedCursor = {
-  version: 2;
-  accounts: Record<string, AccountCursorState>;
 };
 
 export type CombinedListThread = ThreadListItem & {
@@ -59,181 +38,49 @@ export async function loadCombinedThreads({
   }>;
   logger: Logger;
 }) {
-  if (!Number.isInteger(limit) || limit < 1) {
-    throw new Error("limit must be a positive integer");
-  }
-
-  const previousCursor = decodeCursor(cursor);
-  const accountsToLoad = accounts.filter(
-    (account) => !previousCursor.accounts[account.id]?.done,
-  );
-
-  const accountPages = await mapWithConcurrency(
-    accountsToLoad,
-    ACCOUNT_CONCURRENCY,
-    async (account) => {
-      const cursorState =
-        previousCursor.accounts[account.id] ?? INITIAL_ACCOUNT_CURSOR;
-      try {
-        const page = await loadPage({
-          account,
-          pageToken: cursorState.pageToken ?? undefined,
-        });
-        return { account, cursorState, page };
-      } catch (error) {
+  const { items, metaBySourceId, failedSourceIds, nextPageToken } =
+    await mergePaginatedSources({
+      sources: accounts,
+      cursor,
+      limit,
+      concurrency: ACCOUNT_CONCURRENCY,
+      compare: (left, right) =>
+        getThreadTimestamp(right) - getThreadTimestamp(left),
+      getItemId: (thread: CombinedListThread) => thread.id,
+      loadPage: async ({ source: account, pageToken }) => {
+        const page = await loadPage({ account, pageToken });
+        return {
+          items: page.threads.map((thread) => ({
+            ...thread,
+            account: {
+              id: account.id,
+              email: account.email,
+              name: account.name,
+              image: account.image,
+            },
+          })),
+          nextPageToken: page.nextPageToken,
+          meta: page.labels,
+        };
+      },
+      onSourceError: ({ source: account, error }) =>
         logger.warn("Failed to load combined mailbox account", {
           error,
           emailAccountId: account.id,
-        });
-        return { account, cursorState, page: null };
-      }
-    },
-  );
+        }),
+    });
 
-  const failedAccountIds: string[] = [];
-  const candidates: CombinedListThread[] = [];
   const labelsByAccount: Record<string, EmailLabels> = {};
-
-  for (const { account, cursorState, page } of accountPages) {
-    if (!page) {
-      failedAccountIds.push(account.id);
-      continue;
-    }
-
-    if (page.labels) {
-      labelsByAccount[account.id] = Object.fromEntries(
-        page.labels.map((label) => [label.id, label]),
-      );
-    }
-
-    const consumedThreadIds = new Set(cursorState.consumedThreadIds);
-    candidates.push(
-      ...page.threads
-        .filter((thread) => !consumedThreadIds.has(thread.id))
-        .map((thread) => ({
-          ...thread,
-          account: {
-            id: account.id,
-            email: account.email,
-            name: account.name,
-            image: account.image,
-          },
-        })),
+  for (const [accountId, labels] of Object.entries(metaBySourceId)) {
+    labelsByAccount[accountId] = Object.fromEntries(
+      labels.map((label) => [label.id, label]),
     );
-  }
-
-  candidates.sort(
-    (left, right) => getThreadTimestamp(right) - getThreadTimestamp(left),
-  );
-  const threads = candidates.slice(0, limit);
-  const returnedThreadIdsByAccount = getThreadIdsByAccount(threads);
-  const pagesByAccountId = new Map(
-    accountPages.map((page) => [page.account.id, page]),
-  );
-  const nextCursor = emptyCursor();
-
-  for (const account of accounts) {
-    const accountPage = pagesByAccountId.get(account.id);
-    if (!accountPage) {
-      nextCursor.accounts[account.id] =
-        previousCursor.accounts[account.id] ?? INITIAL_ACCOUNT_CURSOR;
-      continue;
-    }
-    if (!accountPage.page) {
-      nextCursor.accounts[account.id] = accountPage.cursorState;
-      continue;
-    }
-
-    const consumedThreadIds = new Set([
-      ...accountPage.cursorState.consumedThreadIds,
-      ...(returnedThreadIdsByAccount.get(account.id) ?? []),
-    ]);
-    const hasUnconsumedThreads = accountPage.page.threads.some(
-      (thread) => !consumedThreadIds.has(thread.id),
-    );
-    if (hasUnconsumedThreads) {
-      nextCursor.accounts[account.id] = {
-        ...accountPage.cursorState,
-        consumedThreadIds: [...consumedThreadIds],
-      };
-    } else if (accountPage.page.nextPageToken) {
-      nextCursor.accounts[account.id] = {
-        pageToken: accountPage.page.nextPageToken,
-        consumedThreadIds: [],
-        done: false,
-      };
-    } else {
-      nextCursor.accounts[account.id] = DONE_ACCOUNT_CURSOR;
-    }
   }
 
   return {
-    threads,
+    threads: items,
     labelsByAccount,
-    nextPageToken: Object.values(nextCursor.accounts).some(
-      (state) => !state.done,
-    )
-      ? encodeCursor(nextCursor)
-      : null,
-    failedAccountIds,
+    nextPageToken,
+    failedAccountIds: failedSourceIds,
   };
-}
-
-function getThreadIdsByAccount(threads: CombinedListThread[]) {
-  const threadIds = new Map<string, string[]>();
-  for (const thread of threads) {
-    const accountThreadIds = threadIds.get(thread.account.id) ?? [];
-    accountThreadIds.push(thread.id);
-    threadIds.set(thread.account.id, accountThreadIds);
-  }
-  return threadIds;
-}
-
-function encodeCursor(cursor: CombinedCursor) {
-  return Buffer.from(JSON.stringify(cursor)).toString("base64url");
-}
-
-function decodeCursor(cursor: string | null): CombinedCursor {
-  if (!cursor) return emptyCursor();
-
-  try {
-    const parsed: unknown = JSON.parse(
-      Buffer.from(cursor, "base64url").toString("utf8"),
-    );
-    if (
-      !isRecord(parsed) ||
-      parsed.version !== 2 ||
-      !isRecord(parsed.accounts)
-    ) {
-      return emptyCursor();
-    }
-
-    const accounts = Object.fromEntries(
-      Object.entries(parsed.accounts).filter(
-        (entry): entry is [string, AccountCursorState] =>
-          isAccountCursorState(entry[1]),
-      ),
-    );
-    return { version: 2, accounts };
-  } catch {
-    return emptyCursor();
-  }
-}
-
-function emptyCursor(): CombinedCursor {
-  return { version: 2, accounts: {} };
-}
-
-function isAccountCursorState(value: unknown): value is AccountCursorState {
-  return (
-    isRecord(value) &&
-    (typeof value.pageToken === "string" || value.pageToken === null) &&
-    Array.isArray(value.consumedThreadIds) &&
-    value.consumedThreadIds.every((threadId) => typeof threadId === "string") &&
-    typeof value.done === "boolean"
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/web/utils/threads/load.test.ts
+++ b/apps/web/utils/threads/load.test.ts
@@ -214,6 +214,64 @@ describe("loadThreads", () => {
       expect(second.threads.map((loaded) => loaded.id)).toContain("a-oldest");
     });
 
+    it("does not repeat a shared thread when the other label reaches it later", async () => {
+      const pagesByLabel: Record<string, Record<string, unknown>> = {
+        "label-a": {
+          first: {
+            threads: [thread("shared", "3000"), thread("a-old", "1000")],
+            nextPageToken: null,
+          },
+        },
+        "label-b": {
+          first: {
+            threads: [thread("b-mid", "2000")],
+            nextPageToken: "b-page-2",
+          },
+          "b-page-2": {
+            threads: [thread("shared", "3000")],
+            nextPageToken: null,
+          },
+        },
+      };
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn(
+          async ({
+            query,
+            pageToken,
+          }: {
+            query: { labelIds: string[] };
+            pageToken?: string;
+          }) => {
+            const labelId = query.labelIds.includes("label-a")
+              ? "label-a"
+              : "label-b";
+            return pagesByLabel[labelId][pageToken ?? "first"];
+          },
+        ),
+      };
+      const load = (nextPageToken?: string) =>
+        loadThreads({
+          query: {
+            labelIds: ["INBOX"],
+            anyLabelIds: ["label-a", "label-b"],
+            limit: 2,
+            nextPageToken,
+          },
+          emailAccountId: "account-1",
+          emailProvider: emailProvider as never,
+          messageFormat: "metadata",
+        });
+
+      const first = await load();
+      expect(first.threads.map((loaded) => loaded.id)).toEqual([
+        "shared",
+        "b-mid",
+      ]);
+
+      const second = await load(first.nextPageToken ?? undefined);
+      expect(second.threads.map((loaded) => loaded.id)).not.toContain("shared");
+    });
+
     it("fails the request rather than silently narrowing the split", async () => {
       const emailProvider = {
         getThreadsWithQuery: vi.fn(async ({ query }) => {

--- a/apps/web/utils/threads/load.test.ts
+++ b/apps/web/utils/threads/load.test.ts
@@ -269,7 +269,10 @@ describe("loadThreads", () => {
       ]);
 
       const second = await load(first.nextPageToken ?? undefined);
-      expect(second.threads.map((loaded) => loaded.id)).not.toContain("shared");
+      expect(second.threads.map((loaded) => loaded.id)).toEqual(["a-old"]);
+      // Skipping the repeat still consumes it, so the label finishes rather
+      // than serving the same page for ever.
+      expect(second.nextPageToken).toBeUndefined();
     });
 
     it("fails the request rather than silently narrowing the split", async () => {

--- a/apps/web/utils/threads/load.test.ts
+++ b/apps/web/utils/threads/load.test.ts
@@ -120,6 +120,139 @@ describe("loadThreads", () => {
       "hidden-message",
     ]);
   });
+
+  describe("multi-label splits", () => {
+    const thread = (id: string, internalDate: string) => ({
+      id,
+      snippet: id,
+      messages: [
+        {
+          id: `${id}-message`,
+          threadId: id,
+          internalDate,
+          headers: { from: "sender@example.com" },
+        },
+      ],
+    });
+
+    it("queries each label separately and merges them newest-first", async () => {
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn(async ({ query }) => ({
+          threads: query.labelIds.includes("label-a")
+            ? [thread("older", "1000")]
+            : [thread("newer", "2000")],
+          nextPageToken: null,
+        })),
+      };
+
+      const result = await loadThreads({
+        query: { labelIds: ["INBOX"], anyLabelIds: ["label-a", "label-b"] },
+        emailAccountId: "account-1",
+        emailProvider: emailProvider as never,
+        messageFormat: "metadata",
+      });
+
+      expect(result.threads.map((loaded) => loaded.id)).toEqual([
+        "newer",
+        "older",
+      ]);
+      // Each label keeps the caller's own filters, so the split stays in the inbox.
+      for (const [{ query }] of emailProvider.getThreadsWithQuery.mock.calls) {
+        expect(query.anyLabelIds).toBeUndefined();
+        expect(query.labelIds[0]).toBe("INBOX");
+      }
+    });
+
+    it("returns a thread carrying several of the labels only once", async () => {
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn().mockResolvedValue({
+          threads: [thread("shared", "1000")],
+          nextPageToken: null,
+        }),
+      };
+
+      const result = await loadThreads({
+        query: { labelIds: ["INBOX"], anyLabelIds: ["label-a", "label-b"] },
+        emailAccountId: "account-1",
+        emailProvider: emailProvider as never,
+        messageFormat: "metadata",
+      });
+
+      expect(result.threads.map((loaded) => loaded.id)).toEqual(["shared"]);
+      expect(result.nextPageToken).toBeUndefined();
+    });
+
+    it("re-serves rows a full page could not fit before advancing a label", async () => {
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn(async ({ query }) => ({
+          threads: query.labelIds.includes("label-a")
+            ? [thread("a-newest", "3000"), thread("a-oldest", "1000")]
+            : [thread("b-middle", "2000")],
+          nextPageToken: "label-page-2",
+        })),
+      };
+      const load = (nextPageToken?: string) =>
+        loadThreads({
+          query: {
+            labelIds: ["INBOX"],
+            anyLabelIds: ["label-a", "label-b"],
+            limit: 2,
+            nextPageToken,
+          },
+          emailAccountId: "account-1",
+          emailProvider: emailProvider as never,
+          messageFormat: "metadata",
+        });
+
+      const first = await load();
+      expect(first.threads.map((loaded) => loaded.id)).toEqual([
+        "a-newest",
+        "b-middle",
+      ]);
+
+      const second = await load(first.nextPageToken ?? undefined);
+      expect(second.threads.map((loaded) => loaded.id)).toContain("a-oldest");
+    });
+
+    it("fails the request rather than silently narrowing the split", async () => {
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn(async ({ query }) => {
+          if (query.labelIds.includes("label-b")) throw new Error("Boom");
+          return { threads: [thread("only-a", "1000")], nextPageToken: null };
+        }),
+      };
+
+      await expect(
+        loadThreads({
+          query: { labelIds: ["INBOX"], anyLabelIds: ["label-a", "label-b"] },
+          emailAccountId: "account-1",
+          emailProvider: emailProvider as never,
+          messageFormat: "metadata",
+        }),
+      ).rejects.toThrow("Boom");
+    });
+
+    it("keeps a single label on the provider's own query", async () => {
+      const emailProvider = {
+        getThreadsWithQuery: vi.fn().mockResolvedValue({
+          threads: [],
+          nextPageToken: null,
+        }),
+      };
+
+      await loadThreads({
+        query: { labelIds: ["INBOX"], anyLabelIds: ["label-a"] },
+        emailAccountId: "account-1",
+        emailProvider: emailProvider as never,
+        messageFormat: "metadata",
+      });
+
+      expect(emailProvider.getThreadsWithQuery).toHaveBeenCalledTimes(1);
+      expect(
+        emailProvider.getThreadsWithQuery.mock.calls[0][0].query.labelIds,
+      ).toEqual(["INBOX", "label-a"]);
+    });
+  });
 });
 
 function executedRule(id: string, createdAt: Date) {

--- a/apps/web/utils/threads/load.ts
+++ b/apps/web/utils/threads/load.ts
@@ -193,7 +193,7 @@ async function fetchThreadsPage({
       getThreadTimestamp(right) - getThreadTimestamp(left),
     getItemId: (thread: EmailThread) => thread.id,
     // A thread carrying several of the labels must still show up once.
-    getItemKey: (thread) => thread.id,
+    dedupeItemKey: (thread) => thread.id,
     loadPage: async ({ source, pageToken: labelPageToken }) => {
       const page = await emailProvider.getThreadsWithQuery({
         query: queryForLabels([source.id]),

--- a/apps/web/utils/threads/load.ts
+++ b/apps/web/utils/threads/load.ts
@@ -1,8 +1,12 @@
-import type { EmailProvider } from "@/utils/email/types";
+import type { EmailProvider, EmailThread } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import { isDefined } from "@/utils/types";
 import prisma from "@/utils/prisma";
+import { mergePaginatedSources } from "@/utils/threads/merge-paginated-sources";
+import { getThreadTimestamp } from "@/utils/threads/sort";
 import type { ThreadsQuery } from "@/utils/threads/validation";
+
+const LABEL_CONCURRENCY = 4;
 
 export async function loadThreads({
   query,
@@ -17,19 +21,13 @@ export async function loadThreads({
 }) {
   const maxResults = query.limit || 50;
   const pageToken = query.nextPageToken || undefined;
-  const { threads, nextPageToken } = query.q
-    ? await emailProvider.searchThreads({
-        query: query.q,
-        maxResults,
-        pageToken,
-        messageFormat,
-      })
-    : await emailProvider.getThreadsWithQuery({
-        query,
-        maxResults,
-        pageToken,
-        messageFormat,
-      });
+  const { threads, nextPageToken } = await fetchThreadsPage({
+    query,
+    emailProvider,
+    maxResults,
+    pageToken,
+    messageFormat,
+  });
 
   const threadIds = threads.map((thread) => thread.id);
   const executedRules = await prisma.executedRule.findMany({
@@ -140,4 +138,79 @@ function aggregateThreadPlans<
   }
 
   return [...latestByRule.values()];
+}
+
+/**
+ * `anyLabelIds` has no provider equivalent — Gmail's `labelIds` and Graph's
+ * category filter both mean "all of these". Two or more labels are served by
+ * running one query per label and merging them newest-first.
+ */
+async function fetchThreadsPage({
+  query,
+  emailProvider,
+  maxResults,
+  pageToken,
+  messageFormat,
+}: {
+  query: ThreadsQuery;
+  emailProvider: EmailProvider;
+  maxResults: number;
+  pageToken?: string;
+  messageFormat: "full" | "metadata";
+}): Promise<{ threads: EmailThread[]; nextPageToken?: string }> {
+  if (query.q) {
+    return emailProvider.searchThreads({
+      query: query.q,
+      maxResults,
+      pageToken,
+      messageFormat,
+    });
+  }
+
+  // A repeated label would run the same query twice and collide in the cursor.
+  const anyLabelIds = [...new Set(query.anyLabelIds ?? [])];
+  const queryForLabels = (labelIds: string[]): ThreadsQuery => ({
+    ...query,
+    anyLabelIds: undefined,
+    labelIds: [...(query.labelIds ?? []), ...labelIds],
+  });
+
+  if (anyLabelIds.length < 2) {
+    return emailProvider.getThreadsWithQuery({
+      query: anyLabelIds.length ? queryForLabels(anyLabelIds) : query,
+      maxResults,
+      pageToken,
+      messageFormat,
+    });
+  }
+
+  const merged = await mergePaginatedSources({
+    sources: anyLabelIds.map((labelId) => ({ id: labelId })),
+    cursor: pageToken ?? null,
+    limit: maxResults,
+    concurrency: LABEL_CONCURRENCY,
+    compare: (left, right) =>
+      getThreadTimestamp(right) - getThreadTimestamp(left),
+    getItemId: (thread: EmailThread) => thread.id,
+    // A thread carrying several of the labels must still show up once.
+    getItemKey: (thread) => thread.id,
+    loadPage: async ({ source, pageToken: labelPageToken }) => {
+      const page = await emailProvider.getThreadsWithQuery({
+        query: queryForLabels([source.id]),
+        maxResults,
+        pageToken: labelPageToken,
+        messageFormat,
+      });
+      return { items: page.threads, nextPageToken: page.nextPageToken };
+    },
+    // Dropping a failed label would silently narrow the split.
+    onSourceError: ({ error }) => {
+      throw error;
+    },
+  });
+
+  return {
+    threads: merged.items,
+    nextPageToken: merged.nextPageToken ?? undefined,
+  };
 }

--- a/apps/web/utils/threads/merge-paginated-sources.ts
+++ b/apps/web/utils/threads/merge-paginated-sources.ts
@@ -80,7 +80,12 @@ export async function mergePaginatedSources<
     string,
     { item: TItem; itemIdBySource: Map<string, string> }
   >();
-  const previouslyEmitted = new Set(previousCursor.emitted);
+  // A key stays here until every source has run past the row, so a row two
+  // sources share is served once however far apart their pages are.
+  const pendingByEmittedKey = new Map(
+    previousCursor.emitted.map((entry) => [entry.key, new Set(entry.pending)]),
+  );
+  const skippedItemIdsBySource = new Map<string, string[]>();
   const keyFor = (item: TItem, source: TSource) =>
     dedupeItemKey?.(item) ?? `${source.id}:${getItemId(item)}`;
 
@@ -95,7 +100,16 @@ export async function mergePaginatedSources<
     for (const item of page.items) {
       if (consumedIds.has(getItemId(item))) continue;
       const key = keyFor(item, source);
-      if (previouslyEmitted.has(key)) continue;
+      const stillPending = pendingByEmittedKey.get(key);
+      if (stillPending) {
+        // This source has now caught up to a row already served, so consume it
+        // here rather than leaving the page looking unfinished forever.
+        stillPending.delete(source.id);
+        const skipped = skippedItemIdsBySource.get(source.id) ?? [];
+        skipped.push(getItemId(item));
+        skippedItemIdsBySource.set(source.id, skipped);
+        continue;
+      }
       const candidate = candidatesByKey.get(key);
       if (candidate) {
         candidate.itemIdBySource.set(source.id, getItemId(item));
@@ -112,7 +126,7 @@ export async function mergePaginatedSources<
     compare(left.item, right.item),
   );
   const returned = candidates.slice(0, limit);
-  const returnedItemIdsBySource = new Map<string, string[]>();
+  const returnedItemIdsBySource = new Map(skippedItemIdsBySource);
   for (const { itemIdBySource } of returned) {
     for (const [sourceId, itemId] of itemIdBySource) {
       const itemIds = returnedItemIdsBySource.get(sourceId) ?? [];
@@ -161,13 +175,29 @@ export async function mergePaginatedSources<
     }
   }
 
-  // A row two sources share can sit on different provider pages, so recent
-  // keys are remembered until the slower source has caught up past them.
   if (dedupeItemKey) {
-    nextCursor.emitted = [
-      ...returned.map(({ item }) => dedupeItemKey(item)),
-      ...previousCursor.emitted,
-    ].slice(0, EMITTED_KEY_MEMORY);
+    for (const { item, itemIdBySource } of returned) {
+      const key = dedupeItemKey(item);
+      if (pendingByEmittedKey.has(key)) continue;
+      pendingByEmittedKey.set(
+        key,
+        new Set(
+          sources
+            .map((source) => source.id)
+            .filter((sourceId) => !itemIdBySource.has(sourceId)),
+        ),
+      );
+    }
+    // A source that is finished will never surface the row, so it stops
+    // holding the key and the ledger drains instead of growing.
+    nextCursor.emitted = [...pendingByEmittedKey]
+      .map(([key, pending]) => ({
+        key,
+        pending: [...pending].filter(
+          (sourceId) => nextCursor.sources[sourceId]?.done === false,
+        ),
+      }))
+      .filter((entry) => entry.pending.length > 0);
   }
 
   return {
@@ -191,12 +221,14 @@ type SourceCursorState = {
 type MergedCursor = {
   version: 3;
   sources: Record<string, SourceCursorState>;
-  /** Keys already served, so a row two sources share is not served twice. */
-  emitted: string[];
+  /**
+   * Rows already served, each with the sources that have yet to reach them, so
+   * a row two sources share is served once and then forgotten.
+   */
+  emitted: EmittedKey[];
 };
 
-/** A shared row surfaces in the other source within a few pages, or never. */
-const EMITTED_KEY_MEMORY = 200;
+type EmittedKey = { key: string; pending: string[] };
 
 const INITIAL_SOURCE_CURSOR: SourceCursorState = {
   pageToken: null,
@@ -236,7 +268,9 @@ function decodeCursor(cursor: string | null): MergedCursor {
       version: 3,
       sources,
       emitted: Array.isArray(parsed.emitted)
-        ? parsed.emitted.filter((key): key is string => typeof key === "string")
+        ? parsed.emitted.flatMap((entry) =>
+            isEmittedKey(entry) ? [entry] : [],
+          )
         : [],
     };
   } catch {
@@ -263,6 +297,15 @@ function toSourceCursorState(value: unknown): SourceCursorState | null {
     consumedIds: consumed.filter((id): id is string => typeof id === "string"),
     done: value.done,
   };
+}
+
+function isEmittedKey(value: unknown): value is EmittedKey {
+  return (
+    isRecord(value) &&
+    typeof value.key === "string" &&
+    Array.isArray(value.pending) &&
+    value.pending.every((sourceId) => typeof sourceId === "string")
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/threads/merge-paginated-sources.ts
+++ b/apps/web/utils/threads/merge-paginated-sources.ts
@@ -19,7 +19,7 @@ export async function mergePaginatedSources<
   concurrency,
   compare,
   getItemId,
-  getItemKey = (item, source) => `${source.id}:${getItemId(item)}`,
+  dedupeItemKey,
   loadPage,
   onSourceError,
 }: {
@@ -32,11 +32,11 @@ export async function mergePaginatedSources<
   /** Identifies a row within its own source, for consumed-row tracking. */
   getItemId: (item: TItem) => string;
   /**
-   * Identifies a row across sources. Rows sharing a key are returned once and
-   * marked consumed on every source that produced them. Defaults to keeping
-   * sources independent.
+   * Identifies a row across sources, for sources that can return the same one.
+   * Rows sharing a key are served once and remembered so a later page cannot
+   * repeat them. Leave unset when sources never overlap.
    */
-  getItemKey?: (item: TItem, source: TSource) => string;
+  dedupeItemKey?: (item: TItem) => string;
   loadPage: (input: { source: TSource; pageToken?: string }) => Promise<{
     items: TItem[];
     nextPageToken?: string | null;
@@ -74,10 +74,15 @@ export async function mergePaginatedSources<
 
   const failedSourceIds: string[] = [];
   const metaBySourceId: Record<string, TMeta> = {};
+  // Each source keeps the row's own id, because two sources can identify the
+  // same row differently and each needs its own id marked consumed.
   const candidatesByKey = new Map<
     string,
-    { item: TItem; sourceIds: Set<string> }
+    { item: TItem; itemIdBySource: Map<string, string> }
   >();
+  const previouslyEmitted = new Set(previousCursor.emitted);
+  const keyFor = (item: TItem, source: TSource) =>
+    dedupeItemKey?.(item) ?? `${source.id}:${getItemId(item)}`;
 
   for (const { source, cursorState, page } of sourcePages) {
     if (!page) {
@@ -89,13 +94,17 @@ export async function mergePaginatedSources<
     const consumedIds = new Set(cursorState.consumedIds);
     for (const item of page.items) {
       if (consumedIds.has(getItemId(item))) continue;
-      const key = getItemKey(item, source);
+      const key = keyFor(item, source);
+      if (previouslyEmitted.has(key)) continue;
       const candidate = candidatesByKey.get(key);
       if (candidate) {
-        candidate.sourceIds.add(source.id);
+        candidate.itemIdBySource.set(source.id, getItemId(item));
         continue;
       }
-      candidatesByKey.set(key, { item, sourceIds: new Set([source.id]) });
+      candidatesByKey.set(key, {
+        item,
+        itemIdBySource: new Map([[source.id, getItemId(item)]]),
+      });
     }
   }
 
@@ -104,10 +113,10 @@ export async function mergePaginatedSources<
   );
   const returned = candidates.slice(0, limit);
   const returnedItemIdsBySource = new Map<string, string[]>();
-  for (const { item, sourceIds } of returned) {
-    for (const sourceId of sourceIds) {
+  for (const { itemIdBySource } of returned) {
+    for (const [sourceId, itemId] of itemIdBySource) {
       const itemIds = returnedItemIdsBySource.get(sourceId) ?? [];
-      itemIds.push(getItemId(item));
+      itemIds.push(itemId);
       returnedItemIdsBySource.set(sourceId, itemIds);
     }
   }
@@ -152,6 +161,15 @@ export async function mergePaginatedSources<
     }
   }
 
+  // A row two sources share can sit on different provider pages, so recent
+  // keys are remembered until the slower source has caught up past them.
+  if (dedupeItemKey) {
+    nextCursor.emitted = [
+      ...returned.map(({ item }) => dedupeItemKey(item)),
+      ...previousCursor.emitted,
+    ].slice(0, EMITTED_KEY_MEMORY);
+  }
+
   return {
     items: returned.map(({ item }) => item),
     metaBySourceId,
@@ -173,7 +191,12 @@ type SourceCursorState = {
 type MergedCursor = {
   version: 3;
   sources: Record<string, SourceCursorState>;
+  /** Keys already served, so a row two sources share is not served twice. */
+  emitted: string[];
 };
+
+/** A shared row surfaces in the other source within a few pages, or never. */
+const EMITTED_KEY_MEMORY = 200;
 
 const INITIAL_SOURCE_CURSOR: SourceCursorState = {
   pageToken: null,
@@ -197,38 +220,49 @@ function decodeCursor(cursor: string | null): MergedCursor {
     const parsed: unknown = JSON.parse(
       Buffer.from(cursor, "base64url").toString("utf8"),
     );
-    if (
-      !isRecord(parsed) ||
-      parsed.version !== 3 ||
-      !isRecord(parsed.sources)
-    ) {
-      return emptyCursor();
-    }
+    if (!isRecord(parsed)) return emptyCursor();
+    // A page loaded before this shipped still holds a v2 cursor. Reading it
+    // keeps "load more" moving forward instead of restarting from page one.
+    const rawSources = parsed.version === 3 ? parsed.sources : parsed.accounts;
+    if (!isRecord(rawSources)) return emptyCursor();
 
     const sources = Object.fromEntries(
-      Object.entries(parsed.sources).filter(
-        (entry): entry is [string, SourceCursorState] =>
-          isSourceCursorState(entry[1]),
-      ),
+      Object.entries(rawSources).flatMap((entry) => {
+        const state = toSourceCursorState(entry[1]);
+        return state ? [[entry[0], state] as const] : [];
+      }),
     );
-    return { version: 3, sources };
+    return {
+      version: 3,
+      sources,
+      emitted: Array.isArray(parsed.emitted)
+        ? parsed.emitted.filter((key): key is string => typeof key === "string")
+        : [],
+    };
   } catch {
     return emptyCursor();
   }
 }
 
 function emptyCursor(): MergedCursor {
-  return { version: 3, sources: {} };
+  return { version: 3, sources: {}, emitted: [] };
 }
 
-function isSourceCursorState(value: unknown): value is SourceCursorState {
-  return (
-    isRecord(value) &&
-    (typeof value.pageToken === "string" || value.pageToken === null) &&
-    Array.isArray(value.consumedIds) &&
-    value.consumedIds.every((itemId) => typeof itemId === "string") &&
-    typeof value.done === "boolean"
-  );
+function toSourceCursorState(value: unknown): SourceCursorState | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.pageToken !== "string" && value.pageToken !== null) {
+    return null;
+  }
+  if (typeof value.done !== "boolean") return null;
+  // v2 named this field consumedThreadIds.
+  const consumed = value.consumedIds ?? value.consumedThreadIds;
+  if (!Array.isArray(consumed)) return null;
+
+  return {
+    pageToken: value.pageToken,
+    consumedIds: consumed.filter((id): id is string => typeof id === "string"),
+    done: value.done,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/threads/merge-paginated-sources.ts
+++ b/apps/web/utils/threads/merge-paginated-sources.ts
@@ -1,0 +1,236 @@
+import { mapWithConcurrency } from "@/utils/async";
+
+/**
+ * Merges several independently paginated providers into one ordered list.
+ *
+ * Each source keeps its own page token, so a slow or exhausted source never
+ * holds the others back. Rows a page loaded but could not fit under `limit`
+ * are remembered as "consumed" instead of being dropped, so the next page
+ * re-serves them before advancing that source's token.
+ */
+export async function mergePaginatedSources<
+  TSource extends { id: string },
+  TItem,
+  TMeta,
+>({
+  sources,
+  cursor,
+  limit,
+  concurrency,
+  compare,
+  getItemId,
+  getItemKey = (item, source) => `${source.id}:${getItemId(item)}`,
+  loadPage,
+  onSourceError,
+}: {
+  sources: TSource[];
+  cursor: string | null;
+  limit: number;
+  concurrency: number;
+  /** Orders the merged rows; the first `limit` are returned. */
+  compare: (left: TItem, right: TItem) => number;
+  /** Identifies a row within its own source, for consumed-row tracking. */
+  getItemId: (item: TItem) => string;
+  /**
+   * Identifies a row across sources. Rows sharing a key are returned once and
+   * marked consumed on every source that produced them. Defaults to keeping
+   * sources independent.
+   */
+  getItemKey?: (item: TItem, source: TSource) => string;
+  loadPage: (input: { source: TSource; pageToken?: string }) => Promise<{
+    items: TItem[];
+    nextPageToken?: string | null;
+    meta?: TMeta;
+  }>;
+  onSourceError: (input: { source: TSource; error: unknown }) => void;
+}) {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("limit must be a positive integer");
+  }
+
+  const previousCursor = decodeCursor(cursor);
+  const sourcesToLoad = sources.filter(
+    (source) => !previousCursor.sources[source.id]?.done,
+  );
+
+  const sourcePages = await mapWithConcurrency(
+    sourcesToLoad,
+    concurrency,
+    async (source) => {
+      const cursorState =
+        previousCursor.sources[source.id] ?? INITIAL_SOURCE_CURSOR;
+      try {
+        const page = await loadPage({
+          source,
+          pageToken: cursorState.pageToken ?? undefined,
+        });
+        return { source, cursorState, page };
+      } catch (error) {
+        onSourceError({ source, error });
+        return { source, cursorState, page: null };
+      }
+    },
+  );
+
+  const failedSourceIds: string[] = [];
+  const metaBySourceId: Record<string, TMeta> = {};
+  const candidatesByKey = new Map<
+    string,
+    { item: TItem; sourceIds: Set<string> }
+  >();
+
+  for (const { source, cursorState, page } of sourcePages) {
+    if (!page) {
+      failedSourceIds.push(source.id);
+      continue;
+    }
+    if (page.meta !== undefined) metaBySourceId[source.id] = page.meta;
+
+    const consumedIds = new Set(cursorState.consumedIds);
+    for (const item of page.items) {
+      if (consumedIds.has(getItemId(item))) continue;
+      const key = getItemKey(item, source);
+      const candidate = candidatesByKey.get(key);
+      if (candidate) {
+        candidate.sourceIds.add(source.id);
+        continue;
+      }
+      candidatesByKey.set(key, { item, sourceIds: new Set([source.id]) });
+    }
+  }
+
+  const candidates = [...candidatesByKey.values()].sort((left, right) =>
+    compare(left.item, right.item),
+  );
+  const returned = candidates.slice(0, limit);
+  const returnedItemIdsBySource = new Map<string, string[]>();
+  for (const { item, sourceIds } of returned) {
+    for (const sourceId of sourceIds) {
+      const itemIds = returnedItemIdsBySource.get(sourceId) ?? [];
+      itemIds.push(getItemId(item));
+      returnedItemIdsBySource.set(sourceId, itemIds);
+    }
+  }
+
+  const pagesBySourceId = new Map(
+    sourcePages.map((sourcePage) => [sourcePage.source.id, sourcePage]),
+  );
+  const nextCursor = emptyCursor();
+
+  for (const source of sources) {
+    const sourcePage = pagesBySourceId.get(source.id);
+    if (!sourcePage) {
+      nextCursor.sources[source.id] =
+        previousCursor.sources[source.id] ?? INITIAL_SOURCE_CURSOR;
+      continue;
+    }
+    if (!sourcePage.page) {
+      nextCursor.sources[source.id] = sourcePage.cursorState;
+      continue;
+    }
+
+    const consumedIds = new Set([
+      ...sourcePage.cursorState.consumedIds,
+      ...(returnedItemIdsBySource.get(source.id) ?? []),
+    ]);
+    const hasUnconsumedItems = sourcePage.page.items.some(
+      (item) => !consumedIds.has(getItemId(item)),
+    );
+    if (hasUnconsumedItems) {
+      nextCursor.sources[source.id] = {
+        ...sourcePage.cursorState,
+        consumedIds: [...consumedIds],
+      };
+    } else if (sourcePage.page.nextPageToken) {
+      nextCursor.sources[source.id] = {
+        pageToken: sourcePage.page.nextPageToken,
+        consumedIds: [],
+        done: false,
+      };
+    } else {
+      nextCursor.sources[source.id] = DONE_SOURCE_CURSOR;
+    }
+  }
+
+  return {
+    items: returned.map(({ item }) => item),
+    metaBySourceId,
+    failedSourceIds,
+    nextPageToken: Object.values(nextCursor.sources).some(
+      (state) => !state.done,
+    )
+      ? encodeCursor(nextCursor)
+      : null,
+  };
+}
+
+type SourceCursorState = {
+  pageToken: string | null;
+  consumedIds: string[];
+  done: boolean;
+};
+
+type MergedCursor = {
+  version: 3;
+  sources: Record<string, SourceCursorState>;
+};
+
+const INITIAL_SOURCE_CURSOR: SourceCursorState = {
+  pageToken: null,
+  consumedIds: [],
+  done: false,
+};
+const DONE_SOURCE_CURSOR: SourceCursorState = {
+  pageToken: null,
+  consumedIds: [],
+  done: true,
+};
+
+function encodeCursor(cursor: MergedCursor) {
+  return Buffer.from(JSON.stringify(cursor)).toString("base64url");
+}
+
+function decodeCursor(cursor: string | null): MergedCursor {
+  if (!cursor) return emptyCursor();
+
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8"),
+    );
+    if (
+      !isRecord(parsed) ||
+      parsed.version !== 3 ||
+      !isRecord(parsed.sources)
+    ) {
+      return emptyCursor();
+    }
+
+    const sources = Object.fromEntries(
+      Object.entries(parsed.sources).filter(
+        (entry): entry is [string, SourceCursorState] =>
+          isSourceCursorState(entry[1]),
+      ),
+    );
+    return { version: 3, sources };
+  } catch {
+    return emptyCursor();
+  }
+}
+
+function emptyCursor(): MergedCursor {
+  return { version: 3, sources: {} };
+}
+
+function isSourceCursorState(value: unknown): value is SourceCursorState {
+  return (
+    isRecord(value) &&
+    (typeof value.pageToken === "string" || value.pageToken === null) &&
+    Array.isArray(value.consumedIds) &&
+    value.consumedIds.every((itemId) => typeof itemId === "string") &&
+    typeof value.done === "boolean"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/web/utils/threads/sort.ts
+++ b/apps/web/utils/threads/sort.ts
@@ -1,12 +1,20 @@
 import { internalDateToDate } from "@/utils/date";
 
-/** Undated threads collapse to 0 so they sort to the end of a list. */
+/**
+ * A thread is as recent as its newest message. Providers hand back thread
+ * messages in their own order, so the position in the array means nothing.
+ * Undated threads collapse to 0 so they sort to the end of a list.
+ */
 export function getThreadTimestamp(thread: {
   messages: Array<{ internalDate?: string | null }>;
 }) {
-  return (
-    internalDateToDate(thread.messages.at(-1)?.internalDate, {
-      fallbackToNow: false,
-    }).getTime() || 0
-  );
+  let newest = 0;
+  for (const message of thread.messages) {
+    const timestamp =
+      internalDateToDate(message.internalDate, {
+        fallbackToNow: false,
+      }).getTime() || 0;
+    if (timestamp > newest) newest = timestamp;
+  }
+  return newest;
 }

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 export const threadsQuery = z.object({
@@ -11,6 +12,9 @@ export const threadsQuery = z.object({
   nextPageToken: microsoftGraphPageTokenSchema,
   labelId: z.string().nullish(), // For Google
   labelIds: z.array(z.string()).nullish(), // For Google
+  // Threads matching any one of these labels, on top of `labelIds`, which all
+  // have to match. Served by fanning out one provider query per label.
+  anyLabelIds: z.array(z.string()).max(MAX_SPLIT_LABELS).nullish(),
   excludeLabelNames: z.array(z.string()).nullish(), // For Google
   after: z.coerce.date().nullish(),
   before: z.coerce.date().nullish(),


### PR DESCRIPTION
A split tab could only filter on a single label, so describing a slice that spans two of them had no representable answer and came back as "no match" with no explanation. Split filters are now a list of labels, served by one provider query per label merged newest-first behind a shared cursor that the combined mailbox loader also reuses in place of its own copy of that pagination logic.

- The picker's search box only filters now; the AI moved behind its own view, and the bulk rule-label controls moved into a footer instead of sitting among the label rows.
- The AI suggests rather than creates: it preselects matching labels, prefills a name and shows its reasoning, so anything it produces can be adjusted or built by hand.
- Deleting a label now narrows wider splits and removes only the ones left empty, instead of failing against the old single-value column.
- Validation: focused unit tests, migration and raw SQL exercised against a real database, AI regression suite, and the emulated browser suite for this area with screenshots inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create mail split tabs combining up to five labels.
  - Get AI suggestions for matching labels, tab names, and explanations from natural-language descriptions before saving.
  - Browse combined-label threads with merged, deduplicated results and continued pagination.
  - Search and select labels more easily in the split picker.

- **Bug Fixes**
  - Removing a mailbox label now updates affected split tabs without deleting tabs that contain other labels.
  - Improved multi-label filtering and provider pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->