### PR TITLE
fix: Disconnect invalid Gmail grants during webhook processing

### DIFF
--- a/apps/web/utils/webhook/google/process-history.test.ts
+++ b/apps/web/utils/webhook/google/process-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { processHistoryForUser } from "./process-history";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { getHistory } from "@/utils/gmail/history";
 import {
   getWebhookEmailAccount,
@@ -33,8 +34,13 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-vi.mock("@/utils/error", () => ({
+vi.mock("@/utils/error", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/error")>()),
   captureException: vi.fn(),
+}));
+
+vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
+  cleanupInvalidTokens: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/utils/email/rate-limit", () => ({
@@ -315,5 +321,86 @@ describe("processHistoryForUser - 404 Handling", () => {
       expect.any(Object),
     );
     expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("processHistoryForUser - authentication failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEmailProviderRateLimitState).mockResolvedValue(null);
+    vi.mocked(cleanupInvalidTokens).mockResolvedValue(undefined);
+    vi.mocked(validateWebhookAccount).mockResolvedValue({
+      success: true,
+      data: {
+        emailAccount: {
+          id: "account-123",
+          email: "user@example.com",
+          userId: "user-123",
+          lastSyncedHistoryId: "1000",
+          account: {
+            access_token: "original-access-token",
+            refresh_token: "failed-refresh-token",
+            expires_at: new Date(Date.now() + 3_600_000),
+          },
+          rules: [],
+        },
+        hasAutomationRules: false,
+        hasAiAccess: false,
+      },
+    } as any);
+  });
+
+  it.each([
+    "invalid_grant",
+    "Token refresh failed: invalid_grant",
+  ])("cleans up the failed grant before acknowledging %s from a Gmail API call", async (message) => {
+    vi.mocked(getHistory).mockRejectedValueOnce(new Error(message));
+
+    const response = await processHistoryForUser(
+      { emailAddress: "user@example.com", historyId: 2000 },
+      {},
+      logger,
+    );
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledExactlyOnceWith({
+      emailAccountId: "account-123",
+      reason: "invalid_grant",
+      // Access tokens can rotate during client creation without changing the grant.
+      failedRefreshToken: "failed-refresh-token",
+      logger: expect.any(Object),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges invalid grants even if cleanup fails", async () => {
+    vi.mocked(getHistory).mockRejectedValueOnce(new Error("invalid_grant"));
+    vi.mocked(cleanupInvalidTokens).mockRejectedValueOnce(
+      new Error("Database unavailable"),
+    );
+
+    const response = await processHistoryForUser(
+      { emailAddress: "user@example.com", historyId: 2000 },
+      {},
+      logger,
+    );
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledOnce();
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it("does not disconnect accounts for transient Gmail API failures", async () => {
+    vi.mocked(getHistory).mockRejectedValueOnce(
+      new Error("Service unavailable"),
+    );
+
+    await processHistoryForUser(
+      { emailAddress: "user@example.com", historyId: 2000 },
+      {},
+      logger,
+    );
+
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/webhook/google/process-history.ts
+++ b/apps/web/utils/webhook/google/process-history.ts
@@ -2,6 +2,7 @@ import uniqBy from "lodash/uniqBy";
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getGmailClientWithRefresh } from "@/utils/gmail/client";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { GmailLabel } from "@/utils/gmail/label";
 import { captureException, isInvalidGrantError } from "@/utils/error";
 import {
@@ -198,6 +199,17 @@ export async function processHistoryForUser(
   } catch (error) {
     if (isInvalidGrantError(error)) {
       logger.warn("Invalid grant", { email });
+      await cleanupInvalidTokens({
+        emailAccountId: validatedEmailAccount.id,
+        reason: "invalid_grant",
+        // Client creation can rotate the access token while retaining this grant.
+        failedRefreshToken: accountRefreshToken,
+        logger,
+      }).catch((cleanupError) =>
+        logger.error("Failed to clean up webhook authentication failure", {
+          cleanupError,
+        }),
+      );
       return NextResponse.json({ ok: true });
     }
 


### PR DESCRIPTION
Gmail webhook processing now cleans up invalid grants before acknowledging the webhook, allowing the existing account disconnection and reconnection notification flow to run for API-call failures.

- Pass the failed refresh token so stale requests cannot clear a newer grant; access-token rotation does not prevent cleanup.
- Preserve webhook acknowledgement if cleanup fails and leave transient API failures connected.
- Validation: regression tests failed before the fix; all 28 focused webhook, Gmail client, and credential cleanup tests pass. Formatting checks pass.
- Performance: additional database and notification work occurs only on invalid-grant failures; successful webhook processing is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Google webhook processing now cleans up invalid Gmail authentication tokens after an `invalid_grant` failure.
  - Webhook acknowledgments remain successful even if token cleanup encounters an error.
  - Temporary Gmail API errors no longer trigger token cleanup.

- **Tests**
  - Added coverage for invalid-token cleanup, successful acknowledgments, cleanup failures, and transient API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->