### PR TITLE
mail: Focus email before leaving draft with Escape

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import {
@@ -437,6 +438,38 @@ test("leaves the draft before returning to the list with Escape", async ({
   await page.keyboard.press("Escape");
   await expect(conversations).toBeVisible();
   await expect(message).toBeHidden();
+});
+
+test("returns focus from a draft in a single-message email panel", async ({
+  page,
+}, testInfo) => {
+  const { emailAccountId } = await openMail(page);
+  await page.route("**/api/user/no-reply", async (route) => {
+    const response = await route.fetch({
+      url: new URL(
+        "/api/threads/thr_playwright_reply?includeDrafts=true",
+        route.request().url(),
+      ).toString(),
+    });
+    const { thread }: ThreadResponse = await response.json();
+    await route.fulfill({ json: [thread] });
+  });
+  await page.goto(`/${emailAccountId}/no-reply?thread-id=thr_playwright_reply`);
+  const message = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  await expect(message).toBeVisible();
+  await expect(message).not.toHaveAttribute("data-selected");
+  await message.getByRole("button", { name: "Reply", exact: true }).click();
+  const editor = message.getByRole("textbox", { name: "Email message" });
+  await editor.fill("A draft in the email panel.");
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
+
+  await editor.press("Escape");
+
+  await expect(message).toBeFocused();
+  await expect(editor).toContainText("A draft in the email panel.");
+  await capturePlaywrightCheckpoint(page, testInfo, "panel-draft-escape-focus");
 });
 
 test("opens and sends a reply from the reader with Enter", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -403,6 +403,40 @@ test("selects the sender when composing from all accounts", async ({
   }
 });
 
+test("leaves the draft before returning to the list with Escape", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Reply Workflow Message",
+  ).click();
+  const message = page.locator(
+    '[data-thread-message-id="msg_playwright_reply"]',
+  );
+  await message.getByRole("button", { name: "Reply", exact: true }).click();
+  const editor = message.getByRole("textbox", { name: "Email message" });
+  await editor.fill("A draft preserved when leaving the input.");
+  const threadUrl = page.url();
+
+  await editor.press("Escape");
+  await expect(message).toBeFocused();
+  await expect(page).toHaveURL(threadUrl);
+  await expect(editor).toContainText(
+    "A draft preserved when leaving the input.",
+  );
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "draft-escape-focuses-message",
+  );
+
+  await page.keyboard.press("Escape");
+  await expect(conversations).toBeVisible();
+  await expect(message).toBeHidden();
+});
+
 test("opens and sends a reply from the reader with Enter", async ({
   page,
 }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -418,6 +418,8 @@ test("leaves the draft before returning to the list with Escape", async ({
   await message.getByRole("button", { name: "Reply", exact: true }).click();
   const editor = message.getByRole("textbox", { name: "Email message" });
   await editor.fill("A draft preserved when leaving the input.");
+  // The reply tooltip owns Escape until its exit animation finishes.
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
   const threadUrl = page.url();
 
   await editor.press("Escape");

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -92,7 +92,10 @@ import { useMailSettings } from "@/hooks/useMailSettings";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useThread } from "@/hooks/useThread";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
-import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
+import {
+  isTypingTarget,
+  type ShortcutHandlers,
+} from "@/lib/shortcuts/registry";
 import {
   createMailSplitAction,
   createMailSplitFromPromptAction,
@@ -989,7 +992,19 @@ export function MailShell() {
         : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
-        : () => {
+        : (event) => {
+            if (
+              event?.target instanceof HTMLElement &&
+              isTypingTarget(event.target)
+            ) {
+              const message = event.target.closest<HTMLElement>(
+                "[data-thread-message-id]",
+              );
+              if (message) {
+                message.focus({ preventScroll: true });
+                return;
+              }
+            }
             if (selection.hasSelection) selection.clear();
             else if (layout === "list") closeReader();
           },

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -92,10 +92,7 @@ import { useMailSettings } from "@/hooks/useMailSettings";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useThread } from "@/hooks/useThread";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
-import {
-  isTypingTarget,
-  type ShortcutHandlers,
-} from "@/lib/shortcuts/registry";
+import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
 import {
   createMailSplitAction,
   createMailSplitFromPromptAction,
@@ -992,19 +989,7 @@ export function MailShell() {
         : () => openAt(clampedIndex),
       backToList: isMailOverlayOpen
         ? undefined
-        : (event) => {
-            if (
-              event?.target instanceof HTMLElement &&
-              isTypingTarget(event.target)
-            ) {
-              const message = event.target.closest<HTMLElement>(
-                "[data-thread-message-id]",
-              );
-              if (message) {
-                message.focus({ preventScroll: true });
-                return;
-              }
-            }
+        : () => {
             if (selection.hasSelection) selection.clear();
             else if (layout === "list") closeReader();
           },

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -34,6 +34,7 @@ import { EmailAttachments } from "@/components/email-list/EmailAttachments";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { formatReplySubject } from "@/utils/email/subject";
 import { env } from "@/env";
+import { isTypingTarget } from "@/lib/shortcuts/registry";
 import type { ContactsResponse } from "@/app/api/user/contacts/route";
 import { toastError } from "@/components/Toast";
 import { getActionErrorMessage } from "@/utils/error";
@@ -124,6 +125,17 @@ export function EmailMessage({
   const onMessageKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       if (
+        selected !== undefined &&
+        event.key === "Escape" &&
+        !event.defaultPrevented &&
+        isTypingTarget(event.target)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.currentTarget.focus({ preventScroll: true });
+        return;
+      }
+      if (
         event.target !== event.currentTarget ||
         (event.key !== "Enter" && event.key !== " ")
       )
@@ -136,7 +148,7 @@ export function EmailMessage({
         onToggle?.();
       }
     },
-    [expanded, onReply, onToggle, showReplyButton],
+    [expanded, onReply, onToggle, selected, showReplyButton],
   );
 
   return (

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -144,7 +144,7 @@ export function EmailMessage({
     <li
       data-thread-message-id={message.id}
       data-selected={selected}
-      tabIndex={selected === undefined ? undefined : -1}
+      tabIndex={selected !== undefined || composeMode ? -1 : undefined}
       aria-current={selected || undefined}
       onFocusCapture={onSelect}
       onClickCapture={onSelect}
@@ -152,14 +152,14 @@ export function EmailMessage({
       onKeyDownCapture={(event) => {
         // Handle draft Escape before the rich-text editor consumes it.
         if (
-          selected !== undefined &&
+          composeMode &&
           event.key === "Escape" &&
           !event.defaultPrevented &&
           isTypingTarget(event.target) &&
           event.target instanceof Element &&
           event.target.closest('[data-inline-reply="true"]') &&
           !event.target.closest(
-            '[role="dialog"], [role="menu"], [role="listbox"]',
+            '[role="dialog"], [role="menu"], [role="listbox"], [role="combobox"][aria-expanded="true"]',
           )
         ) {
           event.preventDefault();

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -125,19 +125,6 @@ export function EmailMessage({
   const onMessageKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       if (
-        selected !== undefined &&
-        event.key === "Escape" &&
-        !event.defaultPrevented &&
-        isTypingTarget(event.target) &&
-        event.target instanceof Element &&
-        event.target.closest('[data-inline-reply="true"]')
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-        event.currentTarget.focus({ preventScroll: true });
-        return;
-      }
-      if (
         event.target !== event.currentTarget ||
         (event.key !== "Enter" && event.key !== " ")
       )
@@ -150,7 +137,7 @@ export function EmailMessage({
         onToggle?.();
       }
     },
-    [expanded, onReply, onToggle, selected, showReplyButton],
+    [expanded, onReply, onToggle, showReplyButton],
   );
 
   return (
@@ -162,6 +149,24 @@ export function EmailMessage({
       onFocusCapture={onSelect}
       onClickCapture={onSelect}
       onKeyDown={onMessageKeyDown}
+      onKeyDownCapture={(event) => {
+        // Handle draft Escape before the rich-text editor consumes it.
+        if (
+          selected !== undefined &&
+          event.key === "Escape" &&
+          !event.defaultPrevented &&
+          isTypingTarget(event.target) &&
+          event.target instanceof Element &&
+          event.target.closest('[data-inline-reply="true"]') &&
+          !event.target.closest(
+            '[role="dialog"], [role="menu"], [role="listbox"]',
+          )
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.currentTarget.focus({ preventScroll: true });
+        }
+      }}
       className={cn(
         "group/message min-w-0 border-l-2 border-transparent outline-none transition-colors focus-within:border-primary",
         selected && "border-primary",

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -128,7 +128,9 @@ export function EmailMessage({
         selected !== undefined &&
         event.key === "Escape" &&
         !event.defaultPrevented &&
-        isTypingTarget(event.target)
+        isTypingTarget(event.target) &&
+        event.target instanceof Element &&
+        event.target.closest('[data-inline-reply="true"]')
       ) {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
Escape while editing an inline draft now focuses the current email before a second Escape returns to the list.

- Handles the first Escape in the message keyboard handler and preserves existing list navigation.
- Adds a browser regression test covering focus, draft preservation, and return-to-list navigation.
- Validation is handled by CI; no additional database or network calls are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Escape while composing a reply now preserves the draft and returns focus to the message.
  * The first Escape press keeps the thread URL unchanged.
  * Pressing Escape a second time returns to the conversation list and hides the message.
  * Reply interactions now behave consistently when dismissing inline reply controls, including when other menus or dialogs are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->