### PR TITLE
ci: Reduce browser jobs and narrow shared-feature coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
-      targets: ${{ steps.targets.outputs.targets }}
+      batches: ${{ steps.targets.outputs.batches }}
       changed_tests: ${{ steps.changes.outputs.PLAYWRIGHT_CHANGED_TEST_FILES }}
     steps:
       - uses: actions/checkout@v4
@@ -121,23 +121,23 @@ jobs:
         run: bash scripts/pnpm-install-without-desktop.sh --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-      - name: Select isolated specs
+      - name: Select isolated spec batches
         id: targets
         working-directory: apps/web
         run: |
-          targets="$(node __tests__/playwright/run-emulated-suite.mjs --list-targets)"
-          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          batches="$(node __tests__/playwright/run-emulated-suite.mjs --list-batches)"
+          echo "batches=$batches" >> "$GITHUB_OUTPUT"
 
   playwright:
-    name: E2E ${{ matrix.target.name }}
+    name: E2E ${{ matrix.batch.name }}
     needs: select
-    if: needs.select.outputs.targets != '[]'
+    if: needs.select.outputs.batches != '[]'
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.select.outputs.targets) }}
+        batch: ${{ fromJSON(needs.select.outputs.batches) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:16
@@ -224,15 +224,18 @@ jobs:
 
       - name: Run Playwright tests
         id: playwright_tests
-        run: pnpm -F inbox-zero-ai test:playwright:emulated "$TEST_TARGET"
+        shell: bash
+        run: |
+          mapfile -t targets < <(jq -r '.[]' <<< "$TEST_TARGETS")
+          pnpm -F inbox-zero-ai test:playwright:emulated "${targets[@]}"
         env:
-          TEST_TARGET: ${{ matrix.target.path }}
+          TEST_TARGETS: ${{ toJSON(matrix.batch.paths) }}
 
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-spec-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target.name }}
+          name: playwright-spec-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.batch.name }}
           path: |
             apps/web/.tmp/playwright/blob-report
             apps/web/test-results
@@ -291,7 +294,7 @@ jobs:
         if: always()
         env:
           SELECTION_RESULT: ${{ needs.select.result }}
-          TARGETS: ${{ needs.select.outputs.targets }}
+          TARGETS: ${{ needs.select.outputs.batches }}
           TEST_RESULT: ${{ needs.playwright.result }}
         run: |
           test "$SELECTION_RESULT" = success

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         batch: ${{ fromJSON(needs.select.outputs.batches) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.batch.timeoutMinutes }}
     services:
       postgres:
         image: postgres:16

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -23,7 +23,12 @@ The package-level emulated command runs each spec with a fresh Next process,
 emulator, and authenticated mailbox, then merges the reports. Tests inside a
 spec remain serial. This avoids state leaking between specs and bounds the
 development server's compiled route graph. CI selects the affected specs once
-and runs each spec in its own matrix job.
+and distributes them across at most 12 matrix jobs. Each job installs dependencies,
+browsers, and database services once, then runs its specs sequentially with the
+same per-spec isolation. Selections of 12 or fewer specs retain one job per spec.
+The selection job lists each batch's specs in its GitHub summary; each test job
+reports per-spec durations and exit statuses. A failing spec does not skip the
+remaining specs in its batch, and any failure fails the combined `Web E2E` check.
 Pass one or more areas or spec paths when iterating on focused flows:
 
 ```sh
@@ -70,7 +75,7 @@ Shared Playwright setup and configuration changes use the full suite. Pushes to
 Run `node apps/web/scripts/measure-playwright-selection.mjs` from the repository
 root to record selected spec counts for representative changes. An optional
 first argument loads another selector module, allowing before/after comparisons
-against the same source tree. These are job-count measurements, not wall-clock
+against the same source tree. These are spec-count measurements, not wall-clock
 predictions; see [the initial comparison](selection-comparison.md).
 
 CI captures the final state of every selected test, and tests can add

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -23,9 +23,9 @@ The package-level emulated command runs each spec with a fresh Next process,
 emulator, and authenticated mailbox, then merges the reports. Tests inside a
 spec remain serial. This avoids state leaking between specs and bounds the
 development server's compiled route graph. CI selects the affected specs once
-and distributes them across at most 12 matrix jobs. Each job installs dependencies,
+and distributes them across at most 20 matrix jobs. Each job installs dependencies,
 browsers, and database services once, then runs its specs sequentially with the
-same per-spec isolation. Selections of 12 or fewer specs retain one job per spec.
+same per-spec isolation. Selections of 20 or fewer specs retain one job per spec.
 The selection job lists each batch's specs in its GitHub summary; each test job
 reports per-spec durations and exit statuses. A failing spec does not skip the
 remaining specs in its batch, and any failure fails the combined `Web E2E` check.

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -29,8 +29,9 @@ same per-spec isolation. Selections of 20 or fewer specs retain one job per spec
 The selection job lists each batch's specs in its GitHub summary; each test job
 reports per-spec durations and exit statuses. A failing spec does not skip the
 remaining specs in its batch, and any failure fails the combined `Web E2E` check.
-CI bounds each Playwright invocation to six minutes and allocates eight minutes
-per selected spec to its job, including setup and cleanup headroom.
+CI bounds each Playwright invocation to eight minutes, including cold web-server
+startup and authentication setup. Each job gets four additional minutes for
+dependency installation and artifact handling, plus eight minutes per selected spec.
 Pass one or more areas or spec paths when iterating on focused flows:
 
 ```sh

