### PR TITLE
INB-355: Add select-all option to mail thread list

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -154,6 +154,45 @@ test("selects ranges and opens conversations with the keyboard", async ({
   await expect(conversations).toBeVisible();
 });
 
+test("selects and clears all conversations from the list toolbar", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  const options = conversations.getByRole("option");
+  const conversationCount = await options.count();
+  expect(conversationCount).toBeGreaterThan(1);
+
+  const selectAll = page.getByRole("checkbox", {
+    name: "Select all conversations",
+  });
+  await expect(selectAll).not.toBeChecked();
+
+  await selectAll.click();
+
+  await expect(
+    page.getByText(`${conversationCount} selected`, { exact: true }),
+  ).toBeVisible();
+  await expect(selectAll).toBeChecked();
+  await expect.poll(() => allRowsAreSelected(options, true)).toBe(true);
+  await capturePlaywrightCheckpoint(page, testInfo, "select-all-conversations");
+
+  await options.nth(1).getByRole("checkbox").click();
+
+  await expect(
+    page.getByText(`${conversationCount - 1} selected`, { exact: true }),
+  ).toBeVisible();
+  await expect(selectAll).toHaveAttribute("aria-checked", "mixed");
+
+  await selectAll.click();
+  await expect(selectAll).toBeChecked();
+  await expect.poll(() => allRowsAreSelected(options, true)).toBe(true);
+
+  await selectAll.click();
+  await expect(selectAll).not.toBeChecked();
+  await expect(page.getByText(/\d+ selected/)).toHaveCount(0);
+  await expect.poll(() => allRowsAreSelected(options, false)).toBe(true);
+});
+
 test("selects every conversation with Command A", async ({ page }) => {
   const { conversations } = await openMail(page);
   const options = conversations.getByRole("option");

--- a/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ListToolbar.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Kbd } from "@/components/Kbd";
 import { Tooltip } from "@/components/Tooltip";
+import { Checkbox } from "@/components/ui/checkbox";
 import type { MailLayoutMode } from "@/app/(app)/[emailAccountId]/mail/types";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
@@ -30,7 +31,9 @@ export type ListToolbarProps = {
   onToggleLayout: () => void;
   onTogglePreview: () => void;
   onToggleAssistant: () => void;
+  threadCount: number;
   selectedCount: number;
+  onSelectAll: () => void;
   onArchiveSelected: () => void;
   onDeleteSelected: () => void;
   /** Omitted when the current view can't label (combined inboxes). */
@@ -48,16 +51,47 @@ export function ListToolbar({
   onToggleLayout,
   onTogglePreview,
   onToggleAssistant,
+  threadCount,
   selectedCount,
+  onSelectAll,
   onArchiveSelected,
   onDeleteSelected,
   onLabelSelected,
   onClearSelection,
 }: ListToolbarProps) {
   const LayoutIcon = layout === "split" ? ColumnsIcon : RowsIcon;
+  const allSelected = threadCount > 0 && selectedCount === threadCount;
+  let selectAllState: boolean | "indeterminate" = false;
+  if (allSelected) {
+    selectAllState = true;
+  } else if (selectedCount > 0) {
+    selectAllState = "indeterminate";
+  }
 
   return (
     <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-3">
+      <Tooltip
+        content={
+          allSelected
+            ? "Deselect all conversations"
+            : "Select all conversations"
+        }
+      >
+        <Checkbox
+          aria-label="Select all conversations"
+          checked={selectAllState}
+          className="size-4 rounded border-input"
+          disabled={threadCount === 0}
+          onCheckedChange={(checked) => {
+            if (checked === true) {
+              onSelectAll();
+            } else {
+              onClearSelection();
+            }
+          }}
+        />
+      </Tooltip>
+
       {/* Selection swaps the toolbar's controls in place so the list never
           shifts down to make room for a new row. */}
       {selectedCount > 0 ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1392,7 +1392,9 @@ export function MailShell() {
               onTogglePreview={togglePreview}
               onToggleAssistant={() => toggleSidebar(["chat-sidebar"])}
               showLayoutToggle={!isAllAccounts}
+              threadCount={threads.length}
               selectedCount={selection.selectedCount}
+              onSelectAll={selection.selectAll}
               onArchiveSelected={archiveTargets}
               onDeleteSelected={trashTargets}
               onLabelSelected={canLabel ? openLabelPicker : undefined}


### PR DESCRIPTION
Adds a master checkbox to the mail list toolbar so users can select or clear every loaded conversation. The control reflects checked and indeterminate selection states while reusing the existing thread-selection logic.

- Adds an accessible select-all/deselect-all toolbar control
- Covers checked, mixed, reselect, and clear states in the emulated Playwright suite
- Validation: `pnpm -F inbox-zero-ai test:playwright:emulated mail/triage-actions.spec.ts` (7 passed)
- Performance: constant-time toolbar state derivation and existing O(n) set creation only on select-all; no new database or network calls; low hot-path risk
- Linear: https://linear.app/inbox-zero-ai/issue/INB-355/add-select-all-option-to-thread-list-in-mail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a select-all checkbox to the mail toolbar.
  * The checkbox supports selected, partially selected, and unselected states.
  * Users can select all conversations, clear selections, or reselect all from the toolbar.
  * The control is disabled when no conversations are available.

* **Tests**
  * Added coverage for select-all, partial deselection, mixed selection state, and clearing selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->