### PR TITLE
mail: Separate thread fetching and share split query construction

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -19,7 +19,7 @@ import { LoadingMiniSpinner } from "@/components/Loading";
 import { Button } from "@/components/ui/button";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { cn } from "@/utils/utils";
+import { cn } from "@/utils";
 
 export type ThreadListProps = {
   threads: ListThread[];

--- a/apps/web/app/api/threads/all/route.ts
+++ b/apps/web/app/api/threads/all/route.ts
@@ -6,6 +6,7 @@ import { withAuth } from "@/utils/middleware";
 import { loadCombinedThreads } from "@/utils/threads/load-combined";
 import { loadThreads, toListThreads } from "@/utils/threads/load";
 import { threadsQuery } from "@/utils/threads/validation";
+import { labelIdsToThreadsQuery } from "@/utils/mail/split-query";
 import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 
 export const maxDuration = 30;
@@ -63,9 +64,7 @@ export const GET = withAuth("threads/all", async (request) => {
 
         const loaded = await loadThreads({
           query: threadsQuery.parse({
-            ...(matchingLabelIds.length === 1
-              ? { labelIds: [matchingLabelIds[0], "INBOX"] }
-              : { labelIds: ["INBOX"], anyLabelIds: matchingLabelIds }),
+            ...labelIdsToThreadsQuery(matchingLabelIds),
             limit,
             nextPageToken: pageToken,
           }),

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -24,9 +24,7 @@ export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
     case MailSplitKind.LABEL: {
       if (!split.values.length)
         throw new Error(`Split "${split.name}" has no label`);
-      if (split.values.length === 1)
-        return { labelIds: [split.values[0], "INBOX"] };
-      return { labelIds: ["INBOX"], anyLabelIds: split.values };
+      return labelIdsToThreadsQuery(split.values);
     }
     case MailSplitKind.CATEGORY: {
       const [category] = split.values;
@@ -65,4 +63,9 @@ export function getPortableLabelSplits(
       ? [{ ...split, labelNames }]
       : [];
   });
+}
+
+export function labelIdsToThreadsQuery(labelIds: string[]): ThreadsQuery {
+  if (labelIds.length === 1) return { labelIds: [labelIds[0], "INBOX"] };
+  return { labelIds: ["INBOX"], anyLabelIds: labelIds };
 }

--- a/apps/web/utils/threads/fetch-page.test.ts
+++ b/apps/web/utils/threads/fetch-page.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchThreadsPage } from "@/utils/threads/fetch-page";
+
+describe("fetchThreadsPage", () => {
+  it.each([
+    { anyLabelIds: ["label-a"] },
+    { anyLabelIds: ["label-a", "label-b"] },
+  ])("preserves a required singular label when matching any of $anyLabelIds", async ({
+    anyLabelIds,
+  }) => {
+    const emailProvider = {
+      getThreadsWithQuery: vi.fn(async ({ query }) => ({
+        threads: query.labelIds.includes("required-label")
+          ? []
+          : [{ id: "outside-required-label", messages: [] }],
+      })),
+    };
+
+    const result = await fetchThreadsPage({
+      query: { labelId: "required-label", anyLabelIds },
+      emailProvider: emailProvider as never,
+      maxResults: 50,
+      messageFormat: "metadata",
+    });
+
+    expect(result.threads).toEqual([]);
+  });
+});

--- a/apps/web/utils/threads/fetch-page.test.ts
+++ b/apps/web/utils/threads/fetch-page.test.ts
@@ -24,5 +24,14 @@ describe("fetchThreadsPage", () => {
     });
 
     expect(result.threads).toEqual([]);
+    const queriedLabels = emailProvider.getThreadsWithQuery.mock.calls.map(
+      ([{ query }]) => query.labelIds,
+    );
+    expect(queriedLabels).toHaveLength(anyLabelIds.length);
+    expect(queriedLabels).toEqual(
+      expect.arrayContaining(
+        anyLabelIds.map((labelId) => ["required-label", labelId]),
+      ),
+    );
   });
 });

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -34,10 +34,14 @@ export async function fetchThreadsPage({
 
   // A repeated label would run the same query twice and collide in the cursor.
   const anyLabelIds = [...new Set(query.anyLabelIds ?? [])];
+  let requiredLabelIds = query.labelIds ?? [];
+  if (!requiredLabelIds.length && query.labelId) {
+    requiredLabelIds = [query.labelId];
+  }
   const queryForLabels = (labelIds: string[]): ThreadsQuery => ({
     ...query,
     anyLabelIds: undefined,
-    labelIds: [...(query.labelIds ?? []), ...labelIds],
+    labelIds: [...requiredLabelIds, ...labelIds],
   });
 
   if (anyLabelIds.length < 2) {

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -1,0 +1,81 @@
+import type { EmailProvider, EmailThread } from "@/utils/email/types";
+import { mergePaginatedSources } from "@/utils/threads/merge-paginated-sources";
+import { getThreadTimestamp } from "@/utils/threads/sort";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+
+const LABEL_CONCURRENCY = 4;
+
+/**
+ * `anyLabelIds` has no provider equivalent — Gmail's `labelIds` and Graph's
+ * category filter both mean "all of these". Two or more labels are served by
+ * running one query per label and merging them newest-first.
+ */
+export async function fetchThreadsPage({
+  query,
+  emailProvider,
+  maxResults,
+  pageToken,
+  messageFormat,
+}: {
+  query: ThreadsQuery;
+  emailProvider: EmailProvider;
+  maxResults: number;
+  pageToken?: string;
+  messageFormat: "full" | "metadata";
+}): Promise<{ threads: EmailThread[]; nextPageToken?: string }> {
+  if (query.q) {
+    return emailProvider.searchThreads({
+      query: query.q,
+      maxResults,
+      pageToken,
+      messageFormat,
+    });
+  }
+
+  // A repeated label would run the same query twice and collide in the cursor.
+  const anyLabelIds = [...new Set(query.anyLabelIds ?? [])];
+  const queryForLabels = (labelIds: string[]): ThreadsQuery => ({
+    ...query,
+    anyLabelIds: undefined,
+    labelIds: [...(query.labelIds ?? []), ...labelIds],
+  });
+
+  if (anyLabelIds.length < 2) {
+    return emailProvider.getThreadsWithQuery({
+      query: anyLabelIds.length ? queryForLabels(anyLabelIds) : query,
+      maxResults,
+      pageToken,
+      messageFormat,
+    });
+  }
+
+  const merged = await mergePaginatedSources({
+    sources: anyLabelIds.map((labelId) => ({ id: labelId })),
+    cursor: pageToken ?? null,
+    limit: maxResults,
+    concurrency: LABEL_CONCURRENCY,
+    compare: (left, right) =>
+      getThreadTimestamp(right) - getThreadTimestamp(left),
+    getItemId: (thread: EmailThread) => thread.id,
+    // A thread carrying several of the labels must still show up once.
+    dedupeItemKey: (thread) => thread.id,
+    loadPage: async ({ source, pageToken: labelPageToken }) => {
+      const page = await emailProvider.getThreadsWithQuery({
+        query: queryForLabels([source.id]),
+        maxResults,
+        pageToken: labelPageToken,
+        messageFormat,
+      });
+      return { items: page.threads, nextPageToken: page.nextPageToken };
+    },
+    // Dropping a failed label would silently narrow the split.
+    onSourceError: ({ error }) => {
+      throw error;
+    },
+  });
+
+  return {
+    threads: merged.items,
+    nextPageToken: merged.nextPageToken ?? undefined,
+  };
+}

--- a/apps/web/utils/threads/load.ts
+++ b/apps/web/utils/threads/load.ts
@@ -1,12 +1,9 @@
-import type { EmailProvider, EmailThread } from "@/utils/email/types";
+import type { EmailProvider } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import { isDefined } from "@/utils/types";
 import prisma from "@/utils/prisma";
-import { mergePaginatedSources } from "@/utils/threads/merge-paginated-sources";
-import { getThreadTimestamp } from "@/utils/threads/sort";
+import { fetchThreadsPage } from "@/utils/threads/fetch-page";
 import type { ThreadsQuery } from "@/utils/threads/validation";
-
-const LABEL_CONCURRENCY = 4;
 
 export async function loadThreads({
   query,
@@ -138,79 +135,4 @@ function aggregateThreadPlans<
   }
 
   return [...latestByRule.values()];
-}
-
-/**
- * `anyLabelIds` has no provider equivalent — Gmail's `labelIds` and Graph's
- * category filter both mean "all of these". Two or more labels are served by
- * running one query per label and merging them newest-first.
- */
-async function fetchThreadsPage({
-  query,
-  emailProvider,
-  maxResults,
-  pageToken,
-  messageFormat,
-}: {
-  query: ThreadsQuery;
-  emailProvider: EmailProvider;
-  maxResults: number;
-  pageToken?: string;
-  messageFormat: "full" | "metadata";
-}): Promise<{ threads: EmailThread[]; nextPageToken?: string }> {
-  if (query.q) {
-    return emailProvider.searchThreads({
-      query: query.q,
-      maxResults,
-      pageToken,
-      messageFormat,
-    });
-  }
-
-  // A repeated label would run the same query twice and collide in the cursor.
-  const anyLabelIds = [...new Set(query.anyLabelIds ?? [])];
-  const queryForLabels = (labelIds: string[]): ThreadsQuery => ({
-    ...query,
-    anyLabelIds: undefined,
-    labelIds: [...(query.labelIds ?? []), ...labelIds],
-  });
-
-  if (anyLabelIds.length < 2) {
-    return emailProvider.getThreadsWithQuery({
-      query: anyLabelIds.length ? queryForLabels(anyLabelIds) : query,
-      maxResults,
-      pageToken,
-      messageFormat,
-    });
-  }
-
-  const merged = await mergePaginatedSources({
-    sources: anyLabelIds.map((labelId) => ({ id: labelId })),
-    cursor: pageToken ?? null,
-    limit: maxResults,
-    concurrency: LABEL_CONCURRENCY,
-    compare: (left, right) =>
-      getThreadTimestamp(right) - getThreadTimestamp(left),
-    getItemId: (thread: EmailThread) => thread.id,
-    // A thread carrying several of the labels must still show up once.
-    dedupeItemKey: (thread) => thread.id,
-    loadPage: async ({ source, pageToken: labelPageToken }) => {
-      const page = await emailProvider.getThreadsWithQuery({
-        query: queryForLabels([source.id]),
-        maxResults,
-        pageToken: labelPageToken,
-        messageFormat,
-      });
-      return { items: page.threads, nextPageToken: page.nextPageToken };
-    },
-    // Dropping a failed label would silently narrow the split.
-    onSourceError: ({ error }) => {
-      throw error;
-    },
-  });
-
-  return {
-    threads: merged.items,
-    nextPageToken: merged.nextPageToken ?? undefined,
-  };
 }


### PR DESCRIPTION
Separate provider-page fetching from thread enrichment and centralize label-query construction for normal splits and combined inboxes.

- Move provider fetching and multi-label pagination into `utils/threads/fetch-page.ts` and share `labelIdsToThreadsQuery` across both split paths.
- Preserve a required singular label when combining it with optional labels, with two regression tests covering single-label and multi-label queries.
- Correct the shared utility import in the thread list to unblock the build.
- Validation: 40 focused tests passed; repository lint passed after formatting, while a local browser comparison was blocked by database authentication.
- Database and network call counts remain unchanged, with no added hot-path I/O.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread loading for searches and label-based filters.
  - Combined results across multiple labels are now sorted newest first and deduplicated.
  - Required labels are consistently preserved in filtered thread lists.
  - Improved pagination and next-page behavior for filtered results.
  - Retrieval errors are now surfaced instead of silently hidden.
  - Multi-label filtered views now provide more complete and reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->