### PR TITLE
fix(mail): wait for complete mailbox reconciliation

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/archive-reconciliation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/archive-reconciliation.spec.ts
@@ -78,6 +78,7 @@ test("keeps an archive hidden while mailbox sync has older pages remaining", asy
     });
   });
 
+  const cleanupErrors: unknown[] = [];
   try {
     await conversation.getByRole("checkbox").click();
     await page.getByRole("button", { name: "Archive", exact: true }).click();
@@ -112,9 +113,23 @@ test("keeps an archive hidden while mailbox sync has older pages remaining", asy
     await capturePlaywrightCheckpoint(page, testInfo, "archive-reconciled");
   } finally {
     finalPage.resolve();
-    await page.unrouteAll({ behavior: "wait" });
-    await page.request.post(`/api/threads/${THREAD_ID}/unarchive`, {
-      headers: { "X-Email-Account-ID": emailAccountId },
+    await page.unrouteAll({ behavior: "wait" }).catch((error) => {
+      cleanupErrors.push(error);
     });
+    await page.request
+      .post(`/api/threads/${THREAD_ID}/unarchive`, {
+        headers: { "X-Email-Account-ID": emailAccountId },
+      })
+      .then((response) => expect(response.ok()).toBe(true))
+      .catch((error) => {
+        cleanupErrors.push(error);
+      });
+    for (const error of cleanupErrors) {
+      testInfo.annotations.push({
+        type: "cleanup-error",
+        description: String(error),
+      });
+    }
   }
+  expect(cleanupErrors).toEqual([]);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/archive-reconciliation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/archive-reconciliation.spec.ts
@@ -1,0 +1,120 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
+
+const THREAD_ID = "thr_playwright_archive";
+const SUBJECT = "Archive Action Message";
+
+test("keeps an archive hidden while mailbox sync has older pages remaining", async ({
+  page,
+}, testInfo) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const conversation = conversationWithSubject(page, conversations, SUBJECT);
+  await expect(conversation).toHaveCount(1);
+  const response = await page.request.get(`/api/threads/${THREAD_ID}`, {
+    headers: { "X-Email-Account-ID": emailAccountId },
+  });
+  expect(response.ok()).toBe(true);
+  const { thread } = await response.json();
+  const messageIds = thread.messages.map(
+    (message: { id: string }) => message.id,
+  );
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          async (accountId) =>
+            new Promise<boolean>((resolve, reject) => {
+              const request = indexedDB.open("inbox-zero-email-cache");
+              request.onerror = () => reject(request.error);
+              request.onsuccess = () => {
+                const database = request.result;
+                const transaction = database.transaction("mailboxSyncStates");
+                const state = transaction
+                  .objectStore("mailboxSyncStates")
+                  .get(accountId);
+                state.onsuccess = () =>
+                  resolve(state.result?.hasMore === false);
+                state.onerror = () => reject(state.error);
+                transaction.oncomplete = () => database.close();
+              };
+            }),
+          emailAccountId,
+        ),
+      { timeout: 60_000 },
+    )
+    .toBe(true);
+  const finalPage = Promise.withResolvers<void>();
+  let syncRequests = 0;
+
+  await page.route("**/api/mobile/mailbox-sync", async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    syncRequests += 1;
+    if (syncRequests === 1) {
+      // An older page may still contain the messages removed by the archive.
+      await route.fulfill({
+        response,
+        json: { ...body, hasMore: true, upsertedMessages: thread.messages },
+      });
+      return;
+    }
+    await finalPage.promise;
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        hasMore: false,
+        deletedMessageIds: [...body.deletedMessageIds, ...messageIds],
+        upsertedMessages: body.upsertedMessages.filter(
+          (message: { id: string }) => !messageIds.includes(message.id),
+        ),
+      },
+    });
+  });
+
+  try {
+    await conversation.getByRole("checkbox").click();
+    await page.getByRole("button", { name: "Archive", exact: true }).click();
+    await expect.poll(() => syncRequests).toBeGreaterThanOrEqual(2);
+    await expect
+      .poll(() =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "archive",
+          threadId: THREAD_ID,
+        }),
+      )
+      .toMatchObject({ status: "reconciling" });
+    await expect(conversation).toHaveCount(0);
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "archive-awaiting-final-page",
+    );
+
+    finalPage.resolve();
+    await expect
+      .poll(() =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "archive",
+          threadId: THREAD_ID,
+        }),
+      )
+      .toMatchObject({ status: "succeeded" });
+    await expect(conversation).toHaveCount(0);
+    await capturePlaywrightCheckpoint(page, testInfo, "archive-reconciled");
+  } finally {
+    finalPage.resolve();
+    await page.unrouteAll({ behavior: "wait" });
+    await page.request.post(`/api/threads/${THREAD_ID}/unarchive`, {
+      headers: { "X-Email-Account-ID": emailAccountId },
+    });
+  }
+});