--- a/apps/web/__tests__/playwright/README.md
+++ b/apps/web/__tests__/playwright/README.md
@@ -29,6 +29,8 @@ same per-spec isolation. Selections of 20 or fewer specs retain one job per spec
 The selection job lists each batch's specs in its GitHub summary; each test job
 reports per-spec durations and exit statuses. A failing spec does not skip the
 remaining specs in its batch, and any failure fails the combined `Web E2E` check.
+CI bounds each Playwright invocation to six minutes and allocates eight minutes
+per selected spec to its job, including setup and cleanup headroom.
 Pass one or more areas or spec paths when iterating on focused flows:
 
 ```sh
@@ -64,7 +66,11 @@ reuse existing specs and screenshot checkpoints. Shared app dependencies, route
 entry points, and area files with no matching feature keep the whole area.
 Missing entry points or a spec without a declaration also disable narrowing for
 that area. Areas without a manifest retain their existing selection behavior.
-Mail is the first area with feature declarations.
+Mail is the first area with feature declarations. Explicit shared-feature entry
+points in `sharedFeatureMappings` use focused cross-page coverage: command-palette
+changes run its command, starring, theme, and settings-dialog specs. This mapping
+does not extend to those entry points' imported foundations. Missing target specs
+fall back to broad coverage, and other files in the PR still add their own tests.
 
 On PRs, UI dependencies under `utils/` and `lib/` also trigger selection; unrelated
 utilities with no connection to tested routes are skipped. Unit-test changes

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -12,10 +13,18 @@ import {
   fullSuites,
   selectChangedPlaywrightTargets,
 } from "../../utils/playwright/emulated-suite-selection.mjs";
-import { expandPlaywrightTargets } from "../../utils/playwright/emulated-suite-targets.mjs";
+import {
+  batchPlaywrightTargets,
+  expandPlaywrightTargets,
+} from "../../utils/playwright/emulated-suite-targets.mjs";
 const listTargets = process.argv.includes("--list-targets");
+const listBatches = process.argv.includes("--list-batches");
 const requestedPaths = getRequestedPlaywrightPaths(
-  process.argv.slice(2).filter((argument) => argument !== "--list-targets"),
+  process.argv
+    .slice(2)
+    .filter(
+      (argument) => !["--list-targets", "--list-batches"].includes(argument),
+    ),
 );
 const changedSelection = requestedPaths.length
   ? undefined
@@ -29,12 +38,34 @@ const selectedPaths = requestedPaths.length
     ? fullSuites.map(getPlaywrightTargetPath)
     : (changedSelection?.targetFiles ?? []);
 const targets = expandPlaywrightTargets(selectedPaths, process.cwd());
-if (listTargets) {
+if (listTargets || listBatches) {
+  const batches = batchPlaywrightTargets(targets);
+  if (listBatches && process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      [
+        `## Browser selection: ${targets.length} specs in ${batches.length} jobs`,
+        "",
+        changedSelection?.reason ?? "Explicitly requested specs.",
+        "",
+        "| Job | Specs |",
+        "| --- | --- |",
+        ...batches.map(
+          ({ name, paths }) =>
+            `| ${name} | ${paths.map((spec) => getRelativeSpecPath(spec)).join(", ")} |`,
+        ),
+        "",
+      ].join("\n"),
+    );
+  }
   await new Promise((resolve, reject) => {
-    process.stdout.write(`${JSON.stringify(targets)}\n`, (error) => {
-      if (error) reject(error);
-      else resolve();
-    });
+    process.stdout.write(
+      `${JSON.stringify(listBatches ? batches : targets)}\n`,
+      (error) => {
+        if (error) reject(error);
+        else resolve();
+      },
+    );
   });
   process.exit(0);
 }
