### PR TITLE
mail: Handle missing child folders in sidebar

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.test.ts
@@ -19,6 +19,25 @@ function folder(
 }
 
 describe("getMailSidebarFolders", () => {
+  it("keeps folders with missing child arrays without crashing", () => {
+    const leaf = folder("leaf");
+    Reflect.deleteProperty(leaf, "childFolders");
+    const systemFolder = folder("sent", [], "SENT");
+    Reflect.deleteProperty(systemFolder, "childFolders");
+
+    const result = getMailSidebarFolders([
+      folder("parent", [leaf]),
+      systemFolder,
+      folder("sibling"),
+    ]);
+
+    expect(result.map(({ id, depth }) => ({ id, depth }))).toEqual([
+      { id: "parent", depth: 0 },
+      { id: "leaf", depth: 1 },
+      { id: "sibling", depth: 0 },
+    ]);
+  });
+
   it("omits duplicate system rows but keeps folders nested below them", () => {
     const result = getMailSidebarFolders([
       folder(

--- a/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/outlook-folder-list.ts
@@ -8,7 +8,10 @@ export function getMailSidebarFolders(
 ): MailSidebarFolder[] {
   return folders.flatMap((folder) => {
     const childDepth = folder.systemType ? depth : depth + 1;
-    const children = getMailSidebarFolders(folder.childFolders, childDepth);
+    const children = getMailSidebarFolders(
+      folder.childFolders ?? [],
+      childDepth,
+    );
     return folder.systemType ? children : [{ ...folder, depth }, ...children];
   });
 }


### PR DESCRIPTION
Prevent the mail sidebar from crashing when an Outlook folder has no child-folder array.

- Treat missing child folders as empty while preserving folder order and nesting.
- Added a regression test that reproduced the error before the fix; all three focused tests and formatting checks pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Outlook mail folder navigation when a folder has no child-folder data.
  - Folder lists now load without errors and preserve the correct hierarchy and indentation for surrounding folders.

- **Tests**
  - Added coverage for folder structures with missing child-folder information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->