### PR TITLE
fix: clarify promotional email classification

### DIFF
--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -46,6 +46,89 @@ const rules = [
   conversations,
 ];
 
+const promotionalBoundaryCases = [
+  {
+    name: "founder coordinating their own launch",
+    email: getEmail({
+      from: "partner@launchstudio.example",
+      subject: "Your launch campaign is ready for approval",
+      content:
+        "Hi, we've finished the landing page and promotional emails for your company's launch. Please review the attached campaign copy and confirm whether we can publish tomorrow. We still need your decision on the introductory offer before we send it to your subscribers.",
+    }),
+    expectedRule: "Conversations",
+  },
+  {
+    name: "agency client requesting campaign changes",
+    email: getEmail({
+      from: "client@retailer.example",
+      subject: "Changes to our summer sale ads",
+      content:
+        "Hi team, your agency manages our paid campaigns. Please replace the 20% discount with free shipping in this week's ads and send over the revised creative for approval. Can you also explain why conversions dropped yesterday? We need your recommendation before increasing the budget.",
+    }),
+    expectedRule: "Conversations",
+  },
+  {
+    name: "automated alert about the user's advertising campaign",
+    email: getEmail({
+      from: "alerts@adplatform.example",
+      subject: "Your launch ads have stopped running",
+      content:
+        "The campaign you manage, Spring Launch, has been paused because its payment method was declined. Your ads are no longer being served. Update your billing details to resume delivery. View affected campaigns in your advertising account.",
+    }),
+    expectedRule: "Notification",
+  },
+  {
+    name: "subscriber dashboard magic link",
+    email: getEmail({
+      from: "Member Benefits <support@makersdigest.example>",
+      subject: "Your magic link to unlock your member benefits",
+      content:
+        "Thanks for being a paid member of Makers Digest! Open your dashboard to activate the partner apps included with your membership. Unlock your benefits: https://members.makersdigest.example/auth/callback#token=synthetic-example. Enjoy creating with your new apps!",
+    }),
+    expectedRule: "Notification",
+  },
+  {
+    name: "requested verification with an upsell",
+    email: getEmail({
+      from: "hello@canvascloud.example",
+      subject: "Confirm your email and start creating",
+      content:
+        "Enter code 123456 to verify the account you just created. It expires in 10 minutes. Once verified, explore our premium templates or upgrade for unlimited designs.",
+    }),
+    expectedRule: "Notification",
+  },
+  {
+    name: "account recovery in Spanish with promotional footer",
+    email: getEmail({
+      from: "cuentas@studio.example",
+      subject: "Recupera el acceso a tu cuenta",
+      content:
+        "Recibimos tu solicitud para restablecer la contraseña. Continúa aquí: https://studio.example/reset?token=synthetic-example. El enlace caduca en 15 minutos. Descubre también nuestra oferta anual con un 30% de descuento.",
+    }),
+    expectedRule: "Notification",
+  },
+  {
+    name: "optional member benefit promotion",
+    email: getEmail({
+      from: "Member Benefits <support@makersdigest.example>",
+      subject: "Explore this month's free member apps",
+      content:
+        "Your membership includes a growing collection of partner apps. This month, try a new design tool and a writing assistant at no extra cost. Browse the offers any time at https://members.makersdigest.example/benefits. Pick something new to try!",
+    }),
+    expectedRule: "Marketing",
+  },
+  {
+    name: "promotional urgency without an account obligation",
+    email: getEmail({
+      from: "offers@canvascloud.example",
+      subject: "Action required: your exclusive offer expires tonight",
+      content:
+        "Claim 40% off an optional upgrade before midnight. Sign in to view the deal and unlock premium templates. Your current plan continues as usual if you skip this offer.",
+    }),
+    expectedRule: "Marketing",
+  },
+];
+
 const multiRuleStressRules = [
   getRule(
     "Receipts, invoices, purchase confirmations, payment receipts, renewal receipts, and order summaries where a payment succeeded or an invoice is available.",
@@ -723,6 +806,39 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
       );
     }
   });
