### PR TITLE
fix: classify email send failures and retain diagnostics

### DIFF
--- a/apps/web/app/api/messages/send/route.test.ts
+++ b/apps/web/app/api/messages/send/route.test.ts
@@ -6,6 +6,7 @@ import {
   DURABLE_MULTIPART_EMAIL_SEND_LIMITS,
 } from "@/utils/email/durable-email-send.validation";
 import { EMAIL_SEND_LIMITS } from "@/utils/types/mail";
+import { createScopedLogger, type Logger } from "@/utils/logger";
 import { POST } from "./route";
 
 const executeDurableEmailSend = vi.hoisted(() => vi.fn());
@@ -18,7 +19,7 @@ const emailProvider = vi.hoisted(() => ({
 
 type MockedRequest = NextRequest & {
   auth: { emailAccountId: string; userId: string };
-  logger: { error: () => void };
+  logger: Logger;
 };
 
 vi.mock("@/utils/email/durable-email-send", () => ({
@@ -38,7 +39,7 @@ vi.mock("@/utils/middleware", () => ({
       handler(
         Object.assign(request, {
           auth: { emailAccountId: "account-1", userId: "user-1" },
-          logger: { error: vi.fn() },
+          logger: createScopedLogger("messages-send-test"),
         }) as MockedRequest,
       ),
 }));
@@ -114,6 +115,7 @@ describe("POST /api/messages/send", () => {
       result: { messageId: "message-1", threadId: "thread-1" },
     });
     expect(executeDurableEmailSend).toHaveBeenCalledWith({
+      logger: expect.objectContaining({ error: expect.any(Function) }),
       emailAccountId: "account-1",
       getEmailProvider: expect.any(Function),
       input,
@@ -175,6 +177,7 @@ describe("POST /api/messages/send", () => {
       result: { messageId: "message-1", threadId: "thread-1" },
     });
     expect(executeDurableEmailSend).toHaveBeenCalledWith({
+      logger: expect.objectContaining({ error: expect.any(Function) }),
       emailAccountId: "account-1",
       getEmailProvider: expect.any(Function),
       input: {

--- a/apps/web/app/api/messages/send/route.ts
+++ b/apps/web/app/api/messages/send/route.ts
@@ -36,6 +36,7 @@ export const POST = withEmailAccount("messages/send", async (request) => {
     const { getEmailProvider, providerName } =
       await getProviderContext(request);
     const result = await executeDurableEmailSend({
+      logger: request.logger,
       emailAccountId: request.auth.emailAccountId,
       getEmailProvider,
       input,
@@ -50,6 +51,7 @@ export const POST = withEmailAccount("messages/send", async (request) => {
     const { getEmailProvider, providerName } =
       await getProviderContext(request);
     const result = await executeDurableEmailSend({
+      logger: request.logger,
       emailAccountId: request.auth.emailAccountId,
       getEmailProvider,
       input,

--- a/apps/web/utils/actions/mail-mutation.ts
+++ b/apps/web/utils/actions/mail-mutation.ts
@@ -52,6 +52,7 @@ export const executeMailMutationAction = actionClient
 
     if (parsedInput.kind === "reply") {
       return executeDurableEmailSend({
+        logger,
         emailAccountId,
         getEmailProvider: () =>
           createEmailProvider({ emailAccountId, provider, logger }),

--- a/apps/web/utils/email/durable-email-send.test.ts
+++ b/apps/web/utils/email/durable-email-send.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import { EmailSendOperationStatus } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
 import { SafeError } from "@/utils/error";
 import { executeDurableEmailSend } from "./durable-email-send";
 
@@ -42,6 +43,7 @@ describe("executeDurableEmailSend", () => {
     });
 
     const outcome = await executeDurableEmailSend({
+      logger: createScopedLogger("test"),
       emailAccountId: "account",
       getEmailProvider: async () => provider,
       input,
@@ -58,12 +60,50 @@ describe("executeDurableEmailSend", () => {
     expect(prisma.emailSendOperation.updateMany).not.toHaveBeenCalled();
   });
 
+  it("rejects provider setup failures without marking delivery uncertain", async () => {
+    const outcome = await executeDurableEmailSend({
+      logger: createScopedLogger("test"),
+      emailAccountId: "account",
+      getEmailProvider: async () => {
+        throw new Error("Provider unavailable");
+      },
+      input,
+      provider: "google",
+    });
+
+    expect(outcome.status).toBe("rejected");
+    expect(prisma.emailSendOperation.deleteMany).toHaveBeenCalled();
+    expect(prisma.emailSendOperation.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps a persistence failure uncertain after the provider accepts the send", async () => {
+    const provider = createMockEmailProvider({
+      sendEmailWithHtml: vi
+        .fn()
+        .mockResolvedValue({ messageId: "sent", threadId: "thread" }),
+    });
+    prisma.emailSendOperation.update.mockRejectedValue(
+      new SafeError("Storage failed"),
+    );
+    const outcome = await executeDurableEmailSend({
+      logger: createScopedLogger("test"),
+      emailAccountId: "account",
+      getEmailProvider: async () => provider,
+      input,
+      provider: "google",
+    });
+
+    expect(outcome).toEqual({ status: "uncertain" });
+    expect(prisma.emailSendOperation.deleteMany).not.toHaveBeenCalled();
+  });
+
   it("keeps unexplained provider failures uncertain", async () => {
     const provider = createMockEmailProvider({
       sendEmailWithHtml: vi.fn().mockRejectedValue(new Error("socket hang up")),
     });
 
     const outcome = await executeDurableEmailSend({
+      logger: createScopedLogger("test"),
       emailAccountId: "account",
       getEmailProvider: async () => provider,
       input,

--- a/apps/web/utils/email/durable-email-send.ts
+++ b/apps/web/utils/email/durable-email-send.ts
@@ -6,6 +6,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import { MAIL_MUTATION_RETRY_WINDOW_MS } from "@/utils/email-cache/policy";
 import { SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import type { DurableEmailSendBody } from "./durable-email-send.validation";
 
@@ -15,13 +16,16 @@ export async function executeDurableEmailSend({
   emailAccountId,
   getEmailProvider,
   input,
+  logger,
   provider,
 }: {
   emailAccountId: string;
   getEmailProvider: () => Promise<EmailProvider>;
   input: DurableEmailSendBody;
+  logger: Logger;
   provider: string;
 }) {
+  logger = logger.with({ mutationId: input.mutationId });
   const payloadHash = createHash("sha256")
     .update(
       JSON.stringify({
@@ -65,27 +69,36 @@ export async function executeDurableEmailSend({
       },
       data: { status: EmailSendOperationStatus.UNCERTAIN },
     });
+    if (stale.count) logger.warn("Email send processing lease expired");
     return stale.count
       ? { status: "uncertain" as const }
       : { status: "retry" as const };
   }
 
+  let stage: "provider_setup" | "send" | "persist_result" = "provider_setup";
   try {
     const emailProvider = await getEmailProvider();
+    stage = "send";
     const result = await emailProvider.sendEmailWithHtml(input.email);
+    stage = "persist_result";
     await prisma.emailSendOperation.update({
       where: { id: existing.id },
       data: { result, status: EmailSendOperationStatus.SENT },
     });
     return { status: "applied" as const, result };
   } catch (error) {
-    if (isEmailProviderRateLimitError({ error, provider })) {
+    logger.error("Email send operation failed", { error, stage });
+    if (
+      stage !== "persist_result" &&
+      isEmailProviderRateLimitError({ error, provider })
+    ) {
       await prisma.emailSendOperation.deleteMany({
         where: { id: existing.id },
       });
       return { status: "retry" as const };
     }
     if (
+      stage !== "persist_result" &&
       classifyEmailAccountProviderIssue({
         error,
         provider: provider as "google" | "microsoft",
@@ -98,13 +111,19 @@ export async function executeDurableEmailSend({
     }
     // Providers throw SafeError for checks that run before anything is sent,
     // so the outcome is known and the operation can be retried later.
-    if (error instanceof SafeError) {
+    if (
+      stage === "provider_setup" ||
+      (stage === "send" && error instanceof SafeError)
+    ) {
       await prisma.emailSendOperation.deleteMany({
         where: { id: existing.id },
       });
       return {
         status: "rejected" as const,
-        error: error.safeMessage ?? error.message,
+        error:
+          error instanceof SafeError
+            ? (error.safeMessage ?? error.message)
+            : "Could not prepare the email account. Please try again.",
       };
     }
     await prisma.emailSendOperation.updateMany({

--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -1,5 +1,6 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import { assert, describe, expect, it, vi } from "vitest";
+import { SafeError } from "@/utils/error";
 import { sendEmailWithHtml } from "./mail";
 
 vi.mock("@/utils/mail", async (importOriginal) => ({
@@ -82,7 +83,9 @@ describe("sending a Gmail draft from the reader", () => {
       Object.assign(new Error("Not found"), { code: 404 }),
     );
 
-    await expect(sendEmailWithHtml(gmail, email)).rejects.toThrow("Not found");
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toBeInstanceOf(
+      SafeError,
+    );
 
     expect(drafts.send).not.toHaveBeenCalled();
     expect(messages.send).not.toHaveBeenCalled();

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -14,6 +14,7 @@ import { createReplyContent, formatEmailDate } from "@/utils/gmail/reply";
 import type { EmailForAction } from "@/utils/ai/types";
 import { createScopedLogger } from "@/utils/logger";
 import {
+  extractErrorInfo,
   withGmailNonIdempotentWriteRetry,
   withGmailRetry,
 } from "@/utils/gmail/retry";
@@ -116,7 +117,21 @@ export async function sendEmailWithHtml(
   const raw = await createRawMailMessage({ ...body, messageText });
   const { replyToEmail } = body;
   if (replyToEmail?.messageId) {
-    const message = await getMessage(replyToEmail.messageId, gmail, "metadata");
+    const message = await getMessage(
+      replyToEmail.messageId,
+      gmail,
+      "metadata",
+    ).catch((error: unknown) => {
+      if (extractErrorInfo(error).status === 404) {
+        logger.warn("Reply source disappeared before sending", {
+          messageId: replyToEmail.messageId,
+        });
+        throw new SafeError(
+          "The reply source changed or is no longer available. Reopen the thread before sending.",
+        );
+      }
+      throw error;
+    });
     if (message.labelIds?.includes(GmailLabel.DRAFT)) {
       if (message.labelIds.includes(GmailLabel.SENT)) {
         throw new SafeError(

--- a/apps/web/utils/scheduled-email/service.ts
+++ b/apps/web/utils/scheduled-email/service.ts
@@ -164,6 +164,7 @@ export async function processScheduledEmail(
       include: { account: true },
     });
     const outcome = await executeDurableEmailSend({
+      logger,
       emailAccountId: row.emailAccountId,
       provider: account.account.provider,
       getEmailProvider: () =>


### PR DESCRIPTION
Provider setup failures and missing reply sources could be reported as uncertain delivery even when sending had not started. Classify these as recoverable failures, and log the failure stage and mutation ID for send diagnostics.

- Preserve duplicate-send protection when sending or recording its result fails ambiguously.
- Pass the request logger through immediate, scheduled, and REST API sending.
- Validation: 87 focused tests passed across durable sending, Gmail sending, mail actions, scheduled emails, and REST API handlers; Biome checks passed.
- Performance: no additional database or provider calls on successful sends; diagnostics run on failure paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email-send error handling and reporting across replies and scheduled messages.
  * Users now receive a clear message when a reply’s source message is no longer available, with guidance to reopen the thread.
  * Prevented retry behavior after an email provider has accepted a message, reducing duplicate-send risk.
  * Improved handling of provider setup and persistence failures, including clearer outcomes for uncertain sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->