### PR TITLE
INB-357: Preserve collapsed signatures when composing

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -92,16 +92,25 @@ test("keeps the collapsed signature when typing after clicking below it", async 
 
   const signatureBox = await signatureBlock.boundingBox();
   if (!signatureBox) throw new Error("Signature block has no bounding box");
+  const editorBox = await editor.boundingBox();
+  if (!editorBox) throw new Error("Editor has no bounding box");
 
-  await signatureBlock.click({
-    position: {
-      x: signatureBox.width / 2,
-      y: signatureBox.height - 4,
-    },
-  });
+  const clickPosition = {
+    x: editorBox.width / 2,
+    y: editorBox.height - 4,
+  };
+  expect(editorBox.y + clickPosition.y).toBeGreaterThan(
+    signatureBox.y + signatureBox.height,
+  );
+  await editor.click({ position: clickPosition });
   await page.keyboard.type("Draft body");
 
   await expect(editor).toContainText("Draft body");
+  expect(
+    await signatureBlock.evaluate(
+      (block) => block.previousElementSibling?.textContent ?? "",
+    ),
+  ).toContain("Draft body");
   await expect(signatureBlock).toHaveCount(1);
   await expect(
     dialog.getByRole("button", { name: "Show signature" }),

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -107,10 +107,24 @@ test("keeps the collapsed signature when typing after clicking below it", async 
 
   await expect(editor).toContainText("Draft body");
   expect(
-    await signatureBlock.evaluate(
-      (block) => block.previousElementSibling?.textContent ?? "",
-    ),
-  ).toContain("Draft body");
+    await editor.evaluate((element) => {
+      const signature = element.querySelector(
+        "[data-email-preserved-kind='signature']",
+      );
+      if (!signature) return false;
+
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        if (walker.currentNode.textContent?.includes("Draft body")) {
+          return Boolean(
+            walker.currentNode.compareDocumentPosition(signature) &
+              Node.DOCUMENT_POSITION_FOLLOWING,
+          );
+        }
+      }
+      return false;
+    }),
+  ).toBe(true);
   await expect(signatureBlock).toHaveCount(1);
   await expect(
     dialog.getByRole("button", { name: "Show signature" }),

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -77,6 +77,42 @@ test("focuses the message field from the empty composer body", async ({
   await expect(editor).toBeFocused();
 });
 
+test("keeps the collapsed signature when typing after clicking below it", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const editor = dialog.getByRole("textbox", { name: "Email message" });
+  const signatureBlock = dialog.locator(
+    "[data-email-preserved-kind='signature']",
+  );
+  await expect(signatureBlock).toBeVisible();
+
+  const signatureBox = await signatureBlock.boundingBox();
+  if (!signatureBox) throw new Error("Signature block has no bounding box");
+
+  await signatureBlock.click({
+    position: {
+      x: signatureBox.width / 2,
+      y: signatureBox.height - 4,
+    },
+  });
+  await page.keyboard.type("Draft body");
+
+  await expect(editor).toContainText("Draft body");
+  await expect(signatureBlock).toHaveCount(1);
+  await expect(
+    dialog.getByRole("button", { name: "Show signature" }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "composer-click-below-collapsed-signature",
+  );
+});
+
 test("highlights URLs while typing and pasting", async ({ page }, testInfo) => {
   await openMail(page);
   await page.getByRole("button", { name: /^Compose/ }).click();

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -95,13 +95,13 @@ test("keeps the collapsed signature when typing after clicking below it", async 
   const editorBox = await editor.boundingBox();
   if (!editorBox) throw new Error("Editor has no bounding box");
 
+  const emptySpaceTop = signatureBox.y + signatureBox.height;
+  const emptySpaceHeight = editorBox.y + editorBox.height - emptySpaceTop;
+  expect(emptySpaceHeight).toBeGreaterThan(8);
   const clickPosition = {
     x: editorBox.width / 2,
-    y: editorBox.height - 4,
+    y: emptySpaceTop - editorBox.y + emptySpaceHeight / 2,
   };
-  expect(editorBox.y + clickPosition.y).toBeGreaterThan(
-    signatureBox.y + signatureBox.height,
-  );
   await editor.click({ position: clickPosition });
   await page.keyboard.type("Draft body");
 

--- a/packages/email-editor/src/web/EmailEditor.tsx
+++ b/packages/email-editor/src/web/EmailEditor.tsx
@@ -216,9 +216,18 @@ const RichEmailEditor = forwardRef<
             ) {
               return false;
             }
-            const preservedBlock = target.closest(
-              "[data-email-preserved-kind]",
-            );
+            let preservedBlock = target.closest("[data-email-preserved-kind]");
+            const lastEditorChild = view.dom.lastElementChild;
+            if (
+              !preservedBlock &&
+              target === view.dom &&
+              lastEditorChild?.matches("[data-email-preserved-kind]") &&
+              event.clientY > lastEditorChild.getBoundingClientRect().bottom
+            ) {
+              preservedBlock = view.dom.querySelector(
+                "[data-email-preserved-kind]",
+              );
+            }
             if (!preservedBlock) return false;
 
             event.preventDefault();

--- a/packages/email-editor/src/web/EmailEditor.tsx
+++ b/packages/email-editor/src/web/EmailEditor.tsx
@@ -209,7 +209,11 @@ const RichEmailEditor = forwardRef<
         handleDOMEvents: {
           mousedown: (view, event) => {
             const target = event.target;
-            if (!(target instanceof Element) || target.closest("button")) {
+            if (
+              !(target instanceof Element) ||
+              event.button !== 0 ||
+              target.closest("button")
+            ) {
               return false;
             }
             const preservedBlock = target.closest(

--- a/packages/email-editor/src/web/EmailEditor.tsx
+++ b/packages/email-editor/src/web/EmailEditor.tsx
@@ -206,6 +206,28 @@ const RichEmailEditor = forwardRef<
           dir: "auto",
           role: "textbox",
         },
+        handleDOMEvents: {
+          mousedown: (view, event) => {
+            const target = event.target;
+            if (!(target instanceof Element) || target.closest("button")) {
+              return false;
+            }
+            const preservedBlock = target.closest(
+              "[data-email-preserved-kind]",
+            );
+            if (!preservedBlock) return false;
+
+            event.preventDefault();
+            const blockPosition = view.posAtDOM(preservedBlock, 0);
+            const selection = TextSelection.near(
+              view.state.doc.resolve(blockPosition),
+              -1,
+            );
+            view.dispatch(view.state.tr.setSelection(selection));
+            view.focus();
+            return true;
+          },
+        },
         handleClick: (_view, _position, event) => {
           const link = (event.target as HTMLElement | null)?.closest("a");
           if (!(link instanceof HTMLAnchorElement)) return false;

--- a/packages/email-editor/src/web/EmailEditor.tsx
+++ b/packages/email-editor/src/web/EmailEditor.tsx
@@ -220,13 +220,10 @@ const RichEmailEditor = forwardRef<
             const lastEditorChild = view.dom.lastElementChild;
             if (
               !preservedBlock &&
-              target === view.dom &&
               lastEditorChild?.matches("[data-email-preserved-kind]") &&
               event.clientY > lastEditorChild.getBoundingClientRect().bottom
             ) {
-              preservedBlock = view.dom.querySelector(
-                "[data-email-preserved-kind]",
-              );
+              preservedBlock = lastEditorChild;
             }
             if (!preservedBlock) return false;
 

--- a/packages/email-editor/src/web/email-extensions.tsx
+++ b/packages/email-editor/src/web/email-extensions.tsx
@@ -19,7 +19,7 @@ const PreservedEmailBlockNode = Node.create({
   name: "preservedEmailBlock",
   group: "block",
   atom: true,
-  selectable: true,
+  selectable: false,
   isolating: true,
 
   addAttributes() {


### PR DESCRIPTION
Fix composer caret placement so typing after clicking a collapsed preserved signature inserts text before the signature instead of replacing it. Preserved blocks remain intact while their controls continue to work.

- Route primary clicks inside or below trailing preserved blocks to the preceding text selection, while preserving controls and non-primary click behavior.
- Add emulated Playwright regression coverage for typing near a collapsed signature.
- Tests: email-editor unit suite (27 passed), email-editor typecheck, and focused Ultracite check passed.
- Browser validation: the focused emulated compose suite passed in PR CI (15 tests).
- Performance: adds small DOM ancestry and geometry checks on editor mousedown and dispatches only for preserved-block interactions; no database or network calls and negligible hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-357/clicking-below-collapsed-signature-in-composer-overwrites


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved editing behavior around preserved email blocks, including signatures.
  - Clicking empty space below these blocks now places the cursor in the editor without selecting the block.
  - Preserved blocks remain collapsed when users enter nearby content, while normal button interactions continue to work.
  - Preserved email blocks can no longer be selected accidentally during editing.

- **Tests**
  - Added coverage for composer interactions, signature visibility, cursor placement, and draft text entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
