### PR TITLE
feat: label cleanup - remove label or trash filed mail after N days

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/LabelCleanupSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/LabelCleanupSetting.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { TrashIcon } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import type { LabelCleanupsResponse } from "@/app/api/user/label-cleanup/route";
+import { LabelCleanupAction } from "@/generated/prisma/enums";
+import { useLabels } from "@/hooks/useLabels";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import {
+  deleteLabelCleanupAction,
+  saveLabelCleanupAction,
+} from "@/utils/actions/label-cleanup";
+import { getActionErrorMessage } from "@/utils/error";
+import { formatShortDate } from "@/utils/date";
+import { SettingCard } from "@/components/SettingCard";
+import { LoadingContent } from "@/components/LoadingContent";
+import { LabelCombobox } from "@/components/LabelCombobox";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MutedText } from "@/components/Typography";
+import { toastError, toastSuccess } from "@/components/Toast";
+
+const ACTION_LABELS: Record<LabelCleanupAction, string> = {
+  [LabelCleanupAction.REMOVE_LABEL]: "Remove the label",
+  [LabelCleanupAction.TRASH]: "Move to trash",
+};
+
+export function LabelCleanupSetting() {
+  return (
+    <SettingCard
+      title="Label cleanup"
+      description="Keep filed folders from growing forever: after a number of days, take the label off or trash the mail."
+      right={
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline" size="sm">
+              Manage
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-3xl">
+            <DialogHeader>
+              <DialogTitle>Label cleanup</DialogTitle>
+              <DialogDescription>
+                Runs once a day. "Remove the label" leaves the email in All
+                Mail, just out of that folder; "Move to trash" lets Gmail delete
+                it after 30 more days. Applies to whole threads.
+              </DialogDescription>
+            </DialogHeader>
+            <Content />
+          </DialogContent>
+        </Dialog>
+      }
+    />
+  );
+}
+
+function Content() {
+  const { emailAccountId } = useAccount();
+  const { data, isLoading, error, mutate } = useSWR<LabelCleanupsResponse>(
+    "/api/user/label-cleanup",
+  );
+  const labels = useLabels();
+
+  const [labelId, setLabelId] = useState("");
+  const [afterDays, setAfterDays] = useState("30");
+  const [action, setAction] = useState<LabelCleanupAction>(
+    LabelCleanupAction.REMOVE_LABEL,
+  );
+
+  const save = useAction(saveLabelCleanupAction.bind(null, emailAccountId), {
+    onSuccess: () => {
+      toastSuccess({ description: "Cleanup saved" });
+      setLabelId("");
+      mutate();
+    },
+    onError: (e) => {
+      toastError({ description: getActionErrorMessage(e.error) });
+    },
+  });
+
+  const remove = useAction(
+    deleteLabelCleanupAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Cleanup removed" });
+        mutate();
+      },
+      onError: (e) => {
+        toastError({ description: getActionErrorMessage(e.error) });
+      },
+    },
+  );
+
+  const selected = labels.userLabels.find((l) => l.id === labelId);
+  const days = Number.parseInt(afterDays, 10);
+  const canSave = !!selected && Number.isInteger(days) && days >= 1;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-[220px] flex-1">
+          <LabelCombobox
+            userLabels={labels.userLabels}
+            isLoading={labels.isLoading}
+            mutate={labels.mutate}
+            value={{ id: labelId, name: selected?.name ?? null }}
+            onChangeValue={setLabelId}
+            emailAccountId={emailAccountId}
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-sm text-muted-foreground">after</span>
+          <Input
+            type="number"
+            min={1}
+            max={3650}
+            value={afterDays}
+            onChange={(e) => setAfterDays(e.target.value)}
+            className="w-20"
+            aria-label="Days"
+          />
+          <span className="text-sm text-muted-foreground">days</span>
+        </div>
+        <Select
+          value={action}
+          onValueChange={(v) => setAction(v as LabelCleanupAction)}
+        >
+          <SelectTrigger className="w-44" aria-label="Cleanup action">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.values(LabelCleanupAction).map((value) => (
+              <SelectItem key={value} value={value}>
+                {ACTION_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          size="sm"
+          disabled={!canSave || save.isExecuting}
+          loading={save.isExecuting}
+          onClick={() => {
+            if (!selected) return;
+            save.execute({
+              labelId: selected.id,
+              labelName: selected.name,
+              afterDays: days,
+              action,
+            });
+          }}
+        >
+          Save
+        </Button>
+      </div>
+
+      <LoadingContent loading={isLoading} error={error}>
+        {data?.cleanups.length ? (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Label</TableHead>
+                <TableHead>After</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Last run</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.cleanups.map((cleanup) => (
+                <TableRow key={cleanup.id}>
+                  <TableCell className="font-medium">
+                    {cleanup.labelName}
+                  </TableCell>
+                  <TableCell>{cleanup.afterDays} days</TableCell>
+                  <TableCell>{ACTION_LABELS[cleanup.action]}</TableCell>
+                  <TableCell>
+                    <MutedText>
+                      {cleanup.lastRunAt
+                        ? `${formatShortDate(new Date(cleanup.lastRunAt))} · ${cleanup.lastRunCount ?? 0} thread${cleanup.lastRunCount === 1 ? "" : "s"}`
+                        : "Not yet"}
+                    </MutedText>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label={`Remove cleanup for ${cleanup.labelName}`}
+                      disabled={remove.isExecuting}
+                      onClick={() => remove.execute({ id: cleanup.id })}
+                    >
+                      <TrashIcon className="size-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <MutedText>No cleanups yet. Pick a label above to add one.</MutedText>
+        )}
+      </LoadingContent>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
@@ -8,6 +8,7 @@ import { FollowUpRemindersSetting } from "@/app/(app)/[emailAccountId]/assistant
 import { HiddenAiDraftLinksSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/HiddenAiDraftLinksSetting";
 import { ReferralSignatureSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/ReferralSignatureSetting";
 import { LearnedPatternsSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/LearnedPatternsSetting";
+import { LabelCleanupSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/LabelCleanupSetting";
 import { PersonalSignatureSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/PersonalSignatureSetting";
 import { SentWithSignatureSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/SentWithSignatureSetting";
 import { MultiRuleSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting";
@@ -40,6 +41,11 @@ export function SettingsTab() {
         <AboutSetting />
         <PersonalSignatureSetting />
         <SentWithSignatureSetting />
+      </div>
+
+      <div className="space-y-2">
+        <SectionHeader>Housekeeping</SectionHeader>
+        <LabelCleanupSetting />
       </div>
 
       {!autoDraftDisabled && (

--- a/apps/web/app/api/cron/label-cleanup/route.ts
+++ b/apps/web/app/api/cron/label-cleanup/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
+import { withError } from "@/utils/middleware";
+import { captureException } from "@/utils/error";
+import { runLabelCleanups } from "@/utils/label-cleanup/run-label-cleanup";
+
+export const maxDuration = 800;
+
+export const GET = withError("cron/label-cleanup", async (request) => {
+  if (!hasCronSecret(request)) {
+    captureException(new Error("Unauthorized request: api/cron/label-cleanup"));
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const results = await runLabelCleanups({ logger: request.logger });
+  return NextResponse.json({ results });
+});
+
+export const POST = withError("cron/label-cleanup", async (request) => {
+  if (!(await hasPostCronSecret(request))) {
+    captureException(
+      new Error("Unauthorized cron request: api/cron/label-cleanup"),
+    );
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const results = await runLabelCleanups({ logger: request.logger });
+  return NextResponse.json({ results });
+});

--- a/apps/web/app/api/user/label-cleanup/route.ts
+++ b/apps/web/app/api/user/label-cleanup/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import prisma from "@/utils/prisma";
+import { withEmailAccount } from "@/utils/middleware";
+
+export type LabelCleanupsResponse = Awaited<
+  ReturnType<typeof getLabelCleanups>
+>;
+
+async function getLabelCleanups({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  const cleanups = await prisma.labelCleanup.findMany({
+    where: { emailAccountId },
+    select: {
+      id: true,
+      labelId: true,
+      labelName: true,
+      afterDays: true,
+      action: true,
+      lastRunAt: true,
+      lastRunCount: true,
+    },
+    orderBy: { labelName: "asc" },
+  });
+  return { cleanups };
+}
+
+export const GET = withEmailAccount("user/label-cleanup", async (request) => {
+  const emailAccountId = request.auth.emailAccountId;
+  const result = await getLabelCleanups({ emailAccountId });
+  return NextResponse.json(result);
+});

--- a/apps/web/prisma/migrations/20260909000000_add_label_cleanup/migration.sql
+++ b/apps/web/prisma/migrations/20260909000000_add_label_cleanup/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "LabelCleanupAction" AS ENUM ('REMOVE_LABEL', 'TRASH');
+
+-- CreateTable
+CREATE TABLE "LabelCleanup" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+    "labelId" TEXT NOT NULL,
+    "labelName" TEXT NOT NULL,
+    "afterDays" INTEGER NOT NULL,
+    "action" "LabelCleanupAction" NOT NULL,
+    "lastRunAt" TIMESTAMP(3),
+    "lastRunCount" INTEGER,
+
+    CONSTRAINT "LabelCleanup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LabelCleanup_emailAccountId_labelId_key" ON "LabelCleanup"("emailAccountId", "labelId");
+
+-- CreateIndex
+CREATE INDEX "LabelCleanup_emailAccountId_idx" ON "LabelCleanup"("emailAccountId");
+
+-- AddForeignKey
+ALTER TABLE "LabelCleanup" ADD CONSTRAINT "LabelCleanup_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -190,6 +190,7 @@ model EmailAccount {
   account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
 
   labels              Label[]
+  labelCleanups       LabelCleanup[]
   rules               Rule[]
   executedRules       ExecutedRule[]
   newsletters         Newsletter[]
@@ -548,6 +549,32 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+}
+
+// "After N days, take the label off / trash" for mail a rule filed under a
+// label, so folders like Later or Newsletters don't grow forever.
+model LabelCleanup {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  labelId      String // provider label id
+  labelName    String // for display; the id is what runs
+  afterDays    Int
+  action       LabelCleanupAction
+  lastRunAt    DateTime?
+  lastRunCount Int?
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  @@unique([emailAccountId, labelId])
+  @@index([emailAccountId])
+}
+
+enum LabelCleanupAction {
+  REMOVE_LABEL
+  TRASH
 }
 
 model Label {

--- a/apps/web/utils/actions/label-cleanup.ts
+++ b/apps/web/utils/actions/label-cleanup.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import prisma from "@/utils/prisma";
+import { actionClient } from "@/utils/actions/safe-action";
+import {
+  deleteLabelCleanupBody,
+  saveLabelCleanupBody,
+} from "@/utils/actions/label-cleanup.validation";
+
+export const saveLabelCleanupAction = actionClient
+  .metadata({ name: "saveLabelCleanup" })
+  .inputSchema(saveLabelCleanupBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { labelId, labelName, afterDays, action },
+    }) => {
+      await prisma.labelCleanup.upsert({
+        where: { emailAccountId_labelId: { emailAccountId, labelId } },
+        update: { labelName, afterDays, action },
+        create: { emailAccountId, labelId, labelName, afterDays, action },
+      });
+    },
+  );
+
+export const deleteLabelCleanupAction = actionClient
+  .metadata({ name: "deleteLabelCleanup" })
+  .inputSchema(deleteLabelCleanupBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
+    await prisma.labelCleanup.deleteMany({ where: { id, emailAccountId } });
+  });

--- a/apps/web/utils/actions/label-cleanup.validation.ts
+++ b/apps/web/utils/actions/label-cleanup.validation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { LabelCleanupAction } from "@/generated/prisma/enums";
+
+export const saveLabelCleanupBody = z.object({
+  labelId: z.string().min(1),
+  labelName: z.string().min(1),
+  afterDays: z.number().int().min(1).max(3650),
+  action: z.nativeEnum(LabelCleanupAction),
+});
+export type SaveLabelCleanupBody = z.infer<typeof saveLabelCleanupBody>;
+
+export const deleteLabelCleanupBody = z.object({
+  id: z.string().min(1),
+});
+export type DeleteLabelCleanupBody = z.infer<typeof deleteLabelCleanupBody>;

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1360,6 +1360,27 @@ export class GmailProvider implements EmailProvider {
     };
   }
 
+  async listMessageIds(options: {
+    labelIds: string[];
+    query?: string;
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{
+    messages: { id: string; threadId: string }[];
+    nextPageToken?: string;
+  }> {
+    const response = await getMessages(this.client, {
+      labelIds: options.labelIds,
+      query: options.query,
+      maxResults: options.maxResults || 100,
+      pageToken: options.pageToken || undefined,
+    });
+    return {
+      messages: response.messages || [],
+      nextPageToken: response.nextPageToken || undefined,
+    };
+  }
+
   async searchMessages(options: {
     query: string;
     maxResults?: number;

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -296,6 +296,19 @@ export interface EmailProvider {
     labelId: string;
     labelName: string | null;
   }): Promise<{ usedFallback?: boolean; actualLabelId?: string }>;
+  /**
+   * Ids only, for bulk operations over a label. Optional: providers without
+   * label-scoped listing leave it out and label cleanup skips them.
+   */
+  listMessageIds?(options: {
+    labelIds: string[];
+    query?: string;
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{
+    messages: { id: string; threadId: string }[];
+    nextPageToken?: string;
+  }>;
   markMessagesReadState(messageIds: string[], read: boolean): Promise<void>;
   markMessagesStarredState(
     messageIds: string[],

--- a/apps/web/utils/label-cleanup/run-label-cleanup.test.ts
+++ b/apps/web/utils/label-cleanup/run-label-cleanup.test.ts
@@ -1,0 +1,115 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { cleanupLabel } from "./run-label-cleanup";
+import { LabelCleanupAction } from "@/generated/prisma/enums";
+import type { EmailProvider } from "@/utils/email/types";
+import { createTestLogger } from "@/__tests__/helpers";
+
+const logger = createTestLogger();
+
+// The runner's account loop is not exercised here; keep the provider factory
+// (and its mail parsers) out of the import graph.
+vi.mock("@/utils/email/provider", () => ({ createEmailProvider: vi.fn() }));
+vi.mock("@/utils/prisma", () => ({ default: {} }));
+
+describe("cleanupLabel", () => {
+  const listMessageIds = vi.fn();
+  const removeThreadLabel = vi.fn().mockResolvedValue(undefined);
+  const trashThread = vi.fn().mockResolvedValue(undefined);
+  const provider = {
+    listMessageIds,
+    removeThreadLabel,
+    trashThread,
+  } as unknown as EmailProvider;
+
+  const baseArgs = {
+    provider,
+    ownerEmail: "user@example.com",
+    labelId: "Label_1",
+    afterDays: 30,
+    logger,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listMessageIds.mockResolvedValue({
+      messages: [
+        { id: "m1", threadId: "t1" },
+        { id: "m2", threadId: "t1" },
+        { id: "m3", threadId: "t2" },
+      ],
+    });
+  });
+
+  it("removes the label from each old thread once", async () => {
+    const processed = await cleanupLabel({
+      ...baseArgs,
+      action: LabelCleanupAction.REMOVE_LABEL,
+    });
+
+    expect(listMessageIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labelIds: ["Label_1"],
+        query: "older_than:30d",
+      }),
+    );
+    expect(removeThreadLabel).toHaveBeenCalledTimes(2);
+    expect(removeThreadLabel).toHaveBeenCalledWith("t1", "Label_1");
+    expect(removeThreadLabel).toHaveBeenCalledWith("t2", "Label_1");
+    expect(trashThread).not.toHaveBeenCalled();
+    expect(processed).toBe(2);
+  });
+
+  it("trashes threads when the action is trash", async () => {
+    await cleanupLabel({ ...baseArgs, action: LabelCleanupAction.TRASH });
+
+    expect(trashThread).toHaveBeenCalledTimes(2);
+    expect(trashThread).toHaveBeenCalledWith(
+      "t1",
+      "user@example.com",
+      "automation",
+    );
+    expect(removeThreadLabel).not.toHaveBeenCalled();
+  });
+
+  it("follows pagination", async () => {
+    listMessageIds
+      .mockResolvedValueOnce({
+        messages: [{ id: "m1", threadId: "t1" }],
+        nextPageToken: "next",
+      })
+      .mockResolvedValueOnce({ messages: [{ id: "m2", threadId: "t2" }] });
+
+    const processed = await cleanupLabel({
+      ...baseArgs,
+      action: LabelCleanupAction.REMOVE_LABEL,
+    });
+
+    expect(listMessageIds).toHaveBeenCalledTimes(2);
+    expect(listMessageIds).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pageToken: "next" }),
+    );
+    expect(processed).toBe(2);
+  });
+
+  it("keeps going when one thread fails", async () => {
+    removeThreadLabel.mockRejectedValueOnce(new Error("gone"));
+
+    const processed = await cleanupLabel({
+      ...baseArgs,
+      action: LabelCleanupAction.REMOVE_LABEL,
+    });
+
+    expect(processed).toBe(1);
+  });
+
+  it("skips providers that cannot list by label", async () => {
+    const processed = await cleanupLabel({
+      ...baseArgs,
+      provider: { removeThreadLabel, trashThread } as unknown as EmailProvider,
+      action: LabelCleanupAction.REMOVE_LABEL,
+    });
+
+    expect(processed).toBe(0);
+    expect(removeThreadLabel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/label-cleanup/run-label-cleanup.ts
+++ b/apps/web/utils/label-cleanup/run-label-cleanup.ts
@@ -1,0 +1,145 @@
+import { LabelCleanupAction } from "@/generated/prisma/enums";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { EmailProvider } from "@/utils/email/types";
+import { captureException } from "@/utils/error";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+// Bound a single run so one huge label can't starve the rest; the next run
+// picks up where this one left off since it always looks at the oldest mail.
+const MAX_MESSAGES_PER_RUN = 1000;
+const PAGE_SIZE = 100;
+
+export async function runLabelCleanups({ logger }: { logger: Logger }) {
+  const cleanups = await prisma.labelCleanup.findMany({
+    select: {
+      id: true,
+      labelId: true,
+      labelName: true,
+      afterDays: true,
+      action: true,
+      emailAccount: {
+        select: {
+          id: true,
+          email: true,
+          account: { select: { provider: true } },
+        },
+      },
+    },
+  });
+
+  logger.info("Running label cleanups", { count: cleanups.length });
+
+  const results: { id: string; processed: number; error?: string }[] = [];
+
+  for (const cleanup of cleanups) {
+    const log = logger.with({
+      emailAccountId: cleanup.emailAccount.id,
+      labelId: cleanup.labelId,
+      action: cleanup.action,
+    });
+
+    try {
+      const provider = await createEmailProvider({
+        emailAccountId: cleanup.emailAccount.id,
+        provider: cleanup.emailAccount.account.provider,
+        logger: log,
+      });
+
+      const processed = await cleanupLabel({
+        provider,
+        ownerEmail: cleanup.emailAccount.email,
+        labelId: cleanup.labelId,
+        afterDays: cleanup.afterDays,
+        action: cleanup.action,
+        logger: log,
+      });
+
+      await prisma.labelCleanup.update({
+        where: { id: cleanup.id },
+        data: { lastRunAt: new Date(), lastRunCount: processed },
+      });
+
+      results.push({ id: cleanup.id, processed });
+    } catch (error) {
+      log.error("Label cleanup failed", { error });
+      captureException(error, {
+        extra: {
+          cleanupId: cleanup.id,
+          emailAccountId: cleanup.emailAccount.id,
+        },
+      });
+      results.push({
+        id: cleanup.id,
+        processed: 0,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Takes the label off (or trashes) every thread under it whose mail is older
+ * than the cutoff. Returns how many threads were touched.
+ */
+export async function cleanupLabel({
+  provider,
+  ownerEmail,
+  labelId,
+  afterDays,
+  action,
+  logger,
+}: {
+  provider: EmailProvider;
+  ownerEmail: string;
+  labelId: string;
+  afterDays: number;
+  action: LabelCleanupAction;
+  logger: Logger;
+}): Promise<number> {
+  if (!provider.listMessageIds) {
+    logger.info("Provider cannot list by label, skipping cleanup");
+    return 0;
+  }
+
+  const threadIds = new Set<string>();
+  let pageToken: string | undefined;
+  let scanned = 0;
+
+  do {
+    const page = await provider.listMessageIds({
+      labelIds: [labelId],
+      query: `older_than:${afterDays}d`,
+      maxResults: PAGE_SIZE,
+      pageToken,
+    });
+    for (const message of page.messages) threadIds.add(message.threadId);
+    scanned += page.messages.length;
+    pageToken = page.nextPageToken;
+  } while (pageToken && scanned < MAX_MESSAGES_PER_RUN);
+
+  let processed = 0;
+  for (const threadId of threadIds) {
+    try {
+      if (action === LabelCleanupAction.TRASH) {
+        await provider.trashThread(threadId, ownerEmail, "automation");
+      } else {
+        await provider.removeThreadLabel(threadId, labelId);
+      }
+      processed++;
+    } catch (error) {
+      logger.warn("Could not clean up thread", { threadId, error });
+    }
+  }
+
+  logger.info("Label cleanup done", {
+    scanned,
+    threads: threadIds.size,
+    processed,
+    hasMore: !!pageToken,
+  });
+
+  return processed;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,13 @@ services:
         ) &
         (
           while true; do
+            echo \"[cron] Cleaning up labeled mail...\"
+            curl -s -X GET 'http://web:3000/api/cron/label-cleanup' -H \"Authorization: Bearer $${CRON_SECRET}\" || echo \"[cron] Warning: label-cleanup request failed\"
+            sleep 86400
+          done
+        ) &
+        (
+          while true; do
             echo \"[cron] Renewing email watches...\"
             curl -s -X GET 'http://web:3000/api/watch/all' -H \"Authorization: Bearer $${CRON_SECRET}\" || echo \"[cron] Warning: watch request failed\"
             sleep 21600


### PR DESCRIPTION
## Summary

Rules file mail under labels, but nothing ever takes it back out, so folders like "Later" or "Newsletters" grow forever. This adds **Label cleanup** (Assistant → Settings → Housekeeping): per label, "after N days, remove the label" (the thread stays in All Mail, just leaves that folder) or "move to trash" (for a black‑hole style label; the provider purges trash on its own schedule). It's the retention half of a SaneBox‑style setup.

## How it works

- `LabelCleanup` model (per account + label id: `afterDays`, `action`, last run stats) + migration.
- `GET/POST /api/cron/label-cleanup` (cron secret) → `runLabelCleanups`: for each entry, list messages under the label older than N days, then `removeThreadLabel` or `trashThread` per thread. Capped at 1,000 messages per run so a large backlog drains over a few nights; the next run always sees the oldest mail first.
- New optional provider method `listMessageIds({ labelIds, query })` — ids only, no message fetch. Implemented for Gmail (`messages.list` with `labelIds`); providers without it are skipped with a log line.
- Settings dialog: label picker (`LabelCombobox`), days, action; table of entries with "last run · N threads"; save/delete server actions.
- The compose cron loop gets a daily entry for the endpoint.

## Test plan

- [x] `utils/label-cleanup/run-label-cleanup.test.ts`: remove-label / trash per thread (deduped across messages), pagination, per-thread failure tolerance, provider without listing.
- [x] biome, `tsc` clean on touched files; server-action and enum-import checks pass.
- [x] Deployed on a self-hosted instance: migration applies, endpoint returns `{"results":[]}` with no entries, cron entry runs.
- [ ] Manual: add an entry for a label with old mail, hit the endpoint, confirm threads leave the label / land in trash and the row shows the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Housekeeping settings for automatic label cleanup.
  * Users can configure labels to be removed or moved to Trash after a selected number of days.
  * Added cleanup rule status, including last-run details, with options to save or delete rules.
  * Cleanup runs automatically each day and processes eligible email threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->