### PR TITLE
fix(mail): show starred indicator in email reader

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
@@ -43,4 +43,14 @@ test("toggles a star with S and the command palette while preserving unread", as
   await expect(
     row.getByText("Starred conversation", { exact: true }),
   ).toHaveCount(0);
+  await row.click();
+  const readerStarStatus = page
+    .getByTestId("thread-reader")
+    .getByRole("img", { name: "Starred conversation", exact: true });
+  await expect(readerStarStatus).toHaveCount(0);
+  await page.keyboard.press("s");
+  await expect(readerStarStatus).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "starred-reader-subject");
+  await page.keyboard.press("s");
+  await expect(readerStarStatus).toHaveCount(0);
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ReaderToolbar.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 
 type ReaderToolbarProps = {
   subject: string;
+  isStarred: boolean;
   labels: EmailMessageCellLabel[];
   /**
    * Chips navigate to a label's view and nothing else: a label carries no
@@ -37,6 +38,7 @@ type ReaderToolbarProps = {
  */
 export function ReaderToolbar({
   subject,
+  isStarred,
   labels,
   labelHref,
   onRemoveLabel,
@@ -62,9 +64,19 @@ export function ReaderToolbar({
 
       <div className="min-w-56 flex-1">
         <div className="flex flex-wrap items-center gap-2">
-          <h1 className="font-title font-medium text-2xl text-foreground leading-tight tracking-tight">
-            {subject}
-          </h1>
+          <div className="flex min-w-0 items-center gap-2">
+            {isStarred && (
+              <span
+                className="size-1.5 shrink-0 rounded-full bg-yellow-400"
+                role="img"
+                aria-label="Starred conversation"
+                title="Starred conversation"
+              />
+            )}
+            <h1 className="font-title font-medium text-2xl text-foreground leading-tight tracking-tight">
+              {subject}
+            </h1>
+          </div>
           {labels.map((label) => (
             <MailLabelChip
               color={label.color}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -9,6 +9,7 @@ import {
 import dynamic from "next/dynamic";
 import { Loader2Icon, MailIcon } from "lucide-react";
 import { ReaderToolbar } from "@/app/(app)/[emailAccountId]/mail/ReaderToolbar";
+import { isThreadStarred } from "@/app/(app)/[emailAccountId]/mail/star-state";
 import type {
   ListThread,
   MailLayoutMode,
@@ -134,6 +135,7 @@ export function ThreadReader({
     messageExpansion?: ComponentProps<typeof ReaderToolbar>["messageExpansion"],
   ) => (
     <ReaderToolbar
+      isStarred={isThreadStarred(thread?.messages ?? messages)}
       messageExpansion={messageExpansion}
       labelHref={labelHref}
       labels={labels}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -135,7 +135,9 @@ export function ThreadReader({
     messageExpansion?: ComponentProps<typeof ReaderToolbar>["messageExpansion"],
   ) => (
     <ReaderToolbar
-      isStarred={isThreadStarred(thread?.messages ?? messages)}
+      isStarred={isThreadStarred(
+        thread?.messages.length ? thread.messages : messages,
+      )}
       messageExpansion={messageExpansion}
       labelHref={labelHref}
       labels={labels}


### PR DESCRIPTION
Shows a yellow indicator beside the email subject when a conversation is starred, using the existing shared star-state logic.

- Adds browser coverage for starring and unstarring in the reader, including a screenshot checkpoint.
- Formatting and CI browser checks passed, and the starred-reader screenshot was inspected.
- Adds no database or network calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The conversation reader now shows a visible starred indicator beside the subject when a thread is starred.
  - The indicator reflects the conversation’s current starred status, including changes made with the keyboard shortcut.
  - Keyboard shortcuts can star or unstar conversations directly from the reader view.

- **Bug Fixes**
  - Improved consistency between a conversation’s starred state and its display in the reader view, including when starring or unstarring conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->