+
+  describeEvalMatrix(
+    "promotional boundary",
+    (model, emailAccount) => {
+      for (const tc of promotionalBoundaryCases) {
+        test(
+          tc.name,
+          async () => {
+            const result = await aiChooseRule({
+              email: tc.email,
+              rules,
+              emailAccount,
+              logger,
+            });
+            const actual = result.rules.map(({ rule }) => rule.name);
+            const pass = actual.length === 1 && actual[0] === tc.expectedRule;
+
+            evalReporter.record({
+              testName: `promotional boundary: ${tc.name}`,
+              model: model.label,
+              pass,
+              expected: tc.expectedRule,
+              actual: actual.join(", ") || "no match",
+            });
+
+            expect(actual).toEqual([tc.expectedRule]);
+          },
+          TIMEOUT,
+        );
+      }
+    },
+    { multiRuleSelectionEnabled: true },
+  );
 
   describeEvalMatrix(
     "choose-rule multi-rule false positives",

--- a/apps/web/prisma/migrations/20260908120000_clarify_marketing_rule_default/migration.sql
+++ b/apps/web/prisma/migrations/20260908120000_clarify_marketing_rule_default/migration.sql
@@ -1,0 +1,6 @@
+-- Update the stock marketing prompt; preserve customized instructions.
+UPDATE "Rule"
+SET "updatedAt" = CURRENT_TIMESTAMP,
+    "instructions" = 'Marketing: Promotions, sales, and offers that can be safely archived. Exclude emails whose main purpose is account access, a transaction, or a service update, even if they include promotional content.'
+WHERE "systemType" = 'MARKETING'
+  AND "instructions" = 'Marketing: Promotional emails about products, services, sales, or offers';

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -253,7 +253,7 @@ async function getAiResponseMultiRule({
   <priority>
   - Review all available rules and select those that genuinely match this email.
   - You can select multiple rules, but BE SELECTIVE - it's rare that you need to select more than 1-2 rules.
-  - Respect each rule's stated scope. If none applies, set "noMatchFound" to true rather than choosing the closest category.
+  - Only set "noMatchFound" to true if no rules can reasonably apply. There is usually a rule that matches.
   </priority>
 
   <isPrimary_field>

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -253,7 +253,7 @@ async function getAiResponseMultiRule({
   <priority>
   - Review all available rules and select those that genuinely match this email.
   - You can select multiple rules, but BE SELECTIVE - it's rare that you need to select more than 1-2 rules.
-  - Only set "noMatchFound" to true if no rules can reasonably apply. There is usually a rule that matches.
+  - Respect each rule's stated scope. If none applies, set "noMatchFound" to true rather than choosing the closest category.
   </priority>
 
   <isPrimary_field>

--- a/apps/web/utils/rule/consts.ts
+++ b/apps/web/utils/rule/consts.ts
@@ -80,7 +80,7 @@ const ruleConfig: Record<
   [SystemType.MARKETING]: {
     name: "Marketing",
     instructions:
-      "Marketing: Promotional emails about products, services, sales, or offers",
+      "Marketing: Promotions, sales, and offers that can be safely archived. Exclude emails whose main purpose is account access, a transaction, or a service update, even if they include promotional content.",
     label: "Marketing",
     runOnThreads: false,
     categoryAction: "label_archive",


### PR DESCRIPTION
Clarifies the default Marketing rule so promotional copy does not cause account-access, transactional, or service emails to be archived.

- Adds eight synthetic classification evals covering access messages, campaign work, and ordinary promotions.
- Migrates only Marketing rules that exactly match the previous default, preserving customized instructions.
- Validation: all eight boundary evals passed; the full classification run passed 43/44, with one failure in a separate custom-rule fixture; formatting and in-memory migration predicate checks passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Clarified marketing email classification to better identify promotional, sales, and offer-related messages.
  - Account-access emails, transaction notifications, and service updates are no longer classified as marketing solely because they include promotional content.
  - Improved handling of borderline promotional scenarios, including automated alerts, verification messages, account recovery emails, and member benefit offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->