@@ -53,7 +84,13 @@ if (!dryRun) {
 }
 
 let failed = false;
-const timings = [];
+
+if (!dryRun && process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    "## Isolated browser specs\n\n| Spec | Seconds | Exit status |\n| --- | ---: | ---: |\n",
+  );
+}
 
 if (requestedPaths.length) {
   console.log(`Running ${targets.length} requested Playwright target(s).`);
@@ -114,15 +151,21 @@ for (const target of targets) {
   }
 
   const seconds = Math.round((Date.now() - startedAt) / 1000);
-  timings.push({ target: target.name, seconds, status: result.status });
+  const timing = { target: target.name, seconds, status: result.status };
   console.log(
     `Finished ${target.name} in ${seconds}s (exit ${result.status}).`,
   );
   if (!dryRun) {
     writeFileSync(
       path.join(testResultsDir, `timings-${target.name}.json`),
-      JSON.stringify(timings, null, 2),
+      JSON.stringify([timing], null, 2),
     );
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(
+        process.env.GITHUB_STEP_SUMMARY,
+        `| ${getRelativeSpecPath(target.path)} | ${seconds} | ${result.status} |\n`,
+      );
+    }
   }
   if (result.status !== 0) failed = true;
 }
@@ -136,6 +179,10 @@ if (!dryRun && targets.length && !process.env.PLAYWRIGHT_SKIP_REPORT_MERGE) {
   if (mergeResult.status !== 0) failed = true;
 }
 process.exitCode = failed ? 1 : 0;