--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -1,4 +1,5 @@
 {
+  "archive-reconciliation.spec.ts": ["app/(app)/MailMutationOutboxManager.tsx"],
   "account-selection.spec.ts": [
     "app/(app)/[emailAccountId]/mail/MailSidebar.tsx",
     "app/(app)/[emailAccountId]/mail/use-combined-mail-threads.ts"

--- a/apps/web/app/(app)/MailMutationOutboxManager.test.tsx
+++ b/apps/web/app/(app)/MailMutationOutboxManager.test.tsx
@@ -94,7 +94,9 @@ describe("MailMutationOutboxManager", () => {
     outbox.renewBatch.mockResolvedValue(0);
     outbox.renewSyncGroup.mockResolvedValue([]);
     outbox.resumeBlocked.mockResolvedValue(0);
-    mailbox.syncNow.mockResolvedValue({ hasMore: false, pagesSynced: 1 });
+    mailbox.syncNow
+      .mockReset()
+      .mockResolvedValue({ hasMore: false, pagesSynced: 1 });
   });
 
   afterEach(() => {
@@ -274,6 +276,36 @@ describe("MailMutationOutboxManager", () => {
     });
   });
 
+  it("keeps an archived thread hidden until every mailbox page is reconciled", async () => {
+    const mutation = archiveMutation();
+    const syncGroup = wireSyncGroup(mutation);
+    const finalPage = Promise.withResolvers<{
+      hasMore: boolean;
+      pagesSynced: number;
+    }>();
+    outbox.claim.mockResolvedValueOnce(mutation).mockResolvedValue(undefined);
+    action.execute.mockResolvedValue({ data: { status: "applied" } });
+    mailbox.syncNow
+      .mockResolvedValueOnce({ hasMore: true, pagesSynced: 1 })
+      .mockReturnValueOnce(finalPage.promise);
+
+    render(<MailMutationOutboxManager />);
+    await settlePromises();
+
+    expect(cache.settle).toHaveBeenCalledWith(mutation);
+    expect(outbox.completeSyncGroup).not.toHaveBeenCalled();
+    expect(mailbox.syncNow).toHaveBeenCalledTimes(2);
+
+    finalPage.resolve({ hasMore: false, pagesSynced: 1 });
+    await settlePromises();
+
+    expect(outbox.completeSyncGroup).toHaveBeenCalledWith(
+      syncGroup,
+      expect.any(String),
+    );
+    expect(action.execute).toHaveBeenCalledOnce();
+  });
+
   it("renews the sync-group lease while mailbox reconciliation is pending", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -323,6 +355,36 @@ describe("MailMutationOutboxManager", () => {
       expect.any(String),
     );
     expect(outbox.completeSyncGroup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "later page fails",
+    "cache unavailable",
+  ])("keeps the archive pending when %s during reconciliation", async (failure) => {
+    const mutation = archiveMutation();
+    const syncGroup = wireSyncGroup(mutation);
+    outbox.claim.mockResolvedValueOnce(mutation).mockResolvedValue(undefined);
+    action.execute.mockResolvedValue({ data: { status: "applied" } });
+    mailbox.syncNow.mockResolvedValueOnce({ hasMore: true, pagesSynced: 1 });
+    if (failure === "later page fails") {
+      mailbox.syncNow.mockRejectedValueOnce(new Error("offline"));
+    } else {
+      mailbox.syncNow.mockResolvedValueOnce({ hasMore: false, pagesSynced: 0 });
+    }
+
+    render(<MailMutationOutboxManager />);
+    await settlePromises();
+
+    expect(outbox.completeSyncGroup).not.toHaveBeenCalled();
+    expect(outbox.retrySyncGroup).toHaveBeenCalledWith(
+      syncGroup,
+      {
+        error: "Mailbox reconciliation failed",
+        nextAttemptAt: expect.any(Number),
+      },
+      expect.any(String),
+    );
+    expect(action.execute).toHaveBeenCalledOnce();
   });
 
   it("backs off from the persisted reconciliation attempt after reload", async () => {

--- a/apps/web/app/(app)/MailMutationOutboxManager.tsx
+++ b/apps/web/app/(app)/MailMutationOutboxManager.tsx
@@ -324,7 +324,14 @@ async function reconcileSyncGroupWithLeaseHeartbeat(
     }).catch(() => {});
   }, LEASE_MS / 2);
   try {
-    await syncMailboxNow(group.emailAccountId);
+    let hasMore = true;
+    while (hasMore) {
+      const result = await syncMailboxNow(group.emailAccountId);
+      if (!result.pagesSynced) {
+        throw new Error("Mailbox reconciliation made no progress");
+      }
+      hasMore = result.hasMore;
+    }
     await completeMailMutationSyncGroup(group, ownerId);
   } finally {
     clearInterval(heartbeat);

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -192,7 +192,10 @@ describe("mailbox sync coordinator", () => {
     await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
   });
 
-  it("does not repopulate an account cache cleared during a request", async () => {
+  it.each([
+    1, 2,
+  ])("does not report progress for a cache cleared during page %s", async (clearedPage) => {
+    let requests = 0;
     const requestStarted = Promise.withResolvers<void>();
     const pendingPage = Promise.withResolvers<{
       accountId: string;
@@ -205,6 +208,17 @@ describe("mailbox sync coordinator", () => {
     const sync = syncMailboxPages({
       emailAccountId: "account-1",
       fetchPage: () => {
+        requests += 1;
+        if (requests < clearedPage) {
+          return Promise.resolve({
+            accountId: "account-1",
+            cursor: "earlier-page",
+            deletedMessageIds: [],
+            hasMore: true,
+            reset: true,
+            upsertedMessages: [],
+          });
+        }
         requestStarted.resolve();
         return pendingPage.promise;
       },
@@ -223,6 +237,29 @@ describe("mailbox sync coordinator", () => {
 
     await expect(sync).resolves.toEqual({ hasMore: false, pagesSynced: 0 });
     await expect(readMailboxSyncState("account-1")).resolves.toBeUndefined();
+  });
+
+  it.each([
+    1, 2,
+  ])("does not complete when cache storage disappears on page %s", async (unavailablePage) => {
+    let requests = 0;
+    const fetchPage = vi.fn(async () => {
+      requests += 1;
+      if (requests === unavailablePage) vi.stubGlobal("indexedDB", undefined);
+      return {
+        accountId: "account-1",
+        cursor: `cursor-${requests}`,
+        deletedMessageIds: [],
+        hasMore: requests < unavailablePage,
+        reset: requests === 1,
+        upsertedMessages: [],
+      };
+    });
+
+    await expect(
+      syncMailboxPages({ emailAccountId: "account-1", fetchPage }),
+    ).rejects.toThrow("Mailbox sync page was not persisted");
+    expect(fetchPage).toHaveBeenCalledTimes(unavailablePage);
   });
 
   it("sends the account-scoped sync request through the app API", async () => {

--- a/apps/web/utils/email-cache/mailbox-sync.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.ts
@@ -72,18 +72,19 @@ export async function syncMailboxPages({
   while (hasMore && pagesSynced < maxPages) {
     const response = await fetchPage(input);
     if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
-      return { hasMore: false, pagesSynced };
+      return { hasMore: false, pagesSynced: 0 };
     }
     if (response.accountId !== emailAccountId) {
       throw new Error("Mailbox sync response account mismatch");
     }
     const { accountId: _accountId, ...page } = response;
-    await applyMailboxSyncPage({
+    const applied = await applyMailboxSyncPage({
       emailAccountId,
       page,
       after: resumeCursor ? undefined : initialAfter,
       now: now?.getTime() ?? Date.now(),
     });
+    if (!applied) throw new Error("Mailbox sync page was not persisted");
     pagesSynced += 1;
     hasMore = page.hasMore;
     input = { cursor: page.cursor, limit: DEFAULT_PAGE_LIMIT };

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -55,7 +55,8 @@ export async function applyMailboxSyncPage({
 }) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
   const database = await getEmailCacheDatabase();
-  if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch))
+    return false;
 
   const transaction = database.transaction(
     ["mailboxMessages", "mailboxSyncStates", "threadDetails"],
@@ -150,7 +151,7 @@ export async function applyMailboxSyncPage({
   ]);
   await transaction.done;
 
-  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
+  if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) return false;
   invalidateThreadCaches({
     emailAccountId,
     threadIds: [...changedThreadIds],
@@ -158,6 +159,7 @@ export async function applyMailboxSyncPage({
   });
   scheduleEmailCacheCleanup();
   notifyMailboxStoreChange(emailAccountId);
+  return true;
 }
 
 export async function readMailboxSyncState(emailAccountId: string) {


### PR DESCRIPTION
Mailbox mutations could be marked reconciled after one sync page even when more pages remained, allowing archive protection to end before the local mailbox caught up. Reconciliation now waits for all pages, counts only persisted cache writes, and retries when sync makes no progress.

- Preserve pending mutations through paginated sync and later-page failures.
- Added unit and emulated browser regressions; verified failure on the old code and success with the fix. Focused unit tests pass, and browser screenshots were inspected.
- Performance: remaining sync pages run sequentially through the existing scheduler; no additional mutation requests or database schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email archiving reliability when mailbox synchronization has additional pages to process.
  * Archived conversations now remain hidden while reconciliation completes.
  * Mail mutations report success only after all required mailbox pages have synchronized.
  * Sync failures, stalled reconciliation, and incomplete mailbox-page processing now retry instead of being marked complete prematurely.
  * Improved handling of interrupted or unavailable mailbox cache storage to prevent incomplete synchronization results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->