### PR TITLE
fix: prevent long email text from overflowing the reader

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -34,6 +34,7 @@
     "app/(app)/[emailAccountId]/mail/MailLabelChip.tsx",
     "app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx"
   ],
+  "message-overflow.spec.ts": ["components/email-list/EmailContents.tsx"],
   "navigation-and-views.spec.ts": [
     "app/(app)/[emailAccountId]/mail/MailSidebar.tsx",
     "app/(app)/[emailAccountId]/mail/MailboxItemContextMenu.tsx",

--- a/apps/web/__tests__/playwright/emulated/mail/message-overflow.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/message-overflow.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail } from "./mail-test-helpers";
+
+for (const format of ["plain", "html", "styled-html"] as const) {
+  test(`wraps long links in ${format} messages`, async ({ page }, testInfo) => {
+    const url = `https://example.com/account?reference=${"abcdef0123456789".repeat(24)}`;
+    await page.route(
+      "**/api/threads/thr_playwright_reader?**",
+      async (route) => {
+        const response = await route.fetch();
+        const body: ThreadResponse = await response.json();
+        const message = body.thread.messages.at(-1);
+        if (!message) throw new Error("Reader fixture has no messages");
+        message.textPlain = `Account details:\n\n${url}\n\nEnd of message.`;
+        message.textHtml = "";
+        if (format !== "plain") {
+          const style =
+            format === "styled-html"
+              ? ' style="font-family: Arial; font-size: 16px"'
+              : "";
+          message.textHtml = `<div${style}><p>Account details:</p><a href="${url}">${url}</a><p>End of message.</p></div>`;
+        }
+        await route.fulfill({ response, json: body });
+      },
+    );
+
+    const { emailAccountId } = await openMail(page);
+    await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
+      waitUntil: "domcontentloaded",
+    });
+    const message = page.locator("li[data-thread-message-id]").last();
+    const content =
+      format === "plain"
+        ? message.locator("pre")
+        : message.frameLocator("iframe").locator("body");
+    await expect(
+      content.getByRole("link", { name: url, exact: true }),
+    ).toHaveAttribute("href", url);
+
+    for (const width of [1280, 390]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expect
+        .poll(() =>
+          content.evaluate(
+            (element) => element.scrollWidth - element.clientWidth,
+          ),
+        )
+        .toBeLessThanOrEqual(1);
+      await expect
+        .poll(() =>
+          message.evaluate((element) => {
+            let overflow = 0;
+            for (
+              let ancestor: HTMLElement | null = element;
+              ancestor;
+              ancestor = ancestor.parentElement
+            ) {
+              overflow = Math.max(
+                overflow,
+                ancestor.scrollWidth - ancestor.clientWidth,
+              );
+            }
+            return overflow;
+          }),
+        )
+        .toBeLessThanOrEqual(1);
+      await capturePlaywrightCheckpoint(
+        page,
+        testInfo,
+        `message-${format}-${width}`,
+      );
+    }
+  });
+}

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -171,7 +171,7 @@ export function PlainEmail({ text }: { text: string }) {
   return (
     // `pre` keeps the sender's line breaks; the font stack keeps it readable.
     <pre
-      className="whitespace-pre-wrap font-sans text-foreground"
+      className="whitespace-pre-wrap font-sans text-foreground [overflow-wrap:anywhere]"
       style={BODY_TYPE}
     >
       {segments.map((segment, index) =>
@@ -231,6 +231,7 @@ function getIframeHtml(
       body {
         background-color: white;
         font-family: ${SANS_FONT_STACK};
+        overflow-wrap: anywhere;
       }
       table { max-width: 100% !important; overflow-x: auto; }
       img { max-width: 100% !important; height: auto; }
@@ -259,6 +260,7 @@ function getIframeHtml(
       /* Base styles - apply our font as a baseline; inline styles on inner elements still win */
       body {
         font-family: ${SANS_FONT_STACK};
+        overflow-wrap: anywhere;
       }
       body:not([style]):not([bgcolor]) {
         margin: 0;


### PR DESCRIPTION
Long links and other unbroken text could extend beyond the email reader and cause horizontal scrolling. Allow text to wrap within plain-text messages and both HTML rendering styles while preserving link destinations.

- Add and register a focused browser regression test covering plain text, HTML, and styled HTML at desktop and mobile widths.
- Validation: reproduce plain-text overflow before the fix; run the focused browser spec and inspect screenshots; check formatting with Biome; all 32 browser suite-selection tests pass.
- CSS-only behavior change with no additional runtime processing or network calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long URLs and other unbroken text in email messages now wrap correctly instead of causing horizontal overflow.
  * Improved readability of plain-text, HTML, and styled HTML messages across desktop and mobile viewports.
  * Links in messages continue to render correctly while remaining within the available message area.

* **Tests**
  * Added coverage to verify link rendering and overflow behavior across multiple message formats and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->