### PR TITLE
fix(settings): show the email used for code sign-in

### DIFF
--- a/apps/web/app/(app)/settings/EmailOtpSection.tsx
+++ b/apps/web/app/(app)/settings/EmailOtpSection.tsx
@@ -16,7 +16,11 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 
-export function EmailOtpSection() {
+export function EmailOtpSection({
+  hasMultipleAccounts,
+}: {
+  hasMultipleAccounts: boolean;
+}) {
   const { data, isLoading, error, mutate } = useSWR<EmailOtpSettingsResponse>(
     "/api/user/email-otp",
   );
@@ -34,6 +38,11 @@ export function EmailOtpSection() {
         <Item size="sm">
           <ItemContent>
             <ItemTitle>Allow sign-in with a one-time email code</ItemTitle>
+            {data.emailOtpEnabled && hasMultipleAccounts && (
+              <ItemDescription className="line-clamp-none break-all">
+                Sign in with {data.email}.
+              </ItemDescription>
+            )}
             {!data.emailDeliveryConfigured && (
               <ItemDescription className="line-clamp-none">
                 Email delivery unavailable.

--- a/apps/web/app/(app)/settings/SettingsContent.tsx
+++ b/apps/web/app/(app)/settings/SettingsContent.tsx
@@ -181,7 +181,7 @@ export function SettingsContent() {
 
       <SettingsGroup icon={<UserIcon className="size-5" />} title="Account">
         <ItemCard>
-          <EmailOtpSection />
+          <EmailOtpSection hasMultipleAccounts={emailAccounts.length > 1} />
           <ItemSeparator />
           <AppearanceSection />
           <ItemSeparator />


### PR DESCRIPTION
Show the primary sign-in email beneath the email-code setting when access is enabled and multiple mailboxes are connected. Reuses existing settings data without additional API or database calls.

Validation is delegated to CI; no local checks were run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account settings now display the configured sign-in email address when email one-time password authentication is enabled for users with multiple accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->