### PR TITLE
fix: escape Outlook contact search values

### DIFF
--- a/apps/web/utils/outlook/contact.test.ts
+++ b/apps/web/utils/outlook/contact.test.ts
@@ -3,6 +3,26 @@ import { createTestLogger } from "@/__tests__/helpers";
 import { searchContacts } from "./contact";
 
 describe("searchContacts", () => {
+  it.each([
+    ["no-reply@example.com", '"no-reply@example.com"'],
+    ["  First Last  ", '"First Last"'],
+    ['First "Nickname" Last', String.raw`"First \"Nickname\" Last"`],
+  ])("quotes the People API search literal for %s", async (query, expected) => {
+    const { api } = createGraphClient({});
+
+    await searchContacts(
+      { getClient: () => ({ api }) } as never,
+      query,
+      createTestLogger(),
+    );
+
+    const peopleRequest =
+      api.mock.results[
+        api.mock.calls.findIndex(([endpoint]) => endpoint === "/me/people")
+      ].value;
+    expect(peopleRequest.search).toHaveBeenCalledWith(expected);
+  });
+
   it("loads saved Outlook contacts and maps all usable addresses", async () => {
     const { api } = createGraphClient({
       contactPages: [

--- a/apps/web/utils/outlook/contact.ts
+++ b/apps/web/utils/outlook/contact.ts
@@ -1,3 +1,4 @@
+import { escapeSearchValue } from "@/utils/outlook/search-escape";
 import type { Contact, Person } from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { withMicrosoftGraphRetry } from "@/utils/microsoft/retry";
@@ -145,7 +146,9 @@ async function searchRelevantPeople(
     .api("/me/people")
     .select("displayName,scoredEmailAddresses,userPrincipalName");
 
-  if (query) request = request.search(query);
+  if (query) {
+    request = request.search(`"${escapeSearchValue(query)}"`);
+  }
 
   const response: { value?: Person[] } = await withMicrosoftGraphRetry(
     () => request.top(MAX_CONTACT_RESULTS).get(),

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -1,3 +1,4 @@
+import { escapeSearchValue } from "@/utils/outlook/search-escape";
 import PostalMime from "postal-mime";
 import { ResponseType } from "@microsoft/microsoft-graph-client";
 import type {
@@ -193,12 +194,12 @@ export function sanitizeKqlValue(value: string): string {
   const normalized = value.trim();
   if (!normalized) return "";
 
-  return normalized
-    .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"');
+  return escapeSearchValue(
+    normalized
+      .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
 }
 
 /**
@@ -223,7 +224,7 @@ export function sanitizeKqlFieldQuery(query: string): string {
 
   const hasSpaces = sanitizedValue.includes(" ");
 
-  sanitizedValue = sanitizedValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  sanitizedValue = escapeSearchValue(sanitizedValue);
 
   if (hasSpaces) {
     return `${field}:"${sanitizedValue}"`;

--- a/apps/web/utils/outlook/search-escape.ts
+++ b/apps/web/utils/outlook/search-escape.ts
@@ -1,0 +1,3 @@
+export function escapeSearchValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}


### PR DESCRIPTION
Fix Outlook contact searches containing punctuation by quoting and escaping search values.

- Share search-value escaping with existing message search sanitizers.
- Add regression coverage for email addresses, spaces, and embedded quotes.
- Validation: 79 contact and message tests pass; formatting checks pass.
- No additional database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Outlook contact and message searches by correctly escaping backslashes and quotation marks.
  * Search queries containing email addresses, surrounding whitespace, or quoted names are now handled more reliably.
* **Tests**
  * Added coverage for escaped search literals across multiple contact search formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->