### PR TITLE
INB-356: Exclude drafts from thread participants

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.test.ts
@@ -38,6 +38,25 @@ describe("getThreadParticipantNames", () => {
     ).toEqual(["Bah"]);
   });
 
+  it("does not count an unsent draft as participation by the account owner", () => {
+    expect(
+      getThreadParticipantNames(
+        [
+          message({
+            from: "Bah <bah@example.com>",
+            to: "owner@example.com",
+          }),
+          message({
+            from: "owner@example.com",
+            to: "Bah <bah@example.com>",
+            labelIds: ["DRAFT"],
+          }),
+        ],
+        "owner@example.com",
+      ),
+    ).toEqual(["Bah"]);
+  });
+
   it("keeps recipient names for an outgoing-only thread", () => {
     expect(
       getThreadParticipantNames(
@@ -51,8 +70,31 @@ describe("getThreadParticipantNames", () => {
       ),
     ).toEqual(["Jordan", "Taylor"]);
   });
+
+  it("keeps recipient names for a draft-only thread", () => {
+    expect(
+      getThreadParticipantNames(
+        [
+          message({
+            from: "owner@example.com",
+            to: "Jordan <jordan@example.com>",
+            labelIds: ["DRAFT"],
+          }),
+        ],
+        "owner@example.com",
+      ),
+    ).toEqual(["Jordan"]);
+  });
 });
 
-function message({ from, to }: { from: string; to: string }) {
-  return { headers: { from, to } };
+function message({
+  from,
+  to,
+  labelIds,
+}: {
+  from: string;
+  to: string;
+  labelIds?: string[];
+}) {
+  return { headers: { from, to }, labelIds };
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-participants.ts
@@ -3,10 +3,12 @@ import {
   extractNameFromEmail,
   splitRecipientList,
 } from "@/utils/email";
+import { GmailLabel } from "@/utils/gmail/label";
 import type { ParsedMessageHeaders } from "@/utils/types";
 
 type ParticipantMessage = {
   headers: Pick<ParsedMessageHeaders, "from" | "to">;
+  labelIds?: string[] | null;
 };
 
 export function getThreadParticipantNames(
@@ -15,16 +17,23 @@ export function getThreadParticipantNames(
 ) {
   const normalizedUserEmail = canonicalizeEmailAddress(userEmail);
   const senders = new Map<string, string>();
+  const nonDraftMessages = messages.filter(
+    (message) => !message.labelIds?.includes(GmailLabel.DRAFT),
+  );
 
-  for (const message of messages) {
+  for (const message of nonDraftMessages) {
     addParticipant(senders, message.headers.from, normalizedUserEmail);
   }
 
-  const isOutgoingOnly = senders.size === 1 && senders.has(normalizedUserEmail);
-  if (!isOutgoingOnly) return [...senders.values()];
+  const hasOnlyAccountOwnerAsSender =
+    senders.size === 1 && senders.has(normalizedUserEmail);
+  if (senders.size > 0 && !hasOnlyAccountOwnerAsSender) {
+    return [...senders.values()];
+  }
 
   const recipients = new Map<string, string>();
-  for (const message of messages) {
+  const recipientMessages = senders.size > 0 ? nonDraftMessages : messages;
+  for (const message of recipientMessages) {
     for (const recipient of splitRecipientList(message.headers.to)) {
       addParticipant(recipients, recipient, normalizedUserEmail);
     }


### PR DESCRIPTION
Exclude unsent drafts when determining active thread senders so the account owner is not incorrectly shown as a participant. Preserve recipient names for threads that contain only drafts.

- Filter draft messages out of sender participation
- Add regression coverage for received threads with drafts and draft-only threads
- Tests: focused Vitest suite passes (5 tests); Ultracite check passes
- Linear: https://linear.app/inbox-zero-ai/issue/INB-356/thread-participant-list-incorrectly-includes-me-when-only-a-draft

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Draft messages are no longer incorrectly counted when identifying thread participants.
  - Recipient names remain visible for outgoing threads that contain only draft messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->