### PR TITLE
mail: Align and lighten date section headings

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -19,6 +19,7 @@ import { LoadingMiniSpinner } from "@/components/Loading";
 import { Button } from "@/components/ui/button";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/utils/utils";
 
 export type ThreadListProps = {
   threads: ListThread[];
@@ -151,7 +152,10 @@ export function ThreadList({
                   {group.label ? (
                     <div
                       aria-hidden
-                      className="pt-4 pr-5 pb-1.5 pl-9 font-medium text-muted-foreground text-sm"
+                      className={cn(
+                        "pt-4 pr-5 pb-1.5 font-normal text-muted-foreground text-sm",
+                        selectionEnabled ? "pl-[3.25rem]" : "pl-8",
+                      )}
                     >
                       {group.label}
                     </div>


### PR DESCRIPTION
Align mail date section headings with sender text and reduce their font weight to regular. Account for the narrower leading indicator when selection is disabled.

- Validation: Biome and whitespace checks passed.
- Browser layout verification was blocked by local database authentication failure.
- Styling-only change with no additional database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated thread list date-group headers with improved alignment when selection is enabled.
  * Reduced the font weight of date-group labels for a lighter visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->