### PR TITLE
fix: open settings dialog from command palette

### DIFF
--- a/apps/web/__tests__/playwright/emulated/settings/settings-dialog.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/settings-dialog.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 import { test } from "../playwright-test";
 import { getEmailAccount } from "../account-test-helpers";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 
 test("opens settings in a dialog from a url and from the nav", async ({
   page,
@@ -36,3 +37,43 @@ test("opens settings in a dialog from a url and from the nav", async ({
   await expect(dialog).toBeHidden();
   await expect(page).not.toHaveURL(/settings=open/);
 });
+
+for (const view of ["mail", "settings"]) {
+  test(`opens settings from Command K in ${view} without leaving the page`, async ({
+    page,
+  }, testInfo) => {
+    const { id: emailAccountId } = await getEmailAccount(page);
+    const pathname = view === "mail" ? `/${emailAccountId}/mail` : "/settings";
+    await page.goto(pathname);
+    await expect(
+      view === "mail"
+        ? page.getByRole("listbox", { name: "Conversations" })
+        : page.getByRole("heading", { name: "Settings", exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await page.keyboard.press(`${modifier}+KeyK`);
+    const search = page.getByPlaceholder("Type a command or search...");
+    await expect(search).toBeVisible();
+    await search.fill("settings");
+    await page.getByRole("option", { name: "Settings", exact: true }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Email Accounts", exact: true }),
+    ).toBeVisible();
+    await expect(search).toBeHidden();
+    expect(new URL(page.url()).pathname).toBe(pathname);
+    await expect(page).toHaveURL(/settings=open/);
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      `command-k-settings-${view}`,
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+    expect(new URL(page.url()).pathname).toBe(pathname);
+    await expect(page).not.toHaveURL(/settings=open/);
+  });
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -19,7 +19,7 @@ import { LoadingMiniSpinner } from "@/components/Loading";
 import { Button } from "@/components/ui/button";
 import type { EmailLabels } from "@/providers/email-label-types";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { cn } from "@/utils/utils";
+import { cn } from "@/utils";
 
 export type ThreadListProps = {
   threads: ListThread[];

--- a/apps/web/hooks/useCommandPaletteCommands.ts
+++ b/apps/web/hooks/useCommandPaletteCommands.ts
@@ -17,6 +17,7 @@ import {
   MailsIcon,
 } from "lucide-react";
 import type { Command } from "@/lib/commands/types";
+import { useSettingsDialog } from "@/hooks/useSettingsDialog";
 import { useRules } from "@/hooks/useRules";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
@@ -33,6 +34,7 @@ export function useCommandPaletteCommands({
   enabled?: boolean;
 } = {}) {
   const router = useRouter();
+  const { openSettings } = useSettingsDialog();
   const { emailAccountId, provider } = useAccount();
   const { data: rulesData, isLoading: rulesLoading } = useRules(
     undefined,
@@ -43,7 +45,21 @@ export function useCommandPaletteCommands({
   const showIntegrations = useIntegrationsEnabled();
 
   const commands = useMemo<Command[]>(() => {
-    if (!enabled) return [];
+    const generalSettingsCommands: Command[] = [
+      {
+        id: "settings-general",
+        label: "Settings",
+        description: "General account settings",
+        icon: SettingsIcon,
+        section: "settings",
+        priority: 1,
+        keywords: ["settings", "preferences", "configuration"],
+        action: () => {
+          openSettings();
+        },
+      },
+    ];
+    if (!enabled) return generalSettingsCommands;
 
     const navigationItems = [
       {
@@ -121,16 +137,6 @@ export function useCommandPaletteCommands({
 
     const settingsCommands: Command[] = [
       {
-        id: "settings-general",
-        label: "Settings",
-        description: "General account settings",
-        icon: SettingsIcon,
-        section: "settings",
-        priority: 1,
-        keywords: ["settings", "preferences", "configuration"],
-        action: () => router.push("/settings"),
-      },
-      {
         id: "settings-assistant",
         label: "Assistant Settings",
         description: "Configure AI assistant behavior",
@@ -185,11 +191,17 @@ export function useCommandPaletteCommands({
         router.push(prefixPath(emailAccountId, `/assistant/rule/${rule.id}`)),
     }));
 
-    return [...navigationCommands, ...settingsCommands, ...ruleCommands];
+    return [
+      ...navigationCommands,
+      ...generalSettingsCommands,
+      ...settingsCommands,
+      ...ruleCommands,
+    ];
   }, [
     emailAccountId,
     enabled,
     provider,
+    openSettings,
     router,
     rulesData,
     showCleaner,


### PR DESCRIPTION
Make Settings available in the mail command palette and open the shared settings dialog from both mail and non-mail views, preserving the current page through the existing settings hook.

- Add browser coverage for opening and closing settings from both views.
- Correct a mail thread utility import that blocked the CI build.
- Validation: formatting, six command-palette unit tests, and settings browser tests pass; both dialog screenshots were visually checked.