### PR TITLE
mail: Fix calendar cards for duplicate invitation attachments

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/calendar-invitation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/calendar-invitation.spec.ts
@@ -11,7 +11,21 @@ test("shows inline calendar responses with the current RSVP", async ({
     const body: ThreadResponse = await response.json();
     const message = body.thread.messages.at(0);
     if (!message) throw new Error("Reader fixture has no messages");
-    message.calendarContent = "BEGIN:VCALENDAR";
+    message.isMeetingInvitation = true;
+    message.attachments = ["text/calendar", "application/ics"].map(
+      (mimeType, index) => ({
+        attachmentId: `calendar-${index}`,
+        filename: "invite.ics",
+        mimeType,
+        size: 100,
+        headers: {
+          "content-description": "",
+          "content-id": "",
+          "content-transfer-encoding": "base64",
+          "content-type": mimeType,
+        },
+      }),
+    );
     await route.fulfill({ response, json: body });
   });
   await page.route("**/api/messages/calendar-invitation?**", (route) =>

--- a/apps/web/utils/calendar/invitations/constants.ts
+++ b/apps/web/utils/calendar/invitations/constants.ts
@@ -1,4 +1,5 @@
 export const CALENDAR_INVITATION_LIMITS = {
+  attachments: 2,
   content: 256_000,
   encoded: 350_000,
 } as const;

--- a/apps/web/utils/calendar/invitations/detection.test.ts
+++ b/apps/web/utils/calendar/invitations/detection.test.ts
@@ -13,7 +13,7 @@ describe("invitation eligibility", () => {
     ).toBe(false);
   });
 
-  it("rejects multiple calendar attachments even on native meeting messages", () => {
+  it("rejects excessive calendar attachments even on native meeting messages", () => {
     const attachment = {
       attachmentId: "attachment",
       filename: "invite.ics",
@@ -30,7 +30,7 @@ describe("invitation eligibility", () => {
       isCalendarInvitationMessage({
         ...getEmail(),
         isMeetingInvitation: true,
-        attachments: [attachment, attachment],
+        attachments: [attachment, attachment, attachment],
       }),
     ).toBe(false);
   });

--- a/apps/web/utils/calendar/invitations/detection.ts
+++ b/apps/web/utils/calendar/invitations/detection.ts
@@ -1,3 +1,4 @@
+import { CALENDAR_INVITATION_LIMITS } from "@/utils/calendar/invitations/constants";
 import type { ParsedMessage } from "@/utils/types";
 import { GmailLabel } from "@/utils/gmail/label";
 import { isCalendarInviteAttachment } from "@/utils/parse/calender-event";
@@ -9,11 +10,11 @@ export function isCalendarInvitationMessage(message: ParsedMessage) {
   )
     return false;
   const attachments = getCalendarAttachments(message);
-  if (attachments.length > 1) return false;
+  if (attachments.length > CALENDAR_INVITATION_LIMITS.attachments) return false;
   return (
     !!message.calendarContent ||
     message.isMeetingInvitation === true ||
-    attachments.length === 1
+    attachments.length > 0
   );
 }
 

--- a/apps/web/utils/calendar/invitations/service.test.ts
+++ b/apps/web/utils/calendar/invitations/service.test.ts
@@ -229,6 +229,31 @@ describe("loading calendar invitations", () => {
     expect(mocks.respond).not.toHaveBeenCalled();
   });
 
+  it("rejects inline content that conflicts with a single attachment", async () => {
+    getMessage.mockResolvedValue({
+      ...getEmail(),
+      calendarContent: content,
+      attachments: [
+        {
+          attachmentId: "download",
+          filename: "invite.ics",
+          size: content.length,
+        },
+      ],
+    });
+    getAttachment.mockResolvedValue({
+      data: Buffer.from(
+        content.replace("meeting@example.com", "other@example.com"),
+      ).toString("base64"),
+      size: content.length,
+    });
+    await expect(respondToCalendarInvitation(params)).rejects.toThrow(
+      "does not contain an invitation",
+    );
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(mocks.respond).not.toHaveBeenCalled();
+  });
+
   it("rejects oversized duplicate attachments before downloading", async () => {
     getMessage.mockResolvedValue({
       ...getEmail(),

--- a/apps/web/utils/calendar/invitations/service.test.ts
+++ b/apps/web/utils/calendar/invitations/service.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmail, createTestLogger } from "@/__tests__/helpers";
+import { parseMessage } from "@/utils/gmail/message";
+import { CALENDAR_INVITATION_LIMITS } from "@/utils/calendar/invitations/constants";
 import type { EmailProvider } from "@/utils/email/types";
 import {
   getCalendarInvitation,
@@ -143,6 +145,111 @@ describe("responding to calendar invitations", () => {
 });
 
 describe("loading calendar invitations", () => {
+  it.each([
+    false,
+    true,
+  ])("loads duplicate calendar attachments (inline content: %s)", async (inline) => {
+    getMessage.mockResolvedValue(
+      parseMessage(
+        {
+          payload: {
+            mimeType: "multipart/mixed",
+            body: {},
+            parts: [
+              {
+                mimeType: "multipart/alternative",
+                body: {},
+                parts: [
+                  {
+                    mimeType: "text/calendar",
+                    body: inline
+                      ? {
+                          data: Buffer.from(content).toString("base64url"),
+                          size: content.length,
+                        }
+                      : { attachmentId: "calendar", size: content.length },
+                  },
+                ],
+              },
+              {
+                mimeType: "application/ics",
+                filename: "invite.ics",
+                body: { attachmentId: "download", size: content.length },
+              },
+            ],
+          },
+        },
+        { includeCalendarContent: true },
+      ),
+    );
+    getAttachment.mockResolvedValue({
+      data: Buffer.from(content).toString("base64url"),
+      size: content.length,
+    });
+    expect((await getCalendarInvitation(params)).invitation).not.toBeNull();
+  });
+
+  it.each([
+    false,
+    true,
+  ])("rejects conflicting calendar attachments before responding (inline: %s)", async (inline) => {
+    getMessage.mockResolvedValue({
+      ...getEmail(),
+      isMeetingInvitation: true,
+      calendarContent: inline ? content : undefined,
+      attachments: [
+        {
+          attachmentId: "calendar",
+          filename: "",
+          mimeType: "text/calendar",
+          size: content.length,
+        },
+        {
+          attachmentId: "download",
+          filename: "invite.ics",
+          mimeType: "application/ics",
+          size: content.length,
+        },
+      ],
+    });
+    getAttachment.mockResolvedValueOnce({
+      data: Buffer.from(content).toString("base64"),
+      size: content.length,
+    });
+    getAttachment.mockResolvedValueOnce({
+      data: Buffer.from(
+        content.replace("meeting@example.com", "other@example.com"),
+      ).toString("base64"),
+      size: content.length,
+    });
+    await expect(respondToCalendarInvitation(params)).rejects.toThrow(
+      "does not contain an invitation",
+    );
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(mocks.respond).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized duplicate attachments before downloading", async () => {
+    getMessage.mockResolvedValue({
+      ...getEmail(),
+      calendarContent: content,
+      attachments: [
+        {
+          attachmentId: "calendar",
+          filename: "invite.ics",
+          size: content.length,
+        },
+        {
+          attachmentId: "large-calendar",
+          filename: "invite.ics",
+          size: CALENDAR_INVITATION_LIMITS.content + 1,
+        },
+      ],
+    });
+    expect(await getCalendarInvitation(params)).toEqual({ invitation: null });
+    expect(getAttachment).not.toHaveBeenCalled();
+  });
+
   it("returns the current calendar response without exposing raw invitation data", async () => {
     mocks.connections.mockResolvedValue([
       { provider: "google", refreshToken: "refresh" },

--- a/apps/web/utils/calendar/invitations/service.ts
+++ b/apps/web/utils/calendar/invitations/service.ts
@@ -110,27 +110,35 @@ async function getInvitationFromMessage(
     includeCalendarContent: true,
   });
   if (!isCalendarInvitationMessage(message)) return null;
-  if (message.calendarContent)
-    return parseCalendarInvitation(message.calendarContent, email);
   const attachments = getCalendarAttachments(message);
+  if (message.calendarContent && attachments.length <= 1)
+    return parseCalendarInvitation(message.calendarContent, email);
   if (
-    attachments.length !== 1 ||
-    attachments[0].size > CALENDAR_INVITATION_LIMITS.content
+    attachments.some(
+      (attachment) => attachment.size > CALENDAR_INVITATION_LIMITS.content,
+    )
   )
     return null;
-  const attachment = await emailProvider.getAttachment(
-    messageId,
-    attachments[0].attachmentId,
-  );
-  if (
-    attachment.size > CALENDAR_INVITATION_LIMITS.content ||
-    attachment.data.length > CALENDAR_INVITATION_LIMITS.encoded
-  )
+
+  let content = message.calendarContent || undefined;
+  if (content && content.length > CALENDAR_INVITATION_LIMITS.content)
     return null;
-  return parseCalendarInvitation(
-    Buffer.from(attachment.data, "base64").toString("utf8"),
-    email,
-  );
+  for (const metadata of attachments) {
+    const attachment = await emailProvider.getAttachment(
+      messageId,
+      metadata.attachmentId,
+    );
+    if (
+      attachment.size > CALENDAR_INVITATION_LIMITS.content ||
+      attachment.data.length > CALENDAR_INVITATION_LIMITS.encoded
+    )
+      return null;
+    const decoded = Buffer.from(attachment.data, "base64").toString("utf8");
+    // Calendar emails can include both a MIME alternative and a downloadable copy.
+    if (content !== undefined && content !== decoded) return null;
+    content = decoded;
+  }
+  return content ? parseCalendarInvitation(content, email) : null;
 }
 
 async function findInvitationEvent({

--- a/apps/web/utils/calendar/invitations/service.ts
+++ b/apps/web/utils/calendar/invitations/service.ts
@@ -111,8 +111,6 @@ async function getInvitationFromMessage(
   });
   if (!isCalendarInvitationMessage(message)) return null;
   const attachments = getCalendarAttachments(message);
-  if (message.calendarContent && attachments.length <= 1)
-    return parseCalendarInvitation(message.calendarContent, email);
   if (
     attachments.some(
       (attachment) => attachment.size > CALENDAR_INVITATION_LIMITS.content,


### PR DESCRIPTION
Calendar invitations could be hidden when an email includes duplicate calendar attachments. Allow the card to load and verify matching attachment contents before accepting a response; conflicting or oversized copies remain rejected.

- Added synthetic Gmail MIME regression coverage using TDD and updated the browser test for duplicate attachments.
- Validation: 57 focused unit tests, focused lint, and desktop/mobile browser checks.
- Performance: at most two attachment downloads when loading duplicate invitations; no additional list-view or database work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar invitations can now be loaded from up to two matching calendar attachments, including duplicate content.
  * Inline invitation content is validated against attached calendar files.

* **Bug Fixes**
  * Improved handling of oversized, conflicting, and invalid calendar attachments.
  * Invitations are rejected when attachments exceed the supported limit or contain mismatched content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->