### PR TITLE
INB-358: Preserve compose drafts when closing the composer

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -165,6 +165,15 @@ test("restores a new message draft after closing the composer", async ({
 
   await dialog.getByRole("button", { name: "Discard draft" }).click();
   await expect(dialog).toBeHidden();
+
+  await page.getByRole("button", { name: /^Compose/ }).click();
+  await expect(toField).toHaveValue("");
+  await expect(subjectField).toHaveValue("");
+  await expect(messageField).not.toContainText(
+    "Keep this message after closing.",
+  );
+  await dialog.getByRole("button", { name: "Discard draft" }).click();
+  await expect(dialog).toBeHidden();
 });
 
 test("highlights URLs while typing and pasting", async ({ page }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -136,6 +136,37 @@ test("keeps the collapsed signature when typing after clicking below it", async 
   );
 });
 
+test("restores a new message draft after closing the composer", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const toField = dialog.getByRole("textbox", { name: "To" });
+  const subjectField = dialog.getByPlaceholder("Subject");
+  const messageField = dialog.getByRole("textbox", { name: "Email message" });
+  await toField.fill("recipient@example.com");
+  await subjectField.fill("Preserved compose draft");
+  await messageField.fill("Keep this message after closing.");
+
+  await dialog.getByRole("button", { name: "Close compose" }).click();
+  await expect(dialog).toBeHidden();
+  await page.getByRole("button", { name: /^Compose/ }).click();
+
+  await expect(toField).toHaveValue("recipient@example.com");
+  await expect(subjectField).toHaveValue("Preserved compose draft");
+  await expect(messageField).toContainText("Keep this message after closing.");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "restored-new-message-draft",
+  );
+
+  await dialog.getByRole("button", { name: "Discard draft" }).click();
+  await expect(dialog).toBeHidden();
+});
+
 test("highlights URLs while typing and pasting", async ({ page }, testInfo) => {
   await openMail(page);
   await page.getByRole("button", { name: /^Compose/ }).click();

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -81,6 +81,7 @@ import {
 import type { StoredReplyDraft } from "@/utils/email-cache/database";
 import type {
   ReplyDraftContent,
+  ReplyDraftIdentity,
   ReplyDraftMode,
 } from "@/utils/email-cache/reply-drafts";
 import { createPreservedEmailBlocks } from "@/utils/email/preserved-blocks";
@@ -178,14 +179,16 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
       )
     : "";
 
+  const localDraftIdentity = props.draftSessionId
+    ? {
+        emailAccountId: selectedEmailAccountId,
+        threadId: props.replyingToEmail?.threadId ?? props.draftSessionId,
+        messageId: props.draftSessionId,
+      }
+    : undefined;
+
   const localDraft = useLocalReplyDraft(
-    props.draftSessionId && props.replyingToEmail?.threadId
-      ? {
-          emailAccountId: selectedEmailAccountId,
-          threadId: props.replyingToEmail.threadId,
-          messageId: props.draftSessionId,
-        }
-      : undefined,
+    localDraftIdentity,
     props.draftKeyMessageId && props.replyingToEmail?.threadId
       ? {
           emailAccountId: selectedEmailAccountId,
@@ -204,6 +207,7 @@ export function ComposeEmailForm(props: ComposeEmailFormProps) {
         <ShortcutsProvider scopes={MAIL_SHORTCUT_SCOPES}>
           <ComposeEmailFormContent
             {...props}
+            localDraftIdentity={localDraftIdentity}
             storedDraft={localDraft.draft}
             draftLoadError={localDraft.error}
             accountProvider={selectedAccountProvider}
@@ -224,7 +228,6 @@ function ComposeEmailFormContent({
   draftKeyMessageId,
   providerDraftMessageId,
   draftMode,
-  draftSessionId,
   storedDraft,
   draftLoadError,
   replyingToEmail,
@@ -239,7 +242,9 @@ function ComposeEmailFormContent({
   onMarkDone,
   onClose,
   onDiscard,
+  localDraftIdentity,
 }: ComposeEmailFormProps & {
+  localDraftIdentity?: ReplyDraftIdentity;
   storedDraft?: StoredReplyDraft;
   draftLoadError?: Error;
   accountProvider: string;
@@ -436,14 +441,7 @@ function ComposeEmailFormContent({
     flush: flushDraft,
     saveError: draftSaveError,
   } = useReplyDraftPersistence({
-    identity:
-      isInlineReply && draftSessionId
-        ? {
-            emailAccountId: selectedEmailAccountId,
-            threadId: replyingToEmail!.threadId!,
-            messageId: draftSessionId,
-          }
-        : undefined,
+    identity: localDraftIdentity,
     initialRevision: storedDraft?.revision,
     loadError: draftLoadError,
     getContent: getDraftContent,
@@ -871,6 +869,16 @@ function ComposeEmailFormContent({
         );
         if (result?.data) {
           deliveryAccepted = true;
+          if (!replyingToEmail) {
+            try {
+              await clearLocalDraft();
+            } catch {
+              toastError({
+                description:
+                  "Email sent, but its local draft copy could not be cleared.",
+              });
+            }
+          }
           toastSuccess({ description: "Email sent!" });
           if (markDoneAfterSend) onMarkDone?.();
           onSuccess?.(result.data.messageId ?? "", result.data.threadId ?? "");
@@ -1516,7 +1524,7 @@ function ComposeEmailFormContent({
           {providerAutosave.error}
         </p>
       )}
-      {isInlineReply && draftSaveError && (
+      {localDraftIdentity && draftSaveError && (
         <p role="alert" className="text-xs text-destructive">
           {draftSaveError}
         </p>

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -869,7 +869,7 @@ function ComposeEmailFormContent({
         );
         if (result?.data) {
           deliveryAccepted = true;
-          if (!replyingToEmail) {
+          if (localDraftIdentity) {
             try {
               await clearLocalDraft();
             } catch {
@@ -906,6 +906,7 @@ function ComposeEmailFormContent({
       resumeProviderAutosave,
       initialDraft,
       isInlineReply,
+      localDraftIdentity,
       sendAt,
       remindAt,
       requestId,

--- a/apps/web/hooks/useReplyDraftPersistence.test.ts
+++ b/apps/web/hooks/useReplyDraftPersistence.test.ts
@@ -60,4 +60,25 @@ describe("useReplyDraftPersistence", () => {
     await act(() => vi.advanceTimersByTimeAsync(300));
     expect(save).toHaveBeenCalledTimes(2);
   });
+
+  it("flushes the latest draft when the composer closes before the debounce", async () => {
+    vi.useFakeTimers();
+    save.mockResolvedValue({});
+    const { result, unmount } = renderHook(() =>
+      useReplyDraftPersistence({
+        identity: {
+          emailAccountId: "account",
+          threadId: "compose:new-message",
+          messageId: "compose:new-message",
+        },
+        getContent: () => content,
+      }),
+    );
+
+    act(() => result.current.capture());
+    unmount();
+    await act(() => vi.advanceTimersByTimeAsync(0));
+
+    expect(save).toHaveBeenCalledWith(content);
+  });
 });

--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -127,6 +127,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
               )}
             >
               <ComposeEmailFormLazy
+                draftSessionId="compose:new-message"
                 fromAccounts={accountsData?.emailAccounts}
                 layout="window"
                 onClose={closeCompose}

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -223,7 +223,7 @@ export function createReplyDraftWriter(
         if ((previous?.revision ?? 0) !== revision) {
           await transaction.done;
           throw new Error(
-            "This draft changed in another tab. Reopen the reply to load that version.",
+            "This draft changed in another tab. Reopen the composer to load that version.",
           );
         }
         await transaction.store.put({
@@ -251,7 +251,9 @@ export function createReplyDraftWriter(
     save(content: ReplyDraftContent) {
       if (stopped)
         return Promise.reject(
-          new Error("This draft is closed. Reopen the reply before editing."),
+          new Error(
+            "This draft is closed. Reopen the composer before editing.",
+          ),
         );
       return write(content);
     },


### PR DESCRIPTION
Preserves new-message drafts locally when the composer closes and restores them the next time it opens. Sent or explicitly discarded messages clear the local copy.

- Adds a stable per-account compose draft session and surfaces local save errors
- Clears persisted compose drafts after successful delivery or explicit discard
- Adds unit coverage for unmount flushing and an emulated browser restoration test
- Tests: focused unit test, exact Playwright restoration flow, and Ultracite checks passed
- Performance: adds debounced local IndexedDB writes while composing and one local read on open; no new server database or network calls, with low hot-path risk

Linear: https://linear.app/inbox-zero-ai/issue/INB-358/composer-discards-message-without-saving-draft-or-prompting-user-on

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - New-message and reply drafts now persist more reliably when closing, reopening, or leaving the composer.
  - Draft content is saved when the composer closes before automatic saving completes.
  - Successfully sent messages now clear their local drafts.
  - Draft-saving errors appear consistently across composer types.
  - Updated error messages refer to the composer for clearer guidance.
  - Discarding a restored draft now opens a fully empty composer.

- **Tests**
  - Added coverage for restoring composer fields and saving drafts during composer closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->