### PR TITLE
mail: Unify split storage and add management dialogs

### DIFF
--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -81,8 +81,8 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
       expect(reordered.map(({ id }) => id)).toEqual([
         rows[2].id,
-        rows[0].id,
         rows[1].id,
+        rows[0].id,
       ]);
       expect(reordered.map(({ order }) => order)).toEqual([0, 1, 2]);
       await reorderMailSplits({

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -1,19 +1,12 @@
-import { Client } from "pg";
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
-import {
-  ActionType,
-  MailSplitKind,
-  SystemType,
-} from "@/generated/prisma/enums";
+import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import {
   createMailSplit,
   removeLabelFromMailSplits,
+  reorderMailSplits,
 } from "@/utils/mail/splits.server";
-import {
-  seedDefaultMailSplits,
-  setDefaultMailSplits,
-} from "@/utils/mail/default-splits.server";
+import { setDefaultMailSplits } from "@/utils/mail/default-splits.server";
 
 const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
 
@@ -47,56 +40,84 @@ describe.skipIf(!RUN_DB_TESTS)(
       await prisma.user.deleteMany({ where: { email: accountEmail } });
     });
 
-    test("preserves a saved split created while default initialization waits", async () => {
-      const lockClient = new Client({
-        connectionString: process.env.DATABASE_URL,
-      });
-      await lockClient.connect();
-      await lockClient.query("BEGIN");
-
-      try {
-        await lockClient.query(
-          "SELECT pg_advisory_xact_lock(742931, hashtext($1))",
-          [emailAccountId],
-        );
-        await lockClient.query(
-          `INSERT INTO "MailSplit" (
-            "id", "createdAt", "updatedAt", "name", "kind", "order", "emailAccountId"
-          ) VALUES ($1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, $2, $3, 0, $4)`,
-          [
-            "concurrent-saved-split",
-            "Saved",
-            MailSplitKind.UNREAD,
-            emailAccountId,
-          ],
-        );
-
-        const seeding = seedDefaultMailSplits({
-          emailAccountId,
-          rules: [
-            {
-              systemType: SystemType.RECEIPT,
-              actions: [{ type: ActionType.LABEL, labelId: "receipt-label" }],
-            },
-          ],
-        });
-
-        await waitForSeederLock(lockClient);
-        await lockClient.query("COMMIT");
-        await seeding;
-      } catch (error) {
-        await lockClient.query("ROLLBACK");
-        throw error;
-      } finally {
-        await lockClient.end();
+    test("stores, deletes, and restores inbox and unread splits as rows", async () => {
+      for (const kind of [MailSplitKind.INBOX, MailSplitKind.UNREAD]) {
+        const draft = { emailAccountId, name: kind, kind, values: [] };
+        expect((await createMailSplit(draft))?.status).toBe("created");
+        await prisma.mailSplit.deleteMany({ where: { emailAccountId, kind } });
+        expect(
+          await prisma.mailSplit.count({ where: { emailAccountId, kind } }),
+        ).toBe(0);
+        expect((await createMailSplit(draft))?.status).toBe("created");
       }
+      expect(await prisma.mailSplit.count({ where: { emailAccountId } })).toBe(
+        2,
+      );
+    });
 
-      const splits = await prisma.mailSplit.findMany({
-        where: { emailAccountId },
+    test("reorders every kind while keeping omitted rows and ignoring stale IDs", async () => {
+      const rows = [];
+      for (const kind of [
+        MailSplitKind.INBOX,
+        MailSplitKind.UNREAD,
+        MailSplitKind.LABEL,
+      ]) {
+        const row = await createMailSplit({
+          emailAccountId,
+          name: kind,
+          kind,
+          values: kind === MailSplitKind.LABEL ? ["label-1"] : [],
+        });
+        if (row?.status !== "created") throw new Error("Could not seed split");
+        rows.push(row);
+      }
+      await reorderMailSplits({
+        emailAccountId,
+        ids: [rows[2].id, "deleted", rows[0].id],
       });
-
-      expect(splits).toHaveLength(1);
-      expect(splits[0]?.id).toBe("concurrent-saved-split");
+      const reordered = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+        orderBy: { order: "asc" },
+      });
+      expect(reordered.map(({ id }) => id)).toEqual([
+        rows[2].id,
+        rows[0].id,
+        rows[1].id,
+      ]);
+      expect(reordered.map(({ order }) => order)).toEqual([0, 1, 2]);
+      await reorderMailSplits({
+        emailAccountId: "another-account",
+        ids: rows.map(({ id }) => id),
+      });
+      expect(
+        await prisma.mailSplit.findMany({
+          where: { emailAccountId },
+          orderBy: { order: "asc" },
+        }),
+      ).toEqual(reordered);
+      await Promise.all([
+        reorderMailSplits({
+          emailAccountId,
+          ids: [rows[1].id, rows[2].id, rows[0].id],
+        }),
+        createMailSplit({
+          emailAccountId,
+          name: "New",
+          kind: MailSplitKind.LABEL,
+          values: ["new-label"],
+        }),
+      ]);
+      const concurrent = await prisma.mailSplit.findMany({
+        where: { emailAccountId },
+        orderBy: { order: "asc" },
+      });
+      expect(concurrent.map(({ name }) => name)).toEqual([
+        "UNREAD",
+        "LABEL",
+        "INBOX",
+        "New",
+      ]);
+      expect(concurrent.map(({ order }) => order)).toEqual([0, 1, 2, 3]);
     });
 
     // The insert goes through raw SQL, so the array parameter needs a real
@@ -182,23 +203,3 @@ describe.skipIf(!RUN_DB_TESTS)(
     });
   },
 );
-
-async function waitForSeederLock(client: Client) {
-  for (let attempt = 0; attempt < 100; attempt++) {
-    const result = await client.query<{ waiting: boolean }>(`
-      SELECT EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE pid <> pg_backend_pid()
-          AND wait_event_type = 'Lock'
-          AND wait_event = 'advisory'
-          AND query LIKE '%pg_advisory_xact_lock(742931%'
-      ) AS waiting
-    `);
-    if (result.rows[0]?.waiting) return;
-
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-
-  throw new Error("Default split seeder did not wait for the account lock");
-}

--- a/apps/web/__tests__/db/mail-split-migration.test.ts
+++ b/apps/web/__tests__/db/mail-split-migration.test.ts
@@ -25,14 +25,22 @@ describe.skipIf(!process.env.RUN_DB_TESTS)("mail split migration", () => {
           UNIQUE ("emailAccountId", "name")
         );
         CREATE UNIQUE INDEX "MailSplit_emailAccountId_order_key" ON "MailSplit" ("emailAccountId", "order");
-        INSERT INTO "EmailAccount" VALUES ('new', '{}'), ('hidden', '{all,unread}'), ('custom', '{unread}');
+        INSERT INTO "EmailAccount" VALUES ('new', '{}'), ('hidden', '{all,unread}'), ('custom', '{unread}'), ('capped', '{}');
         INSERT INTO "MailSplit" VALUES ('label', NOW(), NOW(), 'All', 'LABEL', '{label-1}', 0, 'custom');
+        INSERT INTO "MailSplit"
+        SELECT 'label-' || n, NOW(), NOW(), 'Custom ' || n, 'LABEL', '{label-1}', n - 1, 'capped'
+        FROM generate_series(1, 12) n;
       `);
       await client.query(migration);
       const result = await client.query(
         'SELECT "emailAccountId", "name", "kind", "order" FROM "MailSplit" ORDER BY "emailAccountId", "order"',
       );
-      expect(result.rows).toEqual([
+      expect(
+        result.rows.filter((row) => row.emailAccountId === "capped"),
+      ).toHaveLength(14);
+      expect(
+        result.rows.filter((row) => row.emailAccountId !== "capped"),
+      ).toEqual([
         { emailAccountId: "custom", name: "All (2)", kind: "INBOX", order: 0 },
         { emailAccountId: "custom", name: "All", kind: "LABEL", order: 2 },
         { emailAccountId: "new", name: "All", kind: "INBOX", order: 0 },

--- a/apps/web/__tests__/db/mail-split-migration.test.ts
+++ b/apps/web/__tests__/db/mail-split-migration.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { Client } from "pg";
+import { describe, expect, test } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../../prisma/migrations/20260908180000_unify_mail_splits/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe.skipIf(!process.env.RUN_DB_TESTS)("mail split migration", () => {
+  test("materializes visible defaults and preserves hidden splits and name collisions", async () => {
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    try {
+      await client.query(`
+        BEGIN;
+        CREATE TEMP TABLE "EmailAccount" ("id" text PRIMARY KEY, "mailHiddenBuiltInSplits" text[] NOT NULL DEFAULT '{}');
+        CREATE TEMP TABLE "MailSplit" (
+          "id" text PRIMARY KEY, "createdAt" timestamp, "updatedAt" timestamp,
+          "name" text NOT NULL, "kind" "MailSplitKind" NOT NULL,
+          "values" text[] NOT NULL DEFAULT '{}', "order" integer NOT NULL, "emailAccountId" text NOT NULL,
+          UNIQUE ("emailAccountId", "name")
+        );
+        CREATE UNIQUE INDEX "MailSplit_emailAccountId_order_key" ON "MailSplit" ("emailAccountId", "order");
+        INSERT INTO "EmailAccount" VALUES ('new', '{}'), ('hidden', '{all,unread}'), ('custom', '{unread}');
+        INSERT INTO "MailSplit" VALUES ('label', NOW(), NOW(), 'All', 'LABEL', '{label-1}', 0, 'custom');
+      `);
+      await client.query(migration);
+      const result = await client.query(
+        'SELECT "emailAccountId", "name", "kind", "order" FROM "MailSplit" ORDER BY "emailAccountId", "order"',
+      );
+      expect(result.rows).toEqual([
+        { emailAccountId: "custom", name: "All (2)", kind: "INBOX", order: 0 },
+        { emailAccountId: "custom", name: "All", kind: "LABEL", order: 2 },
+        { emailAccountId: "new", name: "All", kind: "INBOX", order: 0 },
+        { emailAccountId: "new", name: "Unread", kind: "UNREAD", order: 1 },
+      ]);
+    } finally {
+      await client.query("ROLLBACK");
+      await client.end();
+    }
+  });
+});

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -99,6 +99,7 @@ test("shows a combined picker and creates a matching split", async ({
   await expect(conversations.getByRole("option")).toHaveCount(1);
   await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-created");
 
+  await page.getByRole("button", { name: "Manage splits" }).click();
   await page
     .getByRole("button", { name: "Remove the Promotions split" })
     .click();
@@ -197,6 +198,7 @@ test("builds one tab from several labels and names it", async ({
     conversationWithSubject(page, conversations, "Project Label Message"),
   ).toBeVisible();
 
+  await page.getByRole("button", { name: "Manage splits" }).click();
   await page
     .getByRole("button", { name: "Remove the Two labels split" })
     .click();
@@ -222,6 +224,7 @@ for (const accountScope of ["single", "all"] as const) {
       exact: true,
     });
     await expect(split).toBeVisible();
+    await page.getByRole("button", { name: "Manage splits" }).click();
     await page
       .getByRole("button", { name: "Remove the Project Alpha split" })
       .click();
@@ -236,9 +239,11 @@ for (const accountScope of ["single", "all"] as const) {
           const response = await request.get("/api/mail/settings", {
             headers: { "X-Email-Account-ID": emailAccountId },
           });
-          return new Set((await response.json()).hiddenBuiltInSplits);
+          return (await response.json()).splits.some(
+            (split: { name: string }) => split.name === name,
+          );
         })
-        .toEqual(new Set(name === "All" ? ["all"] : ["all", "unread"]));
+        .toBe(false);
       await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
         0,
       );
@@ -256,9 +261,11 @@ for (const accountScope of ["single", "all"] as const) {
           const response = await request.get("/api/mail/settings", {
             headers: { "X-Email-Account-ID": emailAccountId },
           });
-          return new Set((await response.json()).hiddenBuiltInSplits);
+          return (await response.json()).splits.some(
+            (split: { name: string }) => split.name === name,
+          );
         })
-        .toEqual(new Set(name === "All" ? ["unread"] : []));
+        .toBe(true);
       await expect(
         page.getByRole("button", { name, exact: true }),
       ).toBeVisible();
@@ -274,3 +281,49 @@ for (const accountScope of ["single", "all"] as const) {
     }
   });
 }
+
+test("keeps removal in the dialog and persists tab order", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  await expect(
+    page.getByRole("button", { name: /Remove the .* split/ }),
+  ).toHaveCount(0);
+  const tabs = page.locator("button[data-split-tab]");
+  const original = await tabs.allTextContents();
+  expect(original.length).toBeGreaterThanOrEqual(2);
+  await page.getByRole("button", { name: "Manage splits" }).click();
+  const dialog = page.getByRole("dialog", { name: "Manage splits" });
+  await dialog
+    .getByRole("button", { name: `Move ${original[1]} up`, exact: true })
+    .click();
+  await expect(
+    dialog.getByRole("button", { name: `Move ${original[1]} up`, exact: true }),
+  ).toBeDisabled();
+  await expect(dialog.getByRole("list")).toHaveAttribute("aria-busy", "false");
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-manage-splits");
+  await dialog.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(tabs.first()).toHaveText(original[1]);
+  await expect(tabs.filter({ hasText: original[0] })).toHaveAttribute(
+    "aria-current",
+    "true",
+  );
+  await page.reload();
+  await expect(tabs.first()).toHaveText(original[1]);
+  await page.getByRole("button", { name: "Manage splits" }).click();
+  const rows = dialog.getByRole("listitem");
+  await rows.nth(1).locator("[data-drag-split]").dragTo(rows.first());
+  await expect(dialog.getByRole("list")).toHaveAttribute("aria-busy", "false");
+  await dialog.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(tabs).toHaveText(original);
+  await page.reload();
+  await expect(tabs).toHaveText(original);
+  await expect(
+    page.getByRole("listbox", { name: "Conversations" }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-splits-clean-tab-bar",
+  );
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1143,7 +1143,6 @@ export function MailShell() {
 
   const onDeleteSplit = useCallback(
     async (splitId: string) => {
-      if (activeSplitId === splitId) setActiveSplitId(null);
       const result = await deleteMailSplitAction(emailAccountId, {
         id: splitId,
       });
@@ -1151,9 +1150,10 @@ export function MailShell() {
         toast.error(getActionErrorMessage(result));
         return;
       }
+      if (activeSplitIdRef.current === splitId) setActiveSplitId(null);
       await mutateSettings();
     },
-    [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
+    [emailAccountId, mutateSettings, setActiveSplitId],
   );
 
   const onSetDefaultSplits = useCallback(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -40,7 +40,7 @@ import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
 import type {
   NewSplitDraft,
   NewSplitOption,
-} from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
+} from "@/app/(app)/[emailAccountId]/mail/NewSplitDialog";
 import { LabelPickerDialog } from "@/app/(app)/[emailAccountId]/mail/LabelPickerDialog";
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
@@ -97,6 +97,7 @@ import {
   createMailSplitAction,
   suggestMailSplitAction,
   deleteMailSplitAction,
+  reorderMailSplitsAction,
   setDefaultMailSplitsAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
@@ -122,7 +123,7 @@ import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions
 import type { LabelCount } from "@/app/api/labels/counts/route";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getEmailTerminology } from "@/utils/terminology";
-import { BUILT_IN_SPLITS } from "@/utils/mail/built-in-splits";
+import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { GMAIL_LABEL_COLORS } from "@/utils/gmail/label-colors";
 import { OUTLOOK_CATEGORY_COLORS } from "@/utils/outlook/category-colors";
 
@@ -164,9 +165,7 @@ export function MailShell() {
   });
   const openThreadId = openThreadQuery["thread-id"];
   const openThreadAccountId = openThreadQuery["thread-account-id"];
-  const [activeSplitId, setActiveSplitId] = useQueryState("split", {
-    defaultValue: "all",
-  });
+  const [activeSplitId, setActiveSplitId] = useQueryState("split");
   const activeSplitIdRef = useRef(activeSplitId);
   activeSplitIdRef.current = activeSplitId;
   const [accountScope, setAccountScope] = useQueryState("accountScope");
@@ -307,29 +306,20 @@ export function MailShell() {
     [settings?.splits, userLabels],
   );
 
-  const splits = useMemo(() => {
-    const builtInSplits = BUILT_IN_SPLITS.filter(
-      (split) => !settings?.hiddenBuiltInSplits?.includes(split.id),
-    );
-    const savedSplits = (settings?.splits ?? []).filter(
-      (split) =>
-        !isAllAccounts ||
-        split.kind === MailSplitKind.INBOX ||
-        split.kind === MailSplitKind.UNREAD ||
-        combinedLabelSplits.some((portable) => portable.id === split.id),
-    );
-    return [...builtInSplits, ...savedSplits];
-  }, [
-    combinedLabelSplits,
-    isAllAccounts,
-    settings?.splits,
-    settings?.hiddenBuiltInSplits,
-  ]);
+  const splits = useMemo(
+    () =>
+      (settings?.splits ?? []).filter(
+        (split) =>
+          !isAllAccounts ||
+          split.kind === MailSplitKind.INBOX ||
+          split.kind === MailSplitKind.UNREAD ||
+          combinedLabelSplits.some((portable) => portable.id === split.id),
+      ),
+    [settings?.splits, isAllAccounts, combinedLabelSplits],
+  );
   const activeSplit =
-    splits.find((split) => split.id === activeSplitId) ??
-    splits[0] ??
-    BUILT_IN_SPLITS[0];
-  const displayedActiveSplitId = activeSplit.id;
+    splits.find((split) => split.id === activeSplitId) ?? splits[0];
+  const displayedActiveSplitId = activeSplit?.id ?? null;
   const activeCombinedLabelNames = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
   )?.labelNames;
@@ -362,7 +352,9 @@ export function MailShell() {
     if (searchQuery) return { q: searchQuery };
     if (scopeQuery) return scopeQuery;
 
-    return mailSplitToThreadsQuery(activeSplit);
+    return activeSplit
+      ? mailSplitToThreadsQuery(activeSplit)
+      : { type: "inbox" };
   }, [searchQuery, scopeQuery, activeSplit]);
 
   const accountThreadState = useMailThreads({
@@ -374,7 +366,7 @@ export function MailShell() {
     accounts: combinedAccounts,
     emailAccountId,
     enabled: isAllAccounts,
-    isUnread: !searchQuery && activeSplit.kind === MailSplitKind.UNREAD,
+    isUnread: !searchQuery && activeSplit?.kind === MailSplitKind.UNREAD,
     labelNames: searchQuery ? undefined : activeCombinedLabelNames,
     searchQuery: searchQuery ?? undefined,
   });
@@ -929,14 +921,20 @@ export function MailShell() {
     setScopeFolderId(null);
     setSearchParam(null);
     if (
-      !BUILT_IN_SPLITS.some((split) => split.id === activeSplitId) &&
+      !settings?.splits.some(
+        (split) =>
+          split.id === activeSplitId &&
+          (split.kind === MailSplitKind.INBOX ||
+            split.kind === MailSplitKind.UNREAD),
+      ) &&
       !combinedLabelSplits.some((split) => split.id === activeSplitId)
     ) {
-      setActiveSplitId("all");
+      setActiveSplitId(null);
     }
     setAccountScope("all");
   }, [
     activeSplitId,
+    settings?.splits,
     combinedLabelSplits,
     selection.clear,
     setAccountScope,
@@ -1081,11 +1079,12 @@ export function MailShell() {
     : "category";
   const newSplitOptions: NewSplitOption[] = useMemo(
     () => [
-      ...BUILT_IN_SPLITS.filter((split) =>
-        settings?.hiddenBuiltInSplits?.includes(split.id),
+      ...INITIAL_MAIL_SPLITS.filter(
+        (initial) =>
+          !settings?.splits.some((split) => split.kind === initial.kind),
       ).map((split) => ({
         ...split,
-        id: `state:${split.id}`,
+        id: `state:${split.kind}`,
         group: "state" as const,
       })),
       ...(isAllAccounts ? [] : categories).map((category) => ({
@@ -1103,13 +1102,7 @@ export function MailShell() {
         group: "label" as const,
       })),
     ],
-    [
-      categories,
-      categoryGroup,
-      visibleLabels,
-      isAllAccounts,
-      settings?.hiddenBuiltInSplits,
-    ],
+    [categories, categoryGroup, visibleLabels, isAllAccounts, settings?.splits],
   );
 
   const onCreateSplit = useCallback(
@@ -1150,16 +1143,7 @@ export function MailShell() {
 
   const onDeleteSplit = useCallback(
     async (splitId: string) => {
-      const builtIn = BUILT_IN_SPLITS.find((split) => split.id === splitId);
-      if (builtIn) {
-        updatePreferences({
-          hiddenBuiltInSplits: [
-            ...new Set([...(settings?.hiddenBuiltInSplits ?? []), builtIn.id]),
-          ],
-        });
-        return;
-      }
-      if (activeSplitId === splitId) setActiveSplitId("all");
+      if (activeSplitId === splitId) setActiveSplitId(null);
       const result = await deleteMailSplitAction(emailAccountId, {
         id: splitId,
       });
@@ -1167,16 +1151,9 @@ export function MailShell() {
         toast.error(getActionErrorMessage(result));
         return;
       }
-      mutateSettings();
+      await mutateSettings();
     },
-    [
-      emailAccountId,
-      mutateSettings,
-      activeSplitId,
-      setActiveSplitId,
-      settings?.hiddenBuiltInSplits,
-      updatePreferences,
-    ],
+    [emailAccountId, mutateSettings, activeSplitId, setActiveSplitId],
   );
 
   const onSetDefaultSplits = useCallback(
@@ -1195,7 +1172,7 @@ export function MailShell() {
           (split) => split.id === activeSplitIdRef.current,
         )
       ) {
-        setActiveSplitId("all");
+        setActiveSplitId(null);
       }
       return true;
     },
@@ -1280,7 +1257,7 @@ export function MailShell() {
             : setScopeLabelId(null),
         ]);
       }
-      if (deletedActiveSplit) setActiveSplitId("all");
+      if (deletedActiveSplit) setActiveSplitId(null);
       await Promise.all([
         item.kind === "folder" ? mutateFolders() : mutateLabels(),
         mutateCounts(),
@@ -1427,6 +1404,17 @@ export function MailShell() {
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}
+                onReorder={async (ids) => {
+                  const result = await reorderMailSplitsAction(emailAccountId, {
+                    ids,
+                  });
+                  if (result?.serverError || result?.validationErrors) {
+                    toast.error(getActionErrorMessage(result));
+                    return;
+                  }
+                  if (!activeSplitId) setActiveSplitId(displayedActiveSplitId);
+                  await mutateSettings();
+                }}
                 newSplitOptions={newSplitOptions}
                 onCreateSplit={onCreateSplit}
                 onSuggestSplit={onSuggestSplit}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ManageSplitsDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ManageSplitsDialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  GripVerticalIcon,
+  Settings2Icon,
+  Trash2Icon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { MailSplitTab } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
+
+export function ManageSplitsDialog({
+  splits,
+  onDelete,
+  onReorder,
+}: {
+  splits: MailSplitTab[];
+  onDelete: (id: string) => Promise<void>;
+  onReorder: (ids: string[]) => Promise<void>;
+}) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+
+  const move = async (id: string, targetId: string) => {
+    if (isSaving || id === targetId) return;
+    const ids = splits.map((split) => split.id);
+    const from = ids.indexOf(id);
+    const to = ids.indexOf(targetId);
+    if (from < 0 || to < 0) return;
+    ids.splice(from, 1);
+    ids.splice(to, 0, id);
+    setIsSaving(true);
+    try {
+      await onReorder(ids);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setIsSaving(true);
+    try {
+      await onDelete(id);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 rounded-full text-muted-foreground"
+          aria-label="Manage splits"
+        >
+          <Settings2Icon className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Manage splits</DialogTitle>
+          <DialogDescription>
+            Drag tabs into order or use the arrows. Removing a split does not
+            delete its emails or labels. Changes save automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="space-y-2" aria-label="Split order" aria-busy={isSaving}>
+          {splits.map((split, index) => (
+            <li
+              key={split.id}
+              className="flex items-center gap-2 rounded-lg border bg-background p-2"
+              onDragOver={(event) => {
+                if (draggedId && !isSaving) event.preventDefault();
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                if (draggedId) move(draggedId, split.id);
+                setDraggedId(null);
+              }}
+            >
+              <span
+                draggable={!isSaving}
+                onDragStart={(event) => {
+                  event.dataTransfer.setData("text/plain", split.id);
+                  event.dataTransfer.effectAllowed = "move";
+                  setDraggedId(split.id);
+                }}
+                onDragEnd={() => setDraggedId(null)}
+                className="cursor-grab p-1 text-muted-foreground active:cursor-grabbing"
+                aria-hidden="true"
+                data-drag-split={split.id}
+              >
+                <GripVerticalIcon className="size-4" />
+              </span>
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {split.name}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                aria-label={`Move ${split.name} up`}
+                disabled={isSaving || index === 0}
+                onClick={() => move(split.id, splits[index - 1].id)}
+              >
+                <ArrowUpIcon className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                aria-label={`Move ${split.name} down`}
+                disabled={isSaving || index === splits.length - 1}
+                onClick={() => move(split.id, splits[index + 1].id)}
+              >
+                <ArrowDownIcon className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove the ${split.name} split`}
+                disabled={isSaving}
+                onClick={() => remove(split.id)}
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+        {!splits.length && (
+          <p className="text-muted-foreground text-sm">
+            No splits yet. Use the + button to add one.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -14,14 +14,17 @@ import {
 } from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 import { cn } from "@/utils";
 
-export type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
+type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
 
 export type NewSplitOption = {
   /** Unique across every group; identifies the choice, not the split. */
@@ -45,7 +48,7 @@ export type NewSplitSuggestion = {
   reasoning: string;
 };
 
-export type NewSplitPopoverProps = {
+type NewSplitDialogProps = {
   options: NewSplitOption[];
   onCreate: (draft: NewSplitDraft) => Promise<boolean>;
   /** Resolves a free-text description into a selection of the options above. */
@@ -70,14 +73,14 @@ const DESCRIBE_EXAMPLES = ["Mail I still owe a reply", "Invoices and receipts"];
 const FOOTER_BUTTON_CLASS =
   "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
-export function NewSplitPopover({
+export function NewSplitDialog({
   options,
   onCreate,
   onSuggest,
   canAddDefaultSplits,
   canRemoveDefaultSplits,
   onSetDefaultSplits,
-}: NewSplitPopoverProps) {
+}: NewSplitDialogProps) {
   const [open, setOpen] = useState(false);
   const [isDescribing, setIsDescribing] = useState(false);
   const [prompt, setPrompt] = useState("");
@@ -190,14 +193,20 @@ export function NewSplitPopover({
   };
 
   return (
-    <Popover open={open} onOpenChange={changeOpen}>
-      <PopoverTrigger
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <DialogTrigger
         aria-label="New split"
         className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <PlusIcon className="size-3.5" />
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-80 p-0 text-foreground">
+      </DialogTrigger>
+      <DialogContent className="gap-0 p-0 text-foreground">
+        <DialogHeader className="p-4 pr-10">
+          <DialogTitle>New split</DialogTitle>
+          <DialogDescription>
+            Choose labels or a category for a new inbox tab.
+          </DialogDescription>
+        </DialogHeader>
         {isDescribing ? (
           <div className="space-y-3 p-3">
             <div className="flex items-center gap-2">
@@ -259,7 +268,7 @@ export function NewSplitPopover({
           </div>
         ) : (
           <div>
-            <Command filter={filterByName}>
+            <Command filter={filterByName} className="h-auto">
               <CommandInput
                 placeholder="Search labels and categories"
                 aria-label="Search labels and categories"
@@ -403,8 +412,8 @@ export function NewSplitPopover({
             )}
           </div>
         )}
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { XIcon } from "lucide-react";
+import { ManageSplitsDialog } from "@/app/(app)/[emailAccountId]/mail/ManageSplitsDialog";
 import { useEffect, useRef } from "react";
 import {
   type NewSplitDraft,
   type NewSplitOption,
-  NewSplitPopover,
+  NewSplitDialog,
   type NewSplitSuggestion,
-} from "@/app/(app)/[emailAccountId]/mail/NewSplitPopover";
+} from "@/app/(app)/[emailAccountId]/mail/NewSplitDialog";
 import { cn } from "@/utils";
 
 export type MailSplitTab = {
@@ -15,11 +15,12 @@ export type MailSplitTab = {
   name: string;
 };
 
-export type SplitTabsProps = {
+type SplitTabsProps = {
   splits: MailSplitTab[];
   activeSplitId: string | null;
   onSelect: (splitId: string) => void;
-  onDelete: (splitId: string) => void;
+  onDelete: (splitId: string) => Promise<void>;
+  onReorder: (ids: string[]) => Promise<void>;
   newSplitOptions: NewSplitOption[];
   onCreateSplit: (draft: NewSplitDraft) => Promise<boolean>;
   onSuggestSplit: (prompt: string) => Promise<NewSplitSuggestion | null>;
@@ -34,6 +35,7 @@ export function SplitTabs({
   activeSplitId,
   onSelect,
   onDelete,
+  onReorder,
   newSplitOptions,
   onCreateSplit,
   onSuggestSplit,
@@ -94,19 +96,16 @@ export function SplitTabs({
             >
               {split.name}
             </button>
-            <button
-              type="button"
-              onClick={() => onDelete(split.id)}
-              aria-label={`Remove the ${split.name} split`}
-              className="rounded-full p-0.5 text-muted-foreground hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <XIcon className="size-3" />
-            </button>
           </div>
         );
       })}
 
-      <NewSplitPopover
+      <ManageSplitsDialog
+        splits={splits}
+        onDelete={onDelete}
+        onReorder={onReorder}
+      />
+      <NewSplitDialog
         options={newSplitOptions}
         onCreate={onCreateSplit}
         onSuggest={onSuggestSplit}

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-account-url.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-account-url.test.ts
@@ -6,7 +6,7 @@ describe("getMailAccountUrl", () => {
     const url = new URL(
       getMailAccountUrl(
         "next-account",
-        "?accountScope=all&thread-id=thread&thread-account-id=previous-account&side-panel-thread-id=thread&labelId=label&type=label&layout=list&q=receipt",
+        "?accountScope=all&split=previous-account-split&thread-id=thread&thread-account-id=previous-account&side-panel-thread-id=thread&labelId=label&type=label&layout=list&q=receipt",
       ),
       "https://example.com",
     );

--- a/apps/web/app/(app)/[emailAccountId]/mail/mail-account-url.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/mail-account-url.ts
@@ -3,6 +3,7 @@ export function getMailAccountUrl(accountId: string, search: string) {
   const hasAccountScopedFilter =
     params.has("labelId") || params.has("folderId");
   params.delete("accountScope");
+  params.delete("split");
   params.delete("thread-id");
   params.delete("thread-account-id");
   params.delete("side-panel-thread-id");

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
-import { hiddenBuiltInSplitsSchema } from "@/utils/actions/mail-split.validation";
 import { getDefaultMailSplitDraftsForAccount } from "@/utils/mail/default-splits.server";
 
 export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
@@ -13,7 +12,6 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
       select: {
         mailLayout: true,
         mailExpandedPreview: true,
-        mailHiddenBuiltInSplits: true,
         mailSplits: {
           // createdAt breaks ties so tab order can't shuffle between requests
           orderBy: [{ order: "asc" }, { createdAt: "asc" }],
@@ -33,9 +31,6 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
   return {
     layout: emailAccount?.mailLayout ?? null,
     expandedPreview: emailAccount?.mailExpandedPreview ?? false,
-    hiddenBuiltInSplits: hiddenBuiltInSplitsSchema.parse(
-      emailAccount?.mailHiddenBuiltInSplits ?? [],
-    ),
     splits: emailAccount?.mailSplits ?? [],
     defaultSplits,
   };

--- a/apps/web/prisma/migrations/20260908180000_unify_mail_splits/migration.sql
+++ b/apps/web/prisma/migrations/20260908180000_unify_mail_splits/migration.sql
@@ -1,0 +1,33 @@
+DROP INDEX "MailSplit_emailAccountId_order_key";
+CREATE INDEX "MailSplit_emailAccountId_order_idx" ON "MailSplit"("emailAccountId", "order");
+
+UPDATE "MailSplit" SET "order" = "order" + 2;
+
+INSERT INTO "MailSplit" ("id", "createdAt", "updatedAt", "name", "kind", "values", "order", "emailAccountId")
+SELECT
+  gen_random_uuid()::text, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+  available_name."name", defaults."kind"::"MailSplitKind", ARRAY[]::TEXT[],
+  defaults."order", account."id"
+FROM "EmailAccount" account
+CROSS JOIN (VALUES ('all', 'All', 'INBOX', 0), ('unread', 'Unread', 'UNREAD', 1))
+  AS defaults("key", "name", "kind", "order")
+CROSS JOIN LATERAL (
+  SELECT CASE WHEN suffix = 1 THEN defaults."name"
+    ELSE defaults."name" || ' (' || suffix || ')' END AS "name"
+  FROM generate_series(1, (SELECT COUNT(*)::integer + 1 FROM "MailSplit" WHERE "emailAccountId" = account."id")) suffix
+  WHERE NOT EXISTS (
+    SELECT 1 FROM "MailSplit" existing
+    WHERE existing."emailAccountId" = account."id"
+      AND existing."name" = CASE WHEN suffix = 1 THEN defaults."name"
+        ELSE defaults."name" || ' (' || suffix || ')' END
+  )
+  ORDER BY suffix LIMIT 1
+) available_name
+WHERE NOT (defaults."key" = ANY(account."mailHiddenBuiltInSplits"))
+  AND NOT EXISTS (
+    SELECT 1 FROM "MailSplit" existing
+    WHERE existing."emailAccountId" = account."id"
+      AND existing."kind" = defaults."kind"::"MailSplitKind"
+  );
+
+ALTER TABLE "EmailAccount" DROP COLUMN "mailHiddenBuiltInSplits";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -160,7 +160,6 @@ model EmailAccount {
 
   mailLayout          MailLayout @default(LIST)
   mailExpandedPreview Boolean    @default(false)
-  mailHiddenBuiltInSplits String[] @default([])
 
   includeInAllAccounts Boolean @default(true)
 
@@ -257,7 +256,7 @@ model MailSplit {
   emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
 
   @@unique([emailAccountId, name])
-  @@unique([emailAccountId, order])
+  @@index([emailAccountId, order])
 }
 
 model Organization {

--- a/apps/web/scripts/measure-playwright-selection.mjs
+++ b/apps/web/scripts/measure-playwright-selection.mjs
@@ -11,7 +11,7 @@ const appRoot = path.resolve(import.meta.dirname, "..");
 const mail = "apps/web/app/(app)/[emailAccountId]/mail/";
 const scenarios = {
   "Split tabs": [`${mail}SplitTabs.tsx`],
-  "Nested split picker": [`${mail}NewSplitPopover.tsx`],
+  "Nested split picker": [`${mail}NewSplitDialog.tsx`],
   "Sender profile": [`${mail}SenderContextPanel.tsx`],
   "Sender profile hook": [`${mail}use-public-contact-context.ts`],
   "Label picker": [`${mail}LabelPickerDialog.tsx`],

--- a/apps/web/utils/actions/mail-mailbox-item.test.ts
+++ b/apps/web/utils/actions/mail-mailbox-item.test.ts
@@ -141,24 +141,16 @@ describe("mailbox item actions", () => {
     expect(result?.serverError).toBeUndefined();
     expect(method).toHaveBeenCalledWith(`${kind}-1`);
     if (kind === "label") {
-      // One statement, so splits keep their other labels and only the ones
-      // this label emptied are deleted.
-      expect(prisma.$executeRaw).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.stringContaining("array_remove"),
-          expect.stringContaining("DELETE FROM"),
-        ]),
-        "label-1",
-        EMAIL_ACCOUNT_ID,
-        "label-1",
-      );
+      expect(prisma.$transaction).toHaveBeenCalled();
     } else {
       expect(prisma.$executeRaw).not.toHaveBeenCalled();
     }
   });
 
   it("retries saved-view cleanup after a successful provider deletion", async () => {
-    prisma.$executeRaw.mockRejectedValueOnce(new Error("Database unavailable"));
+    prisma.$transaction.mockRejectedValueOnce(
+      new Error("Database unavailable"),
+    );
 
     const firstResult = await deleteMailboxItemAction(EMAIL_ACCOUNT_ID, {
       kind: "label",
@@ -174,7 +166,7 @@ describe("mailbox item actions", () => {
     );
     expect(retryResult?.serverError).toBeUndefined();
     expect(mockDeleteLabel).toHaveBeenCalledTimes(2);
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
   });
 
   it("keeps saved views when provider deletion fails", async () => {

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -10,6 +10,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import {
   createMailSplitAction,
   renameMailSplitAction,
+  reorderMailSplitsAction,
   setDefaultMailSplitsAction,
   suggestMailSplitAction,
   updateMailPreferencesAction,
@@ -58,6 +59,14 @@ describe("mail split actions", () => {
     } as never);
   });
 
+  it("rejects duplicate IDs before reordering", async () => {
+    const result = await reorderMailSplitsAction(EMAIL_ACCOUNT_ID, {
+      ids: ["split-1", "split-1"],
+    });
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
   it("creates splits behind an account-scoped database lock", async () => {
     const split = {
       id: "split-1",
@@ -101,7 +110,7 @@ describe("mail split actions", () => {
       values: ["label-1"],
     });
 
-    expect(result?.serverError).toBe("You can only have 12 splits.");
+    expect(result?.serverError).toBe("You can only have 14 splits.");
   });
 
   it("returns a user-safe error when a split name already exists", async () => {
@@ -177,35 +186,6 @@ describe("mail split actions", () => {
     expect(result?.data?.optionIds).toEqual(["state:unread"]);
   });
 
-  it.each([
-    { id: "all", name: "All", kind: MailSplitKind.INBOX },
-    { id: "unread", name: "Unread", kind: MailSplitKind.UNREAD },
-  ])("restores the hidden $name tab instead of saving a duplicate", async (builtIn) => {
-    prisma.$executeRaw.mockResolvedValue(1);
-
-    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: builtIn.name,
-      kind: builtIn.kind,
-      values: [],
-    });
-
-    expect(result?.data?.split).toEqual({ ...builtIn, values: [] });
-    expect(prisma.$executeRaw).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.stringContaining("array_remove")]),
-      builtIn.id,
-      EMAIL_ACCOUNT_ID,
-    );
-    expect(prisma.$transaction).not.toHaveBeenCalled();
-  });
-
-  it("rejects duplicate hidden split IDs before writing preferences", async () => {
-    const result = await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
-      hiddenBuiltInSplits: ["all", "all"],
-    });
-    expect(result?.validationErrors).toBeDefined();
-    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
-  });
-
   it("drops options the AI invented rather than passing them to the picker", async () => {
     vi.mocked(aiPromptToSplit).mockResolvedValue({
       reasoning: "Nothing here covers mail from a specific person",
@@ -257,22 +237,7 @@ describe("mail split actions", () => {
       enabled: true,
     });
 
-    expect(result?.serverError).toBe("You can only have 12 splits.");
-  });
-
-  it("persists and restores hidden built-in splits", async () => {
-    for (const hiddenBuiltInSplits of [["all", "unread"], []] as (
-      | "all"
-      | "unread"
-    )[][]) {
-      await updateMailPreferencesAction(EMAIL_ACCOUNT_ID, {
-        hiddenBuiltInSplits,
-      });
-      expect(prisma.emailAccount.update).toHaveBeenLastCalledWith({
-        where: { id: EMAIL_ACCOUNT_ID },
-        data: { mailHiddenBuiltInSplits: hiddenBuiltInSplits },
-      });
-    }
+    expect(result?.serverError).toBe("You can only have 14 splits.");
   });
 
   it("persists the selected mail layout", async () => {

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -59,9 +59,12 @@ describe("mail split actions", () => {
     } as never);
   });
 
-  it("rejects duplicate IDs before reordering", async () => {
+  it.each([
+    [],
+    ["split-1", "split-1"],
+  ])("rejects invalid reorder IDs: %j", async (ids) => {
     const result = await reorderMailSplitsAction(EMAIL_ACCOUNT_ID, {
-      ids: ["split-1", "split-1"],
+      ids,
     });
     expect(result?.validationErrors).toBeDefined();
     expect(prisma.$transaction).not.toHaveBeenCalled();

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -60,9 +60,9 @@ describe("mail split actions", () => {
   });
 
   it.each([
-    [],
-    ["split-1", "split-1"],
-  ])("rejects invalid reorder IDs: %j", async (ids) => {
+    { ids: [] },
+    { ids: ["split-1", "split-1"] },
+  ])("rejects invalid reorder IDs: %j", async ({ ids }) => {
     const result = await reorderMailSplitsAction(EMAIL_ACCOUNT_ID, {
       ids,
     });

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -10,6 +10,7 @@ import {
   createMailSplitBody,
   deleteMailSplitBody,
   renameMailSplitBody,
+  reorderMailSplitsBody,
   setDefaultMailSplitsBody,
   suggestMailSplitBody,
   updateMailPreferencesBody,
@@ -17,8 +18,7 @@ import {
 import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { lockMailSplits } from "@/utils/mail/split-lock";
-import { createMailSplit } from "@/utils/mail/splits.server";
-import { BUILT_IN_SPLITS } from "@/utils/mail/built-in-splits";
+import { createMailSplit, reorderMailSplits } from "@/utils/mail/splits.server";
 import {
   MAX_MAIL_SPLITS,
   MAX_SPLIT_LABELS,
@@ -120,7 +120,17 @@ export const deleteMailSplitAction = actionClient
   .inputSchema(deleteMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
     // deleteMany rather than delete so another account's id can never be removed
-    await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
+    await prisma.$transaction([
+      lockMailSplits(emailAccountId),
+      prisma.mailSplit.deleteMany({ where: { id, emailAccountId } }),
+    ]);
+  });
+
+export const reorderMailSplitsAction = actionClient
+  .metadata({ name: "reorderMailSplits" })
+  .inputSchema(reorderMailSplitsBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { ids } }) => {
+    await reorderMailSplits({ emailAccountId, ids });
   });
 
 export const setDefaultMailSplitsAction = actionClient
@@ -145,15 +155,12 @@ export const updateMailPreferencesAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId },
-      parsedInput: { layout, expandedPreview, hiddenBuiltInSplits },
+      parsedInput: { layout, expandedPreview },
     }) => {
       await prisma.emailAccount.update({
         where: { id: emailAccountId },
         data: {
           ...(layout === undefined ? {} : { mailLayout: layout }),
-          ...(hiddenBuiltInSplits === undefined
-            ? {}
-            : { mailHiddenBuiltInSplits: hiddenBuiltInSplits }),
           ...(expandedPreview === undefined
             ? {}
             : { mailExpandedPreview: expandedPreview }),
@@ -165,17 +172,6 @@ export const updateMailPreferencesAction = actionClient
 async function createMailSplitOrThrow(
   data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "values">,
 ) {
-  const builtIn = BUILT_IN_SPLITS.find((split) => split.kind === data.kind);
-  if (builtIn) {
-    await prisma.$executeRaw`
-      UPDATE "EmailAccount"
-      SET "mailHiddenBuiltInSplits" = array_remove("mailHiddenBuiltInSplits", ${builtIn.id}),
-          "updatedAt" = NOW()
-      WHERE id = ${data.emailAccountId}
-    `;
-    return builtIn;
-  }
-
   try {
     const result = await createMailSplit(data);
 

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
-import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
+import {
+  MAX_MAIL_SPLITS,
+  MAX_SPLIT_LABELS,
+} from "@/utils/mail/split-constants";
 
 // LABEL splits carry one or more provider label ids; CATEGORY splits carry a
 // single provider category (e.g. CATEGORY_PERSONAL). INBOX and UNREAD carry none.
@@ -59,18 +62,19 @@ export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
 export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
 export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 
-export const hiddenBuiltInSplitsSchema = z
-  .array(z.enum(["all", "unread"]))
-  .max(2)
-  .refine((ids) => new Set(ids).size === ids.length, {
-    message: "Hidden split IDs must be unique",
-  });
+export const reorderMailSplitsBody = z.object({
+  ids: z
+    .array(z.string().min(1))
+    .max(MAX_MAIL_SPLITS)
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: "Split IDs must be unique",
+    }),
+});
 
 export const updateMailPreferencesBody = z
   .object({
     layout: z.nativeEnum(MailLayout).optional(),
     expandedPreview: z.boolean().optional(),
-    hiddenBuiltInSplits: hiddenBuiltInSplitsSchema.optional(),
   })
   // Every field is optional so a caller can update one preference without
   // restating the others, which would otherwise also accept an empty update.

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -65,6 +65,7 @@ export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
 export const reorderMailSplitsBody = z.object({
   ids: z
     .array(z.string().min(1))
+    .min(1)
     .max(MAX_MAIL_SPLITS)
     .refine((ids) => new Set(ids).size === ids.length, {
       message: "Split IDs must be unique",

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
 import { revalidatePath } from "next/cache";
 import { ONBOARDING_PROCESS_EMAILS_COUNT } from "@/utils/config";
 import { after } from "next/server";
@@ -60,7 +61,7 @@ import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
 import { toCreateOrUpdateRuleCondition } from "@/utils/rule/create-rule-condition";
-import { seedDefaultMailSplits } from "@/utils/mail/default-splits.server";
+import { setDefaultMailSplits } from "@/utils/mail/default-splits.server";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
@@ -486,9 +487,10 @@ export const createRulesOnboardingAction = actionClient
 
       try {
         const systemRules = await Promise.all(defaultSplitRulePromises);
-        await seedDefaultMailSplits({
+        await setDefaultMailSplits({
           emailAccountId,
-          rules: systemRules,
+          defaultSplits: getDefaultMailSplitDrafts(systemRules),
+          enabled: true,
         });
       } catch (error) {
         logger.error("Error creating default mail splits", { error });

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MailSplitKind } from "@/generated/prisma/enums";
 import type { Account } from "better-auth";
 import { cookies } from "next/headers";
 import { createReferral } from "@/utils/referral/referral-code";
@@ -395,6 +396,14 @@ describe("handleLinkAccount", () => {
 
     await handleLinkAccount(getGoogleAccount());
 
+    const upsert = prisma.emailAccount.upsert.mock.calls[0]?.[0];
+    expect(upsert?.create.mailSplits).toEqual({
+      create: [
+        { name: "All", kind: MailSplitKind.INBOX, values: [], order: 0 },
+        { name: "Unread", kind: MailSplitKind.UNREAD, values: [], order: 1 },
+      ],
+    });
+    expect(upsert?.update).not.toHaveProperty("mailSplits");
     expect(mockAfter).toHaveBeenCalledOnce();
     expect(ensureEmailAccountsWatched).not.toHaveBeenCalled();
 

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -1,3 +1,4 @@
+import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { sso } from "@better-auth/sso";
 import { scim } from "@better-auth/scim";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
@@ -717,6 +718,12 @@ export async function handleLinkAccount(account: Account) {
         create: {
           ...data,
           email: normalizedEmail,
+          mailSplits: {
+            create: INITIAL_MAIL_SPLITS.map((split, order) => ({
+              ...split,
+              order,
+            })),
+          },
         },
         select: { id: true },
       }),

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -7,51 +7,14 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import {
   getDefaultMailSplitDraftsForAccount,
-  seedDefaultMailSplits,
   setDefaultMailSplits,
 } from "@/utils/mail/default-splits.server";
 
 vi.mock("@/utils/prisma");
 
-describe("seedDefaultMailSplits", () => {
+describe("default mail splits", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("seeds standard rule labels for an account without saved splits", async () => {
-    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
-
-    await seedDefaultMailSplits({
-      emailAccountId: "account-id",
-      rules: [rule(SystemType.RECEIPT, "receipt-label")],
-    });
-
-    expect(prisma.$queryRaw).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.stringContaining("pg_advisory_xact_lock"),
-      ]),
-      "account-id",
-    );
-    expect(prisma.$executeRaw).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.stringContaining("WHERE NOT EXISTS")]),
-      "account-id",
-      expect.any(String),
-      "account-id",
-    );
-  });
-
-  it("does not access the database when no rule can produce an inbox split", async () => {
-    await seedDefaultMailSplits({
-      emailAccountId: "account-id",
-      rules: [
-        {
-          systemType: SystemType.RECEIPT,
-          actions: [{ type: ActionType.MOVE_FOLDER, labelId: null }],
-        },
-      ],
-    });
-
-    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("loads the enabled standard rules that can provide default splits", async () => {

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -24,61 +24,6 @@ export async function getDefaultMailSplitDraftsForAccount(
   return getDefaultMailSplitDrafts(rules);
 }
 
-export async function seedDefaultMailSplits({
-  emailAccountId,
-  rules,
-}: {
-  emailAccountId: string;
-  rules: Parameters<typeof getDefaultMailSplitDrafts>[0];
-}) {
-  const defaultSplits = getDefaultMailSplitDrafts(rules);
-  if (defaultSplits.length === 0) return;
-
-  const rows = defaultSplits.map((split, order) => ({
-    id: randomUUID(),
-    ...split,
-    order,
-  }));
-
-  await prisma.$transaction([
-    lockMailSplits(emailAccountId),
-    prisma.$executeRaw`
-      INSERT INTO "MailSplit" (
-        "id",
-        "createdAt",
-        "updatedAt",
-        "name",
-        "kind",
-        "values",
-        "order",
-        "emailAccountId"
-      )
-      SELECT
-        defaults."id",
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP,
-        defaults."name",
-        defaults."kind"::"MailSplitKind",
-        defaults."values",
-        defaults."order",
-        ${emailAccountId}
-      FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb) AS defaults(
-        "id" text,
-        "name" text,
-        "kind" text,
-        "values" text[],
-        "order" integer
-      )
-      WHERE NOT EXISTS (
-        SELECT 1
-        FROM "MailSplit"
-        WHERE "emailAccountId" = ${emailAccountId}
-      )
-      ON CONFLICT DO NOTHING
-    `,
-  ]);
-}
-
 export async function setDefaultMailSplits({
   emailAccountId,
   defaultSplits,

--- a/apps/web/utils/mail/initial-splits.ts
+++ b/apps/web/utils/mail/initial-splits.ts
@@ -1,14 +1,12 @@
 import { MailSplitKind } from "@/generated/prisma/enums";
 
-export const BUILT_IN_SPLITS = [
+export const INITIAL_MAIL_SPLITS = [
   {
-    id: "all",
     name: "All",
     kind: MailSplitKind.INBOX,
     values: [] as string[],
   },
   {
-    id: "unread",
     name: "Unread",
     kind: MailSplitKind.UNREAD,
     values: [] as string[],

--- a/apps/web/utils/mail/split-constants.ts
+++ b/apps/web/utils/mail/split-constants.ts
@@ -1,4 +1,4 @@
-export const MAX_MAIL_SPLITS = 12;
+export const MAX_MAIL_SPLITS = 14;
 
 /**
  * One provider query runs per label and each carries its own page token, so a

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -106,7 +106,7 @@ export async function removeLabelFromMailSplits({
   ]);
 }
 
-/** Omitted splits retain their relative order after the visible selection. */
+/** Reorder only the selected slots so hidden splits keep their positions. */
 export async function reorderMailSplits({
   emailAccountId,
   ids,
@@ -117,18 +117,24 @@ export async function reorderMailSplits({
   await prisma.$transaction([
     lockMailSplits(emailAccountId),
     prisma.$executeRaw`
-      WITH ranked AS (
-        SELECT "id", (ROW_NUMBER() OVER (
-          ORDER BY array_position(${ids}::text[], "id") NULLS LAST,
-            "order", "createdAt", "id"
-        ) - 1)::integer AS position
+      WITH selected AS (
+        SELECT "id", "order", "createdAt"
         FROM "MailSplit"
         WHERE "emailAccountId" = ${emailAccountId}
+          AND "id" = ANY(${ids}::text[])
+      ),
+      positions AS (
+        SELECT "order", ROW_NUMBER() OVER (ORDER BY "order", "createdAt", "id") AS slot
+        FROM selected
+      ),
+      reordered AS (
+        SELECT "id", ROW_NUMBER() OVER (ORDER BY array_position(${ids}::text[], "id")) AS slot
+        FROM selected
       )
       UPDATE "MailSplit" split
-      SET "order" = ranked.position, "updatedAt" = CURRENT_TIMESTAMP
-      FROM ranked
-      WHERE split."id" = ranked."id"
+      SET "order" = positions."order", "updatedAt" = CURRENT_TIMESTAMP
+      FROM reordered JOIN positions USING (slot)
+      WHERE split."id" = reordered."id"
     `,
   ]);
 }

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -85,21 +85,50 @@ export async function removeLabelFromMailSplits({
   emailAccountId: string;
   labelId: string;
 }) {
-  // One statement so only the rows this label emptied are deleted, rather than
-  // every empty split the account happens to have.
-  await prisma.$executeRaw`
-    WITH narrowed AS (
-      UPDATE "MailSplit"
-      SET "values" = array_remove("values", ${labelId}),
-          "updatedAt" = NOW()
+  // PostgreSQL cannot update and delete the same row in one CTE statement.
+  // Delete emptied splits first, then narrow the remaining rows atomically.
+  await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$executeRaw`
+      DELETE FROM "MailSplit"
       WHERE "emailAccountId" = ${emailAccountId}
         AND "kind" = 'LABEL'::"MailSplitKind"
         AND ${labelId} = ANY("values")
-      RETURNING "id", "values"
-    )
-    DELETE FROM "MailSplit"
-    WHERE "id" IN (
-      SELECT "id" FROM narrowed WHERE cardinality("values") = 0
-    )
-  `;
+        AND cardinality(array_remove("values", ${labelId})) = 0
+    `,
+    prisma.$executeRaw`
+      UPDATE "MailSplit"
+      SET "values" = array_remove("values", ${labelId}), "updatedAt" = NOW()
+      WHERE "emailAccountId" = ${emailAccountId}
+        AND "kind" = 'LABEL'::"MailSplitKind"
+        AND ${labelId} = ANY("values")
+    `,
+  ]);
+}
+
+/** Omitted splits retain their relative order after the visible selection. */
+export async function reorderMailSplits({
+  emailAccountId,
+  ids,
+}: {
+  emailAccountId: string;
+  ids: string[];
+}) {
+  await prisma.$transaction([
+    lockMailSplits(emailAccountId),
+    prisma.$executeRaw`
+      WITH ranked AS (
+        SELECT "id", (ROW_NUMBER() OVER (
+          ORDER BY array_position(${ids}::text[], "id") NULLS LAST,
+            "order", "createdAt", "id"
+        ) - 1)::integer AS position
+        FROM "MailSplit"
+        WHERE "emailAccountId" = ${emailAccountId}
+      )
+      UPDATE "MailSplit" split
+      SET "order" = ranked.position, "updatedAt" = CURRENT_TIMESTAMP
+      FROM ranked
+      WHERE split."id" = ranked."id"
+    `,
+  ]);
 }


### PR DESCRIPTION
Moves split creation and removal into dialogs and adds drag and button controls for ordering.
All split tabs now use the existing split table, with account-creation defaults, a migration preserving hidden tabs, and atomic reordering instead of separate preference arrays.
Also fixes cleanup of splits whose last label is removed.
Validated with focused unit and real-database tests plus split and calendar browser scenarios, with screenshots inspected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Manage Splits dialog for deleting and reordering mail splits via drag-and-drop or arrow controls.
  * Mail split order now persists across page reloads.
  * Increased the maximum number of mail splits from 12 to 14.
  * Added automatic All and Unread splits for eligible accounts.

* **Improvements**
  * Replaced split creation popovers with dialogs.
  * Mail split selections now reset safely when switching accounts or deleting the active split.
  * Improved migration handling for existing custom and hidden splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->