### PR TITLE
fix: invalidate stale conversation caches during mailbox sync

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-prefetch.ts
@@ -8,6 +8,7 @@ import {
   readCachedThreadDetail,
   writeCachedThreadDetail,
 } from "@/utils/email-cache/threads";
+import { getThreadCacheVersion } from "@/utils/email-cache/thread-invalidation";
 import { prepareEmailHtml } from "@/utils/email/prepare-html.client";
 
 /**
@@ -33,13 +34,14 @@ export async function prefetchThreadDetail({
     threadId,
     options: { includeDrafts: true },
   });
+  let version = getThreadCacheVersion(emailAccountId, threadId);
   const cached = await readCachedThreadDetail({
     emailAccountId,
     threadId,
     variant: request.variant,
   });
   if (isCancelled?.()) return;
-  if (cached) {
+  if (cached && version === getThreadCacheVersion(emailAccountId, threadId)) {
     await mutate<ThreadResponse>(
       request.key,
       (current) => current ?? cached.data,
@@ -55,9 +57,17 @@ export async function prefetchThreadDetail({
 
   const data = await fetchThreadRequest<ThreadResponse | undefined>(
     request,
-    async () => (await fetcher(request.key)) as ThreadResponse | undefined,
+    async (requestVersion) => {
+      version = requestVersion;
+      return (await fetcher(request.key)) as ThreadResponse | undefined;
+    },
   );
-  if (!data || isCancelled?.()) return;
+  if (
+    !data ||
+    isCancelled?.() ||
+    version !== getThreadCacheVersion(emailAccountId, threadId)
+  )
+    return;
   await mutate(request.key, data, {
     populateCache: true,
     revalidate: false,
@@ -68,6 +78,7 @@ export async function prefetchThreadDetail({
       emailAccountId,
       threadId,
       variant: request.variant,
+      version,
       data,
     }),
     prepareVisibleMessageHtml(data),

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig, unstable_serialize } from "swr";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useThread } from "./useThread";
+import { notifyMailboxStoreChange } from "@/utils/email-cache/mailbox";
 
 const cache = vi.hoisted(() => ({
   read: vi.fn(),
@@ -21,6 +22,8 @@ vi.mock("@/utils/email-cache/threads", () => ({
 }));
 
 describe("useThread", () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     vi.clearAllMocks();
     cache.write.mockResolvedValue(undefined);
@@ -122,6 +125,40 @@ describe("useThread", () => {
         threadId: "thread-1",
       }),
     );
+  });
+
+  it("refreshes a cached conversation after its account syncs", async () => {
+    cache.read.mockResolvedValue({
+      data: { thread: { id: "thread-1", messages: [{ id: "old-draft" }] } },
+    });
+    const fetcher = vi.fn().mockResolvedValue({
+      thread: { id: "thread-1", messages: [{ id: "sent-reply" }] },
+    });
+    const { result, unmount } = renderHook(
+      () => useThread({ id: "thread-1" }),
+      { wrapper: createWrapper(fetcher) },
+    );
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages[0]?.id).toBe("old-draft"),
+    );
+
+    await act(async () => notifyMailboxStoreChange("account-2"));
+    expect(fetcher).not.toHaveBeenCalled();
+
+    await act(async () => notifyMailboxStoreChange("account-1"));
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages.map(({ id }) => id)).toEqual([
+        "sent-reply",
+      ]),
+    );
+    expect(cache.write).toHaveBeenCalledWith(
+      expect.objectContaining({ data: result.current.data }),
+    );
+
+    unmount();
+    fetcher.mockClear();
+    await act(async () => notifyMailboxStoreChange("account-1"));
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("falls back to the network when no cached detail exists", async () => {

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -5,7 +5,6 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig, unstable_serialize } from "swr";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useThread } from "./useThread";
-import { notifyMailboxStoreChange } from "@/utils/email-cache/mailbox";
 
 const cache = vi.hoisted(() => ({
   read: vi.fn(),
@@ -125,40 +124,6 @@ describe("useThread", () => {
         threadId: "thread-1",
       }),
     );
-  });
-
-  it("refreshes a cached conversation after its account syncs", async () => {
-    cache.read.mockResolvedValue({
-      data: { thread: { id: "thread-1", messages: [{ id: "old-draft" }] } },
-    });
-    const fetcher = vi.fn().mockResolvedValue({
-      thread: { id: "thread-1", messages: [{ id: "sent-reply" }] },
-    });
-    const { result, unmount } = renderHook(
-      () => useThread({ id: "thread-1" }),
-      { wrapper: createWrapper(fetcher) },
-    );
-    await waitFor(() =>
-      expect(result.current.data?.thread.messages[0]?.id).toBe("old-draft"),
-    );
-
-    await act(async () => notifyMailboxStoreChange("account-2"));
-    expect(fetcher).not.toHaveBeenCalled();
-
-    await act(async () => notifyMailboxStoreChange("account-1"));
-    await waitFor(() =>
-      expect(result.current.data?.thread.messages.map(({ id }) => id)).toEqual([
-        "sent-reply",
-      ]),
-    );
-    expect(cache.write).toHaveBeenCalledWith(
-      expect.objectContaining({ data: result.current.data }),
-    );
-
-    unmount();
-    fetcher.mockClear();
-    await act(async () => notifyMailboxStoreChange("account-1"));
-    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("falls back to the network when no cached detail exists", async () => {

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,7 +1,8 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import useSWR, { unstable_serialize, useSWRConfig } from "swr";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { subscribeToMailboxStore } from "@/utils/email-cache/mailbox";
 import {
   readCachedThreadDetail,
   writeCachedThreadDetail,
@@ -87,10 +88,23 @@ export function useThread(
     {
       keepPreviousData: false,
       revalidateOnMount: !hasMatchingMemoryData,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
     },
   );
+  const { mutate } = swr;
+  useEffect(() => {
+    if (!request) return;
+    const unsubscribe = subscribeToMailboxStore((changedAccountId) => {
+      if (changedAccountId !== emailAccountId) return;
+      // Mailbox sync contains inbox summaries, not full replies and drafts.
+      checkedPersistentCache.current.add(request.cacheIdentity);
+      mutate().catch(() => {});
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [emailAccountId, request, mutate]);
   const data = swr.data?.thread.id === id ? swr.data : undefined;
 
   return {

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -88,8 +88,8 @@ export function useThread(
     {
       keepPreviousData: false,
       revalidateOnMount: !hasMatchingMemoryData,
-      revalidateOnFocus: true,
-      revalidateOnReconnect: true,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
     },
   );
   const data = swr.data?.thread.id === id ? swr.data : undefined;

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import useSWR, { unstable_serialize, useSWRConfig } from "swr";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { subscribeToMailboxStore } from "@/utils/email-cache/mailbox";
 import {
   readCachedThreadDetail,
   writeCachedThreadDetail,
@@ -56,7 +55,7 @@ export function useThread(
     request?.key ?? null,
     request && fetcher && id
       ? () =>
-          fetchThreadRequest(request, async () => {
+          fetchThreadRequest(request, async (version) => {
             if (
               !hasMatchingMemoryData &&
               !checkedPersistentCache.current.has(request.cacheIdentity)
@@ -80,6 +79,7 @@ export function useThread(
               emailAccountId,
               threadId: id,
               variant: request.variant,
+              version,
               data,
             });
             return data;
@@ -92,19 +92,6 @@ export function useThread(
       revalidateOnReconnect: true,
     },
   );
-  const { mutate } = swr;
-  useEffect(() => {
-    if (!request) return;
-    const unsubscribe = subscribeToMailboxStore((changedAccountId) => {
-      if (changedAccountId !== emailAccountId) return;
-      // Mailbox sync contains inbox summaries, not full replies and drafts.
-      checkedPersistentCache.current.add(request.cacheIdentity);
-      mutate().catch(() => {});
-    });
-    return () => {
-      unsubscribe();
-    };
-  }, [emailAccountId, request, mutate]);
   const data = swr.data?.thread.id === id ? swr.data : undefined;
 
   return {

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
 } from "react";
 import { SWRConfig, mutate, useSWRConfig } from "swr";
+import { connectThreadCacheInvalidation } from "@/utils/email-cache/thread-invalidation";
 import { captureException } from "@/utils/error";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
@@ -191,6 +192,11 @@ function PersistedSwrCache() {
   const { cache, mutate: scopedMutate } = useSWRConfig();
   const { emailAccountId } = useAccount();
   const hydratedForRef = useRef<string | null>(null);
+
+  useEffect(
+    () => connectThreadCacheInvalidation(cache, scopedMutate),
+    [cache, scopedMutate],
+  );
 
   useEffect(() => {
     if (!emailAccountId || hydratedForRef.current === emailAccountId) return;

--- a/apps/web/utils/email-cache/database.test.ts
+++ b/apps/web/utils/email-cache/database.test.ts
@@ -1,0 +1,26 @@
+import "fake-indexeddb/auto";
+import { openDB } from "idb";
+import { describe, expect, it } from "vitest";
+import { getEmailCacheDatabase } from "./database";
+
+describe("email cache upgrade", () => {
+  it("drops old conversation details while preserving unsent work", async () => {
+    const previous = await openDB("inbox-zero-email-cache", 8, {
+      upgrade(database) {
+        database.createObjectStore("threadDetails");
+        database.createObjectStore("replyDrafts");
+        database.createObjectStore("mailMutations");
+      },
+    });
+    await previous.put("threadDetails", { stale: true }, "thread-1");
+    await previous.put("replyDrafts", { content: "local draft" }, "draft-1");
+    await previous.put("mailMutations", { status: "pending" }, "send-1");
+    previous.close();
+
+    const database = await getEmailCacheDatabase();
+    expect(await database?.count("threadDetails")).toBe(0);
+    expect(await database?.count("replyDrafts")).toBe(1);
+    expect(await database?.count("mailMutations")).toBe(1);
+    database?.close();
+  });
+});

--- a/apps/web/utils/email-cache/database.ts
+++ b/apps/web/utils/email-cache/database.ts
@@ -3,7 +3,7 @@ import type { ReplyDraftContent } from "./reply-drafts";
 import type { ParsedMessage } from "@/utils/types";
 
 const DATABASE_NAME = "inbox-zero-email-cache";
-const DATABASE_VERSION = 8;
+const DATABASE_VERSION = 9;
 
 export type CachedThreadRow = {
   emailAccountId: string;
@@ -237,6 +237,10 @@ export function getEmailCacheDatabase() {
         mutations.createIndex("byBatch", "batchId");
         mutations.createIndex("byNextAttempt", ["status", "nextAttemptAt"]);
         mutations.createIndex("byUpdatedAt", "updatedAt");
+      }
+      if (oldVersion < 9) {
+        // Older clients could retain details after their sync cursor had advanced.
+        transaction.objectStore("threadDetails").clear();
       }
       if (oldVersion < 8) {
         if (oldVersion >= 6)

--- a/apps/web/utils/email-cache/keys.ts
+++ b/apps/web/utils/email-cache/keys.ts
@@ -34,6 +34,16 @@ export function createThreadDetailRequestKey({
   return [url, emailAccountId];
 }
 
+export function getThreadDetailKeyRange(
+  emailAccountId: string,
+  threadId: string,
+) {
+  return IDBKeyRange.bound(
+    [emailAccountId, threadId, ""],
+    [emailAccountId, threadId, []],
+  );
+}
+
 function normalizeValue(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value))

--- a/apps/web/utils/email-cache/keys.ts
+++ b/apps/web/utils/email-cache/keys.ts
@@ -17,6 +17,23 @@ export function createThreadDetailVariant(options?: {
   return `drafts:${options?.includeDrafts ? 1 : 0}|replies:${options?.parseReplies ? 1 : 0}`;
 }
 
+export function createThreadDetailRequestKey({
+  emailAccountId,
+  threadId,
+  options,
+}: {
+  emailAccountId: string;
+  threadId: string;
+  options?: { includeDrafts?: boolean; parseReplies?: boolean };
+}): [string, string] {
+  const searchParams = new URLSearchParams();
+  if (options?.includeDrafts) searchParams.set("includeDrafts", "true");
+  if (options?.parseReplies) searchParams.set("parseReplies", "true");
+  const query = searchParams.toString();
+  const url = `/api/threads/${encodeURIComponent(threadId)}${query ? `?${query}` : ""}`;
+  return [url, emailAccountId];
+}
+
 function normalizeValue(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value))

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -23,6 +23,86 @@ describe("synced mailbox cache", () => {
     await clearEmailCache();
   });
 
+  it("invalidates all detail variants for changed threads and deleted cached drafts", async () => {
+    const database = await getEmailCacheDatabase();
+    if (!database) throw new Error("Database unavailable");
+    for (const [account, thread, variant] of [
+      ["account-1", "changed", "drafts:0|replies:0"],
+      ["account-1", "changed", "drafts:1|replies:0"],
+      ["account-1", "deleted", "drafts:1|replies:0"],
+      ["account-1", "unrelated", "drafts:1|replies:0"],
+      ["account-2", "changed", "drafts:1|replies:0"],
+    ]) {
+      await database.put("threadDetails", {
+        emailAccountId: account,
+        threadId: thread,
+        variant,
+        data: {
+          thread: {
+            id: thread,
+            messages: [
+              getMessage({
+                id: thread === "deleted" ? "draft" : thread,
+                threadId: thread,
+              }),
+            ],
+          },
+        },
+        fetchedAt: 100,
+        lastAccessedAt: 100,
+        byteSize: 100,
+      });
+    }
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-01"),
+      page: {
+        cursor: "delta",
+        reset: false,
+        hasMore: false,
+        changedThreadIds: ["changed"],
+        deletedMessageIds: [],
+        upsertedMessages: [],
+      },
+    });
+    expect(
+      (await database.getAll("threadDetails")).map((row) => [
+        row.emailAccountId,
+        row.threadId,
+      ]),
+    ).toEqual([
+      ["account-1", "deleted"],
+      ["account-1", "unrelated"],
+      ["account-2", "changed"],
+    ]);
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      page: {
+        cursor: "delta-2",
+        reset: false,
+        hasMore: false,
+        deletedMessageIds: ["draft"],
+        upsertedMessages: [],
+      },
+    });
+    expect(
+      (await database.getAll("threadDetails")).map((row) => row.emailAccountId),
+    ).toEqual(["account-1", "account-2"]);
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      page: {
+        cursor: "reset",
+        reset: true,
+        hasMore: true,
+        deletedMessageIds: [],
+        upsertedMessages: [],
+      },
+    });
+    expect(
+      (await database.getAll("threadDetails")).map((row) => row.emailAccountId),
+    ).toEqual(["account-2"]);
+  });
+
   it("applies snapshots and deltas atomically with their cursor", async () => {
     const first = getMessage({
       id: "message-1",

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -103,6 +103,44 @@ describe("synced mailbox cache", () => {
     ).toEqual(["account-2"]);
   });
 
+  it("clears every variant when a deleted draft identifies the thread", async () => {
+    const database = await getEmailCacheDatabase();
+    if (!database) throw new Error("Database unavailable");
+    for (const includeDrafts of [false, true]) {
+      await database.put("threadDetails", {
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        variant: `drafts:${includeDrafts ? 1 : 0}|replies:0`,
+        data: {
+          thread: {
+            id: "thread-1",
+            messages: [
+              getMessage({ id: "incoming", threadId: "thread-1" }),
+              ...(includeDrafts
+                ? [getMessage({ id: "draft", threadId: "thread-1" })]
+                : []),
+            ],
+          },
+        },
+        fetchedAt: 100,
+        lastAccessedAt: 100,
+        byteSize: 100,
+      });
+    }
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2026-07-01"),
+      page: {
+        cursor: "delta",
+        reset: false,
+        hasMore: false,
+        deletedMessageIds: ["draft"],
+        upsertedMessages: [],
+      },
+    });
+    expect(await database.count("threadDetails")).toBe(0);
+  });
+
   it("applies snapshots and deltas atomically with their cursor", async () => {
     const first = getMessage({
       id: "message-1",

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -1,3 +1,4 @@
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { internalDateToDate, sortByInternalDate } from "@/utils/date";
 import { canonicalizeEmailAddress } from "@/utils/email";
 import type { MailboxSyncPage } from "@/utils/email/types";
@@ -14,6 +15,8 @@ import {
   isEmailCacheEpochCurrent,
   type CachedMailboxMessage,
 } from "./database";
+
+import { invalidateThreadCaches } from "./thread-invalidation";
 
 const mailboxListeners = new Set<(emailAccountId: string) => void>();
 const INDEXED_DB_BATCH_SIZE = 50;
@@ -54,7 +57,7 @@ export async function applyMailboxSyncPage({
   if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
 
   const transaction = database.transaction(
-    ["mailboxMessages", "mailboxSyncStates"],
+    ["mailboxMessages", "mailboxSyncStates", "threadDetails"],
     "readwrite",
   );
   const messages = transaction.objectStore("mailboxMessages");
@@ -65,6 +68,53 @@ export async function applyMailboxSyncPage({
     transaction.abort();
     await transaction.done.catch(() => {});
     throw new Error("Mailbox sync reset requires an after date");
+  }
+
+  const changedThreadIds = new Set([
+    ...(page.changedThreadIds ?? []),
+    ...page.upsertedMessages.map((message) => message.threadId),
+  ]);
+  const deletedIds = new Set(page.deletedMessageIds);
+  const deletedMessages = await Promise.all(
+    page.deletedMessageIds.map((id) => messages.get([emailAccountId, id])),
+  );
+  for (const message of deletedMessages) {
+    if (message) {
+      changedThreadIds.add(message.threadId);
+      deletedIds.delete(message.messageId);
+    }
+  }
+  const details = transaction.objectStore("threadDetails");
+  const detailKeys = page.reset
+    ? await details.index("byAccount").getAllKeys(emailAccountId)
+    : (
+        await Promise.all(
+          [...changedThreadIds].map((threadId) =>
+            details.getAllKeys(
+              IDBKeyRange.bound(
+                [emailAccountId, threadId, ""],
+                [emailAccountId, threadId, []],
+              ),
+            ),
+          ),
+        )
+      ).flat();
+  await Promise.all(detailKeys.map((key) => details.delete(key)));
+  let detailCursor =
+    !page.reset && deletedIds.size
+      ? await details.index("byAccount").openCursor(emailAccountId)
+      : null;
+  while (detailCursor) {
+    const { threadId, data } = detailCursor.value;
+    if (
+      (data as ThreadResponse).thread.messages.some((message) =>
+        deletedIds.has(message.id),
+      )
+    ) {
+      changedThreadIds.add(threadId);
+      await detailCursor.delete();
+    }
+    detailCursor = await detailCursor.continue();
   }
 
   if (page.reset) {
@@ -93,6 +143,11 @@ export async function applyMailboxSyncPage({
   await transaction.done;
 
   if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  invalidateThreadCaches({
+    emailAccountId,
+    threadIds: [...changedThreadIds],
+    reset: page.reset,
+  });
   scheduleEmailCacheCleanup();
   notifyMailboxStoreChange(emailAccountId);
 }

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -16,6 +16,7 @@ import {
   type CachedMailboxMessage,
 } from "./database";
 
+import { getThreadDetailKeyRange } from "./keys";
 import { invalidateThreadCaches } from "./thread-invalidation";
 
 const mailboxListeners = new Set<(emailAccountId: string) => void>();
@@ -91,10 +92,7 @@ export async function applyMailboxSyncPage({
         await Promise.all(
           [...changedThreadIds].map((threadId) =>
             details.getAllKeys(
-              IDBKeyRange.bound(
-                [emailAccountId, threadId, ""],
-                [emailAccountId, threadId, []],
-              ),
+              getThreadDetailKeyRange(emailAccountId, threadId),
             ),
           ),
         )

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -102,6 +102,7 @@ export async function applyMailboxSyncPage({
     !page.reset && deletedIds.size
       ? await details.index("byAccount").openCursor(emailAccountId)
       : null;
+  const discoveredThreadIds = new Set<string>();
   while (detailCursor) {
     const { threadId, data } = detailCursor.value;
     if (
@@ -110,10 +111,19 @@ export async function applyMailboxSyncPage({
       )
     ) {
       changedThreadIds.add(threadId);
-      await detailCursor.delete();
+      discoveredThreadIds.add(threadId);
     }
     detailCursor = await detailCursor.continue();
   }
+
+  const discoveredKeys = (
+    await Promise.all(
+      [...discoveredThreadIds].map((threadId) =>
+        details.getAllKeys(getThreadDetailKeyRange(emailAccountId, threadId)),
+      ),
+    )
+  ).flat();
+  await Promise.all(discoveredKeys.map((key) => details.delete(key)));
 
   if (page.reset) {
     const messageKeys = await messages

--- a/apps/web/utils/email-cache/thread-invalidation.test.tsx
+++ b/apps/web/utils/email-cache/thread-invalidation.test.tsx
@@ -8,8 +8,10 @@ import {
   connectThreadCacheInvalidation,
   invalidateThreadCaches,
   getThreadCacheVersion,
+  canReadPersistedThread,
 } from "./thread-invalidation";
 
+import { readCachedThreadDetail } from "./threads";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
 
 const broadcast = vi.hoisted(() => {
@@ -78,9 +80,21 @@ describe("thread cache invalidation", () => {
     expect(getThreadCacheVersion("account-1", "thread-1")).not.toBe(version);
   });
 
-  it("does not refresh memory when cross-tab persisted deletion fails", async () => {
+  it("refreshes memory but blocks stale disk reads when cross-tab deletion fails", async () => {
     const database = await getEmailCacheDatabase();
     if (!database) throw new Error("Database unavailable");
+    const identity = {
+      emailAccountId: "account-failure",
+      threadId: "thread-1",
+      variant: "drafts:1|replies:0",
+    };
+    await database.put("threadDetails", {
+      ...identity,
+      data: { thread: { id: "thread-1", messages: [] } },
+      fetchedAt: Date.now(),
+      lastAccessedAt: Date.now(),
+      byteSize: 1,
+    });
     const transaction = vi
       .spyOn(database, "transaction")
       .mockImplementationOnce(() => {
@@ -92,12 +106,33 @@ describe("thread cache invalidation", () => {
       await act(async () => {
         broadcast.receive?.(
           new MessageEvent("message", {
-            data: { emailAccountId: "account-1", threadIds: [], reset: true },
+            data: {
+              emailAccountId: "account-failure",
+              threadIds: [],
+              reset: true,
+            },
           }),
         );
       });
       expect(transaction).toHaveBeenCalled();
-      expect(mutate).not.toHaveBeenCalled();
+      expect(mutate).toHaveBeenCalled();
+      await expect(readCachedThreadDetail(identity)).resolves.toBeUndefined();
+      expect(await database.count("threadDetails")).toBe(1);
+      broadcast.receive?.(
+        new MessageEvent("message", {
+          data: {
+            emailAccountId: identity.emailAccountId,
+            threadIds: [],
+            reset: true,
+          },
+        }),
+      );
+      await waitFor(async () =>
+        expect(await database.count("threadDetails")).toBe(0),
+      );
+      expect(
+        canReadPersistedThread(identity.emailAccountId, identity.threadId),
+      ).toBe(true);
     } finally {
       transaction.mockRestore();
       disconnect();

--- a/apps/web/utils/email-cache/thread-invalidation.test.tsx
+++ b/apps/web/utils/email-cache/thread-invalidation.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import useSWR, { SWRConfig, unstable_serialize, useSWRConfig } from "swr";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  connectThreadCacheInvalidation,
+  invalidateThreadCaches,
+} from "./thread-invalidation";
+
+afterEach(cleanup);
+
+describe("thread cache invalidation", () => {
+  it("refreshes only affected account and thread variants", async () => {
+    const fetcher = vi.fn().mockResolvedValue("cached");
+    const { result } = renderHook(
+      () => ({
+        plain: useSWR(["/api/threads/thread-1", "account-1"]).data,
+        drafts: useSWR([
+          "/api/threads/thread-1?includeDrafts=true",
+          "account-1",
+        ]).data,
+        unrelated: useSWR(["/api/threads/thread-2", "account-1"]).data,
+        otherAccount: useSWR(["/api/threads/thread-1", "account-2"]).data,
+        mutate: useSWRConfig().mutate,
+        cache: useSWRConfig().cache,
+      }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <SWRConfig value={{ provider: () => new Map(), fetcher }}>
+            {children}
+          </SWRConfig>
+        ),
+      },
+    );
+    await waitFor(() => expect(result.current.otherAccount).toBe("cached"));
+    const prefetchedKey = [
+      "/api/threads/thread-1?parseReplies=true",
+      "account-1",
+    ];
+    await act(async () => {
+      await result.current.mutate(
+        prefetchedKey,
+        { thread: { id: "thread-1" } },
+        { revalidate: false },
+      );
+    });
+    const disconnect = connectThreadCacheInvalidation(
+      result.current.cache,
+      result.current.mutate,
+    );
+    try {
+      fetcher.mockClear().mockResolvedValue("current");
+      await act(async () =>
+        invalidateThreadCaches({
+          emailAccountId: "account-1",
+          threadIds: ["thread-1"],
+          reset: false,
+        }),
+      );
+      await waitFor(() => expect(result.current.drafts).toBe("current"));
+      expect(result.current.plain).toBe("current");
+      expect(result.current.unrelated).toBe("cached");
+      expect(result.current.otherAccount).toBe("cached");
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      expect(
+        result.current.cache.get(unstable_serialize(prefetchedKey))?.data,
+      ).toBeUndefined();
+      fetcher.mockClear();
+      await act(async () =>
+        invalidateThreadCaches({
+          emailAccountId: "account-1",
+          threadIds: [],
+          reset: false,
+        }),
+      );
+      expect(fetcher).not.toHaveBeenCalled();
+    } finally {
+      disconnect();
+    }
+  });
+});

--- a/apps/web/utils/email-cache/thread-invalidation.test.tsx
+++ b/apps/web/utils/email-cache/thread-invalidation.test.tsx
@@ -78,6 +78,32 @@ describe("thread cache invalidation", () => {
     expect(getThreadCacheVersion("account-1", "thread-1")).not.toBe(version);
   });
 
+  it("does not refresh memory when cross-tab persisted deletion fails", async () => {
+    const database = await getEmailCacheDatabase();
+    if (!database) throw new Error("Database unavailable");
+    const transaction = vi
+      .spyOn(database, "transaction")
+      .mockImplementationOnce(() => {
+        throw new Error("Storage unavailable");
+      });
+    const mutate = vi.fn().mockResolvedValue(undefined);
+    const disconnect = connectThreadCacheInvalidation(new Map(), mutate);
+    try {
+      await act(async () => {
+        broadcast.receive?.(
+          new MessageEvent("message", {
+            data: { emailAccountId: "account-1", threadIds: [], reset: true },
+          }),
+        );
+      });
+      expect(transaction).toHaveBeenCalled();
+      expect(mutate).not.toHaveBeenCalled();
+    } finally {
+      transaction.mockRestore();
+      disconnect();
+    }
+  });
+
   it("refreshes only affected account and thread variants", async () => {
     const fetcher = vi.fn().mockResolvedValue("cached");
     const { result } = renderHook(

--- a/apps/web/utils/email-cache/thread-invalidation.test.tsx
+++ b/apps/web/utils/email-cache/thread-invalidation.test.tsx
@@ -1,16 +1,83 @@
 // @vitest-environment jsdom
+import "fake-indexeddb/auto";
 import type { ReactNode } from "react";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import useSWR, { SWRConfig, unstable_serialize, useSWRConfig } from "swr";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   connectThreadCacheInvalidation,
   invalidateThreadCaches,
+  getThreadCacheVersion,
 } from "./thread-invalidation";
+
+import { clearEmailCache, getEmailCacheDatabase } from "./database";
+
+const broadcast = vi.hoisted(() => {
+  const state = {
+    receive: undefined as ((event: MessageEvent) => void) | undefined,
+  };
+  vi.stubGlobal(
+    "BroadcastChannel",
+    class {
+      addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+        state.receive = listener;
+      }
+      postMessage() {}
+    },
+  );
+  return state;
+});
+
+beforeEach(async () => {
+  await clearEmailCache();
+});
 
 afterEach(cleanup);
 
 describe("thread cache invalidation", () => {
+  it("clears stale persisted rows when another tab invalidates a thread", async () => {
+    const database = await getEmailCacheDatabase();
+    if (!database) throw new Error("Database unavailable");
+    for (const account of ["account-1", "account-2"]) {
+      await database.put("threadDetails", {
+        emailAccountId: account,
+        threadId: "thread-1",
+        variant: "drafts:1|replies:0",
+        data: { thread: { id: "thread-1", messages: [] } },
+        fetchedAt: 1,
+        lastAccessedAt: 1,
+        byteSize: 1,
+      });
+    }
+    const version = getThreadCacheVersion("account-1", "thread-1");
+    broadcast.receive?.(
+      new MessageEvent("message", {
+        data: {
+          emailAccountId: "account-1",
+          threadIds: ["thread-1"],
+          reset: false,
+        },
+      }),
+    );
+    await waitFor(async () =>
+      expect(
+        await database.get("threadDetails", [
+          "account-1",
+          "thread-1",
+          "drafts:1|replies:0",
+        ]),
+      ).toBeUndefined(),
+    );
+    expect(
+      await database.get("threadDetails", [
+        "account-2",
+        "thread-1",
+        "drafts:1|replies:0",
+      ]),
+    ).toBeDefined();
+    expect(getThreadCacheVersion("account-1", "thread-1")).not.toBe(version);
+  });
+
   it("refreshes only affected account and thread variants", async () => {
     const fetcher = vi.fn().mockResolvedValue("cached");
     const { result } = renderHook(

--- a/apps/web/utils/email-cache/thread-invalidation.ts
+++ b/apps/web/utils/email-cache/thread-invalidation.ts
@@ -1,6 +1,11 @@
 import { unstable_serialize, type Cache, type ScopedMutator } from "swr";
 
-import { createThreadDetailRequestKey } from "./keys";
+import {
+  captureEmailCacheEpoch,
+  getEmailCacheDatabase,
+  isEmailCacheEpochCurrent,
+} from "./database";
+import { createThreadDetailRequestKey, getThreadDetailKeyRange } from "./keys";
 
 type ThreadInvalidation = {
   emailAccountId: string;
@@ -26,7 +31,7 @@ channel?.addEventListener("message", (event) => {
     Array.isArray(change.threadIds) &&
     change.threadIds.every((id: unknown) => typeof id === "string")
   )
-    applyThreadInvalidation(change);
+    invalidatePersistedThreadCaches(change).catch(() => {});
 });
 
 export function getThreadCacheVersion(
@@ -105,7 +110,41 @@ export function connectThreadCacheInvalidation(
   };
 }
 
+async function invalidatePersistedThreadCaches(change: ThreadInvalidation) {
+  const epoch = captureEmailCacheEpoch(change.emailAccountId);
+  advanceThreadCacheVersions(change);
+  try {
+    const database = await getEmailCacheDatabase();
+    if (!database || !isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+      return;
+    const transaction = database.transaction("threadDetails", "readwrite");
+    const store = transaction.store;
+    const keys = change.reset
+      ? await store.index("byAccount").getAllKeys(change.emailAccountId)
+      : (
+          await Promise.all(
+            change.threadIds.map((threadId) =>
+              store.getAllKeys(
+                getThreadDetailKeyRange(change.emailAccountId, threadId),
+              ),
+            ),
+          )
+        ).flat();
+    await Promise.all(keys.map((key) => store.delete(key)));
+    await transaction.done;
+  } finally {
+    // Also reject reads that started while the cross-tab deletion was pending.
+    if (isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+      applyThreadInvalidation(change);
+  }
+}
+
 function applyThreadInvalidation(change: ThreadInvalidation) {
+  advanceThreadCacheVersions(change);
+  for (const listener of listeners) listener(change);
+}
+
+function advanceThreadCacheVersions(change: ThreadInvalidation) {
   const state = versions.get(change.emailAccountId);
   if (state) {
     if (change.reset) {
@@ -118,5 +157,4 @@ function applyThreadInvalidation(change: ThreadInvalidation) {
       }
     }
   }
-  for (const listener of listeners) listener(change);
 }

--- a/apps/web/utils/email-cache/thread-invalidation.ts
+++ b/apps/web/utils/email-cache/thread-invalidation.ts
@@ -13,6 +13,9 @@ type ThreadInvalidation = {
   reset: boolean;
 };
 
+const blockedAccounts = new Set<string>();
+const blockedThreads = new Map<string, Set<string>>();
+
 const listeners = new Set<(change: ThreadInvalidation) => void>();
 const versions = new Map<
   string,
@@ -47,8 +50,19 @@ export function getThreadCacheVersion(
   return `${state.account}:${state.threads.get(threadId)}`;
 }
 
+export function canReadPersistedThread(
+  emailAccountId: string,
+  threadId: string,
+) {
+  return (
+    !blockedAccounts.has(emailAccountId) &&
+    !blockedThreads.get(emailAccountId)?.has(threadId)
+  );
+}
+
 export function invalidateThreadCaches(change: ThreadInvalidation) {
   if (!change.reset && !change.threadIds.length) return;
+  allowPersistedThreadReads(change);
   applyThreadInvalidation(change);
   channel?.postMessage(change);
 }
@@ -113,27 +127,38 @@ export function connectThreadCacheInvalidation(
 async function invalidatePersistedThreadCaches(change: ThreadInvalidation) {
   const epoch = captureEmailCacheEpoch(change.emailAccountId);
   advanceThreadCacheVersions(change);
-  const database = await getEmailCacheDatabase();
-  if (!database || !isEmailCacheEpochCurrent(change.emailAccountId, epoch))
-    return;
-  const transaction = database.transaction("threadDetails", "readwrite");
-  const store = transaction.store;
-  const keys = change.reset
-    ? await store.index("byAccount").getAllKeys(change.emailAccountId)
-    : (
-        await Promise.all(
-          change.threadIds.map((threadId) =>
-            store.getAllKeys(
-              getThreadDetailKeyRange(change.emailAccountId, threadId),
+  if (change.reset) blockedAccounts.add(change.emailAccountId);
+  else {
+    const threads =
+      blockedThreads.get(change.emailAccountId) ?? new Set<string>();
+    for (const id of change.threadIds) threads.add(id);
+    blockedThreads.set(change.emailAccountId, threads);
+  }
+  try {
+    const database = await getEmailCacheDatabase();
+    if (!database || !isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+      return;
+    const transaction = database.transaction("threadDetails", "readwrite");
+    const store = transaction.store;
+    const keys = change.reset
+      ? await store.index("byAccount").getAllKeys(change.emailAccountId)
+      : (
+          await Promise.all(
+            change.threadIds.map((threadId) =>
+              store.getAllKeys(
+                getThreadDetailKeyRange(change.emailAccountId, threadId),
+              ),
             ),
-          ),
-        )
-      ).flat();
-  await Promise.all(keys.map((key) => store.delete(key)));
-  await transaction.done;
-  // Also reject reads that started while the cross-tab deletion was pending.
-  if (isEmailCacheEpochCurrent(change.emailAccountId, epoch))
-    applyThreadInvalidation(change);
+          )
+        ).flat();
+    await Promise.all(keys.map((key) => store.delete(key)));
+    await transaction.done;
+    allowPersistedThreadReads(change);
+  } finally {
+    // Failed deletion must not let the refresh hydrate stale persisted data.
+    if (isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+      applyThreadInvalidation(change);
+  }
 }
 
 function applyThreadInvalidation(change: ThreadInvalidation) {
@@ -154,4 +179,16 @@ function advanceThreadCacheVersions(change: ThreadInvalidation) {
       }
     }
   }
+}
+
+function allowPersistedThreadReads(change: ThreadInvalidation) {
+  if (change.reset) {
+    blockedAccounts.delete(change.emailAccountId);
+    blockedThreads.delete(change.emailAccountId);
+    return;
+  }
+  const threads = blockedThreads.get(change.emailAccountId);
+  if (!threads) return;
+  for (const id of change.threadIds) threads.delete(id);
+  if (!threads.size) blockedThreads.delete(change.emailAccountId);
 }

--- a/apps/web/utils/email-cache/thread-invalidation.ts
+++ b/apps/web/utils/email-cache/thread-invalidation.ts
@@ -113,30 +113,27 @@ export function connectThreadCacheInvalidation(
 async function invalidatePersistedThreadCaches(change: ThreadInvalidation) {
   const epoch = captureEmailCacheEpoch(change.emailAccountId);
   advanceThreadCacheVersions(change);
-  try {
-    const database = await getEmailCacheDatabase();
-    if (!database || !isEmailCacheEpochCurrent(change.emailAccountId, epoch))
-      return;
-    const transaction = database.transaction("threadDetails", "readwrite");
-    const store = transaction.store;
-    const keys = change.reset
-      ? await store.index("byAccount").getAllKeys(change.emailAccountId)
-      : (
-          await Promise.all(
-            change.threadIds.map((threadId) =>
-              store.getAllKeys(
-                getThreadDetailKeyRange(change.emailAccountId, threadId),
-              ),
+  const database = await getEmailCacheDatabase();
+  if (!database || !isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+    return;
+  const transaction = database.transaction("threadDetails", "readwrite");
+  const store = transaction.store;
+  const keys = change.reset
+    ? await store.index("byAccount").getAllKeys(change.emailAccountId)
+    : (
+        await Promise.all(
+          change.threadIds.map((threadId) =>
+            store.getAllKeys(
+              getThreadDetailKeyRange(change.emailAccountId, threadId),
             ),
-          )
-        ).flat();
-    await Promise.all(keys.map((key) => store.delete(key)));
-    await transaction.done;
-  } finally {
-    // Also reject reads that started while the cross-tab deletion was pending.
-    if (isEmailCacheEpochCurrent(change.emailAccountId, epoch))
-      applyThreadInvalidation(change);
-  }
+          ),
+        )
+      ).flat();
+  await Promise.all(keys.map((key) => store.delete(key)));
+  await transaction.done;
+  // Also reject reads that started while the cross-tab deletion was pending.
+  if (isEmailCacheEpochCurrent(change.emailAccountId, epoch))
+    applyThreadInvalidation(change);
 }
 
 function applyThreadInvalidation(change: ThreadInvalidation) {

--- a/apps/web/utils/email-cache/thread-invalidation.ts
+++ b/apps/web/utils/email-cache/thread-invalidation.ts
@@ -1,0 +1,122 @@
+import { unstable_serialize, type Cache, type ScopedMutator } from "swr";
+
+import { createThreadDetailRequestKey } from "./keys";
+
+type ThreadInvalidation = {
+  emailAccountId: string;
+  threadIds: string[];
+  reset: boolean;
+};
+
+const listeners = new Set<(change: ThreadInvalidation) => void>();
+const versions = new Map<
+  string,
+  { account: number; threads: Map<string, number> }
+>();
+
+const channel =
+  typeof window !== "undefined" && typeof BroadcastChannel !== "undefined"
+    ? new BroadcastChannel("inbox-zero-thread-invalidation")
+    : null;
+channel?.addEventListener("message", (event) => {
+  const change = event.data;
+  if (
+    typeof change?.emailAccountId === "string" &&
+    typeof change.reset === "boolean" &&
+    Array.isArray(change.threadIds) &&
+    change.threadIds.every((id: unknown) => typeof id === "string")
+  )
+    applyThreadInvalidation(change);
+});
+
+export function getThreadCacheVersion(
+  emailAccountId: string,
+  threadId: string,
+) {
+  let state = versions.get(emailAccountId);
+  if (!state) {
+    state = { account: 0, threads: new Map() };
+    versions.set(emailAccountId, state);
+  }
+  if (!state.threads.has(threadId)) state.threads.set(threadId, 0);
+  return `${state.account}:${state.threads.get(threadId)}`;
+}
+
+export function invalidateThreadCaches(change: ThreadInvalidation) {
+  if (!change.reset && !change.threadIds.length) return;
+  applyThreadInvalidation(change);
+  channel?.postMessage(change);
+}
+
+export function connectThreadCacheInvalidation(
+  cache: Cache,
+  mutate: ScopedMutator,
+) {
+  const listener = ({
+    emailAccountId,
+    threadIds,
+    reset,
+  }: ThreadInvalidation) => {
+    const invalidatedKeys = new Set<string>();
+    const affectedIds = new Set(threadIds);
+    if (reset) {
+      for (const key of cache.keys()) {
+        const threadId = cache.get(key)?.data?.thread?.id;
+        if (typeof threadId === "string") affectedIds.add(threadId);
+      }
+    }
+    for (const threadId of affectedIds) {
+      for (const includeDrafts of [false, true]) {
+        for (const parseReplies of [false, true]) {
+          const key = unstable_serialize(
+            createThreadDetailRequestKey({
+              emailAccountId,
+              threadId,
+              options: { includeDrafts, parseReplies },
+            }),
+          );
+          if (!cache.get(key)) continue;
+          // Prefetched entries aren't reached by SWR's original-key filter.
+          invalidatedKeys.add(key);
+          mutate(key, undefined, { revalidate: true }).catch(() => {});
+        }
+      }
+    }
+    if (!reset) return;
+    mutate(
+      (key) => {
+        if (
+          !Array.isArray(key) ||
+          key[1] !== emailAccountId ||
+          typeof key[0] !== "string" ||
+          invalidatedKeys.has(unstable_serialize(key))
+        )
+          return false;
+        const path = key[0].split("?")[0];
+        return path.startsWith("/api/threads/");
+      },
+      undefined,
+      { revalidate: true },
+    ).catch(() => {});
+  };
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function applyThreadInvalidation(change: ThreadInvalidation) {
+  const state = versions.get(change.emailAccountId);
+  if (state) {
+    if (change.reset) {
+      state.account += 1;
+      state.threads.clear();
+    } else {
+      for (const id of change.threadIds) {
+        const version = state.threads.get(id);
+        if (version !== undefined) state.threads.set(id, version + 1);
+      }
+    }
+  }
+  for (const listener of listeners) listener(change);
+}

--- a/apps/web/utils/email-cache/thread-request.test.ts
+++ b/apps/web/utils/email-cache/thread-request.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { createThreadRequest, fetchThreadRequest } from "./thread-request";
 
+import { invalidateThreadCaches } from "./thread-invalidation";
+
 describe("thread requests", () => {
   it("encodes provider thread IDs in the route path", () => {
     const request = createThreadRequest({
@@ -13,6 +15,27 @@ describe("thread requests", () => {
       "/api/threads/AAMk%2B%2F%3D%20folder?includeDrafts=true",
     );
     expect(request.cacheIdentity).toContain("AAMk+/= folder");
+  });
+
+  it("refetches when sync invalidates an in-flight response", async () => {
+    const response = Promise.withResolvers<string>();
+    const fetcher = vi
+      .fn()
+      .mockReturnValueOnce(response.promise)
+      .mockResolvedValue("current");
+    const request = createThreadRequest({
+      emailAccountId: "account-race",
+      threadId: "thread-1",
+    });
+    const pending = fetchThreadRequest(request, fetcher);
+    invalidateThreadCaches({
+      emailAccountId: "account-race",
+      threadIds: ["thread-1"],
+      reset: false,
+    });
+    response.resolve("stale");
+    await expect(pending).resolves.toBe("current");
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
   it("shares an in-flight response for the same cache identity", async () => {

--- a/apps/web/utils/email-cache/thread-request.ts
+++ b/apps/web/utils/email-cache/thread-request.ts
@@ -1,4 +1,8 @@
-import { createThreadDetailVariant } from "./keys";
+import { getThreadCacheVersion } from "./thread-invalidation";
+import {
+  createThreadDetailVariant,
+  createThreadDetailRequestKey,
+} from "./keys";
 
 export type ThreadRequestOptions = {
   includeDrafts?: boolean;
@@ -18,16 +22,13 @@ export function createThreadRequest({
   threadId: string;
   options?: ThreadRequestOptions;
 }) {
-  const searchParams = new URLSearchParams();
-  if (options?.includeDrafts) searchParams.set("includeDrafts", "true");
-  if (options?.parseReplies) searchParams.set("parseReplies", "true");
-  const query = searchParams.toString();
-  const url = `/api/threads/${encodeURIComponent(threadId)}${query ? `?${query}` : ""}`;
   const variant = createThreadDetailVariant(options);
 
   return {
+    emailAccountId,
+    threadId,
     cacheIdentity: `${emailAccountId}:${threadId}:${variant}`,
-    key: [url, emailAccountId] as [string, string],
+    key: createThreadDetailRequestKey({ emailAccountId, threadId, options }),
     variant,
   };
 }
@@ -39,20 +40,28 @@ export function isThreadRequestInFlight(
 }
 
 export function fetchThreadRequest<T>(
-  request: Pick<ThreadRequest, "cacheIdentity">,
-  fetcher: () => T | PromiseLike<T>,
+  request: ThreadRequest,
+  fetcher: (version: string) => T | PromiseLike<T>,
 ) {
   const existing = inFlightRequests.get(request.cacheIdentity) as
     | Promise<T>
     | undefined;
   if (existing) return existing;
 
-  let fetched: Promise<T>;
-  try {
-    fetched = Promise.resolve(fetcher());
-  } catch (error) {
-    fetched = Promise.reject(error);
-  }
+  const fetched = (async () => {
+    while (true) {
+      const version = getThreadCacheVersion(
+        request.emailAccountId,
+        request.threadId,
+      );
+      const data = await fetcher(version);
+      if (
+        version ===
+        getThreadCacheVersion(request.emailAccountId, request.threadId)
+      )
+        return data;
+    }
+  })();
   const pending = fetched.finally(() => {
     if (inFlightRequests.get(request.cacheIdentity) === pending) {
       inFlightRequests.delete(request.cacheIdentity);

--- a/apps/web/utils/email-cache/threads.test.ts
+++ b/apps/web/utils/email-cache/threads.test.ts
@@ -6,11 +6,38 @@ import {
   clearEmailCacheForAccount,
   getEmailCacheDatabase,
 } from "./database";
+import {
+  getThreadCacheVersion,
+  invalidateThreadCaches,
+} from "./thread-invalidation";
 import { readCachedThreadDetail, writeCachedThreadDetail } from "./threads";
 
 describe("cached thread details", () => {
   beforeEach(async () => {
     await clearEmailCache();
+  });
+
+  it("does not persist a response from before thread invalidation", async () => {
+    const identity = {
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      variant: "drafts:0|replies:0",
+    };
+    const version = getThreadCacheVersion(
+      identity.emailAccountId,
+      identity.threadId,
+    );
+    invalidateThreadCaches({
+      emailAccountId: identity.emailAccountId,
+      threadIds: [identity.threadId],
+      reset: false,
+    });
+    await writeCachedThreadDetail({
+      ...identity,
+      version,
+      data: getThreadResponse({ textPlain: "stale" }),
+    });
+    await expect(readCachedThreadDetail(identity)).resolves.toBeUndefined();
   });
 
   it("isolates thread response variants", async () => {

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -10,6 +10,7 @@ import {
   getEmailCacheDatabase,
   isEmailCacheEpochCurrent,
 } from "./database";
+import { getThreadCacheVersion } from "./thread-invalidation";
 import { EMAIL_CACHE_MAX_AGE_MS } from "./policy";
 
 export type CachedThreadDetail = {
@@ -24,12 +25,14 @@ export async function writeCachedThreadDetail({
   variant,
   data,
   now = Date.now(),
+  version = getThreadCacheVersion(emailAccountId, threadId),
 }: {
   emailAccountId: string;
   threadId: string;
   variant: string;
   data: ThreadResponse;
   now?: number;
+  version?: string;
 }) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
   const sanitized = sanitizeThreadResponse(data);
@@ -38,7 +41,14 @@ export async function writeCachedThreadDetail({
   try {
     const database = await getEmailCacheDatabase();
     if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
-    await database.put("threadDetails", {
+    const transaction = database.transaction("threadDetails", "readwrite");
+    // Wait behind pending sync deletions before checking this response’s version.
+    await transaction.store.getKey([emailAccountId, threadId, variant]);
+    if (version !== getThreadCacheVersion(emailAccountId, threadId)) {
+      await transaction.done;
+      return;
+    }
+    await transaction.store.put({
       emailAccountId,
       threadId,
       variant,
@@ -47,6 +57,7 @@ export async function writeCachedThreadDetail({
       lastAccessedAt: now,
       byteSize,
     });
+    await transaction.done;
     scheduleEmailCacheCleanup();
   } catch {
     scheduleEmailCacheCleanup({ force: true });

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -44,7 +44,10 @@ export async function writeCachedThreadDetail({
     const transaction = database.transaction("threadDetails", "readwrite");
     // Wait behind pending sync deletions before checking this response’s version.
     await transaction.store.getKey([emailAccountId, threadId, variant]);
-    if (version !== getThreadCacheVersion(emailAccountId, threadId)) {
+    if (
+      !isEmailCacheEpochCurrent(emailAccountId, epoch) ||
+      version !== getThreadCacheVersion(emailAccountId, threadId)
+    ) {
       await transaction.done;
       return;
     }

--- a/apps/web/utils/email-cache/threads.ts
+++ b/apps/web/utils/email-cache/threads.ts
@@ -10,7 +10,10 @@ import {
   getEmailCacheDatabase,
   isEmailCacheEpochCurrent,
 } from "./database";
-import { getThreadCacheVersion } from "./thread-invalidation";
+import {
+  getThreadCacheVersion,
+  canReadPersistedThread,
+} from "./thread-invalidation";
 import { EMAIL_CACHE_MAX_AGE_MS } from "./policy";
 
 export type CachedThreadDetail = {
@@ -77,6 +80,7 @@ export async function readCachedThreadDetail({
   threadId: string;
   variant: string;
 }): Promise<CachedThreadDetail | undefined> {
+  if (!canReadPersistedThread(emailAccountId, threadId)) return;
   const epoch = captureEmailCacheEpoch(emailAccountId);
 
   try {
@@ -106,7 +110,11 @@ export async function readCachedThreadDetail({
       byteSize,
     });
     await transaction.done;
-    if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+    if (
+      !isEmailCacheEpochCurrent(emailAccountId, epoch) ||
+      !canReadPersistedThread(emailAccountId, threadId)
+    )
+      return;
     scheduleEmailCacheCleanup();
     return {
       data: sanitized,

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -17,6 +17,7 @@ export interface EmailThread {
 }
 
 export type MailboxSyncPage = {
+  changedThreadIds?: string[];
   cursor: string;
   deletedMessageIds: string[];
   hasMore: boolean;

--- a/apps/web/utils/gmail/mailbox-sync.test.ts
+++ b/apps/web/utils/gmail/mailbox-sync.test.ts
@@ -32,7 +32,7 @@ describe("getGmailMailboxSyncPage", () => {
           messagesAdded: [
             { message: { id: "inbox-message" } },
             { message: { id: "unavailable-label-message" } },
-            { message: { id: "archived-message" } },
+            { message: { id: "archived-message", threadId: "changed-thread" } },
             { message: { id: "old-message" } },
             { message: { id: "missing-message" } },
           ],
@@ -88,6 +88,7 @@ describe("getGmailMailboxSyncPage", () => {
       "inbox-message",
       "unavailable-label-message",
     ]);
+    expect(page.changedThreadIds).toEqual(["changed-thread"]);
     expect(page.deletedMessageIds).toEqual([
       "deleted-message",
       "archived-message",

--- a/apps/web/utils/gmail/mailbox-sync.ts
+++ b/apps/web/utils/gmail/mailbox-sync.ts
@@ -63,9 +63,8 @@ export async function getGmailMailboxSyncPage({
       },
       logger,
     );
-    const { upsertIds, deletedIds } = getGmailMailboxChangeIds(
-      response.history ?? [],
-    );
+    const { upsertIds, deletedIds, changedThreadIds } =
+      getGmailMailboxChangeIds(response.history ?? []);
     const fetchedMessages = await fetchMessages({
       messageIds: upsertIds,
       accessToken,
@@ -96,6 +95,7 @@ export async function getGmailMailboxSyncPage({
         after: decoded.after,
         pageToken: response.nextPageToken ?? undefined,
       }),
+      changedThreadIds: [...changedThreadIds],
       deletedMessageIds: [...deletedIds],
       hasMore: Boolean(response.nextPageToken),
       reset: false,
@@ -118,11 +118,22 @@ export async function getGmailMailboxSyncPage({
 export function getGmailMailboxChangeIds(history: gmail_v1.Schema$History[]): {
   upsertIds: string[];
   deletedIds: Set<string>;
+  changedThreadIds: Set<string>;
 } {
   const upsertIds = new Set<string>();
   const deletedIds = new Set<string>();
+  const changedThreadIds = new Set<string>();
 
   for (const record of history) {
+    for (const change of [
+      ...(record.messagesAdded ?? []),
+      ...(record.messagesDeleted ?? []),
+      ...(record.labelsAdded ?? []),
+      ...(record.labelsRemoved ?? []),
+    ]) {
+      if (change.message?.threadId)
+        changedThreadIds.add(change.message.threadId);
+    }
     for (const change of record.messagesAdded ?? []) {
       if (change.message?.id) upsertIds.add(change.message.id);
     }
@@ -138,7 +149,7 @@ export function getGmailMailboxChangeIds(history: gmail_v1.Schema$History[]): {
   }
 
   for (const messageId of deletedIds) upsertIds.delete(messageId);
-  return { upsertIds: [...upsertIds], deletedIds };
+  return { upsertIds: [...upsertIds], deletedIds, changedThreadIds };
 }
 
 async function getGmailSnapshotPage({


### PR DESCRIPTION
Mailbox sync could leave cached conversations showing stale provider drafts and missing sent replies; preserve Gmail changed-thread IDs and invalidate affected IndexedDB and SWR entries centrally, including prefetched variants and other tabs.
Remove the conversation hook subscription, reject stale in-flight responses, and clear legacy conversation details on cache upgrade while preserving local drafts and queued sends.

- Validation: 64 focused tests, Biome checks, and secret scanning passed.
- Performance: known threads use targeted cache deletion and mounted affected conversations refetch; unresolved message deletions require an account-scoped detail scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread synchronization so mailbox updates appear reliably across tabs and active views.
  - Prevented outdated in-flight or prefetched responses from overwriting newer thread data.
  - Ensured deleted messages and changed threads remove all affected cached details, including draft variants.
  - Preserved cached data for unaffected accounts during targeted synchronization.
  - Improved recovery when synchronization encounters storage errors.
- **Maintenance**
  - Improved cache migration and recovery behavior to keep thread details consistent after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->