### PR TITLE
mail: Invalidate outdated persisted settings cache

### DIFF
--- a/apps/web/providers/SWRProvider.test.tsx
+++ b/apps/web/providers/SWRProvider.test.tsx
@@ -24,7 +24,7 @@ function CacheProbe() {
 }
 
 function snapshotKey(accountId: string) {
-  return `inbox-zero:swr:v1:${accountId}`;
+  return `inbox-zero:swr:v2:${accountId}`;
 }
 
 describe("SWRProvider persisted cache", () => {
@@ -78,6 +78,10 @@ describe("SWRProvider persisted cache", () => {
       });
     });
 
+    scopedCache?.set("/api/mail/settings", {
+      data: { splits: [{ id: "a-split", values: ["a-label"] }] },
+    });
+
     accountState.emailAccountId = "account-b";
     view.rerender(
       <SWRProvider>
@@ -91,6 +95,7 @@ describe("SWRProvider persisted cache", () => {
       });
       // account-b has no counts snapshot: account-a's value must be gone.
       expect(scopedCache?.get("/api/labels/counts")?.data).toBeUndefined();
+      expect(scopedCache?.get("/api/mail/settings")?.data).toBeUndefined();
     });
   });
 

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -146,12 +146,19 @@ describe("swr-persistence", () => {
   it("clears every account on logout but leaves unrelated storage", () => {
     persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
     persistSwrEntries(ACCOUNT_B, cacheWith({ "/api/labels": { labels: [] } }));
+    window.localStorage.setItem(
+      `inbox-zero:swr:v1:${ACCOUNT_A}`,
+      JSON.stringify({ "/api/labels": { labels: [] } }),
+    );
     window.localStorage.setItem("unrelated", "keep-me");
 
     clearPersistedSwrCache();
 
     expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
     expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(0);
+    expect(
+      window.localStorage.getItem(`inbox-zero:swr:v1:${ACCOUNT_A}`),
+    ).toBeNull();
     expect(window.localStorage.getItem("unrelated")).toBe("keep-me");
   });
 

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -48,6 +48,41 @@ describe("swr-persistence", () => {
     expect(readPersistedSwrEntries(ACCOUNT_B).size).toBe(0);
   });
 
+  it("ignores snapshots from the previous cache version", () => {
+    window.localStorage.setItem(
+      `inbox-zero:swr:v1:${ACCOUNT_A}`,
+      JSON.stringify({
+        "/api/mail/settings": {
+          splits: [{ id: "split-1", kind: "LABEL", value: "label-1" }],
+        },
+        "/api/labels": { labels: [] },
+      }),
+    );
+
+    expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
+  });
+
+  it("preserves valid cached mail settings including split filters", () => {
+    const settings = {
+      layout: "SPLIT",
+      expandedPreview: true,
+      splits: [
+        {
+          id: "split-1",
+          name: "Saved",
+          kind: "LABEL",
+          values: ["label-1", "label-2"],
+        },
+        { id: "split-2", name: "Inbox", kind: "INBOX", values: [] },
+      ],
+      defaultSplits: [{ name: "Default", kind: "LABEL", values: ["label-3"] }],
+    };
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/mail/settings": settings }));
+    expect(
+      readPersistedSwrEntries(ACCOUNT_A).get("/api/mail/settings")?.data,
+    ).toEqual(settings);
+  });
+
   it("ignores non-whitelisted cache keys", () => {
     persistSwrEntries(
       ACCOUNT_A,
@@ -58,7 +93,7 @@ describe("swr-persistence", () => {
     );
 
     const stored = window.localStorage.getItem(
-      `inbox-zero:swr:v1:${ACCOUNT_A}`,
+      `inbox-zero:swr:v2:${ACCOUNT_A}`,
     );
     expect(stored).not.toContain("should not persist");
     expect(
@@ -87,7 +122,7 @@ describe("swr-persistence", () => {
   });
 
   it("returns nothing for a corrupt snapshot instead of throwing", () => {
-    window.localStorage.setItem(`inbox-zero:swr:v1:${ACCOUNT_A}`, "{not json");
+    window.localStorage.setItem(`inbox-zero:swr:v2:${ACCOUNT_A}`, "{not json");
 
     expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
   });
@@ -142,10 +177,10 @@ describe("swr-persistence", () => {
   });
 
   it("maps snapshot storage keys back to account ids", () => {
-    expect(accountIdFromSnapshotKey(`inbox-zero:swr:v1:${ACCOUNT_A}`)).toBe(
+    expect(accountIdFromSnapshotKey(`inbox-zero:swr:v2:${ACCOUNT_A}`)).toBe(
       ACCOUNT_A,
     );
-    expect(accountIdFromSnapshotKey("inbox-zero:swr:v1:")).toBeNull();
+    expect(accountIdFromSnapshotKey("inbox-zero:swr:v2:")).toBeNull();
     expect(accountIdFromSnapshotKey("unrelated-key")).toBeNull();
   });
 });

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -1,9 +1,4 @@
-// Persists a small whitelist of SWR cache entries to localStorage so the app
-// shell (sidebar labels, counts, folders, mail settings) renders instantly on
-// a cold load instead of flashing empty. Mail content itself is persisted
-// separately in utils/email-cache (IndexedDB).
-
-const STORAGE_PREFIX = "inbox-zero:swr:v1:";
+const STORAGE_PREFIX = "inbox-zero:swr:v2:";
 
 // These hooks use plain-string SWR keys that are not account-scoped (the
 // account travels in a request header), so the snapshot is namespaced by

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -130,7 +130,7 @@ function persistedStorageKeys(): string[] {
   const keys: string[] = [];
   for (let index = 0; index < window.localStorage.length; index++) {
     const key = window.localStorage.key(index);
-    if (key?.startsWith(STORAGE_PREFIX)) keys.push(key);
+    if (key?.startsWith("inbox-zero:swr:")) keys.push(key);
   }
   return keys;
 }


### PR DESCRIPTION
Prevent mail page crashes caused by restoring cached settings from an outdated response format. Bump the persisted SWR cache version so shell data refreshes once, then continues caching normally; the IndexedDB email cache is unchanged. Logout also clears obsolete SWR cache versions.

Validated with 17 focused cache and provider tests, including obsolete snapshot rejection, current settings persistence, and account isolation. Formatting checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated saved cache handling to use a new storage version.
  * Older cached snapshots are now ignored to prevent stale data from being restored.
  * Account switching now clears cached mail settings along with other account-specific data.
  * Mail settings, including split filters, are preserved correctly when saved and restored.
  * Logging out now removes older saved cache data while preserving unrelated browser storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->