+
+function getRelativeSpecPath(specPath) {
+  return specPath.replace(/^__tests__\/playwright\/emulated\//, "");
+}
 
 function runPlaywright(args, extraEnv) {
   const pnpmExecutable = process.platform === "win32" ? "pnpm.cmd" : "pnpm";

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -122,8 +122,8 @@ for (const target of targets) {
         "-c",
         "playwright.config.mjs",
         "--project=emulated",
-        // Leave room for runner setup within each spec's eight-minute CI budget.
-        ...(process.env.CI ? ["--global-timeout=360000"] : []),
+        // This includes cold web-server startup and authentication setup.
+        ...(process.env.CI ? ["--global-timeout=480000"] : []),
         target.path,
       ],
       {

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -122,6 +122,8 @@ for (const target of targets) {
         "-c",
         "playwright.config.mjs",
         "--project=emulated",
+        // Leave room for runner setup within each spec's eight-minute CI budget.
+        ...(process.env.CI ? ["--global-timeout=360000"] : []),
         target.path,
       ],
       {

--- a/apps/web/utils/playwright/emulated-suite-selection.mjs
+++ b/apps/web/utils/playwright/emulated-suite-selection.mjs
@@ -63,6 +63,24 @@ const sharedAppEntryFiles = [
   "app/(app)/[emailAccountId]/error.tsx",
 ];
 
+// Shared feature entry points have focused coverage; their imported foundations
+// still use the dependency graph's broad fallback.
+const sharedFeatureMappings = [
+  {
+    files: [
+      "components/CommandK.tsx",
+      "hooks/useCommandPaletteCommands.ts",
+      "store/command-palette.ts",
+    ],
+    targets: [
+      "mail/command-palette.spec.ts",
+      "mail/starring.spec.ts",
+      "mail/theme.spec.ts",
+      "settings/settings-dialog.spec.ts",
+    ],
+  },
+];
+
 const directSuiteMappings = [
   ["app/(redirects)/assistant/", ["chat"]],
   ["app/(redirects)/automation/", ["automation"]],
@@ -163,6 +181,7 @@ export function selectChangedPlaywrightTargets(changedFilesInput, appRoot) {
     const { dependenciesBySuite, sharedDependencies } =
       getDependenciesBySuite(appRoot);
     const uncoveredFiles = [];
+    const focusedSharedFiles = [];
 
     for (const file of productFiles) {
       const directlyAffectedSuites = getDirectlyAffectedSuites(file.appPath);
@@ -173,6 +192,24 @@ export function selectChangedPlaywrightTargets(changedFilesInput, appRoot) {
           reason: `${file.repoPath} was deleted or cannot be analyzed.`,
           targetFiles: [],
         };
+      }
+
+      const sharedFeature = sharedFeatureMappings.find(({ files }) =>
+        files.includes(file.appPath),
+      );
+      if (fileExists && sharedFeature) {
+        const featureTargets = sharedFeature.targets.map(
+          getPlaywrightTargetPath,
+        );
+        if (
+          featureTargets.every((target) =>
+            existsSync(path.join(appRoot, target)),
+          )
+        ) {
+          for (const target of featureTargets) targetFiles.add(target);
+          focusedSharedFiles.push(file.repoPath);
+          continue;
+        }
       }
 
       const affectedSuites = directlyAffectedSuites.length
@@ -207,11 +244,14 @@ export function selectChangedPlaywrightTargets(changedFilesInput, appRoot) {
     const uncoveredReason = uncoveredFiles.length
       ? ` No emulated E2E area covers: ${uncoveredFiles.join(", ")}.`
       : "";
+    const sharedFeatureReason = focusedSharedFiles.length
+      ? ` Focused shared-feature coverage: ${focusedSharedFiles.join(", ")}.`
+      : "";
 
     return {
       runFullSuite: false,
       reason: targetFiles.size
-        ? `Selected E2E features and fallback areas from the pull request's changed files.${uncoveredReason}`
+        ? `Selected E2E features and fallback areas from the pull request's changed files.${sharedFeatureReason}${uncoveredReason}`
         : `The changed files do not affect emulated browser coverage.${uncoveredReason}`,
       targetFiles: [...targetFiles],
     };

--- a/apps/web/utils/playwright/emulated-suite-selection.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-selection.test.mjs
@@ -11,6 +11,72 @@ import { expandPlaywrightTargets } from "./emulated-suite-targets.mjs";
 const appRoot = path.resolve(import.meta.dirname, "../..");
 
 describe("emulated Playwright suite selection", () => {
+  test.each([
+    "components/CommandK.tsx",
+    "hooks/useCommandPaletteCommands.ts",
+    "store/command-palette.ts",
+  ])("selects explicit shared-feature coverage for %s", (file) => {
+    const selection = selectChangedPlaywrightTargets(
+      `apps/web/${file}`,
+      appRoot,
+    );
+    expect(selection.runFullSuite).toBe(false);
+    expect(selection.targetFiles.sort()).toEqual([
+      "__tests__/playwright/emulated/mail/command-palette.spec.ts",
+      "__tests__/playwright/emulated/mail/starring.spec.ts",
+      "__tests__/playwright/emulated/mail/theme.spec.ts",
+      "__tests__/playwright/emulated/settings/settings-dialog.spec.ts",
+    ]);
+  });
+
+  test("unions shared-feature coverage with other changes in the same PR", () => {
+    const selection = selectChangedPlaywrightTargets(
+      [
+        "apps/web/hooks/useCommandPaletteCommands.ts",
+        "apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx",
+        "apps/web/__tests__/playwright/emulated/settings/settings-dialog.spec.ts",
+      ].join("\n"),
+      appRoot,
+    );
+    expect(
+      expandPlaywrightTargets(selection.targetFiles, appRoot),
+    ).toHaveLength(5);
+    expect(selection.targetFiles).toContain(
+      "__tests__/playwright/emulated/mail/layout.spec.ts",
+    );
+    expect(selection.reason).toContain("hooks/useCommandPaletteCommands.ts");
+  });
+
+  test("keeps broad coverage when a shared feature's test coverage is missing", () => {
+    withFeatureFixture((root, write) => {
+      write("app/layout.tsx", 'import "@/components/CommandK";');
+      write("components/CommandK.tsx", "");
+      const selection = selectChangedPlaywrightTargets(
+        "apps/web/components/CommandK.tsx",
+        root,
+      );
+      expect(selection.targetFiles).toEqual(
+        fullSuites.map((suite) => `__tests__/playwright/emulated/${suite}`),
+      );
+    });
+  });
+
+  test("a shared-feature edit does not narrow other foundational changes", () => {
+    const selection = selectChangedPlaywrightTargets(
+      [
+        "apps/web/hooks/useCommandPaletteCommands.ts",
+        "apps/web/components/SideNavWithTopNav.tsx",
+      ].join("\n"),
+      appRoot,
+    );
+    expect(expandPlaywrightTargets(selection.targetFiles, appRoot)).toEqual(
+      expandPlaywrightTargets(
+        fullSuites.map((suite) => `__tests__/playwright/emulated/${suite}`),
+        appRoot,
+      ),
+    );
+  });
+
   test("selects the split feature instead of every mail spec", () => {
     const selection = selectChangedPlaywrightTargets(
       "apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx",

--- a/apps/web/utils/playwright/emulated-suite-targets.d.mts
+++ b/apps/web/utils/playwright/emulated-suite-targets.d.mts
@@ -9,4 +9,4 @@ export function getPlaywrightSpecPathFromTargetName(targetName: string): string;
 
 export function batchPlaywrightTargets(
   targets: ReadonlyArray<{ name: string; path: string }>,
-): Array<{ name: string; paths: string[] }>;
+): Array<{ name: string; paths: string[]; timeoutMinutes: number }>;

--- a/apps/web/utils/playwright/emulated-suite-targets.d.mts
+++ b/apps/web/utils/playwright/emulated-suite-targets.d.mts
@@ -6,3 +6,7 @@ export function expandPlaywrightTargets(
 export function getPlaywrightTargetName(specPath: string): string;
 
 export function getPlaywrightSpecPathFromTargetName(targetName: string): string;
+
+export function batchPlaywrightTargets(
+  targets: ReadonlyArray<{ name: string; path: string }>,
+): Array<{ name: string; paths: string[] }>;

--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -12,6 +12,20 @@ export function expandPlaywrightTargets(paths, appRoot) {
   }));
 }
 
+export function batchPlaywrightTargets(targets) {
+  const batchCount = Math.min(targets.length, 12);
+  const batches = Array.from({ length: batchCount }, (_, index) => ({
+    name:
+      targets.length <= batchCount ? targets[index].name : `batch-${index + 1}`,
+    paths: [],
+  }));
+  // Spread neighboring specs across runners so one large area cannot monopolize a job.
+  for (const [index, target] of targets.entries()) {
+    batches[index % batchCount].paths.push(target.path);
+  }
+  return batches;
+}
+
 /**
  * Result directories are named after the spec path with `/` encoded as `_s`.
  * Existing underscores double up first so the encoding stays reversible.

--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -13,7 +13,7 @@ export function expandPlaywrightTargets(paths, appRoot) {
 }
 
 export function batchPlaywrightTargets(targets) {
-  const batchCount = Math.min(targets.length, 12);
+  const batchCount = Math.min(targets.length, 20);
   const batches = Array.from({ length: batchCount }, (_, index) => ({
     name:
       targets.length <= batchCount ? targets[index].name : `batch-${index + 1}`,

--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -23,7 +23,10 @@ export function batchPlaywrightTargets(targets) {
   for (const [index, target] of targets.entries()) {
     batches[index % batchCount].paths.push(target.path);
   }
-  return batches;
+  return batches.map((batch) => ({
+    ...batch,
+    timeoutMinutes: batch.paths.length * 8,
+  }));
 }
 
 /**

--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -25,7 +25,7 @@ export function batchPlaywrightTargets(targets) {
   }
   return batches.map((batch) => ({
     ...batch,
-    timeoutMinutes: batch.paths.length * 8,
+    timeoutMinutes: 4 + batch.paths.length * 8,
   }));
 }
 

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -83,6 +83,9 @@ test("batches a full selection without losing or repeating specs", () => {
   expect(
     batches.every(({ paths }) => paths.length >= 2 && paths.length <= 3),
   ).toBe(true);
+  expect(
+    batches.map(({ timeoutMinutes, paths }) => timeoutMinutes / paths.length),
+  ).toEqual(new Array(20).fill(8));
 });
 
 test("keeps focused selections parallel and creates no empty jobs", () => {
@@ -92,7 +95,11 @@ test("keeps focused selections parallel and creates no empty jobs", () => {
     { name: "settings_sdialog.spec.ts", path: "settings/dialog.spec.ts" },
   ];
   expect(batchPlaywrightTargets(targets)).toEqual(
-    targets.map(({ name, path: specPath }) => ({ name, paths: [specPath] })),
+    targets.map(({ name, path: specPath }) => ({
+      name,
+      paths: [specPath],
+      timeoutMinutes: 8,
+    })),
   );
 });
 
@@ -149,6 +156,7 @@ if (process.argv.includes("test")) {
       ...process.env,
       PATH: `${bin}${path.delimiter}${process.env.PATH}`,
       CALL_LOG: callLog,
+      CI: "true",
       GITHUB_STEP_SUMMARY: summary,
       PLAYWRIGHT_DRY_RUN: "",
       PLAYWRIGHT_SKIP_REPORT_MERGE: "",
@@ -175,12 +183,14 @@ if (process.argv.includes("test")) {
     ["", "true"],
   ]);
   for (const run of runs) {
+    expect(run.args).toContain("--global-timeout=360000");
     expect(existsSync(run.blob)).toBe(true);
     expect(existsSync(path.join(run.output, "evidence.json"))).toBe(true);
   }
   expect(calls.at(-1).args).toContain("merge-reports");
   const timings = readdirSync(path.join(appRoot, "test-results"))
     .filter((file) => file.startsWith("timings-"))
+    .sort()
     .flatMap((file) =>
       JSON.parse(
         readFileSync(path.join(appRoot, "test-results", file), "utf8"),

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -1,8 +1,19 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, test } from "vitest";
 import {
+  batchPlaywrightTargets,
   expandPlaywrightTargets,
   getPlaywrightSpecPathFromTargetName,
   getPlaywrightTargetName,
@@ -55,4 +66,128 @@ test("target names round-trip spec paths that contain underscores", () => {
     expect(targetName).not.toContain("/");
     expect(getPlaywrightSpecPathFromTargetName(targetName)).toBe(specPath);
   }
+});
+
+test("batches a full selection without losing or repeating specs", () => {
+  const targets = Array.from({ length: 43 }, (_, index) => ({
+    name: `spec-${index}`,
+    path: `__tests__/playwright/emulated/mail/spec-${index}.spec.ts`,
+  }));
+  const batches = batchPlaywrightTargets(targets);
+
+  expect(batches).toHaveLength(12);
+  expect(new Set(batches.map(({ name }) => name)).size).toBe(12);
+  expect(batches.flatMap(({ paths }) => paths).sort()).toEqual(
+    targets.map(({ path: specPath }) => specPath).sort(),
+  );
+  expect(
+    batches.every(({ paths }) => paths.length >= 3 && paths.length <= 4),
+  ).toBe(true);
+});
+
+test("keeps focused selections parallel and creates no empty jobs", () => {
+  expect(batchPlaywrightTargets([])).toEqual([]);
+  const targets = [
+    { name: "mail_slayout.spec.ts", path: "mail/layout.spec.ts" },
+    { name: "settings_sdialog.spec.ts", path: "settings/dialog.spec.ts" },
+  ];
+  expect(batchPlaywrightTargets(targets)).toEqual(
+    targets.map(({ name, path: specPath }) => ({ name, paths: [specPath] })),
+  );
+});
+
+test.each([
+  0, 1,
+])("the batch runner preserves reports and isolation after a spec exits %i", (exitStatus) => {
+  const runner = path.resolve(
+    import.meta.dirname,
+    "../../__tests__/playwright/run-emulated-suite.mjs",
+  );
+  const specs = [
+    "automation/first.spec.ts",
+    "mail/second.spec.ts",
+    "settings/third.spec.ts",
+  ];
+  for (const spec of specs) {
+    const file = path.join(appRoot, "__tests__/playwright/emulated", spec);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, "");
+  }
+  const bin = path.join(appRoot, "bin");
+  mkdirSync(bin, { recursive: true });
+  const pnpm = path.join(bin, "pnpm");
+  writeFileSync(
+    pnpm,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const env = process.env;
+fs.appendFileSync(env.CALL_LOG, JSON.stringify({
+  args: process.argv.slice(2),
+  runId: env.PLAYWRIGHT_RUN_ID,
+  blob: env.PLAYWRIGHT_BLOB_REPORT_FILE,
+  output: env.PLAYWRIGHT_OUTPUT_DIR,
+  todoist: env.PLAYWRIGHT_TODOIST_ENABLED,
+  api: env.NEXT_PUBLIC_EXTERNAL_API_ENABLED,
+}) + "\\n");
+if (process.argv.includes("test")) {
+  fs.mkdirSync(path.dirname(env.PLAYWRIGHT_BLOB_REPORT_FILE), { recursive: true });
+  fs.writeFileSync(env.PLAYWRIGHT_BLOB_REPORT_FILE, "report");
+  fs.mkdirSync(env.PLAYWRIGHT_OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(path.join(env.PLAYWRIGHT_OUTPUT_DIR, "evidence.json"), "{}");
+  process.exit(process.argv.at(-1).includes("first.spec.ts") ? ${exitStatus} : 0);
+}
+`,
+  );
+  chmodSync(pnpm, 0o755);
+  const callLog = path.join(appRoot, "calls.jsonl");
+  const summary = path.join(appRoot, "summary.md");
+  const result = spawnSync(process.execPath, [runner, ...specs], {
+    cwd: appRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+      CALL_LOG: callLog,
+      GITHUB_STEP_SUMMARY: summary,
+      PLAYWRIGHT_DRY_RUN: "",
+      PLAYWRIGHT_SKIP_REPORT_MERGE: "",
+      PLAYWRIGHT_RUN_ID: "",
+      PLAYWRIGHT_TODOIST_ENABLED: "",
+      NEXT_PUBLIC_EXTERNAL_API_ENABLED: "",
+    },
+  });
+
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(exitStatus);
+  const calls = readFileSync(callLog, "utf8")
+    .trim()
+    .split("\n")
+    .map(JSON.parse);
+  const runs = calls.filter(({ args }) => args.includes("test"));
+  expect(runs.map(({ args }) => args.at(-1))).toEqual(
+    specs.map((spec) => `__tests__/playwright/emulated/${spec}`),
+  );
+  expect(new Set(runs.map(({ runId }) => runId)).size).toBe(3);
+  expect(runs.map(({ todoist, api }) => [todoist, api])).toEqual([
+    ["true", ""],
+    ["", ""],
+    ["", "true"],
+  ]);
+  for (const run of runs) {
+    expect(existsSync(run.blob)).toBe(true);
+    expect(existsSync(path.join(run.output, "evidence.json"))).toBe(true);
+  }
+  expect(calls.at(-1).args).toContain("merge-reports");
+  const timings = readdirSync(path.join(appRoot, "test-results"))
+    .filter((file) => file.startsWith("timings-"))
+    .flatMap((file) =>
+      JSON.parse(
+        readFileSync(path.join(appRoot, "test-results", file), "utf8"),
+      ),
+    );
+  expect(timings).toHaveLength(3);
+  expect(timings.map(({ status }) => status)).toEqual([exitStatus, 0, 0]);
+  for (const spec of specs)
+    expect(readFileSync(summary, "utf8")).toContain(spec);
 });

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -75,13 +75,13 @@ test("batches a full selection without losing or repeating specs", () => {
   }));
   const batches = batchPlaywrightTargets(targets);
 
-  expect(batches).toHaveLength(12);
-  expect(new Set(batches.map(({ name }) => name)).size).toBe(12);
+  expect(batches).toHaveLength(20);
+  expect(new Set(batches.map(({ name }) => name)).size).toBe(20);
   expect(batches.flatMap(({ paths }) => paths).sort()).toEqual(
     targets.map(({ path: specPath }) => specPath).sort(),
   );
   expect(
-    batches.every(({ paths }) => paths.length >= 3 && paths.length <= 4),
+    batches.every(({ paths }) => paths.length >= 2 && paths.length <= 3),
   ).toBe(true);
 });
 

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -84,7 +84,9 @@ test("batches a full selection without losing or repeating specs", () => {
     batches.every(({ paths }) => paths.length >= 2 && paths.length <= 3),
   ).toBe(true);
   expect(
-    batches.map(({ timeoutMinutes, paths }) => timeoutMinutes / paths.length),
+    batches.map(
+      ({ timeoutMinutes, paths }) => (timeoutMinutes - 4) / paths.length,
+    ),
   ).toEqual(new Array(20).fill(8));
 });
 
@@ -98,7 +100,7 @@ test("keeps focused selections parallel and creates no empty jobs", () => {
     targets.map(({ name, path: specPath }) => ({
       name,
       paths: [specPath],
-      timeoutMinutes: 8,
+      timeoutMinutes: 12,
     })),
   );
 });
@@ -183,7 +185,7 @@ if (process.argv.includes("test")) {
     ["", "true"],
   ]);
   for (const run of runs) {
-    expect(run.args).toContain("--global-timeout=360000");
+    expect(run.args).toContain("--global-timeout=480000");
     expect(existsSync(run.blob)).toBe(true);
     expect(existsSync(path.join(run.output, "evidence.json"))).toBe(true);
   }


### PR DESCRIPTION
Shared command-palette edits currently select every browser spec, and full selections repeat CI setup in one job per spec. Select focused command, starring, theme, and settings-dialog coverage for explicit command-palette entry points, and batch broad selections across at most 20 jobs. Replaying the settings-change file list now selects five specs/jobs instead of 43.

- Keep broad coverage for foundational dependencies, missing coverage targets, Playwright infrastructure, main, and scheduled runs. Other changed files still add their own coverage.
- Preserve a fresh app process, emulator, authenticated account, and report per spec. Continue after a spec fails and retain failure status in the combined Web E2E gate.
- Give each Playwright invocation an eight-minute limit, including cold startup and authentication, and allocate four fixed minutes of job overhead plus eight minutes per spec. Add selected-batch and per-spec timing summaries; keep timing records unique and filesystem-order-independent.

Validation: dependency installation, 38 focused tests, repository formatting checks, and Actionlint pass. A real local batch covering automation, mail layout, and appearance passed all three specs in 2m19s of spec execution; merged reports and screenshots were inspected. The final full-suite CI run passed all 43 specs and the combined Web E2E gate at `70d708916`. Its artifact contains 43 distinct successful timing records and 107 final-state screenshots.

CI experiments:

| Configuration | Spec jobs | Elapsed time | Outcome |
| --- | ---: | ---: | --- |
| Previous per-spec run | 43 | 13m34s | Passed |
| Initial batching experiment | 12 | 14m21s | All 43 specs passed; 104.5 runner-minutes versus 149.4 before |
| Shorter batches | 20 | 11m21s before retry | One OAuth setup failure; the same batch passed unchanged on retry |
| Final configuration | 20 | 9m30s | All 43 specs passed on the first attempt; 117.6 runner-minutes |

The 12-job experiment reduced setup work but lengthened the critical path, so the final cap is deliberately 20. The first 20-job experiment includes a failed initial attempt and is not a clean performance result. The final successful run was about 30% faster than the prior per-spec run and used about 21% fewer spec-job runner-minutes. Separate runs differ in runner availability, so these are observed results rather than a latency guarantee. The five-job settings-change result is a selector replay, not a measured new PR runtime.

Review updates: batch timeouts now scale with selected spec count; timing-file assertions sort directory entries; the 20-job cap is intentional following the measured 12-job experiment. The mapped settings-dialog spec already exercises opening the command palette from both mail and the global settings page. The timeout follow-up adds explicit fixed job overhead and increases the invocation cap to accommodate cold startup. All 38 focused tests pass after this change; the full-suite measurements above precede this timeout-only follow-up.

CI evidence: [baseline](https://github.com/elie222/inbox-zero/actions/runs/34165355833), [12-job experiment](https://github.com/elie222/inbox-zero/actions/runs/34166591298), [20-job run with retry](https://github.com/elie222/inbox-zero/actions/runs/34167551646), [final successful run](https://github.com/elie222/inbox-zero/actions/runs/34169084519).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Automated Playwright coverage now runs in up to 20 isolated batches, improving parallel execution and allowing timeouts to scale with batch size.
  * Shared-feature changes now trigger focused coverage for related command-palette scenarios while preserving broader coverage when needed.
  * Test execution now supports longer-running specs and improved report and artifact isolation.

* **Documentation**
  * Updated Playwright guidance to explain batching, timing limits, focused coverage, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->