### PR TITLE
fix(mail): refresh date groups across midnight

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -5,6 +5,40 @@ import { conversationWithSubject, openMail } from "./mail-test-helpers";
 import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
 import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
 
+test("refreshes date groups after midnight when the tab resumes", async ({
+  page,
+}, testInfo) => {
+  await page.clock.install({ time: new Date() });
+  const { conversations } = await openMail(page);
+  const today = conversations.getByRole("group", {
+    name: "Today",
+    exact: true,
+  });
+  await expect(today).toBeVisible();
+  await expect(today.getByText("Today", { exact: true })).toHaveCount(0);
+  const todayCount = await today.getByRole("option").count();
+  expect(todayCount).toBeGreaterThan(0);
+
+  const afterMidnight = await page.evaluate(() => {
+    const nextDay = new Date();
+    nextDay.setDate(nextDay.getDate() + 1);
+    nextDay.setHours(0, 1, 0, 0);
+    return nextDay.getTime();
+  });
+  // Moving the clock without running timers simulates a suspended tab.
+  await page.clock.setSystemTime(afterMidnight);
+  await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+  await expect(today).toHaveCount(0);
+  const yesterday = conversations.getByRole("group", {
+    name: "Yesterday",
+    exact: true,
+  });
+  await expect(yesterday.getByRole("option")).toHaveCount(todayCount);
+  await expect(yesterday.getByText("Yesterday", { exact: true })).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-date-rollover");
+});
+
 test("switches between list and split reading layouts", async ({
   page,
 }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/layout.spec.ts
@@ -8,7 +8,9 @@ import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
 test("refreshes date groups after midnight when the tab resumes", async ({
   page,
 }, testInfo) => {
-  await page.clock.install({ time: new Date() });
+  // The emulator dates its newest messages 24 hours before setup.
+  const mailboxDay = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  await page.clock.install({ time: mailboxDay });
   const { conversations } = await openMail(page);
   const today = conversations.getByRole("group", {
     name: "Today",

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -75,7 +75,7 @@ export function ThreadList({
     : undefined;
   const dayStart = useDayStart();
   const dateGroups = useMemo(
-    () => groupThreadsByDate(threads, dayStart),
+    () => groupThreadsByDate(threads, new Date(dayStart)),
     [dayStart, threads],
   );
 
@@ -149,7 +149,7 @@ export function ThreadList({
                   key={`${group.label}-${group.startIndex}`}
                   role="group"
                 >
-                  {group.label ? (
+                  {group.label && group.label !== "Today" ? (
                     <div
                       aria-hidden
                       className={cn(
@@ -218,16 +218,25 @@ export function ThreadList({
   );
 }
 
-/** Re-renders the list at local midnight so "Today" and "Yesterday" stay true. */
+/** Refreshes idle lists at midnight and when a suspended tab becomes active. */
 function useDayStart() {
-  const [dayStart, setDayStart] = useState(() => startOfDay(new Date()));
+  const [, setDayStart] = useState(() => startOfDay(new Date()).getTime());
+  // Read the clock on every render, even if a background timer has not fired yet.
+  const dayStart = startOfDay(new Date()).getTime();
 
   useEffect(() => {
+    const refresh = () => setDayStart(startOfDay(new Date()).getTime());
     const timeout = setTimeout(
-      () => setDayStart(startOfDay(new Date())),
-      addDays(dayStart, 1).getTime() - Date.now(),
+      refresh,
+      Math.max(0, addDays(new Date(dayStart), 1).getTime() - Date.now()),
     );
-    return () => clearTimeout(timeout);
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      clearTimeout(timeout);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", refresh);
+    };
   }, [dayStart]);
 
   return dayStart;


### PR DESCRIPTION
Refresh mail date groups across local midnight and when a suspended tab resumes, and hide the visible Today heading.

- Read the current local day on each render while retaining memoized grouping and the midnight timer.
- Add browser regression coverage for tab resume after midnight and heading visibility.
- Validation: 61 focused unit tests, all four focused browser-suite tests, formatting checks, and screenshot inspection passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mail conversation date groups now refresh correctly when the app resumes after midnight or regains focus.
  - Date grouping also updates when page visibility changes, keeping conversations assigned to the correct day.
  - The “Today” date-group header is no longer displayed.
  - Conversation counts remain consistent when messages move between date groups after the day changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->