### PR TITLE
Logging: Improve client crash diagnostic correlation

### DIFF
--- a/apps/web/components/AppErrorBoundary.tsx
+++ b/apps/web/components/AppErrorBoundary.tsx
@@ -34,18 +34,19 @@ export function AppErrorBoundary({
   // biome-ignore lint/correctness/useExhaustiveDependencies: log each boundary error once with the route context captured at that time
   useEffect(() => {
     const logger = createClientLogger("app-error-boundary");
-
-    logger.error(
-      "App error boundary triggered",
-      getAppErrorBoundaryLogContext({
-        error,
-        params,
-        pathname,
-        searchParams,
-      }),
-    );
+    const context = getAppErrorBoundaryLogContext({
+      error,
+      params,
+      pathname,
+      searchParams,
+    });
+    // Correlate with the exception details without copying raw error text into Axiom.
+    const sentryEventId = Sentry.captureException(error, { extra: context });
+    logger.error("App error boundary triggered", {
+      ...context,
+      sentryEventId,
+    });
     logger.flush().catch(() => undefined);
-    Sentry.captureException(error);
   }, [error]);
 
   return (

--- a/apps/web/components/app-error-boundary-log-context.test.ts
+++ b/apps/web/components/app-error-boundary-log-context.test.ts
@@ -4,19 +4,18 @@ import { getAppErrorBoundaryLogContext } from "./app-error-boundary-log-context"
 describe("getAppErrorBoundaryLogContext", () => {
   it("returns only allowlisted route context for client logs", () => {
     const context = getAppErrorBoundaryLogContext({
-      error: {
+      error: Object.assign(new Error("token=secret-value"), {
         digest: "digest-123",
-        message: "token=secret-value",
         name: "TypeError",
         stack: "stack with secret-value",
-      },
+      }),
       params: {
         emailAccountId: "account-123",
         ruleId: "rule-456",
       },
       pathname: "/mail",
       searchParams: new URLSearchParams(
-        "token=secret-value&code=oauth-code&tab=history&ruleId=query-rule-id",
+        "token=secret-value&code=oauth-code&tab=history&ruleId=query-rule-id&thread-id=thread-123&thread-account-id=account-789&q=private-search",
       ),
     });
 
@@ -29,8 +28,18 @@ describe("getAppErrorBoundaryLogContext", () => {
       safeSearchParams: {
         ruleId: "query-rule-id",
         tab: "history",
+        "thread-id": "thread-123",
+        "thread-account-id": "account-789",
       },
-      searchParamKeys: ["token", "code", "tab", "ruleId"],
+      searchParamKeys: [
+        "token",
+        "code",
+        "tab",
+        "ruleId",
+        "thread-id",
+        "thread-account-id",
+        "q",
+      ],
     });
     expect(context).not.toHaveProperty("errorMessage");
     expect(context).not.toHaveProperty("errorStack");

--- a/apps/web/components/app-error-boundary-log-context.ts
+++ b/apps/web/components/app-error-boundary-log-context.ts
@@ -8,7 +8,12 @@ type AppErrorBoundaryLogContextInput = {
   searchParams: Iterable<[string, string]>;
 };
 
-const SAFE_SEARCH_PARAM_KEYS = new Set(["ruleId", "tab"]);
+const SAFE_SEARCH_PARAM_KEYS = new Set([
+  "ruleId",
+  "tab",
+  "thread-id",
+  "thread-account-id",
+]);
 
 export function getAppErrorBoundaryLogContext({
   error,


### PR DESCRIPTION
Client crash logs lack the context needed to correlate failures with captured exception details. Add the Sentry event ID to Axiom logs and include selected conversation and account IDs from allowlisted URL parameters in both systems.

Raw exception text and unrelated query values remain excluded from Axiom. This improves diagnostics; it does not change mail rendering behavior.

Validation: two focused unit tests pass, Biome passes, and git diff --check passes. The change adds small context fields on the error path and no additional database or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by linking application logs with their corresponding Sentry events.
  * Added selected thread-related query parameters to error context, improving troubleshooting details.
* **Tests**
  * Updated error-context coverage to validate additional search parameters and realistic error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->