### PR TITLE
mail: Add split inbox library and condition builder

### DIFF
--- a/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
@@ -1,106 +1,134 @@
 import { describe, expect, it } from "vitest";
-import { MailSplitKind } from "@/generated/prisma/enums";
-import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import { aiPromptToSplitFilters } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccount } from "@/__tests__/helpers";
 
 // Run with: pnpm test-ai ai-regression/ai-prompt-to-split
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
-const TIMEOUT = 15_000;
+const TIMEOUT = 20_000;
 
 const OPTIONS = [
-  { id: "state:unread", name: "Unread", kind: MailSplitKind.UNREAD },
   {
     id: "category:CATEGORY_PERSONAL",
     name: "Personal",
-    kind: MailSplitKind.CATEGORY,
+    kind: "CATEGORY" as const,
+    value: "CATEGORY_PERSONAL",
   },
   {
     id: "category:CATEGORY_PROMOTIONS",
     name: "Promotions",
-    kind: MailSplitKind.CATEGORY,
+    kind: "CATEGORY" as const,
+    value: "CATEGORY_PROMOTIONS",
   },
-  { id: "label:lbl-newsletter", name: "Newsletter", kind: MailSplitKind.LABEL },
-  { id: "label:lbl-receipts", name: "Receipts", kind: MailSplitKind.LABEL },
-  { id: "label:lbl-github", name: "GitHub", kind: MailSplitKind.LABEL },
-  { id: "label:lbl-invoices", name: "Invoices", kind: MailSplitKind.LABEL },
+  {
+    id: "label:lbl-newsletter",
+    name: "Newsletter",
+    kind: "LABEL" as const,
+    value: "lbl-newsletter",
+  },
+  {
+    id: "label:lbl-receipts",
+    name: "Receipts",
+    kind: "LABEL" as const,
+    value: "lbl-receipts",
+  },
+  {
+    id: "label:lbl-github",
+    name: "GitHub",
+    kind: "LABEL" as const,
+    value: "lbl-github",
+  },
 ];
 
-describe.runIf(isAiTest)("aiPromptToSplit", () => {
+const SENDERS = ["priya@northwind.co", "receipts@stripe.com"];
+
+function build(prompt: string) {
+  return aiPromptToSplitFilters({
+    emailAccount: getEmailAccount(),
+    prompt,
+    options: OPTIONS,
+    senders: SENDERS,
+  });
+}
+
+const kinds = (filters: { kind: MailSplitFilterKind }[]) =>
+  filters.map((filter) => filter.kind);
+
+describe.runIf(isAiTest)("aiPromptToSplitFilters", () => {
   it(
     "matches a semantic description to the right label",
     async () => {
-      const result = await aiPromptToSplit({
-        emailAccount: getEmailAccount(),
-        prompt: "invoices and purchase confirmations",
-        options: OPTIONS,
-      });
+      const result = await build("invoices and purchase confirmations");
 
-      expect(result.optionIds).toContain("label:lbl-receipts");
-      expect(result.name).toBeTruthy();
+      expect(result.filters).toContainEqual({
+        kind: MailSplitFilterKind.LABEL,
+        value: "lbl-receipts",
+      });
     },
     TIMEOUT,
   );
 
   it(
-    "matches a description of a read state",
+    "reads a read state as its own condition",
     async () => {
-      const result = await aiPromptToSplit({
-        emailAccount: getEmailAccount(),
-        prompt: "stuff I haven't read yet",
-        options: OPTIONS,
-      });
+      const result = await build("stuff I haven't read yet");
 
-      expect(result.optionIds).toEqual(["state:unread"]);
+      expect(kinds(result.filters)).toContain(MailSplitFilterKind.UNREAD);
     },
     TIMEOUT,
   );
 
   it(
-    "returns no match rather than guessing",
+    "combines conditions when the description names more than one",
     async () => {
-      const result = await aiPromptToSplit({
-        emailAccount: getEmailAccount(),
-        prompt: "urgent emails from my boss",
-        options: OPTIONS,
+      const result = await build("receipts I have not opened yet");
+
+      expect(kinds(result.filters)).toContain(MailSplitFilterKind.UNREAD);
+      expect(result.filters).toContainEqual({
+        kind: MailSplitFilterKind.LABEL,
+        value: "lbl-receipts",
       });
-
-      expect(result.optionIds).toEqual([]);
-    },
-    TIMEOUT,
-  );
-
-  // Observed live: a weak model matched this to an unrelated category and named
-  // the tab after the description, producing a tab that lies about its filter.
-  it(
-    "returns no match for a topic no option covers",
-    async () => {
-      const result = await aiPromptToSplit({
-        emailAccount: getEmailAccount(),
-        prompt: "flight itineraries and travel bookings",
-        options: OPTIONS,
-      });
-
-      expect(result.optionIds).toEqual([]);
+      expect(result.matchAll).toBe(true);
     },
     TIMEOUT,
   );
 
   it(
-    "returns every label a description spans",
+    "turns a named sender into a From condition",
     async () => {
-      const result = await aiPromptToSplit({
-        emailAccount: getEmailAccount(),
-        prompt: "receipts and invoices",
-        options: OPTIONS,
-      });
+      const result = await build("everything from Priya");
 
-      expect(result.optionIds.toSorted()).toEqual([
-        "label:lbl-invoices",
-        "label:lbl-receipts",
-      ]);
-      expect(result.name).toBeTruthy();
+      const from = result.filters.find(
+        (filter) => filter.kind === MailSplitFilterKind.FROM,
+      );
+      expect(from?.value).toContain("priya");
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "returns nothing rather than guessing at a topic no condition covers",
+    async () => {
+      const result = await build("flight itineraries and travel bookings");
+
+      expect(result.filters).toEqual([]);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "never invents a label that isn't among the options",
+    async () => {
+      const result = await build("urgent emails from my boss");
+
+      const labels = result.filters.filter(
+        (filter) => filter.kind === MailSplitFilterKind.LABEL,
+      );
+      for (const label of labels) {
+        expect(OPTIONS.map((option) => option.value)).toContain(label.value);
+      }
     },
     TIMEOUT,
   );

--- a/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-prompt-to-split.test.ts
@@ -7,7 +7,7 @@ import { getEmailAccount } from "@/__tests__/helpers";
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
-const TIMEOUT = 20_000;
+const TIMEOUT = 60_000;
 
 const OPTIONS = [
   {

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import {
   createMailSplit,
@@ -41,12 +41,24 @@ describe.skipIf(!RUN_DB_TESTS)(
     });
 
     test("stores, deletes, and restores inbox and unread splits as rows", async () => {
-      for (const kind of [MailSplitKind.INBOX, MailSplitKind.UNREAD]) {
-        const draft = { emailAccountId, name: kind, kind, values: [] };
+      for (const kind of ["INBOX", MailSplitFilterKind.UNREAD]) {
+        const draft = {
+          emailAccountId,
+          name: kind,
+          matchAll: true,
+          filters:
+            kind === "INBOX"
+              ? []
+              : [{ kind: MailSplitFilterKind.UNREAD, value: null }],
+        };
         expect((await createMailSplit(draft))?.status).toBe("created");
-        await prisma.mailSplit.deleteMany({ where: { emailAccountId, kind } });
+        await prisma.mailSplit.deleteMany({
+          where: { emailAccountId, name: kind },
+        });
         expect(
-          await prisma.mailSplit.count({ where: { emailAccountId, kind } }),
+          await prisma.mailSplit.count({
+            where: { emailAccountId, name: kind },
+          }),
         ).toBe(0);
         expect((await createMailSplit(draft))?.status).toBe("created");
       }
@@ -58,15 +70,24 @@ describe.skipIf(!RUN_DB_TESTS)(
     test("reorders every kind while keeping omitted rows and ignoring stale IDs", async () => {
       const rows = [];
       for (const kind of [
-        MailSplitKind.INBOX,
-        MailSplitKind.UNREAD,
-        MailSplitKind.LABEL,
-      ]) {
+        "INBOX",
+        MailSplitFilterKind.UNREAD,
+        MailSplitFilterKind.LABEL,
+      ] as const) {
         const row = await createMailSplit({
           emailAccountId,
           name: kind,
-          kind,
-          values: kind === MailSplitKind.LABEL ? ["label-1"] : [],
+          matchAll: true,
+          filters:
+            kind === "INBOX"
+              ? []
+              : [
+                  {
+                    kind,
+                    value:
+                      kind === MailSplitFilterKind.LABEL ? "label-1" : null,
+                  },
+                ],
         });
         if (row?.status !== "created") throw new Error("Could not seed split");
         rows.push(row);
@@ -103,8 +124,11 @@ describe.skipIf(!RUN_DB_TESTS)(
         createMailSplit({
           emailAccountId,
           name: "New",
-          kind: MailSplitKind.LABEL,
-          values: ["new-label"],
+          matchAll: false,
+          filters: ["new-label"].map((value) => ({
+            kind: MailSplitFilterKind.LABEL,
+            value,
+          })),
         }),
       ]);
       const concurrent = await prisma.mailSplit.findMany({
@@ -120,29 +144,36 @@ describe.skipIf(!RUN_DB_TESTS)(
       expect(concurrent.map(({ order }) => order)).toEqual([0, 1, 2, 3]);
     });
 
-    // The insert goes through raw SQL, so the array parameter needs a real
-    // database to prove it lands as a Postgres text[] rather than a string.
     test("stores every label of a multi-label split", async () => {
       const result = await createMailSplit({
         emailAccountId,
         name: "Feedback",
-        kind: MailSplitKind.LABEL,
-        values: ["label-users", "label-customers"],
+        matchAll: false,
+        filters: ["label-users", "label-customers"].map((value) => ({
+          kind: MailSplitFilterKind.LABEL,
+          value,
+        })),
       });
 
       expect(result?.status).toBe("created");
       const saved = await prisma.mailSplit.findFirst({
         where: { emailAccountId, name: "Feedback" },
+        include: { filters: { orderBy: { order: "asc" } } },
       });
-      expect(saved?.values).toEqual(["label-users", "label-customers"]);
+      expect(saved?.filters.map((filter) => filter.value)).toEqual([
+        "label-users",
+        "label-customers",
+      ]);
     });
 
     test("adds and removes rule-label defaults without touching a widened split", async () => {
       const defaultSplits = [
         {
           name: "Receipt",
-          kind: MailSplitKind.LABEL,
-          values: ["receipt-label"],
+          labelId: "receipt-label",
+          filters: [
+            { kind: MailSplitFilterKind.LABEL, value: "receipt-label" },
+          ],
         },
       ];
       await setDefaultMailSplits({
@@ -159,8 +190,11 @@ describe.skipIf(!RUN_DB_TESTS)(
       await createMailSplit({
         emailAccountId,
         name: "Receipts and invoices",
-        kind: MailSplitKind.LABEL,
-        values: ["receipt-label", "invoice-label"],
+        matchAll: false,
+        filters: ["receipt-label", "invoice-label"].map((value) => ({
+          kind: MailSplitFilterKind.LABEL,
+          value,
+        })),
       });
 
       await setDefaultMailSplits({
@@ -181,24 +215,30 @@ describe.skipIf(!RUN_DB_TESTS)(
       await createMailSplit({
         emailAccountId,
         name: "Feedback",
-        kind: MailSplitKind.LABEL,
-        values: ["gone"],
+        matchAll: false,
+        filters: ["gone"].map((value) => ({
+          kind: MailSplitFilterKind.LABEL,
+          value,
+        })),
       });
       await createMailSplit({
         emailAccountId,
         name: "Feedback and support",
-        kind: MailSplitKind.LABEL,
-        values: ["gone", "kept"],
+        matchAll: false,
+        filters: ["gone", "kept"].map((value) => ({
+          kind: MailSplitFilterKind.LABEL,
+          value,
+        })),
       });
 
       await removeLabelFromMailSplits({ emailAccountId, labelId: "gone" });
 
       const remaining = await prisma.mailSplit.findMany({
         where: { emailAccountId },
-        select: { name: true, values: true },
+        select: { name: true, filters: { select: { value: true } } },
       });
       expect(remaining).toEqual([
-        { name: "Feedback and support", values: ["kept"] },
+        { name: "Feedback and support", filters: [{ value: "kept" }] },
       ]);
     });
   },

--- a/apps/web/__tests__/db/default-mail-splits.test.ts
+++ b/apps/web/__tests__/db/default-mail-splits.test.ts
@@ -211,6 +211,29 @@ describe.skipIf(!RUN_DB_TESTS)(
       ]);
     });
 
+    test("reports the split limit without partially adding defaults", async () => {
+      await prisma.mailSplit.createMany({
+        data: Array.from({ length: 13 }, (_, order) => ({
+          name: `Existing ${order}`,
+          emailAccountId,
+          order,
+        })),
+      });
+      const result = await setDefaultMailSplits({
+        emailAccountId,
+        enabled: true,
+        defaultSplits: ["One", "Two"].map((name) => ({
+          name,
+          labelId: name,
+          filters: [{ kind: MailSplitFilterKind.LABEL, value: name }],
+        })),
+      });
+      expect(result.status).toBe("limit");
+      expect(await prisma.mailSplit.count({ where: { emailAccountId } })).toBe(
+        13,
+      );
+    });
+
     test("narrows splits that share a deleted label and drops the ones left empty", async () => {
       await createMailSplit({
         emailAccountId,

--- a/apps/web/__tests__/db/mail-split-migration.test.ts
+++ b/apps/web/__tests__/db/mail-split-migration.test.ts
@@ -17,6 +17,7 @@ describe.skipIf(!process.env.RUN_DB_TESTS)("mail split migration", () => {
     try {
       await client.query(`
         BEGIN;
+        CREATE TYPE pg_temp."MailSplitKind" AS ENUM ('INBOX', 'UNREAD', 'LABEL', 'CATEGORY');
         CREATE TEMP TABLE "EmailAccount" ("id" text PRIMARY KEY, "mailHiddenBuiltInSplits" text[] NOT NULL DEFAULT '{}');
         CREATE TEMP TABLE "MailSplit" (
           "id" text PRIMARY KEY, "createdAt" timestamp, "updatedAt" timestamp,

--- a/apps/web/__tests__/db/split-filter-migration.test.ts
+++ b/apps/web/__tests__/db/split-filter-migration.test.ts
@@ -20,7 +20,7 @@ describe.skipIf(!process.env.RUN_DB_TESTS)("split filter migration", () => {
         SET LOCAL search_path = split_filter_migration_test;
         CREATE TYPE "MailSplitKind" AS ENUM ('INBOX', 'UNREAD', 'LABEL', 'CATEGORY');
         CREATE TABLE "MailSplit" ("id" text PRIMARY KEY, "kind" "MailSplitKind", "values" text[]);
-        INSERT INTO "MailSplit" VALUES ('all', 'INBOX', '{}'), ('unread', 'UNREAD', '{}'), ('labels', 'LABEL', '{one,two}'), ('category', 'CATEGORY', '{CATEGORY_PROMOTIONS}');
+        INSERT INTO "MailSplit" VALUES ('empty-label', 'LABEL', '{}'), ('empty-category', 'CATEGORY', '{}'), ('all', 'INBOX', '{}'), ('unread', 'UNREAD', '{}'), ('labels', 'LABEL', '{one,two}'), ('category', 'CATEGORY', '{CATEGORY_PROMOTIONS}');
       `);
       await client.query(migration);
       const result = await client.query(

--- a/apps/web/__tests__/db/split-filter-migration.test.ts
+++ b/apps/web/__tests__/db/split-filter-migration.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { Client } from "pg";
+import { describe, expect, test } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../../prisma/migrations/20260910000000_split_inbox_filters/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe.skipIf(!process.env.RUN_DB_TESTS)("split filter migration", () => {
+  test("preserves inbox, unread, category and label-union semantics", async () => {
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    try {
+      await client.query(`BEGIN;
+        CREATE SCHEMA split_filter_migration_test;
+        SET LOCAL search_path = split_filter_migration_test;
+        CREATE TYPE "MailSplitKind" AS ENUM ('INBOX', 'UNREAD', 'LABEL', 'CATEGORY');
+        CREATE TABLE "MailSplit" ("id" text PRIMARY KEY, "kind" "MailSplitKind", "values" text[]);
+        INSERT INTO "MailSplit" VALUES ('all', 'INBOX', '{}'), ('unread', 'UNREAD', '{}'), ('labels', 'LABEL', '{one,two}'), ('category', 'CATEGORY', '{CATEGORY_PROMOTIONS}');
+      `);
+      await client.query(migration);
+      const result = await client.query(
+        `SELECT s."id", s."matchAll", COALESCE(json_agg(json_build_object('kind', f."kind", 'value', f."value") ORDER BY f."order") FILTER (WHERE f."id" IS NOT NULL), '[]') AS filters FROM "MailSplit" s LEFT JOIN "MailSplitFilter" f ON f."mailSplitId" = s."id" GROUP BY s."id" ORDER BY s."id"`,
+      );
+      expect(result.rows).toEqual([
+        { id: "all", matchAll: true, filters: [] },
+        {
+          id: "category",
+          matchAll: true,
+          filters: [{ kind: "CATEGORY", value: "CATEGORY_PROMOTIONS" }],
+        },
+        {
+          id: "labels",
+          matchAll: false,
+          filters: [
+            { kind: "LABEL", value: "one" },
+            { kind: "LABEL", value: "two" },
+          ],
+        },
+        {
+          id: "unread",
+          matchAll: true,
+          filters: [{ kind: "UNREAD", value: null }],
+        },
+      ]);
+    } finally {
+      await client.query("ROLLBACK");
+      await client.end();
+    }
+  });
+});

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -165,8 +165,7 @@ async function deleteDefaultSplitRule(client: Client, emailAccountId: string) {
   await client.query(
     `DELETE FROM "MailSplit"
      WHERE "emailAccountId" = $1
-       AND kind = 'LABEL'
-       AND "values" = ARRAY[$2]
+       AND EXISTS (SELECT 1 FROM "MailSplitFilter" f WHERE f."mailSplitId" = "MailSplit".id AND f.kind = 'LABEL' AND f.value = $2)
        AND name = 'Calendar'`,
     [emailAccountId, DEFAULT_SPLIT_LABEL_ID],
   );

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -25,10 +25,12 @@ test.beforeEach(async ({ page }) => {
          VALUES (gen_random_uuid()::text, NOW(), $1, $2, true, $3) RETURNING id`,
         [emailAccountId, split.name, order],
       );
+      const splitId = rows.at(0)?.id;
+      if (!splitId) throw new Error("Could not initialize split fixture");
       for (const filter of split.filters.create) {
         await client.query(
           `INSERT INTO "MailSplitFilter" (id, "mailSplitId", kind, value, "order") VALUES (gen_random_uuid()::text, $1, $2, $3, $4)`,
-          [rows[0].id, filter.kind, filter.value, filter.order],
+          [splitId, filter.kind, filter.value, filter.order],
         );
       }
     }

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from "@playwright/test";
-import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { getEmailAccountId } from "../account-test-helpers";
@@ -8,27 +7,9 @@ import {
   conversationWithSubject,
   openMail,
   seedDefaultSplitRule,
-  withClient,
 } from "./mail-test-helpers";
 
 let defaultSplitEmailAccountId: string | undefined;
-
-test.beforeEach(async ({ page }) => {
-  const emailAccountId = await getEmailAccountId(page);
-  // A failed removal test must not change the starting tabs for its retry.
-  await withClient(async (client) => {
-    await client.query('DELETE FROM "MailSplit" WHERE "emailAccountId" = $1', [
-      emailAccountId,
-    ]);
-    for (const [order, split] of INITIAL_MAIL_SPLITS.entries()) {
-      await client.query(
-        `INSERT INTO "MailSplit" (id, "updatedAt", "emailAccountId", name, kind, "values", "order")
-         VALUES (gen_random_uuid()::text, NOW(), $1, $2, $3, $4, $5)`,
-        [emailAccountId, split.name, split.kind, split.values, order],
-      );
-    }
-  });
-});
 
 test.afterEach(async () => {
   if (!defaultSplitEmailAccountId) return;
@@ -36,12 +17,17 @@ test.afterEach(async () => {
   defaultSplitEmailAccountId = undefined;
 });
 
+/** Next's dev indicator otherwise lands in every product screenshot. */
+async function hideDevIndicator(page: Parameters<typeof openMail>[0]) {
+  await page.locator("nextjs-portal").evaluateAll((portals) => {
+    for (const portal of portals) portal.remove();
+  });
+}
+
 test("moves focus with the active split when cycling by keyboard", async ({
   page,
 }, testInfo) => {
   await openMail(page);
-
-  await expect(page.getByTitle("Next split")).toHaveCount(0);
 
   const activeSplit = page.locator('button[aria-current="true"]');
   await expect(activeSplit).toBeVisible();
@@ -57,75 +43,60 @@ test("moves focus with the active split when cycling by keyboard", async ({
   );
 });
 
-test("shows a combined picker and creates a matching split", async ({
+test("builds a split from conditions and shows only matching mail", async ({
   page,
 }, testInfo) => {
   const { conversations } = await openMail(page);
 
   await page.getByRole("button", { name: "New split" }).click();
-
-  const search = page.getByRole("combobox", {
-    name: "Search labels and categories",
-  });
-  await expect(
-    page.getByRole("option", { name: "Promotions", exact: true }),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("option", { name: "Project Alpha, not selected" }),
-  ).toBeVisible();
+  await expect(page.getByText("New split inbox")).toBeVisible();
   await expect(page.getByText(/Compiling/)).toBeHidden();
-  // Keep Next's development indicator out of product screenshots.
-  await page.locator("nextjs-portal").evaluateAll((portals) => {
-    for (const portal of portals) portal.remove();
+  await hideDevIndicator(page);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-library");
+
+  await page.getByRole("button", { name: "Build your own" }).click();
+  await expect(page.getByText("Show mail matching")).toBeVisible();
+
+  await page.getByLabel("Condition field").first().selectOption("CATEGORY");
+  await page.getByLabel("Condition value").first().selectOption({
+    label: "Promotions",
   });
-  await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-initial");
+  await page.getByLabel("Split name").fill("Promos");
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-builder");
 
-  await page.getByRole("button", { name: "Describe a split instead" }).click();
-  await expect(
-    page.getByRole("textbox", { name: "Describe a split" }),
-  ).toBeVisible();
-  await capturePlaywrightCheckpoint(
-    page,
-    testInfo,
-    "mail-new-split-description",
-  );
-  await page.getByRole("button", { name: "Back to the split list" }).click();
+  await page.getByRole("button", { name: "Add split" }).click();
 
-  await search.fill("Promotions");
-  const promotionsOption = page.getByRole("option", {
-    name: "Promotions",
-    exact: true,
-  });
-  await expect(promotionsOption).toBeVisible();
-  await capturePlaywrightCheckpoint(
-    page,
-    testInfo,
-    "mail-new-split-existing-option",
-  );
-
-  await promotionsOption.click();
-  const promotionsSplit = page.getByRole("button", {
-    name: "Promotions",
-    exact: true,
-  });
-  await expect(promotionsSplit).toBeVisible();
-
-  await promotionsSplit.click();
-  await expect(promotionsSplit).toHaveAttribute("aria-current", "true");
+  const promosSplit = page.getByRole("button", { name: "Promos", exact: true });
+  await expect(promosSplit).toBeVisible();
+  await expect(promosSplit).toHaveAttribute("aria-current", "true");
   await expect(
     conversationWithSubject(page, conversations, "Promotion Category Message"),
   ).toBeVisible();
   await expect(conversations.getByRole("option")).toHaveCount(1);
+  await hideDevIndicator(page);
   await capturePlaywrightCheckpoint(page, testInfo, "mail-new-split-created");
 
-  await page.getByRole("button", { name: "Manage splits" }).click();
-  await page
-    .getByRole("button", { name: "Remove the Promotions split" })
-    .click();
-  await expect(promotionsSplit).toHaveCount(0);
+  // The tab's own menu edits the split rather than sending you back to the list.
+  await promosSplit.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit filters and name" }).click();
+  await expect(page.getByText("Edit split")).toBeVisible();
+  await expect(page.getByLabel("Condition value").first()).toHaveValue(
+    /PROMOTIONS/,
+  );
+  await hideDevIndicator(page);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-split-edit");
+
+  await page.getByRole("button", { name: "Add condition" }).click();
+  await expect(page.getByLabel("Condition field")).toHaveCount(2);
+  await page.getByRole("button", { name: "Save changes" }).click();
+  await expect(promosSplit).toBeVisible();
+
+  await promosSplit.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Turn off split" }).click();
+  await expect(promosSplit).toHaveCount(0);
 });
 
-test("organizes split choices and manages all rule labels", async ({
+test("turns a prepared split on from the library", async ({
   page,
 }, testInfo) => {
   const emailAccountId = await getEmailAccountId(page);
@@ -134,217 +105,36 @@ test("organizes split choices and manages all rule labels", async ({
   await openMail(page);
 
   await page.getByRole("button", { name: "New split" }).click();
+  await page.getByRole("button", { name: "General", exact: true }).click();
 
-  await expect(page.getByText("State", { exact: true })).toHaveCount(0);
-  const headingElements = page.locator("[cmdk-group-heading]");
-  await expect(headingElements.filter({ hasText: /^Labels/ })).toBeVisible();
+  // The library only offers label-backed entries when the account has that
+  // label; the fixture's label is "Project Alpha", so use one needing none.
+  const starredTile = page.getByRole("button", {
+    name: "Turn on the Starred split",
+  });
+  await expect(starredTile).toBeVisible();
+  await hideDevIndicator(page);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-split-library");
+
+  await starredTile.click();
   await expect(
-    headingElements.filter({ hasText: /^Categories$/ }),
+    page.getByRole("button", { name: "Turn off the Starred split" }),
   ).toBeVisible();
-  const groupHeadings = await headingElements.allTextContents();
-  expect(
-    groupHeadings.findIndex((heading) => heading.startsWith("Labels")),
-  ).toBeLessThan(
-    groupHeadings.findIndex((heading) => heading.startsWith("Categories")),
-  );
 
-  // The bulk controls sit below the list rather than among the label rows.
-  await expect(
-    page.getByRole("option", { name: "Add a tab for each rule label" }),
-  ).toHaveCount(0);
-  await page
-    .getByRole("button", { name: "Add a tab for each rule label" })
-    .click();
-  const calendarSplit = page.getByRole("button", {
-    name: "Calendar",
+  await page.getByRole("button", { name: "Close" }).click();
+  const starredSplit = page.getByRole("button", {
+    name: "Starred",
     exact: true,
   });
-  await expect(calendarSplit).toBeVisible();
-  await page.getByRole("button", { name: "New split" }).click();
-  await expect(
-    page.getByRole("button", { name: "Remove the rule label tabs" }),
-  ).toBeVisible();
+  await expect(starredSplit).toBeVisible();
+  await hideDevIndicator(page);
   await capturePlaywrightCheckpoint(
     page,
     testInfo,
     "mail-rule-label-splits-added",
   );
 
-  await page
-    .getByRole("button", { name: "Remove the rule label tabs" })
-    .click();
-  await expect(calendarSplit).toHaveCount(0);
-});
-
-test("builds one tab from several labels and names it", async ({
-  page,
-}, testInfo) => {
-  const { conversations } = await openMail(page);
-  const extraLabel = `Split Partner ${testInfo.retry}`;
-  await page.getByRole("button", { name: "Create label" }).click();
-  await page.getByRole("textbox", { name: "New label name" }).fill(extraLabel);
-  await page.getByRole("button", { name: "Add", exact: true }).click();
-  await expect(
-    page.getByRole("link", { name: extraLabel, exact: true }),
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: "New split" }).click();
-  await page
-    .getByRole("option", { name: "Project Alpha, not selected" })
-    .click();
-  await page
-    .getByRole("option", { name: `${extraLabel}, not selected` })
-    .click();
-  // The tick is decorative, so the row's name has to carry the state.
-  await expect(
-    page.getByRole("option", { name: "Project Alpha, selected" }),
-  ).toBeVisible();
-
-  const name = page.getByRole("textbox", { name: "Tab name" });
-  await expect(name).toHaveValue(`Project Alpha, ${extraLabel}`);
-  await name.fill("Two labels");
-  await capturePlaywrightCheckpoint(
-    page,
-    testInfo,
-    "mail-new-split-multi-label",
-  );
-  await page.getByRole("button", { name: "Add tab for 2 labels" }).click();
-
-  const split = page.getByRole("button", { name: "Two labels", exact: true });
-  await expect(split).toHaveAttribute("aria-current", "true");
-  // Both labels feed one tab, so mail carrying either one shows up in it.
-  await expect(
-    conversationWithSubject(page, conversations, "Project Label Message"),
-  ).toBeVisible();
-
-  await page.getByRole("button", { name: "Manage splits" }).click();
-  await page
-    .getByRole("button", { name: "Remove the Two labels split" })
-    .click();
-  await expect(split).toHaveCount(0);
-});
-
-for (const accountScope of ["single", "all"] as const) {
-  test(`${accountScope}: creates and removes splits without selecting them`, async ({
-    page,
-    request,
-  }) => {
-    const { emailAccountId } = await openMail(page);
-    if (accountScope === "all") {
-      await page.goto(`/${emailAccountId}/mail?accountScope=all`);
-    }
-    await page.getByRole("button", { name: "New split" }).click();
-    await page
-      .getByRole("option", { name: "Project Alpha, not selected" })
-      .click();
-    await page.getByRole("button", { name: "Add tab", exact: true }).click();
-    const split = page.getByRole("button", {
-      name: "Project Alpha",
-      exact: true,
-    });
-    await expect(split).toBeVisible();
-    await page.getByRole("button", { name: "Manage splits" }).click();
-    await page
-      .getByRole("button", { name: "Remove the Project Alpha split" })
-      .click();
-    await expect(split).toHaveCount(0);
-
-    for (const name of ["All", "Unread"] as const) {
-      await page
-        .getByRole("button", { name: `Remove the ${name} split` })
-        .click();
-      await expect
-        .poll(async () => {
-          const response = await request.get("/api/mail/settings", {
-            maxRetries: 2,
-            headers: { "X-Email-Account-ID": emailAccountId },
-          });
-          return (await response.json()).splits.some(
-            (split: { name: string }) => split.name === name,
-          );
-        })
-        .toBe(false);
-      await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
-        0,
-      );
-    }
-    await page.reload();
-    await expect(page.getByRole("button", { name: "New split" })).toBeVisible();
-    for (const name of ["All", "Unread"]) {
-      await expect(page.getByRole("button", { name, exact: true })).toHaveCount(
-        0,
-      );
-      await page.getByRole("button", { name: "New split" }).click();
-      await page.getByRole("option", { name, exact: true }).click();
-      await expect
-        .poll(async () => {
-          const response = await request.get("/api/mail/settings", {
-            maxRetries: 2,
-            headers: { "X-Email-Account-ID": emailAccountId },
-          });
-          return (await response.json()).splits.some(
-            (split: { name: string }) => split.name === name,
-          );
-        })
-        .toBe(true);
-      await expect(
-        page.getByRole("button", { name, exact: true }),
-      ).toBeVisible();
-    }
-    await page.reload();
-    await expect(
-      page.getByRole("listbox", { name: "Conversations" }),
-    ).toBeVisible();
-    for (const name of ["All", "Unread"]) {
-      await expect(
-        page.getByRole("button", { name, exact: true }),
-      ).toBeVisible();
-    }
-  });
-}
-
-test("keeps removal in the dialog and persists tab order", async ({
-  page,
-}, testInfo) => {
-  await openMail(page);
-  await expect(
-    page.getByRole("button", { name: /Remove the .* split/ }),
-  ).toHaveCount(0);
-  const tabs = page.locator("button[data-split-tab]");
-  await expect(tabs).toHaveText(INITIAL_MAIL_SPLITS.map((split) => split.name));
-  const original = await tabs.allTextContents();
-  await page.getByRole("button", { name: "Manage splits" }).click();
-  const dialog = page.getByRole("dialog", { name: "Manage splits" });
-  await dialog
-    .getByRole("button", { name: `Move ${original[1]} up`, exact: true })
-    .click();
-  await expect(
-    dialog.getByRole("button", { name: `Move ${original[1]} up`, exact: true }),
-  ).toBeDisabled();
-  await expect(dialog.getByRole("list")).toHaveAttribute("aria-busy", "false");
-  await capturePlaywrightCheckpoint(page, testInfo, "mail-manage-splits");
-  await dialog.getByRole("button", { name: "Close", exact: true }).click();
-  await expect(tabs.first()).toHaveText(original[1]);
-  await expect(tabs.filter({ hasText: original[0] })).toHaveAttribute(
-    "aria-current",
-    "true",
-  );
-  await page.reload();
-  await expect(tabs.first()).toHaveText(original[1]);
-  await page.getByRole("button", { name: "Manage splits" }).click();
-  const rows = dialog.getByRole("listitem");
-  await rows.nth(1).locator("[data-drag-split]").dragTo(rows.first());
-  await expect(dialog.getByRole("list")).toHaveAttribute("aria-busy", "false");
-  await dialog.getByRole("button", { name: "Close", exact: true }).click();
-  await expect(tabs).toHaveText(original);
-  await page.reload();
-  await expect(tabs).toHaveText(original);
-  await expect(
-    page.getByRole("listbox", { name: "Conversations" }),
-  ).toBeVisible();
-  await capturePlaywrightCheckpoint(
-    page,
-    testInfo,
-    "mail-splits-clean-tab-bar",
-  );
+  await starredSplit.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Turn off split" }).click();
+  await expect(starredSplit).toHaveCount(0);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -1,3 +1,4 @@
+import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { expect } from "@playwright/test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
@@ -7,9 +8,32 @@ import {
   conversationWithSubject,
   openMail,
   seedDefaultSplitRule,
+  withClient,
 } from "./mail-test-helpers";
 
 let defaultSplitEmailAccountId: string | undefined;
+
+test.beforeEach(async ({ page }) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await withClient(async (client) => {
+    await client.query('DELETE FROM "MailSplit" WHERE "emailAccountId" = $1', [
+      emailAccountId,
+    ]);
+    for (const [order, split] of INITIAL_MAIL_SPLITS.entries()) {
+      const { rows } = await client.query(
+        `INSERT INTO "MailSplit" (id, "updatedAt", "emailAccountId", name, "matchAll", "order")
+         VALUES (gen_random_uuid()::text, NOW(), $1, $2, true, $3) RETURNING id`,
+        [emailAccountId, split.name, order],
+      );
+      for (const filter of split.filters.create) {
+        await client.query(
+          `INSERT INTO "MailSplitFilter" (id, "mailSplitId", kind, value, "order") VALUES (gen_random_uuid()::text, $1, $2, $3, $4)`,
+          [rows[0].id, filter.kind, filter.value, filter.order],
+        );
+      }
+    }
+  });
+});
 
 test.afterEach(async () => {
   if (!defaultSplitEmailAccountId) return;

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1425,10 +1425,14 @@ export function MailShell() {
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}
-                onEdit={(splitId) => {
-                  setEditingSplitId(splitId);
-                  setIsNewSplitOpen(true);
-                }}
+                onEdit={
+                  isAllAccounts
+                    ? undefined
+                    : (splitId) => {
+                        setEditingSplitId(splitId);
+                        setIsNewSplitOpen(true);
+                      }
+                }
                 onNewSplit={() => {
                   setEditingSplitId(null);
                   setIsNewSplitOpen(true);

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -37,10 +37,12 @@ import { ListSenderCommands } from "@/app/(app)/[emailAccountId]/mail/ListSender
 import { ThreadActionsMenu } from "@/app/(app)/[emailAccountId]/mail/ThreadActionsMenu";
 import { ShortcutsDialog } from "@/app/(app)/[emailAccountId]/mail/ShortcutsDialog";
 import { SplitTabs } from "@/app/(app)/[emailAccountId]/mail/SplitTabs";
-import type {
-  NewSplitDraft,
-  NewSplitOption,
+import {
+  NewSplitDialog,
+  type ExistingSplit,
 } from "@/app/(app)/[emailAccountId]/mail/NewSplitDialog";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import { extractEmailAddress } from "@/utils/email";
 import { LabelPickerDialog } from "@/app/(app)/[emailAccountId]/mail/LabelPickerDialog";
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
@@ -65,7 +67,7 @@ import { requestMailboxSync } from "@/app/(app)/[emailAccountId]/mail/use-mailbo
 import { useThreadActions } from "@/app/(app)/[emailAccountId]/mail/use-thread-actions";
 import { useThreadSelection } from "@/app/(app)/[emailAccountId]/mail/use-thread-selection";
 import { isThreadUnread } from "@/app/(app)/[emailAccountId]/mail/read-state";
-import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import { MailLayout, MailSplitFilterKind } from "@/generated/prisma/enums";
 import { useChat } from "@/providers/ChatProvider";
 import { Sidebar, useSidebar } from "@/components/ui/sidebar";
 import { useAtomValue, useSetAtom } from "jotai";
@@ -94,11 +96,10 @@ import { useThread } from "@/hooks/useThread";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import type { ShortcutHandlers } from "@/lib/shortcuts/registry";
 import {
+  buildMailSplitFromPromptAction,
   createMailSplitAction,
-  suggestMailSplitAction,
   deleteMailSplitAction,
-  reorderMailSplitsAction,
-  setDefaultMailSplitsAction,
+  updateMailSplitAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
 import type { UpdateMailPreferencesBody } from "@/utils/actions/mail-split.validation";
@@ -123,7 +124,6 @@ import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions
 import type { LabelCount } from "@/app/api/labels/counts/route";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getEmailTerminology } from "@/utils/terminology";
-import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { GMAIL_LABEL_COLORS } from "@/utils/gmail/label-colors";
 import { OUTLOOK_CATEGORY_COLORS } from "@/utils/outlook/category-colors";
 
@@ -154,6 +154,8 @@ export function MailShell() {
   const { state: openSidebars, toggleSidebar } = useSidebar();
   const isPaletteOpen = useAtomValue(commandPaletteOpenAtom);
   const senderCommandContext = useAtomValue(senderCommandContextAtom);
+  const [isNewSplitOpen, setIsNewSplitOpen] = useState(false);
+  const [editingSplitId, setEditingSplitId] = useState<string | null>(null);
   const setMailCommandContext = useSetAtom(mailCommandContextAtom);
   // The side panel viewer owns the triage keys while it's open, so this screen
   // stands down rather than both archiving the same keystroke.
@@ -311,8 +313,9 @@ export function MailShell() {
       (settings?.splits ?? []).filter(
         (split) =>
           !isAllAccounts ||
-          split.kind === MailSplitKind.INBOX ||
-          split.kind === MailSplitKind.UNREAD ||
+          split.filters.every(
+            (filter) => filter.kind === MailSplitFilterKind.UNREAD,
+          ) ||
           combinedLabelSplits.some((portable) => portable.id === split.id),
       ),
     [settings?.splits, isAllAccounts, combinedLabelSplits],
@@ -323,29 +326,6 @@ export function MailShell() {
   const activeCombinedLabelNames = combinedLabelSplits.find(
     (split) => split.id === displayedActiveSplitId,
   )?.labelNames;
-  const savedDefaultSplits = useMemo(() => {
-    const defaultLabelIds = new Set(
-      (settings?.defaultSplits ?? []).map((split) => split.values[0]),
-    );
-    return (settings?.splits ?? []).filter(
-      (split) =>
-        split.kind === MailSplitKind.LABEL &&
-        split.values.length === 1 &&
-        defaultLabelIds.has(split.values[0]),
-    );
-  }, [settings?.defaultSplits, settings?.splits]);
-  const canAddDefaultSplits = (settings?.defaultSplits ?? []).some(
-    (defaultSplit) =>
-      !(settings?.splits ?? []).some(
-        (split) =>
-          split.name === defaultSplit.name ||
-          (split.kind === MailSplitKind.LABEL &&
-            split.values.length === 1 &&
-            split.values[0] === defaultSplit.values[0]),
-      ),
-  );
-  const canRemoveDefaultSplits = savedDefaultSplits.length > 0;
-
   const query: ThreadsQuery = useMemo(() => {
     // Search overrides split/scope and covers the whole mailbox, matching
     // what Gmail's and Outlook's own search boxes do by default.
@@ -366,7 +346,12 @@ export function MailShell() {
     accounts: combinedAccounts,
     emailAccountId,
     enabled: isAllAccounts,
-    isUnread: !searchQuery && activeSplit?.kind === MailSplitKind.UNREAD,
+    isUnread:
+      !searchQuery &&
+      !!activeSplit?.filters.length &&
+      activeSplit.filters.every(
+        (filter) => filter.kind === MailSplitFilterKind.UNREAD,
+      ),
     labelNames: searchQuery ? undefined : activeCombinedLabelNames,
     searchQuery: searchQuery ?? undefined,
   });
@@ -924,8 +909,9 @@ export function MailShell() {
       !settings?.splits.some(
         (split) =>
           split.id === activeSplitId &&
-          (split.kind === MailSplitKind.INBOX ||
-            split.kind === MailSplitKind.UNREAD),
+          split.filters.every(
+            (filter) => filter.kind === MailSplitFilterKind.UNREAD,
+          ),
       ) &&
       !combinedLabelSplits.some((split) => split.id === activeSplitId)
     ) {
@@ -1074,46 +1060,73 @@ export function MailShell() {
 
   useShortcuts(handlers, { isDesktopApp });
 
-  const categoryGroup: NewSplitOption["group"] = isOutlook
-    ? "inbox"
-    : "category";
-  const newSplitOptions: NewSplitOption[] = useMemo(
-    () => [
-      ...INITIAL_MAIL_SPLITS.filter(
-        (initial) =>
-          !settings?.splits.some((split) => split.kind === initial.kind),
-      ).map((split) => ({
-        ...split,
-        id: `state:${split.kind}`,
-        group: "state" as const,
-      })),
-      ...(isAllAccounts ? [] : categories).map((category) => ({
-        id: `category:${category.type}`,
-        name: category.name,
-        kind: MailSplitKind.CATEGORY,
-        values: [category.type],
-        group: categoryGroup,
-      })),
-      ...visibleLabels.map((label) => ({
+  const splitLabelChoices = useMemo(
+    () =>
+      visibleLabels.map((label) => ({
         id: `label:${label.id}`,
         name: label.name,
-        kind: MailSplitKind.LABEL,
-        values: [label.id],
-        group: "label" as const,
+        value: label.id,
       })),
-    ],
-    [categories, categoryGroup, visibleLabels, isAllAccounts, settings?.splits],
+    [visibleLabels],
+  );
+  const splitCategoryChoices = useMemo(
+    () =>
+      categories.map((category) => ({
+        id: `category:${category.type}`,
+        name: category.name,
+        value: category.type,
+      })),
+    [categories],
+  );
+  // Senders the reader actually corresponds with, so "Describe it" can turn a
+  // person's name into an address instead of guessing a domain.
+  const splitSenders = useMemo(() => {
+    const seen = new Set<string>();
+    for (const thread of threads) {
+      const from = thread.messages.at(-1)?.headers.from;
+      const address = from ? extractEmailAddress(from) : null;
+      if (address && address !== userEmail) seen.add(address);
+      if (seen.size >= 50) break;
+    }
+    return [...seen];
+  }, [threads, userEmail]);
+
+  const editingSplit: ExistingSplit | null = useMemo(() => {
+    if (!editingSplitId) return null;
+    const split = settings?.splits?.find((s) => s.id === editingSplitId);
+    return split
+      ? {
+          id: split.id,
+          name: split.name,
+          matchAll: split.matchAll,
+          filters: split.filters,
+        }
+      : null;
+  }, [editingSplitId, settings?.splits]);
+
+  const savedSplits: ExistingSplit[] = useMemo(
+    () =>
+      (settings?.splits ?? []).map((split) => ({
+        id: split.id,
+        name: split.name,
+        matchAll: split.matchAll,
+        filters: split.filters,
+      })),
+    [settings?.splits],
   );
 
   const onCreateSplit = useCallback(
-    async (draft: NewSplitDraft) => {
+    async (draft: {
+      name: string;
+      matchAll: boolean;
+      filters: MailSplitFilterDraft[];
+    }) => {
       const result = await createMailSplitAction(emailAccountId, draft);
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
         return false;
       }
       await mutateSettings();
-      // Jump to the new tab so its mail is what the user sees next.
       const split = result?.data?.split;
       if (split) setActiveSplitId(split.id);
       return true;
@@ -1121,16 +1134,43 @@ export function MailShell() {
     [emailAccountId, mutateSettings, setActiveSplitId],
   );
 
-  const onSuggestSplit = useCallback(
+  const onUpdateSplit = useCallback(
+    async (draft: {
+      id: string;
+      name: string;
+      matchAll: boolean;
+      filters: MailSplitFilterDraft[];
+    }) => {
+      const result = await updateMailSplitAction(emailAccountId, draft);
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        return false;
+      }
+      await mutateSettings();
+      return true;
+    },
+    [emailAccountId, mutateSettings],
+  );
+
+  const onDescribeSplit = useCallback(
     async (prompt: string) => {
-      const result = await suggestMailSplitAction(emailAccountId, {
+      const result = await buildMailSplitFromPromptAction(emailAccountId, {
         prompt,
-        options: newSplitOptions.map(({ id, name, kind, values }) => ({
-          id,
-          name,
-          kind,
-          values,
-        })),
+        options: [
+          ...splitLabelChoices.map((label) => ({
+            id: label.id,
+            name: label.name,
+            kind: "LABEL" as const,
+            value: label.value,
+          })),
+          ...splitCategoryChoices.map((category) => ({
+            id: category.id,
+            name: category.name,
+            kind: "CATEGORY" as const,
+            value: category.value,
+          })),
+        ],
+        senders: splitSenders,
       });
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
@@ -1138,7 +1178,7 @@ export function MailShell() {
       }
       return result?.data ?? null;
     },
-    [emailAccountId, newSplitOptions],
+    [emailAccountId, splitCategoryChoices, splitLabelChoices, splitSenders],
   );
 
   const onDeleteSplit = useCallback(
@@ -1148,35 +1188,13 @@ export function MailShell() {
       });
       if (result?.serverError || result?.validationErrors) {
         toast.error(getActionErrorMessage(result));
-        return;
+        return false;
       }
       if (activeSplitIdRef.current === splitId) setActiveSplitId(null);
       await mutateSettings();
-    },
-    [emailAccountId, mutateSettings, setActiveSplitId],
-  );
-
-  const onSetDefaultSplits = useCallback(
-    async (enabled: boolean) => {
-      const result = await setDefaultMailSplitsAction(emailAccountId, {
-        enabled,
-      });
-      if (result?.serverError || result?.validationErrors) {
-        toast.error(getActionErrorMessage(result));
-        return false;
-      }
-      await mutateSettings();
-      if (
-        !enabled &&
-        savedDefaultSplits.some(
-          (split) => split.id === activeSplitIdRef.current,
-        )
-      ) {
-        setActiveSplitId(null);
-      }
       return true;
     },
-    [emailAccountId, mutateSettings, savedDefaultSplits, setActiveSplitId],
+    [emailAccountId, mutateSettings, setActiveSplitId],
   );
 
   const onCreateLabel = useCallback(
@@ -1243,10 +1261,13 @@ export function MailShell() {
         settings?.splits?.some(
           (split) =>
             split.id === activeSplitId &&
-            split.kind === MailSplitKind.LABEL &&
-            // A wider split survives the delete with its remaining labels.
-            split.values.length === 1 &&
-            split.values[0] === item.id,
+            // Deleting the label removes a split defined solely by it.
+            split.filters.length > 0 &&
+            split.filters.every(
+              (filter) =>
+                filter.kind === MailSplitFilterKind.LABEL &&
+                filter.value === item.id,
+            ),
         );
       if (isActive) {
         await Promise.all([
@@ -1400,27 +1421,19 @@ export function MailShell() {
             />
             {!isScoped && !searchQuery && (
               <SplitTabs
-                splits={splits}
+                splits={splits.map((split) => ({ ...split, deletable: true }))}
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}
-                onReorder={async (ids) => {
-                  const result = await reorderMailSplitsAction(emailAccountId, {
-                    ids,
-                  });
-                  if (result?.serverError || result?.validationErrors) {
-                    toast.error(getActionErrorMessage(result));
-                    return;
-                  }
-                  if (!activeSplitId) setActiveSplitId(displayedActiveSplitId);
-                  await mutateSettings();
+                onEdit={(splitId) => {
+                  setEditingSplitId(splitId);
+                  setIsNewSplitOpen(true);
                 }}
-                newSplitOptions={newSplitOptions}
-                onCreateSplit={onCreateSplit}
-                onSuggestSplit={onSuggestSplit}
-                canAddDefaultSplits={canAddDefaultSplits}
-                canRemoveDefaultSplits={canRemoveDefaultSplits}
-                onSetDefaultSplits={onSetDefaultSplits}
+                onNewSplit={() => {
+                  setEditingSplitId(null);
+                  setIsNewSplitOpen(true);
+                }}
+                canCreateSplits={!isAllAccounts}
               />
             )}
             {isAllAccounts && combinedThreadState.failedAccountIds.length ? (
@@ -1552,6 +1565,25 @@ export function MailShell() {
           />
         </EmailAccountScopeProvider>
       ) : null}
+      {!isAllAccounts && (
+        <NewSplitDialog
+          open={isNewSplitOpen}
+          onOpenChange={(open) => {
+            setIsNewSplitOpen(open);
+            if (!open) setEditingSplitId(null);
+          }}
+          labels={splitLabelChoices}
+          categories={splitCategoryChoices}
+          senders={splitSenders}
+          existingSplits={savedSplits}
+          editing={editingSplit}
+          supportsStarred={!isOutlook}
+          onCreate={onCreateSplit}
+          onUpdate={onUpdateSplit}
+          onDelete={onDeleteSplit}
+          onDescribe={onDescribeSplit}
+        />
+      )}
 
       {labelPicker && pickerAccount && (
         <EmailAccountScopeProvider emailAccount={pickerAccount}>

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -18,7 +18,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import {
+  MAX_SPLIT_FILTERS,
+  type MailSplitFilterDraft,
+} from "@/utils/mail/split-filters";
 import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
 import {
   libraryDefinition,
@@ -190,20 +193,38 @@ export function NewSplitDialog({
       categories.map((choice) => [choice.name.toLowerCase(), choice.value]),
     );
 
-    return SPLIT_LIBRARY.filter((entry) => entry.category === category).flatMap(
-      (entry) => {
-        const filters = resolveLibraryEntry(entry, {
-          labelsByName,
-          categoriesByName,
-        });
-        return filters ? [{ entry, filters }] : [];
-      },
-    );
-  }, [categories, category, labels]);
+    return SPLIT_LIBRARY.filter(
+      (entry) =>
+        entry.category === category &&
+        (supportsStarred ||
+          !entry.conditions.some((condition) => condition.kind === "STARRED")),
+    ).flatMap((entry) => {
+      const filters = resolveLibraryEntry(entry, {
+        labelsByName,
+        categoriesByName,
+      });
+      return filters ? [{ entry, filters }] : [];
+    });
+  }, [categories, category, labels, supportsStarred]);
 
-  const isOn = useCallback(
-    (entryName: string) =>
-      existingSplits.some((split) => split.name === entryName),
+  const findLibrarySplit = useCallback(
+    (entry: SplitLibraryEntry, filters: MailSplitFilterDraft[]) =>
+      existingSplits.find(
+        (split) =>
+          split.name === entry.name &&
+          split.matchAll === (entry.matchAll ?? true) &&
+          split.filters.length === filters.length &&
+          JSON.stringify(
+            split.filters
+              .map((filter) => [filter.kind, filter.value ?? null])
+              .sort(),
+          ) ===
+            JSON.stringify(
+              filters
+                .map((filter) => [filter.kind, filter.value ?? null])
+                .sort(),
+            ),
+      ),
     [existingSplits],
   );
 
@@ -234,7 +255,7 @@ export function NewSplitDialog({
     if (isBusy) return;
     setIsBusy(true);
     try {
-      const existing = existingSplits.find((s) => s.name === entry.name);
+      const existing = findLibrarySplit(entry, filters);
       if (existing) await onDelete(existing.id);
       else
         await onCreate({
@@ -400,7 +421,7 @@ export function NewSplitDialog({
                     <LibraryTile
                       key={entry.name}
                       entry={entry}
-                      on={isOn(entry.name)}
+                      on={!!findLibrarySplit(entry, filters)}
                       disabled={isBusy}
                       onInfo={() => setDetail(entry)}
                       onToggle={() => toggleLibraryEntry(entry, filters)}
@@ -466,8 +487,13 @@ export function NewSplitDialog({
 
             <button
               type="button"
+              disabled={conditions.length >= MAX_SPLIT_FILTERS}
               onClick={() =>
-                setConditions((current) => [...current, newCondition()])
+                setConditions((current) =>
+                  current.length < MAX_SPLIT_FILTERS
+                    ? [...current, newCondition()]
+                    : current,
+                )
               }
               className="mt-3 inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-primary text-xs hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
@@ -520,7 +546,12 @@ export function NewSplitDialog({
                     setDetail(null);
                   }}
                 >
-                  {isOn(detail.name) ? "Turn off split" : "Turn on split"}
+                  {findLibrarySplit(
+                    detail,
+                    libraryFiltersFor(detail, labels, categories) ?? [],
+                  )
+                    ? "Turn off split"
+                    : "Turn on split"}
                 </Button>
               </>
             ) : mode === "build" ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -1,415 +1,576 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { ArrowLeftIcon, CheckIcon, PlusIcon, SparklesIcon } from "lucide-react";
-import { MailSplitKind } from "@/generated/prisma/enums";
-import { Button } from "@/components/ui/button";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import { Input } from "@/components/ui/input";
+  ChevronLeftIcon,
+  Loader2Icon,
+  PlusIcon,
+  SparklesIcon,
+  XIcon,
+} from "lucide-react";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogTrigger,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
+  DialogTitle,
 } from "@/components/ui/dialog";
-import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
+import {
+  libraryDefinition,
+  resolveLibraryEntry,
+  SPLIT_LIBRARY,
+  SPLIT_LIBRARY_CATEGORIES,
+  type SplitLibraryEntry,
+} from "@/utils/mail/split-library";
 import { cn } from "@/utils";
 
-type NewSplitOptionGroup = "state" | "inbox" | "category" | "label";
+const YOUR_SPLITS = "Your splits";
 
-export type NewSplitOption = {
-  /** Unique across every group; identifies the choice, not the split. */
+const FIELDS = [
+  { kind: MailSplitFilterKind.LABEL, name: "Has label" },
+  { kind: MailSplitFilterKind.FROM, name: "From" },
+  { kind: MailSplitFilterKind.CATEGORY, name: "In category" },
+  { kind: MailSplitFilterKind.UNREAD, name: "Is unread" },
+  { kind: MailSplitFilterKind.STARRED, name: "Is starred" },
+  { kind: MailSplitFilterKind.OLDER_THAN, name: "Older than" },
+] as const;
+
+export type SplitChoice = { id: string; name: string; value: string };
+
+export type ExistingSplit = {
   id: string;
   name: string;
-  kind: MailSplitKind;
-  /** Label ids or the category key the split filters on. Empty for ALL/UNREAD. */
-  values: string[];
-  group: NewSplitOptionGroup;
+  matchAll: boolean;
+  filters: { kind: MailSplitFilterKind; value: string | null }[];
 };
 
-export type NewSplitDraft = {
-  name: string;
-  kind: MailSplitKind;
-  values: string[];
+export type NewSplitDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  labels: SplitChoice[];
+  categories: SplitChoice[];
+  senders: string[];
+  /** Splits already on the tab strip, so the library can show what's on. */
+  existingSplits: ExistingSplit[];
+  /** Set when the dialog was opened to change a split rather than add one. */
+  editing: ExistingSplit | null;
+  supportsStarred: boolean;
+  onCreate: (split: {
+    name: string;
+    matchAll: boolean;
+    filters: MailSplitFilterDraft[];
+  }) => Promise<boolean>;
+  onUpdate: (split: {
+    id: string;
+    name: string;
+    matchAll: boolean;
+    filters: MailSplitFilterDraft[];
+  }) => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
+  onDescribe: (prompt: string) => Promise<{
+    filters: MailSplitFilterDraft[];
+    name: string | null;
+    matchAll: boolean;
+  } | null>;
 };
 
-export type NewSplitSuggestion = {
-  optionIds: string[];
-  name: string | null;
-  reasoning: string;
-};
-
-type NewSplitDialogProps = {
-  options: NewSplitOption[];
-  onCreate: (draft: NewSplitDraft) => Promise<boolean>;
-  /** Resolves a free-text description into a selection of the options above. */
-  onSuggest: (prompt: string) => Promise<NewSplitSuggestion | null>;
-  canAddDefaultSplits: boolean;
-  canRemoveDefaultSplits: boolean;
-  onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
-};
-
-const GROUPS = [
-  { group: "state", title: undefined },
-  { group: "label", title: "Labels" },
-  { group: "inbox", title: "Inbox" },
-  { group: "category", title: "Categories" },
-] as const satisfies readonly {
-  group: NewSplitOptionGroup;
-  title?: string;
-}[];
-
-const DESCRIBE_EXAMPLES = ["Mail I still owe a reply", "Invoices and receipts"];
-
-const FOOTER_BUTTON_CLASS =
-  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const EXAMPLES = [
+  "unread mail from my accountant",
+  "receipts from Stripe",
+  "notifications I have not read",
+  "anything awaiting my reply",
+];
 
 export function NewSplitDialog({
-  options,
+  open,
+  onOpenChange,
+  labels,
+  categories,
+  existingSplits,
+  editing,
+  supportsStarred,
   onCreate,
-  onSuggest,
-  canAddDefaultSplits,
-  canRemoveDefaultSplits,
-  onSetDefaultSplits,
+  onUpdate,
+  onDelete,
+  onDescribe,
 }: NewSplitDialogProps) {
-  const [open, setOpen] = useState(false);
-  const [isDescribing, setIsDescribing] = useState(false);
+  const [mode, setMode] = useState<"library" | "build" | "describe">("library");
+  const [category, setCategory] = useState(YOUR_SPLITS);
+  const [detail, setDetail] = useState<SplitLibraryEntry | null>(null);
+  const [conditions, setConditions] = useState<MailSplitFilterDraft[]>([]);
+  const [matchAll, setMatchAll] = useState(true);
+  const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [nameOverride, setNameOverride] = useState<string | null>(null);
-  const [note, setNote] = useState<string | null>(null);
-  const [isSuggesting, setIsSuggesting] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
 
-  const optionsById = useMemo(
-    () => new Map(options.map((option) => [option.id, option])),
-    [options],
+  const fields = useMemo(
+    () =>
+      FIELDS.filter(
+        (field) =>
+          supportsStarred || field.kind !== MailSplitFilterKind.STARRED,
+      ),
+    [supportsStarred],
   );
-  const selected = selectedIds.flatMap((id) => {
-    const option = optionsById.get(id);
-    return option ? [option] : [];
-  });
-  const name = nameOverride ?? selected.map((option) => option.name).join(", ");
-  const isBusy = isSuggesting || isSaving;
 
-  const changeOpen = (next: boolean) => {
-    setOpen(next);
-    if (next) return;
-    setIsDescribing(false);
-    setPrompt("");
-    setSelectedIds([]);
-    setNameOverride(null);
-    setNote(null);
-  };
+  const valueOptionsFor = useCallback(
+    (kind: MailSplitFilterKind): SplitChoice[] => {
+      if (kind === MailSplitFilterKind.LABEL) return labels;
+      if (kind === MailSplitFilterKind.CATEGORY) return categories;
+      if (kind === MailSplitFilterKind.OLDER_THAN) {
+        return OLDER_THAN_OPTIONS.map((option) => ({
+          id: option.value,
+          name: option.name,
+          value: option.value,
+        }));
+      }
+      return [];
+    },
+    [categories, labels],
+  );
 
-  const toggleOption = (option: NewSplitOption) => {
-    setNote(null);
-    if (selectedIds.includes(option.id)) {
-      const next = selectedIds.filter((id) => id !== option.id);
-      setSelectedIds(next);
-      if (!next.length) setNameOverride(null);
-      return;
-    }
-    // Only labels stack. Picking one while a read state or category is held
-    // replaces it, because that pair has no query.
-    if (selected.some((held) => held.kind !== MailSplitKind.LABEL)) {
-      setSelectedIds([option.id]);
-      setNameOverride(null);
-      return;
-    }
-    if (selectedIds.length >= MAX_SPLIT_LABELS) {
-      setNote(`A tab can cover up to ${MAX_SPLIT_LABELS} labels.`);
-      return;
-    }
-    setSelectedIds([...selectedIds, option.id]);
-  };
+  const defaultCondition = useCallback(
+    (kind: MailSplitFilterKind): MailSplitFilterDraft => ({
+      kind,
+      value: valueOptionsFor(kind)[0]?.value ?? null,
+    }),
+    [valueOptionsFor],
+  );
 
-  const createSplit = async (draft: NewSplitDraft) => {
-    if (isBusy) return;
-    setIsSaving(true);
-    try {
-      if (await onCreate(draft)) changeOpen(false);
-    } finally {
-      setIsSaving(false);
-    }
-  };
+  /**
+   * A new row starts on a field this account can actually fill in — seeding
+   * "Has label" on an account with no labels would open the builder on a
+   * condition that can't be saved.
+   */
+  const newCondition = useCallback((): MailSplitFilterDraft => {
+    if (labels.length) return defaultCondition(MailSplitFilterKind.LABEL);
+    if (categories.length)
+      return defaultCondition(MailSplitFilterKind.CATEGORY);
+    return defaultCondition(MailSplitFilterKind.UNREAD);
+  }, [categories.length, defaultCondition, labels.length]);
 
-  // Several options only combine when they are all labels; a read state or a
-  // category is always on its own, so the first pick decides the kind.
-  const createFromSelection = () =>
-    createSplit({
-      name: name.trim().slice(0, 60),
-      kind: selected[0]?.kind ?? MailSplitKind.LABEL,
-      values: selected.flatMap((option) => option.values),
-    });
-
-  const suggest = async () => {
-    const trimmedPrompt = prompt.trim();
-    if (!trimmedPrompt || isBusy) return;
-    setIsSuggesting(true);
-    try {
-      const suggestion = await onSuggest(trimmedPrompt);
-      if (!suggestion) return;
-      setNote(suggestion.reasoning);
-
-      const matched = suggestion.optionIds.flatMap((id) => {
-        const option = optionsById.get(id);
-        return option ? [option] : [];
-      });
-      const [first] = matched;
-      if (!first) return;
-
-      // Only labels combine, so a read state or category stands alone. Either
-      // way the picker shows the match for the user to confirm or change.
-      const labels = matched.filter(
-        (option) => option.kind === MailSplitKind.LABEL,
+  // Opening for an edit drops straight into the builder holding that split.
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      setMode("build");
+      setConditions(
+        editing.filters.map(({ kind, value }) => ({ kind, value })),
       );
-      setSelectedIds(labels.length ? labels.map((o) => o.id) : [first.id]);
-      setNameOverride(suggestion.name);
-      setIsDescribing(false);
-      setPrompt("");
+      setMatchAll(editing.matchAll);
+      setName(editing.name);
+    } else {
+      setMode("library");
+      setCategory(YOUR_SPLITS);
+      setConditions([]);
+      setMatchAll(true);
+      setName("");
+    }
+    setDetail(null);
+    setPrompt("");
+  }, [editing, open]);
+
+  const describedName = useMemo(
+    () =>
+      conditions
+        .map((c) => conditionLabel(c, labels, categories))
+        .join(matchAll ? " · " : " or "),
+    [categories, conditions, labels, matchAll],
+  );
+
+  const libraryEntries = useMemo(() => {
+    const labelsByName = new Map(
+      labels.map((label) => [label.name.toLowerCase(), label.value]),
+    );
+    const categoriesByName = new Map(
+      categories.map((choice) => [choice.name.toLowerCase(), choice.value]),
+    );
+
+    return SPLIT_LIBRARY.filter((entry) => entry.category === category).flatMap(
+      (entry) => {
+        const filters = resolveLibraryEntry(entry, {
+          labelsByName,
+          categoriesByName,
+        });
+        return filters ? [{ entry, filters }] : [];
+      },
+    );
+  }, [categories, category, labels]);
+
+  const isOn = useCallback(
+    (entryName: string) =>
+      existingSplits.some((split) => split.name === entryName),
+    [existingSplits],
+  );
+
+  const close = () => onOpenChange(false);
+
+  const save = async () => {
+    if (!conditions.length || isBusy) return;
+    setIsBusy(true);
+    try {
+      const payload = {
+        name: name.trim() || describedName,
+        matchAll,
+        filters: conditions,
+      };
+      const saved = editing
+        ? await onUpdate({ id: editing.id, ...payload })
+        : await onCreate(payload);
+      if (saved) close();
     } finally {
-      setIsSuggesting(false);
+      setIsBusy(false);
     }
   };
 
-  const updateDefaultSplits = async (enabled: boolean) => {
+  const toggleLibraryEntry = async (
+    entry: SplitLibraryEntry,
+    filters: MailSplitFilterDraft[],
+  ) => {
     if (isBusy) return;
-    setIsSaving(true);
+    setIsBusy(true);
     try {
-      if (await onSetDefaultSplits(enabled)) changeOpen(false);
+      const existing = existingSplits.find((s) => s.name === entry.name);
+      if (existing) await onDelete(existing.id);
+      else
+        await onCreate({
+          name: entry.name,
+          matchAll: entry.matchAll ?? true,
+          filters,
+        });
     } finally {
-      setIsSaving(false);
+      setIsBusy(false);
     }
   };
+
+  const describe = async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || isBusy) return;
+    setIsBusy(true);
+    try {
+      const result = await onDescribe(trimmed);
+      if (!result) return;
+      // The conditions land in the builder rather than creating a split, so a
+      // wrong guess costs a click instead of a tab the reader has to undo.
+      setConditions(result.filters);
+      setMatchAll(result.matchAll);
+      if (result.name) setName(result.name);
+      setMode("build");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const title =
+    mode === "build"
+      ? editing
+        ? "Edit split"
+        : "Build a split"
+      : mode === "describe"
+        ? "Describe this split"
+        : "New split inbox";
 
   return (
-    <Dialog open={open} onOpenChange={changeOpen}>
-      <DialogTrigger
-        aria-label="New split"
-        className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          "top-[9vh] flex max-h-[80vh] w-[620px] max-w-[94vw] translate-y-0 flex-col gap-0 overflow-hidden p-0",
+          // The dialog primitive sets `md:w-full` and `sm:rounded-lg`; those
+          // responsive variants outrank an unprefixed override in tailwind-merge.
+          "rounded-2xl sm:rounded-2xl md:w-[620px]",
+        )}
+        hideCloseButton
       >
-        <PlusIcon className="size-3.5" />
-      </DialogTrigger>
-      <DialogContent className="gap-0 p-0 text-foreground">
-        <DialogHeader className="p-4 pr-10">
-          <DialogTitle>New split</DialogTitle>
-          <DialogDescription>
-            Choose labels or a category for a new inbox tab.
+        <div className="flex shrink-0 items-center gap-2.5 border-border border-b px-4 py-3">
+          {(mode !== "library" || detail) && (
+            <button
+              type="button"
+              aria-label="Back"
+              onClick={() => {
+                if (detail) setDetail(null);
+                else {
+                  setMode("library");
+                  if (!editing) setConditions([]);
+                }
+              }}
+              className="flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <ChevronLeftIcon className="size-3.5" />
+            </button>
+          )}
+          <DialogTitle className="min-w-0 flex-1 truncate font-medium text-[15px] tracking-tight">
+            {detail ? detail.name : title}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Add a filtered tab to your inbox.
           </DialogDescription>
-        </DialogHeader>
-        {isDescribing ? (
-          <div className="space-y-3 p-3">
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  setIsDescribing(false);
-                  setNote(null);
-                }}
-                aria-label="Back to the split list"
-                className="rounded p-0.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <ArrowLeftIcon className="size-3.5" />
-              </button>
-              <span className="font-medium text-xs">Describe a split</span>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={close}
+            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <XIcon className="size-3.5" />
+          </button>
+        </div>
+
+        {detail ? (
+          <LibraryDetail entry={detail} />
+        ) : mode === "library" ? (
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <div className="flex w-[142px] shrink-0 flex-col gap-0.5 overflow-y-auto border-border border-r bg-sidebar p-2 scrollbar-thin">
+              <div className="px-2 pt-0.5 pb-1.5 font-medium text-[11px] text-muted-foreground">
+                Category
+              </div>
+              {[YOUR_SPLITS, ...SPLIT_LIBRARY_CATEGORIES].map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setCategory(option)}
+                  aria-current={option === category ? "true" : undefined}
+                  className={cn(
+                    "rounded-lg px-2 py-1.5 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    option === category
+                      ? "bg-card font-medium text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.04),0_0_0_1px_rgba(17,24,39,0.05)]"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                  )}
+                >
+                  {option}
+                </button>
+              ))}
             </div>
-            <p className="text-muted-foreground text-xs">
-              We pick the labels that match. You can change them before the tab
-              is added.
-            </p>
-            <Input
+
+            <div className="min-w-0 flex-1 overflow-y-auto p-3.5 scrollbar-thin">
+              <div className="mb-3.5 grid grid-cols-2 gap-2.5">
+                <RouteCard
+                  icon={<PlusIcon className="size-3.5" />}
+                  label="Build your own"
+                  onClick={() => {
+                    setConditions(
+                      conditions.length ? conditions : [newCondition()],
+                    );
+                    setMode("build");
+                  }}
+                />
+                <RouteCard
+                  icon={<SparklesIcon className="size-3.5" />}
+                  label="Describe it"
+                  onClick={() => setMode("describe")}
+                />
+              </div>
+
+              <div className="mb-2 font-medium text-[11px] text-muted-foreground">
+                {category}
+              </div>
+
+              {category === YOUR_SPLITS ? (
+                existingSplits.length ? (
+                  <div className="grid grid-cols-2 gap-2">
+                    {existingSplits.map((split) => (
+                      <div
+                        key={split.id}
+                        className="flex min-w-0 items-center gap-2 rounded-xl border border-primary/25 bg-primary/5 px-3 py-2.5 text-primary"
+                      >
+                        <span className="min-w-0 flex-1 truncate font-medium text-[13px]">
+                          {split.name}
+                        </span>
+                        <button
+                          type="button"
+                          aria-label={`Turn off the ${split.name} split`}
+                          onClick={() => onDelete(split.id)}
+                          className="flex size-4.5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <XIcon className="size-2.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground text-xs leading-relaxed">
+                    Splits you build yourself land here.
+                  </p>
+                )
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {libraryEntries.map(({ entry, filters }) => (
+                    <LibraryTile
+                      key={entry.name}
+                      entry={entry}
+                      on={isOn(entry.name)}
+                      disabled={isBusy}
+                      onInfo={() => setDetail(entry)}
+                      onToggle={() => toggleLibraryEntry(entry, filters)}
+                    />
+                  ))}
+                  {!libraryEntries.length && (
+                    <p className="col-span-2 text-muted-foreground text-xs leading-relaxed">
+                      Nothing here yet — these splits need labels this account
+                      doesn&apos;t have.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : mode === "build" ? (
+          <div className="min-h-0 flex-1 overflow-y-auto p-3.5 scrollbar-thin">
+            <div className="mb-3 flex items-center gap-2 text-muted-foreground text-xs">
+              <span>Show mail matching</span>
+              <select
+                aria-label="Match all or any condition"
+                value={matchAll ? "all" : "any"}
+                onChange={(event) => setMatchAll(event.target.value === "all")}
+                className="h-7 rounded-lg border border-border bg-background py-0 pr-8 pl-1.5 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="all">all</option>
+                <option value="any">any</option>
+              </select>
+              <span>of these conditions</span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              {conditions.map((condition, index) => (
+                <ConditionRow
+                  // Rows are positional: two "Has label" rows are distinct only
+                  // by where they sit, so the index is the identity.
+                  key={index}
+                  condition={condition}
+                  fields={fields}
+                  valueOptions={valueOptionsFor(condition.kind)}
+                  onChangeField={(kind) =>
+                    setConditions((current) =>
+                      current.map((item, i) =>
+                        i === index ? defaultCondition(kind) : item,
+                      ),
+                    )
+                  }
+                  onChangeValue={(value) =>
+                    setConditions((current) =>
+                      current.map((item, i) =>
+                        i === index ? { ...item, value } : item,
+                      ),
+                    )
+                  }
+                  onRemove={() =>
+                    setConditions((current) =>
+                      current.filter((_, i) => i !== index),
+                    )
+                  }
+                />
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={() =>
+                setConditions((current) => [...current, newCondition()])
+              }
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-primary text-xs hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <PlusIcon className="size-3.5" />
+              Add condition
+            </button>
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col p-3.5">
+            <Textarea
               autoFocus
+              rows={3}
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter") return;
-                event.preventDefault();
-                suggest();
-              }}
-              placeholder="Anything from customers"
-              aria-label="Describe a split"
+              placeholder="Describe what should land in this split…"
               maxLength={300}
-              disabled={isBusy}
-              className="h-8 text-xs"
+              className="resize-none rounded-xl text-[13.5px]"
             />
-            <div className="flex flex-wrap gap-1">
-              {DESCRIBE_EXAMPLES.map((example) => (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {EXAMPLES.map((example) => (
                 <button
                   key={example}
                   type="button"
                   onClick={() => setPrompt(example)}
-                  disabled={isBusy}
-                  className="rounded-full bg-accent px-2 py-0.5 text-muted-foreground text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="rounded-full border border-border bg-muted px-2.5 py-1 text-[11.5px] text-muted-foreground hover:border-primary/25 hover:bg-primary/5 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   {example}
                 </button>
               ))}
             </div>
-            {note && <p className="text-muted-foreground text-xs">{note}</p>}
-            <Button
-              size="sm"
-              className="w-full"
-              onClick={suggest}
-              disabled={!prompt.trim() || isBusy}
-              loading={isSuggesting}
-            >
-              Find matching labels
-            </Button>
           </div>
-        ) : (
-          <div>
-            <Command filter={filterByName} className="h-auto">
-              <CommandInput
-                placeholder="Search labels and categories"
-                aria-label="Search labels and categories"
-                disabled={isBusy}
-                className="h-9 text-xs"
-              />
-              <CommandList className="max-h-56">
-                <CommandEmpty className="py-4 text-center text-muted-foreground text-xs">
-                  No labels or categories match.
-                </CommandEmpty>
-                {GROUPS.map(({ group, title }) => {
-                  const groupOptions = options.filter(
-                    (option) => option.group === group,
-                  );
-                  if (!groupOptions.length) return null;
+        )}
 
-                  return (
-                    <CommandGroup key={group} heading={title}>
-                      {groupOptions.map((option) => {
-                        const isSelected = selectedIds.includes(option.id);
-                        // Labels are picked a few at a time. Anything else adds
-                        // its tab on the spot, unless the AI already put it in
-                        // the selection, where clicking takes it back out.
-                        const isToggle =
-                          option.kind === MailSplitKind.LABEL || isSelected;
-                        return (
-                          <CommandItem
-                            key={option.id}
-                            value={option.id}
-                            // cmdk owns aria-selected for its own highlight, so
-                            // the tick's meaning has to reach screen readers
-                            // through the accessible name instead.
-                            aria-label={
-                              isToggle
-                                ? `${option.name}, ${isSelected ? "selected" : "not selected"}`
-                                : undefined
-                            }
-                            keywords={
-                              title ? [option.name, title] : [option.name]
-                            }
-                            onSelect={() =>
-                              isToggle
-                                ? toggleOption(option)
-                                : createSplit({
-                                    name: option.name,
-                                    kind: option.kind,
-                                    values: option.values,
-                                  })
-                            }
-                            disabled={isBusy}
-                            className="gap-2 text-xs"
-                          >
-                            {isToggle && (
-                              <div
-                                className={cn(
-                                  "flex size-3.5 items-center justify-center rounded-sm border border-primary",
-                                  isSelected
-                                    ? "bg-primary text-primary-foreground"
-                                    : "opacity-50 [&_svg]:invisible",
-                                )}
-                              >
-                                <CheckIcon className="size-3" />
-                              </div>
-                            )}
-                            <span className="truncate">{option.name}</span>
-                          </CommandItem>
-                        );
-                      })}
-                    </CommandGroup>
-                  );
-                })}
-              </CommandList>
-            </Command>
-
-            <div className="border-border border-t p-1">
-              <button
-                type="button"
-                onClick={() => {
-                  setIsDescribing(true);
-                  setNote(null);
-                }}
-                disabled={isBusy}
-                className={`${FOOTER_BUTTON_CLASS} text-primary`}
-              >
-                <SparklesIcon className="size-3.5" />
-                Describe a split instead
-              </button>
-              {canAddDefaultSplits && (
-                <button
-                  type="button"
-                  onClick={() => updateDefaultSplits(true)}
+        {(detail || mode === "build" || mode === "describe") && (
+          <div className="flex shrink-0 items-center gap-2.5 border-border border-t bg-sidebar px-4 py-2.5">
+            {detail ? (
+              <>
+                <div className="flex-1" />
+                <Button
+                  variant="gradient"
+                  size="sm"
                   disabled={isBusy}
-                  className={`${FOOTER_BUTTON_CLASS} text-muted-foreground hover:text-foreground`}
+                  onClick={() => {
+                    const filters = libraryFiltersFor(
+                      detail,
+                      labels,
+                      categories,
+                    );
+                    if (filters) toggleLibraryEntry(detail, filters);
+                    setDetail(null);
+                  }}
                 >
-                  Add a tab for each rule label
-                </button>
-              )}
-              {canRemoveDefaultSplits && (
-                <button
-                  type="button"
-                  onClick={() => updateDefaultSplits(false)}
-                  disabled={isBusy}
-                  className={`${FOOTER_BUTTON_CLASS} text-muted-foreground hover:text-foreground`}
-                >
-                  Remove the rule label tabs
-                </button>
-              )}
-            </div>
-
-            {selected.length > 0 && (
-              <div className="space-y-2 border-border border-t p-3">
-                {note && (
-                  <p className="text-muted-foreground text-xs">{note}</p>
-                )}
+                  {isOn(detail.name) ? "Turn off split" : "Turn on split"}
+                </Button>
+              </>
+            ) : mode === "build" ? (
+              <>
+                <span className="shrink-0 text-muted-foreground text-xs">
+                  Split name
+                </span>
                 <Input
+                  aria-label="Split name"
                   value={name}
-                  onChange={(event) => setNameOverride(event.target.value)}
+                  onChange={(event) => setName(event.target.value)}
                   onKeyDown={(event) => {
                     if (event.key !== "Enter") return;
                     event.preventDefault();
-                    createFromSelection();
+                    save();
                   }}
-                  placeholder="Tab name"
-                  aria-label="Tab name"
+                  placeholder={describedName || "Name this split"}
                   maxLength={60}
-                  disabled={isBusy}
-                  className="h-8 text-xs"
+                  className="h-8 w-[190px] shrink-0 text-xs"
                 />
+                <div className="flex-1" />
                 <Button
+                  variant="gradient"
                   size="sm"
-                  className="w-full"
-                  onClick={createFromSelection}
-                  disabled={!name.trim() || isBusy}
-                  loading={isSaving}
+                  disabled={!conditions.length || isBusy}
+                  onClick={save}
                 >
-                  {selected.length === 1
-                    ? "Add tab"
-                    : `Add tab for ${selected.length} labels`}
+                  {editing ? "Save changes" : "Add split"}
                 </Button>
-              </div>
-            )}
+              </>
+            ) : mode === "describe" ? (
+              <>
+                <div className="flex-1" />
+                <Button
+                  variant="gradient"
+                  size="sm"
+                  disabled={!prompt.trim() || isBusy}
+                  onClick={describe}
+                >
+                  {isBusy ? (
+                    <>
+                      <Loader2Icon className="mr-1.5 size-3.5 animate-spin" />
+                      Building…
+                    </>
+                  ) : (
+                    "Build it"
+                  )}
+                </Button>
+              </>
+            ) : null}
           </div>
         )}
       </DialogContent>
@@ -417,11 +578,267 @@ export function NewSplitDialog({
   );
 }
 
-function filterByName(
-  _value: string,
-  search: string,
-  keywords?: string[],
-): number {
-  const haystack = (keywords ?? []).join(" ").toLowerCase();
-  return haystack.includes(search.toLowerCase().trim()) ? 1 : 0;
+function RouteCard({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-2.5 rounded-xl border border-border bg-card px-3 py-2.5 text-left shadow-sm hover:border-primary/25 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="flex size-4.5 shrink-0 items-center justify-center text-primary">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate font-medium text-[12.5px] text-primary">
+        {label}
+      </span>
+    </button>
+  );
+}
+
+function LibraryTile({
+  entry,
+  on,
+  disabled,
+  onInfo,
+  onToggle,
+}: {
+  entry: SplitLibraryEntry;
+  on: boolean;
+  disabled: boolean;
+  onInfo: () => void;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2.5",
+        on
+          ? "border-primary/25 bg-primary/5 text-primary"
+          : "border-border bg-card text-foreground",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={disabled}
+        className="min-w-0 flex-1 truncate text-left font-medium text-[13px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {entry.name}
+      </button>
+      <button
+        type="button"
+        aria-label={`What the ${entry.name} split does`}
+        onClick={onInfo}
+        className="hidden size-4.5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-focus-within:flex group-hover:flex"
+      >
+        <InfoGlyph />
+      </button>
+      <button
+        type="button"
+        aria-label={
+          on
+            ? `Turn off the ${entry.name} split`
+            : `Turn on the ${entry.name} split`
+        }
+        onClick={onToggle}
+        disabled={disabled}
+        className={cn(
+          "flex size-4.5 shrink-0 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          on
+            ? "bg-primary text-primary-foreground hover:bg-destructive"
+            : "text-muted-foreground hover:bg-primary/10 hover:text-primary",
+        )}
+      >
+        {on ? <CheckGlyph /> : <PlusIcon className="size-3" />}
+      </button>
+    </div>
+  );
+}
+
+function LibraryDetail({ entry }: { entry: SplitLibraryEntry }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin">
+      <div className="p-4">
+        <div className="mb-2 font-medium text-[11px] text-muted-foreground">
+          Definition
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {libraryDefinition(entry).map((row) => (
+            <div
+              key={`${row.key}:${row.value}`}
+              className="flex items-center gap-2.5 rounded-lg border border-border bg-muted px-3 py-2"
+            >
+              <span className="w-12 shrink-0 text-[11.5px] text-muted-foreground">
+                {row.key}
+              </span>
+              <span className="truncate font-mono text-[12px] text-foreground">
+                {row.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConditionRow({
+  condition,
+  fields,
+  valueOptions,
+  onChangeField,
+  onChangeValue,
+  onRemove,
+}: {
+  condition: MailSplitFilterDraft;
+  fields: readonly { kind: MailSplitFilterKind; name: string }[];
+  valueOptions: SplitChoice[];
+  onChangeField: (kind: MailSplitFilterKind) => void;
+  onChangeValue: (value: string) => void;
+  onRemove: () => void;
+}) {
+  const takesFreeText = condition.kind === MailSplitFilterKind.FROM;
+  const takesNoValue =
+    condition.kind === MailSplitFilterKind.UNREAD ||
+    condition.kind === MailSplitFilterKind.STARRED;
+
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        aria-label="Condition field"
+        value={condition.kind}
+        onChange={(event) =>
+          onChangeField(event.target.value as MailSplitFilterKind)
+        }
+        className="h-8 w-[132px] shrink-0 rounded-lg border border-border bg-background px-2 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {fields.map((field) => (
+          <option key={field.kind} value={field.kind}>
+            {field.name}
+          </option>
+        ))}
+      </select>
+
+      {takesNoValue ? (
+        <div className="min-w-0 flex-1" />
+      ) : takesFreeText ? (
+        <Input
+          value={condition.value ?? ""}
+          onChange={(event) => onChangeValue(event.target.value)}
+          placeholder="name@company.com"
+          aria-label="Sender"
+          className="h-8 min-w-0 flex-1 text-xs"
+        />
+      ) : (
+        <select
+          aria-label="Condition value"
+          value={condition.value ?? ""}
+          onChange={(event) => onChangeValue(event.target.value)}
+          className="h-8 min-w-0 flex-1 rounded-lg border border-border bg-background px-2 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {valueOptions.map((option) => (
+            <option key={option.id} value={option.value}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        aria-label="Remove condition"
+        onClick={onRemove}
+        className="flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function InfoGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      className="size-3.5"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 11v5" />
+      <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-2.5"
+    >
+      <path d="m5 12 5 5L20 7" />
+    </svg>
+  );
+}
+
+function libraryFiltersFor(
+  entry: SplitLibraryEntry,
+  labels: SplitChoice[],
+  categories: SplitChoice[],
+) {
+  return resolveLibraryEntry(entry, {
+    labelsByName: new Map(
+      labels.map((label) => [label.name.toLowerCase(), label.value]),
+    ),
+    categoriesByName: new Map(
+      categories.map((choice) => [choice.name.toLowerCase(), choice.value]),
+    ),
+  });
+}
+
+function conditionLabel(
+  condition: MailSplitFilterDraft,
+  labels: SplitChoice[],
+  categories: SplitChoice[],
+): string {
+  switch (condition.kind) {
+    case MailSplitFilterKind.UNREAD:
+      return "Unread";
+    case MailSplitFilterKind.STARRED:
+      return "Starred";
+    case MailSplitFilterKind.FROM:
+      return condition.value ?? "From";
+    case MailSplitFilterKind.OLDER_THAN:
+      return `Older than ${
+        OLDER_THAN_OPTIONS.find((o) => o.value === condition.value)?.name ??
+        condition.value
+      }`;
+    case MailSplitFilterKind.LABEL:
+      return (
+        labels.find((label) => label.value === condition.value)?.name ?? "Label"
+      );
+    case MailSplitFilterKind.CATEGORY:
+      return (
+        categories.find((category) => category.value === condition.value)
+          ?.name ?? "Category"
+      );
+  }
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -24,7 +24,7 @@ export type SplitTabsProps = {
   activeSplitId: string | null;
   onSelect: (splitId: string) => void;
   onDelete: (splitId: string) => void;
-  onEdit: (splitId: string) => void;
+  onEdit?: (splitId: string) => void;
   onNewSplit: () => void;
   /** Split creation stays account-scoped, so it is hidden in All accounts. */
   canCreateSplits: boolean;
@@ -97,9 +97,11 @@ export function SplitTabs({
                 </button>
               </ContextMenuTrigger>
               <ContextMenuContent className="w-44">
-                <ContextMenuItem onSelect={() => onEdit(split.id)}>
-                  Edit filters and name
-                </ContextMenuItem>
+                {onEdit && (
+                  <ContextMenuItem onSelect={() => onEdit(split.id)}>
+                    Edit filters and name
+                  </ContextMenuItem>
+                )}
                 <ContextMenuItem
                   className="text-destructive focus:text-destructive"
                   onSelect={() => onDelete(split.id)}

--- a/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/SplitTabs.tsx
@@ -1,32 +1,33 @@
 "use client";
 
-import { ManageSplitsDialog } from "@/app/(app)/[emailAccountId]/mail/ManageSplitsDialog";
+import { PlusIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import {
-  type NewSplitDraft,
-  type NewSplitOption,
-  NewSplitDialog,
-  type NewSplitSuggestion,
-} from "@/app/(app)/[emailAccountId]/mail/NewSplitDialog";
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { Kbd } from "@/components/Kbd";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { cn } from "@/utils";
 
 export type MailSplitTab = {
   id: string;
   name: string;
+  /** Built-in splits (e.g. All) can't be edited or removed. */
+  deletable: boolean;
 };
 
-type SplitTabsProps = {
+export type SplitTabsProps = {
   splits: MailSplitTab[];
   activeSplitId: string | null;
   onSelect: (splitId: string) => void;
-  onDelete: (splitId: string) => Promise<void>;
-  onReorder: (ids: string[]) => Promise<void>;
-  newSplitOptions: NewSplitOption[];
-  onCreateSplit: (draft: NewSplitDraft) => Promise<boolean>;
-  onSuggestSplit: (prompt: string) => Promise<NewSplitSuggestion | null>;
-  canAddDefaultSplits: boolean;
-  canRemoveDefaultSplits: boolean;
-  onSetDefaultSplits: (enabled: boolean) => Promise<boolean>;
+  onDelete: (splitId: string) => void;
+  onEdit: (splitId: string) => void;
+  onNewSplit: () => void;
+  /** Split creation stays account-scoped, so it is hidden in All accounts. */
+  canCreateSplits: boolean;
   className?: string;
 };
 
@@ -35,13 +36,9 @@ export function SplitTabs({
   activeSplitId,
   onSelect,
   onDelete,
-  onReorder,
-  newSplitOptions,
-  onCreateSplit,
-  onSuggestSplit,
-  canAddDefaultSplits,
-  canRemoveDefaultSplits,
-  onSetDefaultSplits,
+  onEdit,
+  onNewSplit,
+  canCreateSplits,
   className,
 }: SplitTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
@@ -86,33 +83,48 @@ export function SplitTabs({
                 : "text-muted-foreground hover:bg-accent hover:text-foreground",
             )}
           >
-            <button
-              type="button"
-              ref={active ? activeTabRef : undefined}
-              data-split-tab
-              onClick={() => onSelect(split.id)}
-              aria-current={active ? "true" : undefined}
-              className="py-0.5 pr-1.5 after:pointer-events-none after:absolute after:inset-0 after:rounded-full focus-visible:outline-none focus-visible:after:ring-2 focus-visible:after:ring-ring"
-            >
-              {split.name}
-            </button>
+            <ContextMenu>
+              <ContextMenuTrigger asChild disabled={!split.deletable}>
+                <button
+                  type="button"
+                  ref={active ? activeTabRef : undefined}
+                  data-split-tab
+                  onClick={() => onSelect(split.id)}
+                  aria-current={active ? "true" : undefined}
+                  className="py-0.5 pr-1.5 after:pointer-events-none after:absolute after:inset-0 after:rounded-full focus-visible:outline-none focus-visible:after:ring-2 focus-visible:after:ring-ring"
+                >
+                  {split.name}
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="w-44">
+                <ContextMenuItem onSelect={() => onEdit(split.id)}>
+                  Edit filters and name
+                </ContextMenuItem>
+                <ContextMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onSelect={() => onDelete(split.id)}
+                >
+                  Turn off split
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
           </div>
         );
       })}
 
-      <ManageSplitsDialog
-        splits={splits}
-        onDelete={onDelete}
-        onReorder={onReorder}
-      />
-      <NewSplitDialog
-        options={newSplitOptions}
-        onCreate={onCreateSplit}
-        onSuggest={onSuggestSplit}
-        canAddDefaultSplits={canAddDefaultSplits}
-        canRemoveDefaultSplits={canRemoveDefaultSplits}
-        onSetDefaultSplits={onSetDefaultSplits}
-      />
+      {canCreateSplits && (
+        <button
+          type="button"
+          aria-label="New split"
+          onClick={onNewSplit}
+          className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <PlusIcon className="size-3.5" />
+        </button>
+      )}
+
+      <div className="flex-1" />
+      <Kbd title="Next split">{getShortcutHint("nextSplit")}</Kbd>
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -22,8 +22,10 @@ import {
   readSyncedMailboxThreads,
   subscribeToMailboxStore,
 } from "@/utils/email-cache/mailbox";
-import type { ThreadsQuery } from "@/utils/threads/validation";
-import { createSearchParams } from "@/utils/url";
+import {
+  type ThreadsQuery,
+  threadsQueryToSearchParams,
+} from "@/utils/threads/validation";
 import { isThreadUnread } from "./read-state";
 import {
   applyMailMutationOverlayToThreads,
@@ -70,7 +72,7 @@ export function useMailThreads({
       if (!enabled) return null;
       if (previousPageData && !previousPageData.nextPageToken) return null;
 
-      const params = createSearchParams({
+      const params = threadsQueryToSearchParams({
         ...query,
         view: "list",
         ...(pageIndex > 0 && previousPageData?.nextPageToken

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,38 +1,36 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
-import { getDefaultMailSplitDraftsForAccount } from "@/utils/mail/default-splits.server";
 
 export type MailSettingsResponse = Awaited<ReturnType<typeof getMailSettings>>;
 
 async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
-  const [emailAccount, defaultSplits] = await Promise.all([
-    prisma.emailAccount.findUnique({
-      where: { id: emailAccountId },
-      select: {
-        mailLayout: true,
-        mailExpandedPreview: true,
-        mailSplits: {
-          // createdAt breaks ties so tab order can't shuffle between requests
-          orderBy: [{ order: "asc" }, { createdAt: "asc" }],
-          select: {
-            id: true,
-            name: true,
-            kind: true,
-            values: true,
-            order: true,
+  const emailAccount = await prisma.emailAccount.findUnique({
+    where: { id: emailAccountId },
+    select: {
+      mailLayout: true,
+      mailExpandedPreview: true,
+      mailSplits: {
+        // createdAt breaks ties so tab order can't shuffle between requests
+        orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+        select: {
+          id: true,
+          name: true,
+          order: true,
+          matchAll: true,
+          filters: {
+            orderBy: { order: "asc" },
+            select: { kind: true, value: true },
           },
         },
       },
-    }),
-    getDefaultMailSplitDraftsForAccount(emailAccountId),
-  ]);
+    },
+  });
 
   return {
     layout: emailAccount?.mailLayout ?? null,
     expandedPreview: emailAccount?.mailExpandedPreview ?? false,
     splits: emailAccount?.mailSplits ?? [],
-    defaultSplits,
   };
 }
 

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -31,6 +31,7 @@ export const GET = withEmailProvider(
     const after = searchParams.get("after");
     const before = searchParams.get("before");
     const isUnread = searchParams.get("isUnread");
+    const anyOf = searchParams.get("anyOf");
     const view = threadsView.parse(searchParams.get("view"));
 
     const query = threadsQuery.parse({
@@ -47,6 +48,7 @@ export const GET = withEmailProvider(
       after,
       before,
       isUnread,
+      anyOf,
     });
 
     try {

--- a/apps/web/prisma/migrations/20260910000000_split_inbox_filters/migration.sql
+++ b/apps/web/prisma/migrations/20260910000000_split_inbox_filters/migration.sql
@@ -1,0 +1,42 @@
+-- Splits become a named set of filter conditions instead of a single kind+value,
+-- so a split can combine a label with a sender, a category with an age, and so on.
+
+CREATE TYPE "MailSplitFilterKind" AS ENUM ('UNREAD', 'STARRED', 'LABEL', 'CATEGORY', 'FROM', 'OLDER_THAN');
+
+ALTER TABLE "MailSplit" ADD COLUMN "matchAll" BOOLEAN NOT NULL DEFAULT true;
+
+CREATE TABLE "MailSplitFilter" (
+    "id" TEXT NOT NULL,
+    "kind" "MailSplitFilterKind" NOT NULL,
+    "value" TEXT,
+    "order" INTEGER NOT NULL,
+    "mailSplitId" TEXT NOT NULL,
+
+    CONSTRAINT "MailSplitFilter_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MailSplitFilter_mailSplitId_order_key" ON "MailSplitFilter"("mailSplitId", "order");
+CREATE INDEX "MailSplitFilter_mailSplitId_idx" ON "MailSplitFilter"("mailSplitId");
+CREATE INDEX "MailSplitFilter_kind_value_idx" ON "MailSplitFilter"("kind", "value");
+
+ALTER TABLE "MailSplitFilter" ADD CONSTRAINT "MailSplitFilter_mailSplitId_fkey"
+    FOREIGN KEY ("mailSplitId") REFERENCES "MailSplit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Preserve existing label unions as "match any", and built-in inbox rows as
+-- filterless splits. Order and ids remain unchanged.
+UPDATE "MailSplit" SET "matchAll" = false WHERE "kind" = 'LABEL' AND cardinality("values") > 1;
+
+INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
+SELECT 'split-filter-' || s."id" || '-' || value.ordinality,
+       s."kind"::text::"MailSplitFilterKind", value.value, value.ordinality - 1, s."id"
+FROM "MailSplit" s
+CROSS JOIN LATERAL unnest(s."values") WITH ORDINALITY AS value(value, ordinality)
+WHERE s."kind" IN ('LABEL', 'CATEGORY');
+
+INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
+SELECT 'split-filter-' || "id", 'UNREAD'::"MailSplitFilterKind", NULL, 0, "id"
+FROM "MailSplit" WHERE "kind" = 'UNREAD';
+
+ALTER TABLE "MailSplit" DROP COLUMN "kind";
+ALTER TABLE "MailSplit" DROP COLUMN "values";
+DROP TYPE "MailSplitKind";

--- a/apps/web/prisma/migrations/20260910000000_split_inbox_filters/migration.sql
+++ b/apps/web/prisma/migrations/20260910000000_split_inbox_filters/migration.sql
@@ -22,6 +22,9 @@ CREATE INDEX "MailSplitFilter_kind_value_idx" ON "MailSplitFilter"("kind", "valu
 ALTER TABLE "MailSplitFilter" ADD CONSTRAINT "MailSplitFilter_mailSplitId_fkey"
     FOREIGN KEY ("mailSplitId") REFERENCES "MailSplit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
+-- Invalid legacy label/category rows had no usable definition; do not widen them into inbox views.
+DELETE FROM "MailSplit" WHERE "kind" IN ('LABEL', 'CATEGORY') AND cardinality("values") = 0;
+
 -- Preserve existing label unions as "match any", and built-in inbox rows as
 -- filterless splits. Order and ids remain unchanged.
 UPDATE "MailSplit" SET "matchAll" = false WHERE "kind" = 'LABEL' AND cardinality("values") > 1;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -246,20 +246,37 @@ model EmailAccount {
 // ids for LABEL splits and a single provider category for CATEGORY splits; it is empty
 // for INBOX/UNREAD.
 model MailSplit {
-  id        String        @id @default(cuid())
-  createdAt DateTime      @default(now())
-  updatedAt DateTime      @updatedAt
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   name      String
-  kind      MailSplitKind
-  /// Label ids for LABEL splits (one or more), the category for CATEGORY splits, empty otherwise.
-  values    String[]      @default([])
   order     Int
+  /// Whether every filter must match, or any one of them ("Show mail matching
+  /// all/any of these conditions"). A split with no filters is the plain inbox.
+  matchAll  Boolean  @default(true)
 
   emailAccountId String
-  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  emailAccount   EmailAccount      @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  filters        MailSplitFilter[]
 
   @@unique([emailAccountId, name])
   @@index([emailAccountId, order])
+}
+
+/// One condition row in the split builder. A split may hold several of the same
+/// kind (two senders, two labels), so kind is deliberately not unique per split.
+model MailSplitFilter {
+  id    String              @id @default(cuid())
+  kind  MailSplitFilterKind
+  value String?
+  order Int
+
+  mailSplitId String
+  mailSplit   MailSplit @relation(fields: [mailSplitId], references: [id], onDelete: Cascade)
+
+  @@unique([mailSplitId, order])
+  @@index([mailSplitId])
+  @@index([kind, value])
 }
 
 model Organization {
@@ -2015,11 +2032,13 @@ enum MailLayout {
   SPLIT
 }
 
-enum MailSplitKind {
-  INBOX
+enum MailSplitFilterKind {
   UNREAD
+  STARRED
   LABEL
   CATEGORY
+  FROM
+  OLDER_THAN
 }
 
 enum DraftReplyConfidence {

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -42,6 +42,7 @@
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-muted-foreground: var(--muted-foreground);
     --sidebar-primary: 240 5.9% 10%;
     --sidebar-primary-foreground: 0 0% 98%;
     --sidebar-accent: 240 4.8% 95.9%;
@@ -84,6 +85,7 @@
     --chart-5: oklch(0.3 0.18 250);
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-muted-foreground: var(--muted-foreground);
     --sidebar-primary: 224.3 76.3% 48%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 240 3.7% 15.9%;
@@ -135,11 +137,13 @@
     --radius: 0.5rem;
 
     --sidebar-background: 0 0% 98.4%; /* #FBFBFB */
-    --sidebar-foreground: 0 0% 23.9%;
+    --sidebar-foreground: 0 0% 32.2%; /* #525252 */
+    /* Counts and other second-rank text sit a step back from the row label */
+    --sidebar-muted-foreground: 0 0% 65.1%; /* #A6A6A6 */
     --sidebar-primary: 221.2 83.2% 53.3%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 96.5%;
-    --sidebar-accent-foreground: 0 0% 14.1%;
+    --sidebar-accent: 0 0% 94.5%; /* #F1F1F1 */
+    --sidebar-accent-foreground: 0 0% 14.1%; /* #242424 */
     --sidebar-border: 0 0% 93.7%;
     --sidebar-ring: 221.2 83.2% 53.3%;
   }

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -139,7 +139,7 @@
     --sidebar-background: 0 0% 98.4%; /* #FBFBFB */
     --sidebar-foreground: 0 0% 32.2%; /* #525252 */
     /* Counts and other second-rank text sit a step back from the row label */
-    --sidebar-muted-foreground: 0 0% 65.1%; /* #A6A6A6 */
+    --sidebar-muted-foreground: 0 0% 43.1%; /* #6E6E6E */
     --sidebar-primary: 221.2 83.2% 53.3%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 0 0% 94.5%; /* #F1F1F1 */

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -88,6 +88,7 @@ module.exports = {
         sidebar: {
           DEFAULT: "hsl(var(--sidebar-background))",
           foreground: "hsl(var(--sidebar-foreground))",
+          "muted-foreground": "hsl(var(--sidebar-muted-foreground))",
           primary: "hsl(var(--sidebar-primary))",
           "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
           accent: "hsl(var(--sidebar-accent))",

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -1,21 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Prisma } from "@/generated/prisma/client";
-import {
-  ActionType,
-  MailLayout,
-  MailSplitKind,
-  SystemType,
-} from "@/generated/prisma/enums";
+import { MailLayout, MailSplitFilterKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import {
+  buildMailSplitFromPromptAction,
   createMailSplitAction,
-  renameMailSplitAction,
-  reorderMailSplitsAction,
-  setDefaultMailSplitsAction,
-  suggestMailSplitAction,
   updateMailPreferencesAction,
+  updateMailSplitAction,
 } from "@/utils/actions/mail-split";
-import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
+import { aiPromptToSplitFilters } from "@/utils/ai/split/prompt-to-split";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
@@ -24,31 +17,21 @@ vi.mock("@/utils/auth", () => ({
   })),
 }));
 vi.mock("@/utils/ai/split/prompt-to-split", () => ({
-  aiPromptToSplit: vi.fn(),
+  aiPromptToSplitFilters: vi.fn(),
 }));
 
 const EMAIL_ACCOUNT_ID = "email-account-1";
 
 const PROMPT_OPTIONS = [
   {
-    id: "state:unread",
-    name: "Unread",
-    kind: MailSplitKind.UNREAD,
-    values: [],
-  },
-  {
     id: "label:label-1",
     name: "Receipts",
-    kind: MailSplitKind.LABEL,
-    values: ["label-1"],
-  },
-  {
-    id: "label:label-2",
-    name: "Invoices",
-    kind: MailSplitKind.LABEL,
-    values: ["label-2"],
+    kind: "LABEL" as const,
+    value: "label-1",
   },
 ];
+
+const UNREAD_FILTER = { kind: MailSplitFilterKind.UNREAD, value: null };
 
 describe("mail split actions", () => {
   beforeEach(() => {
@@ -59,37 +42,26 @@ describe("mail split actions", () => {
     } as never);
   });
 
-  it.each([
-    { ids: [] },
-    { ids: ["split-1", "split-1"] },
-  ])("rejects invalid reorder IDs: %j", async ({ ids }) => {
-    const result = await reorderMailSplitsAction(EMAIL_ACCOUNT_ID, {
-      ids,
-    });
-    expect(result?.validationErrors).toBeDefined();
-    expect(prisma.$transaction).not.toHaveBeenCalled();
-  });
-
   it("creates splits behind an account-scoped database lock", async () => {
     const split = {
       id: "split-1",
       createdAt: new Date(),
       updatedAt: new Date(),
-      name: "Receipts",
-      kind: MailSplitKind.LABEL,
-      values: ["label-1"],
+      name: "Unread",
+      matchAll: true,
       order: 0,
       emailAccountId: EMAIL_ACCOUNT_ID,
     };
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
       [{ status: "created", ...split }],
+      1,
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Receipts",
-      kind: MailSplitKind.LABEL,
-      values: ["label-1"],
+      name: "Unread",
+      matchAll: true,
+      filters: [UNREAD_FILTER],
     });
 
     expect(result?.data).toEqual({ split });
@@ -105,12 +77,13 @@ describe("mail split actions", () => {
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
       [{ status: "limit" }],
+      0,
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
       name: "Later",
-      kind: MailSplitKind.LABEL,
-      values: ["label-1"],
+      matchAll: true,
+      filters: [UNREAD_FILTER],
     });
 
     expect(result?.serverError).toBe("You can only have 14 splits.");
@@ -120,127 +93,126 @@ describe("mail split actions", () => {
     prisma.$transaction.mockResolvedValue([
       [{ locked: true }],
       [{ status: "duplicate" }],
+      0,
     ] as never);
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Receipts",
-      kind: MailSplitKind.LABEL,
-      values: ["label-1"],
+      name: "Unread",
+      matchAll: true,
+      filters: [UNREAD_FILTER],
     });
 
-    expect(result?.serverError).toBe('You already have a "Receipts" split.');
+    expect(result?.serverError).toBe('You already have a "Unread" split.');
   });
 
   it("handles a duplicate-name constraint race with a safe error", async () => {
     prisma.$transaction.mockRejectedValue(createDuplicateNameError());
 
     const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
-      name: "Receipts",
-      kind: MailSplitKind.LABEL,
-      values: ["label-1"],
-    });
-
-    expect(result?.serverError).toBe('You already have a "Receipts" split.');
-  });
-
-  it("returns the matched options for the picker instead of creating a split", async () => {
-    vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Receipts and Invoices both cover billing mail",
-      optionIds: ["label:label-1", "label:label-2"],
-      name: "Billing",
-    });
-
-    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
-      prompt: "receipts and invoices",
-      options: PROMPT_OPTIONS,
-    });
-
-    expect(result?.data).toEqual({
-      optionIds: ["label:label-1", "label:label-2"],
-      name: "Billing",
-      reasoning: "Receipts and Invoices both cover billing mail",
-    });
-    expect(prisma.$transaction).not.toHaveBeenCalled();
-    // Label ids are stripped before the prompt; the AI only sees id/name/kind.
-    expect(aiPromptToSplit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        prompt: "receipts and invoices",
-        options: [
-          { id: "state:unread", name: "Unread", kind: MailSplitKind.UNREAD },
-          { id: "label:label-1", name: "Receipts", kind: MailSplitKind.LABEL },
-          { id: "label:label-2", name: "Invoices", kind: MailSplitKind.LABEL },
-        ],
-      }),
-    );
-  });
-
-  it("keeps only the first option when the AI mixes a state with labels", async () => {
-    vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Unread receipts",
-      optionIds: ["state:unread", "label:label-1"],
-      name: "Unread receipts",
-    });
-
-    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
-      prompt: "unread receipts",
-      options: PROMPT_OPTIONS,
-    });
-
-    expect(result?.data?.optionIds).toEqual(["state:unread"]);
-  });
-
-  it("drops options the AI invented rather than passing them to the picker", async () => {
-    vi.mocked(aiPromptToSplit).mockResolvedValue({
-      reasoning: "Nothing here covers mail from a specific person",
-      optionIds: ["label:made-up"],
-      name: "Boss",
-    });
-
-    const result = await suggestMailSplitAction(EMAIL_ACCOUNT_ID, {
-      prompt: "emails from my boss",
-      options: PROMPT_OPTIONS,
-    });
-
-    expect(result?.data).toEqual({
-      optionIds: [],
-      name: "Boss",
-      reasoning: "Nothing here covers mail from a specific person",
-    });
-    expect(prisma.$transaction).not.toHaveBeenCalled();
-  });
-
-  it("returns a user-safe error when a rename duplicates a split", async () => {
-    prisma.$transaction.mockRejectedValue(createDuplicateNameError());
-
-    const result = await renameMailSplitAction(EMAIL_ACCOUNT_ID, {
-      id: "split-1",
       name: "Unread",
+      matchAll: true,
+      filters: [UNREAD_FILTER],
     });
 
     expect(result?.serverError).toBe('You already have a "Unread" split.');
   });
 
-  it("returns a user-safe error instead of partially adding defaults", async () => {
-    prisma.rule.findMany.mockResolvedValue([
-      {
-        systemType: SystemType.RECEIPT,
-        actions: [{ type: ActionType.LABEL, labelId: "receipt-label" }],
-      },
-      {
-        systemType: SystemType.NEWSLETTER,
-        actions: [{ type: ActionType.LABEL, labelId: "newsletter-label" }],
-      },
-    ] as never);
-    prisma.$transaction.mockResolvedValue([
-      [{ locked: true }],
-      [{ availableCount: 1, missingCount: 2 }],
-    ] as never);
-
-    const result = await setDefaultMailSplitsAction(EMAIL_ACCOUNT_ID, {
-      enabled: true,
+  it("rejects a condition that needs a value but has none", async () => {
+    const result = await createMailSplitAction(EMAIL_ACCOUNT_ID, {
+      name: "Broken",
+      matchAll: true,
+      filters: [{ kind: MailSplitFilterKind.LABEL, value: null }],
     });
 
-    expect(result?.serverError).toBe("You can only have 14 splits.");
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("hands the AI's conditions back for review instead of creating a split", async () => {
+    vi.mocked(aiPromptToSplitFilters).mockResolvedValue({
+      name: "Unread receipts",
+      matchAll: false,
+      filters: [
+        UNREAD_FILTER,
+        { kind: MailSplitFilterKind.LABEL, value: "label-1" },
+      ],
+    });
+
+    const result = await buildMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
+      prompt: "receipts I have not read",
+      options: PROMPT_OPTIONS,
+      senders: [],
+    });
+
+    expect(result?.data).toEqual({
+      matchAll: false,
+      name: "Unread receipts",
+      filters: [
+        UNREAD_FILTER,
+        { kind: MailSplitFilterKind.LABEL, value: "label-1" },
+      ],
+    });
+    // Nothing is written until the reader confirms in the builder.
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns a user-safe error when the AI finds no usable conditions", async () => {
+    vi.mocked(aiPromptToSplitFilters).mockResolvedValue({
+      name: null,
+      matchAll: true,
+      filters: [],
+    });
+
+    const result = await buildMailSplitFromPromptAction(EMAIL_ACCOUNT_ID, {
+      prompt: "flight itineraries",
+      options: PROMPT_OPTIONS,
+      senders: [],
+    });
+
+    expect(result?.serverError).toBe(
+      "I couldn't find filters in that — name a sender, label or category.",
+    );
+  });
+
+  it("returns a user-safe error when an edit duplicates another split's name", async () => {
+    prisma.$transaction.mockRejectedValue(createDuplicateNameError());
+
+    const result = await updateMailSplitAction(EMAIL_ACCOUNT_ID, {
+      id: "split-1",
+      name: "Unread",
+      matchAll: true,
+      filters: [UNREAD_FILTER],
+    });
+
+    expect(result?.serverError).toBe('You already have a "Unread" split.');
+  });
+
+  it("replaces an edited split's conditions in the same locked transaction", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      { count: 1 },
+      { count: 1 },
+      1,
+    ] as never);
+
+    await updateMailSplitAction(EMAIL_ACCOUNT_ID, {
+      id: "split-1",
+      name: "Receipts",
+      matchAll: false,
+      filters: [{ kind: MailSplitFilterKind.LABEL, value: "label-1" }],
+    });
+
+    // Scoped through the split's owner: `id` is caller-supplied, so another
+    // account's conditions must stay out of reach.
+    expect(prisma.mailSplitFilter.deleteMany).toHaveBeenCalledWith({
+      where: {
+        mailSplitId: "split-1",
+        mailSplit: { emailAccountId: EMAIL_ACCOUNT_ID },
+      },
+    });
+    // One transaction, so a split can't end up renamed but still carrying its
+    // old conditions.
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
   });
 
   it("persists the selected mail layout", async () => {

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -1,32 +1,23 @@
 "use server";
 
 import type { MailSplit } from "@/generated/prisma/client";
-import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { actionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import {
+  buildMailSplitFromPromptBody,
   createMailSplitBody,
   deleteMailSplitBody,
-  renameMailSplitBody,
-  reorderMailSplitsBody,
-  setDefaultMailSplitsBody,
-  suggestMailSplitBody,
   updateMailPreferencesBody,
+  updateMailSplitBody,
 } from "@/utils/actions/mail-split.validation";
-import { aiPromptToSplit } from "@/utils/ai/split/prompt-to-split";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import { aiPromptToSplitFilters } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
+import { createMailSplit, toFilterRows } from "@/utils/mail/splits.server";
 import { lockMailSplits } from "@/utils/mail/split-lock";
-import { createMailSplit, reorderMailSplits } from "@/utils/mail/splits.server";
-import {
-  MAX_MAIL_SPLITS,
-  MAX_SPLIT_LABELS,
-} from "@/utils/mail/split-constants";
-import {
-  getDefaultMailSplitDraftsForAccount,
-  setDefaultMailSplits,
-} from "@/utils/mail/default-splits.server";
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 
 export const createMailSplitAction = actionClient
   .metadata({ name: "createMailSplit" })
@@ -34,119 +25,110 @@ export const createMailSplitAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId },
-      parsedInput: { name, kind, values },
+      parsedInput: { name, filters, matchAll },
     }) => {
       const split = await createMailSplitOrThrow({
         emailAccountId,
         name,
-        kind,
-        values,
+        matchAll,
+        filters,
       });
       return { split };
     },
   );
 
-/**
- * Resolves a description into a selection of the account's own filters. It
- * deliberately stops short of creating the split so the picker can show what
- * was matched and let the user adjust it first.
- */
-export const suggestMailSplitAction = actionClient
-  .metadata({ name: "suggestMailSplit" })
-  .inputSchema(suggestMailSplitBody)
+export const updateMailSplitAction = actionClient
+  .metadata({ name: "updateMailSplit" })
+  .inputSchema(updateMailSplitBody)
   .action(
-    async ({ ctx: { emailAccountId }, parsedInput: { prompt, options } }) => {
-      const emailAccount = await getEmailAccountWithAi({ emailAccountId });
-      if (!emailAccount) throw new SafeError("Email account not found");
-
-      const suggestion = await aiPromptToSplit({
-        emailAccount,
-        prompt,
-        options: options.map(({ id, name, kind }) => ({ id, name, kind })),
-      });
-
-      const optionsById = new Map(options.map((option) => [option.id, option]));
-      const matched = suggestion.optionIds.flatMap((optionId) => {
-        const option = optionsById.get(optionId);
-        return option ? [option] : [];
-      });
-      // Only labels stack into one query, so a mixed pick collapses to the
-      // first option rather than producing a split we cannot run.
-      const selected = matched.every(
-        (option) => option.kind === MailSplitKind.LABEL,
-      )
-        ? matched
-        : matched.slice(0, 1);
-
-      const optionIds = [...new Set(selected.map((option) => option.id))];
-      const capped = optionIds.slice(0, MAX_SPLIT_LABELS);
-
-      return {
-        optionIds: capped,
-        // A name describing more labels than the split ends up with would lie
-        // about the tab, so a truncated match falls back to the label names.
-        name:
-          capped.length === optionIds.length
-            ? suggestion.name?.trim().slice(0, 60) || null
-            : null,
-        reasoning: suggestion.reasoning,
-      };
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { id, name, filters, matchAll },
+    }) => {
+      try {
+        // One transaction so a split can never end up renamed but still
+        // carrying its old conditions. Filters are replaced wholesale rather
+        // than diffed: the builder hands back the conditions it is showing, so
+        // anything missing from that list was removed.
+        const [, { count }] = await prisma.$transaction([
+          lockMailSplits(emailAccountId),
+          prisma.mailSplit.updateMany({
+            where: { id, emailAccountId },
+            data: { name, matchAll },
+          }),
+          // Scoped through the split's owner, so another account's id can't
+          // reach these rows even though `id` is caller-supplied.
+          prisma.mailSplitFilter.deleteMany({
+            where: { mailSplitId: id, mailSplit: { emailAccountId } },
+          }),
+          prisma.$executeRaw`
+            INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
+            SELECT
+              conditions."id",
+              conditions."kind"::"MailSplitFilterKind",
+              conditions."value",
+              conditions."order",
+              ${id}
+            FROM jsonb_to_recordset(${toFilterRows(filters)}::jsonb)
+              AS conditions("id" text, "kind" text, "value" text, "order" integer)
+            WHERE EXISTS (
+              SELECT 1 FROM "MailSplit"
+              WHERE "id" = ${id} AND "emailAccountId" = ${emailAccountId}
+            )
+          `,
+        ]);
+        if (!count) throw new SafeError("Split not found");
+      } catch (error) {
+        if (isDuplicateError(error, "name")) {
+          throw new SafeError(`You already have a "${name}" split.`);
+        }
+        throw error;
+      }
     },
   );
 
-export const renameMailSplitAction = actionClient
-  .metadata({ name: "renameMailSplit" })
-  .inputSchema(renameMailSplitBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { id, name } }) => {
-    try {
-      const [, { count }] = await prisma.$transaction([
-        lockMailSplits(emailAccountId),
-        prisma.mailSplit.updateMany({
-          where: { id, emailAccountId },
-          data: { name },
-        }),
-      ]);
-      if (!count) throw new SafeError("Split not found");
-    } catch (error) {
-      if (isDuplicateError(error, "name")) {
-        throw new SafeError(`You already have a "${name}" split.`);
+/**
+ * Turns a description into conditions the reader then reviews in the builder —
+ * it never creates the split outright, so a wrong guess costs a click, not a tab.
+ */
+export const buildMailSplitFromPromptAction = actionClient
+  .metadata({ name: "buildMailSplitFromPrompt" })
+  .inputSchema(buildMailSplitFromPromptBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { prompt, options, senders },
+    }) => {
+      const emailAccount = await getEmailAccountWithAi({ emailAccountId });
+      if (!emailAccount) throw new SafeError("Email account not found");
+
+      const result = await aiPromptToSplitFilters({
+        emailAccount,
+        prompt,
+        options,
+        senders,
+      });
+
+      if (!result.filters.length) {
+        throw new SafeError(
+          "I couldn't find filters in that — name a sender, label or category.",
+        );
       }
-      throw error;
-    }
-  });
+
+      return {
+        filters: result.filters,
+        name: result.name?.trim() || null,
+        matchAll: result.matchAll,
+      };
+    },
+  );
 
 export const deleteMailSplitAction = actionClient
   .metadata({ name: "deleteMailSplit" })
   .inputSchema(deleteMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
     // deleteMany rather than delete so another account's id can never be removed
-    await prisma.$transaction([
-      lockMailSplits(emailAccountId),
-      prisma.mailSplit.deleteMany({ where: { id, emailAccountId } }),
-    ]);
-  });
-
-export const reorderMailSplitsAction = actionClient
-  .metadata({ name: "reorderMailSplits" })
-  .inputSchema(reorderMailSplitsBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { ids } }) => {
-    await reorderMailSplits({ emailAccountId, ids });
-  });
-
-export const setDefaultMailSplitsAction = actionClient
-  .metadata({ name: "setDefaultMailSplits" })
-  .inputSchema(setDefaultMailSplitsBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { enabled } }) => {
-    const defaultSplits =
-      await getDefaultMailSplitDraftsForAccount(emailAccountId);
-    const result = await setDefaultMailSplits({
-      emailAccountId,
-      defaultSplits,
-      enabled,
-    });
-    if (result?.status === "limit") {
-      throw new SafeError(`You can only have ${MAX_MAIL_SPLITS} splits.`);
-    }
+    await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
   });
 
 export const updateMailPreferencesAction = actionClient
@@ -169,18 +151,31 @@ export const updateMailPreferencesAction = actionClient
     },
   );
 
-async function createMailSplitOrThrow(
-  data: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "values">,
-) {
+async function createMailSplitOrThrow({
+  emailAccountId,
+  name,
+  matchAll,
+  filters,
+}: {
+  emailAccountId: string;
+  name: string;
+  matchAll: boolean;
+  filters: MailSplitFilterDraft[];
+}): Promise<MailSplit> {
   try {
-    const result = await createMailSplit(data);
+    const result = await createMailSplit({
+      emailAccountId,
+      name,
+      matchAll,
+      filters,
+    });
 
     if (!result) {
       throw new SafeError("Could not create split. Please try again.");
     }
     if (result.status !== "created") {
       if (result.status === "duplicate") {
-        throw new SafeError(`You already have a "${data.name}" split.`);
+        throw new SafeError(`You already have a "${name}" split.`);
       }
       throw new SafeError(`You can only have ${MAX_MAIL_SPLITS} splits.`);
     }
@@ -189,7 +184,7 @@ async function createMailSplitOrThrow(
     return split;
   } catch (error) {
     if (isDuplicateError(error, "name")) {
-      throw new SafeError(`You already have a "${data.name}" split.`);
+      throw new SafeError(`You already have a "${name}" split.`);
     }
     throw error;
   }

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -117,7 +117,7 @@ export const buildMailSplitFromPromptAction = actionClient
 
       return {
         filters: result.filters,
-        name: result.name?.trim() || null,
+        name: result.name?.trim().slice(0, 60) || null,
         matchAll: result.matchAll,
       };
     },
@@ -128,7 +128,10 @@ export const deleteMailSplitAction = actionClient
   .inputSchema(deleteMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
     // deleteMany rather than delete so another account's id can never be removed
-    await prisma.mailSplit.deleteMany({ where: { id, emailAccountId } });
+    await prisma.$transaction([
+      lockMailSplits(emailAccountId),
+      prisma.mailSplit.deleteMany({ where: { id, emailAccountId } }),
+    ]);
   });
 
 export const updateMailPreferencesAction = actionClient

--- a/apps/web/utils/actions/mail-split.validation.test.ts
+++ b/apps/web/utils/actions/mail-split.validation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMailSplitBody,
+  updateMailSplitBody,
+} from "@/utils/actions/mail-split.validation";
+
+describe("split conjunction validation", () => {
+  it.each([
+    createMailSplitBody,
+    updateMailSplitBody,
+  ])("rejects conditions that a flat provider query would silently overwrite", (schema) => {
+    const input = {
+      id: "split",
+      name: "Senders",
+      matchAll: true,
+      filters: [
+        { kind: "FROM", value: "one@example.com" },
+        { kind: "FROM", value: "two@example.com" },
+      ],
+    };
+    expect(schema.safeParse(input).success).toBe(false);
+    expect(schema.safeParse({ ...input, matchAll: false }).success).toBe(true);
+    expect(
+      schema.safeParse({
+        ...input,
+        filters: [input.filters[0], input.filters[0]],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -45,7 +45,7 @@ export type SplitPromptOptionInput = z.infer<typeof splitPromptOption>;
 export const buildMailSplitFromPromptBody = z.object({
   prompt: z.string().trim().min(1).max(300),
   options: z.array(splitPromptOption).max(500),
-  senders: z.array(z.string().trim().min(1).max(320)).max(200),
+  senders: z.array(z.string().trim().max(320).pipe(z.email())).max(200),
 });
 export type BuildMailSplitFromPromptBody = z.infer<
   typeof buildMailSplitFromPromptBody

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,76 +1,58 @@
 import { z } from "zod";
-import { MailLayout, MailSplitKind } from "@/generated/prisma/enums";
+import { MailLayout } from "@/generated/prisma/enums";
 import {
-  MAX_MAIL_SPLITS,
-  MAX_SPLIT_LABELS,
-} from "@/utils/mail/split-constants";
-
-// LABEL splits carry one or more provider label ids; CATEGORY splits carry a
-// single provider category (e.g. CATEGORY_PERSONAL). INBOX and UNREAD carry none.
-const kindAndValues = {
-  kind: z.nativeEnum(MailSplitKind),
-  values: z.array(z.string().trim().min(1)).max(MAX_SPLIT_LABELS),
-};
-const hasValidValues = ({
-  kind,
-  values,
-}: {
-  kind: MailSplitKind;
-  values: string[];
-}) => {
-  if (kind === MailSplitKind.LABEL) return values.length >= 1;
-  if (kind === MailSplitKind.CATEGORY) return values.length === 1;
-  return values.length === 0;
-};
-const valuesError = {
-  message:
-    "Label splits need at least one label, category splits exactly one category",
-  path: ["values"],
-};
+  mailSplitFiltersSchema,
+  mailSplitNameSchema,
+} from "@/utils/mail/split-filters";
 
 export const createMailSplitBody = z
-  .object({ name: z.string().trim().min(1).max(60), ...kindAndValues })
-  .refine(hasValidValues, valuesError);
+  .object({
+    name: mailSplitNameSchema,
+    filters: mailSplitFiltersSchema,
+    /** False shows mail matching any one condition instead of all of them. */
+    matchAll: z.boolean().default(true),
+  })
+  .refine(validConjunction, {
+    message: "Use match any for multiple senders or inbox sections",
+    path: ["filters"],
+  });
 export type CreateMailSplitBody = z.infer<typeof createMailSplitBody>;
 
-// The client sends the account's available options (labels, categories, states)
-// so the server doesn't have to re-fetch them from the provider; the AI only
-// ever picks from these, so a made-up option can't reach the UI.
-const splitPromptOption = z
+export const updateMailSplitBody = z
   .object({
-    id: z.string().min(1),
-    name: z.string().trim().min(1),
-    ...kindAndValues,
+    id: z.string(),
+    name: mailSplitNameSchema,
+    filters: mailSplitFiltersSchema,
+    matchAll: z.boolean().default(true),
   })
-  .refine(hasValidValues, valuesError);
+  .refine(validConjunction, {
+    message: "Use match any for multiple senders or inbox sections",
+    path: ["filters"],
+  });
+export type UpdateMailSplitBody = z.infer<typeof updateMailSplitBody>;
 
-export const suggestMailSplitBody = z.object({
+// The client sends the account's available labels and categories so the server
+// doesn't have to re-fetch them from the provider; the AI only ever picks from
+// these, so it can't invent a label that doesn't exist.
+const splitPromptOption = z.object({
+  id: z.string().min(1),
+  name: z.string().trim().min(1),
+  kind: z.enum(["LABEL", "CATEGORY"]),
+  value: z.string().trim().min(1),
+});
+export type SplitPromptOptionInput = z.infer<typeof splitPromptOption>;
+
+export const buildMailSplitFromPromptBody = z.object({
   prompt: z.string().trim().min(1).max(300),
-  options: z.array(splitPromptOption).min(1).max(500),
+  options: z.array(splitPromptOption).max(500),
+  senders: z.array(z.string().trim().min(1).max(320)).max(200),
 });
-export type SuggestMailSplitBody = z.infer<typeof suggestMailSplitBody>;
-
-export const renameMailSplitBody = z.object({
-  id: z.string(),
-  name: z.string().trim().min(1).max(60),
-});
-export type RenameMailSplitBody = z.infer<typeof renameMailSplitBody>;
+export type BuildMailSplitFromPromptBody = z.infer<
+  typeof buildMailSplitFromPromptBody
+>;
 
 export const deleteMailSplitBody = z.object({ id: z.string() });
 export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;
-
-export const setDefaultMailSplitsBody = z.object({ enabled: z.boolean() });
-export type SetDefaultMailSplitsBody = z.infer<typeof setDefaultMailSplitsBody>;
-
-export const reorderMailSplitsBody = z.object({
-  ids: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(MAX_MAIL_SPLITS)
-    .refine((ids) => new Set(ids).size === ids.length, {
-      message: "Split IDs must be unique",
-    }),
-});
 
 export const updateMailPreferencesBody = z
   .object({
@@ -85,3 +67,25 @@ export const updateMailPreferencesBody = z
 export type UpdateMailPreferencesBody = z.infer<
   typeof updateMailPreferencesBody
 >;
+
+function validConjunction(split: {
+  matchAll: boolean;
+  filters: { kind: string; value?: string | null }[];
+}) {
+  if (!split.matchAll) return true;
+  const senders = new Set(
+    split.filters
+      .filter((filter) => filter.kind === "FROM")
+      .map((filter) => filter.value),
+  );
+  const sections = new Set(
+    split.filters
+      .filter(
+        (filter) =>
+          filter.kind === "CATEGORY" &&
+          (filter.value === "focused" || filter.value === "other"),
+      )
+      .map((filter) => filter.value),
+  );
+  return senders.size <= 1 && sections.size <= 1;
+}

--- a/apps/web/utils/ai/split/prompt-to-split.ts
+++ b/apps/web/utils/ai/split/prompt-to-split.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
+import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import { createGenerateObject } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
-import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import {
+  MAX_SPLIT_FILTERS,
+  type MailSplitFilterDraft,
+} from "@/utils/mail/split-filters";
 import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
 
 export type SplitPromptOption = {
@@ -61,6 +65,7 @@ const promptToSplitSchema = z.object({
           ),
       }),
     )
+    .max(MAX_SPLIT_FILTERS)
     .describe("The conditions that define this split. Empty when none fit."),
 });
 
@@ -81,13 +86,14 @@ export async function aiPromptToSplitFilters({
   options: SplitPromptOption[];
   senders: string[];
 }): Promise<PromptToSplitFiltersResult> {
+  const supportsStarred = !isMicrosoftProvider(emailAccount.account.provider);
   const system = `You turn a description of an inbox split into a set of filter conditions.
 
 A split is a tab in the mail client showing a slice of the inbox. The reader reviews and edits your conditions before the split is saved, so prefer a small, obviously-correct set over a clever one.
 
 Condition kinds:
 - UNREAD — mail the reader has not opened
-- STARRED — mail the reader starred
+${supportsStarred ? "- STARRED — mail the reader starred" : "- STARRED is unavailable for this account. Do not return this condition."}
 - LABEL — one of the reader's labels, chosen by optionId from <options>
 - CATEGORY — one of the provider categories, chosen by optionId from <options>
 - FROM — a sender's email address
@@ -134,7 +140,10 @@ ${prompt}
   return {
     name: result.object.name,
     matchAll: result.object.matchAll,
-    filters: toFilters(result.object.conditions, options),
+    filters: toFilters(result.object.conditions, options).filter(
+      (filter) =>
+        supportsStarred || filter.kind !== MailSplitFilterKind.STARRED,
+    ),
   };
 }
 

--- a/apps/web/utils/ai/split/prompt-to-split.ts
+++ b/apps/web/utils/ai/split/prompt-to-split.ts
@@ -1,61 +1,112 @@
 import { z } from "zod";
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import { createGenerateObject } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
-import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
 
 export type SplitPromptOption = {
   id: string;
   name: string;
-  kind: MailSplitKind;
+  kind: "LABEL" | "CATEGORY";
+  value: string;
 };
 
+// Flat rather than a discriminated union: model-facing schemas travel better
+// across providers when the root and its rows stay plain objects.
 const promptToSplitSchema = z.object({
   reasoning: z
     .string()
-    .describe(
-      "One short sentence naming the options you picked and why, or why none of them fit. Shown to the user.",
-    ),
-  optionIds: z
-    .array(z.string())
-    .describe(
-      `Ids of every option the split should cover, at most ${MAX_SPLIT_LABELS}. Empty when nothing fits. More than one id is only allowed for label options, and means the split shows mail carrying any of those labels.`,
-    ),
+    .describe("One short sentence explaining the conditions you chose"),
   name: z
     .string()
     .nullable()
+    .describe("A short tab name, at most three words. Null if unsure."),
+  matchAll: z
+    .boolean()
     .describe(
-      "A short tab name covering everything the split shows, at most three words. Null when optionIds is empty.",
+      "True when mail must meet every condition, false when meeting any one of them is enough",
     ),
+  conditions: z
+    .array(
+      z.object({
+        kind: z
+          .enum([
+            "UNREAD",
+            "STARRED",
+            "LABEL",
+            "CATEGORY",
+            "FROM",
+            "OLDER_THAN",
+          ])
+          .describe("Which kind of condition this row is"),
+        optionId: z
+          .string()
+          .nullable()
+          .describe(
+            "For LABEL and CATEGORY: the id of one of the listed options. Null for every other kind.",
+          ),
+        sender: z
+          .string()
+          .nullable()
+          .describe(
+            "For FROM: the sender's email address. Null for every other kind.",
+          ),
+        age: z
+          .string()
+          .nullable()
+          .describe(
+            `For OLDER_THAN: one of ${OLDER_THAN_OPTIONS.map((o) => o.value).join(", ")}. Null for every other kind.`,
+          ),
+      }),
+    )
+    .describe("The conditions that define this split. Empty when none fit."),
 });
-export type PromptToSplitResult = z.infer<typeof promptToSplitSchema>;
 
-export async function aiPromptToSplit({
+export type PromptToSplitFiltersResult = {
+  filters: MailSplitFilterDraft[];
+  name: string | null;
+  matchAll: boolean;
+};
+
+export async function aiPromptToSplitFilters({
   emailAccount,
   prompt,
   options,
+  senders,
 }: {
   emailAccount: EmailAccountWithAI;
   prompt: string;
   options: SplitPromptOption[];
-}): Promise<PromptToSplitResult> {
-  const system = `You match a user's description of an inbox split to their existing mail filters.
+  senders: string[];
+}): Promise<PromptToSplitFiltersResult> {
+  const system = `You turn a description of an inbox split into a set of filter conditions.
 
-A split is a tab in the mail client that shows a filtered slice of the inbox. Each option is one available filter: a read state, a provider category, or one of the user's labels. You cannot create new filters; you can only pick from the options given.
+A split is a tab in the mail client showing a slice of the inbox. The reader reviews and edits your conditions before the split is saved, so prefer a small, obviously-correct set over a clever one.
+
+Condition kinds:
+- UNREAD — mail the reader has not opened
+- STARRED — mail the reader starred
+- LABEL — one of the reader's labels, chosen by optionId from <options>
+- CATEGORY — one of the provider categories, chosen by optionId from <options>
+- FROM — a sender's email address
+- OLDER_THAN — mail older than 3d, 1w or 1m
 
 Instructions:
-- Pick an option only when its filter means the same thing as part of what the user described. Match by meaning, in any language, not only exact wording.
-- A description that covers several of the user's labels should return every matching label id, up to ${MAX_SPLIT_LABELS} of them. The split then shows mail carrying any of them. Example: "invoices and receipts" returns both label ids when both labels exist.
-- Only label options can be combined. Read states and categories are exclusive: return exactly one id when you pick one.
-- If the description is narrower than an option's filter, leave that option out. Example: the user asks for "emails from my bank" and the closest option is a broad "Personal" category — that tab would mostly show unrelated mail, so it is not a match.
-- Return an empty list rather than a loose match. A sender, person, or topic that no option covers has no match.
-- The name must describe everything the picked options show together. Never name the split after only a subset of what it will contain.
-- The reasoning is shown to the user, so say which options you picked, or say plainly that none of their labels or categories cover the description.`;
+- Only use LABEL or CATEGORY when an option in <options> means the same thing as the description. Never invent an id, and never pick a loosely related option just to return something.
+- For a sender the description names, use FROM with the address. <senders> lists people the reader corresponds with; use one of those addresses when the description names a person, otherwise use an explicit email address from the description. Do not guess addresses or use bare domains.
+- Return an empty list of conditions when the description names something none of these kinds can express. An empty list is a better answer than a wrong filter.
+- Set matchAll false only when the description asks for alternatives ("X or Y"). Default to true.
+- The name must describe everything the split will show, not just one condition.`;
 
   const userPrompt = `<options>
-${options.map((option) => `- id: ${option.id} | name: ${option.name} | type: ${kindLabel(option.kind)}`).join("\n")}
+${options.map((option) => `- id: ${option.id} | name: ${option.name} | type: ${option.kind === "CATEGORY" ? "category" : "label"}`).join("\n") || "(none)"}
 </options>
+
+<senders>
+${senders.join("\n") || "(none)"}
+</senders>
 
 <description>
 ${prompt}
@@ -80,18 +131,53 @@ ${prompt}
     schema: promptToSplitSchema,
   });
 
-  return result.object;
+  return {
+    name: result.object.name,
+    matchAll: result.object.matchAll,
+    filters: toFilters(result.object.conditions, options),
+  };
 }
 
-function kindLabel(kind: MailSplitKind): string {
-  switch (kind) {
-    case MailSplitKind.UNREAD:
-      return "read state";
-    case MailSplitKind.CATEGORY:
-      return "category";
-    case MailSplitKind.LABEL:
-      return "label";
-    default:
-      return "inbox";
-  }
+/**
+ * Resolves the model's rows against the options the client actually sent, so a
+ * hallucinated label id drops the condition rather than creating a broken split.
+ */
+function toFilters(
+  conditions: z.infer<typeof promptToSplitSchema>["conditions"],
+  options: SplitPromptOption[],
+): MailSplitFilterDraft[] {
+  const olderThanValues = new Set(OLDER_THAN_OPTIONS.map((o) => o.value));
+
+  return conditions.flatMap((condition): MailSplitFilterDraft[] => {
+    switch (condition.kind) {
+      case "UNREAD":
+        return [{ kind: MailSplitFilterKind.UNREAD, value: null }];
+      case "STARRED":
+        return [{ kind: MailSplitFilterKind.STARRED, value: null }];
+      case "LABEL":
+      case "CATEGORY": {
+        const option = options.find((o) => o.id === condition.optionId);
+        if (!option) return [];
+        return [
+          {
+            kind:
+              option.kind === "CATEGORY"
+                ? MailSplitFilterKind.CATEGORY
+                : MailSplitFilterKind.LABEL,
+            value: option.value,
+          },
+        ];
+      }
+      case "FROM": {
+        const sender = condition.sender?.trim();
+        if (!sender || !z.email().safeParse(sender).success) return [];
+        return [{ kind: MailSplitFilterKind.FROM, value: sender }];
+      }
+      case "OLDER_THAN": {
+        const age = condition.age?.trim() ?? "";
+        if (!olderThanValues.has(age)) return [];
+        return [{ kind: MailSplitFilterKind.OLDER_THAN, value: age }];
+      }
+    }
+  });
 }

--- a/apps/web/utils/ai/split/prompt-to-split.ts
+++ b/apps/web/utils/ai/split/prompt-to-split.ts
@@ -94,7 +94,7 @@ Condition kinds:
 - OLDER_THAN — mail older than 3d, 1w or 1m
 
 Instructions:
-- Only use LABEL or CATEGORY when an option in <options> means the same thing as the description. Never invent an id, and never pick a loosely related option just to return something.
+- Match LABEL and CATEGORY options by their everyday meaning, including descriptions of the mail that belongs in them; the reader need not use the exact label name. Use a clear semantic fit, but never invent an id or select an unrelated option just to return something.
 - For a sender the description names, use FROM with the address. <senders> lists people the reader corresponds with; use one of those addresses when the description names a person, otherwise use an explicit email address from the description. Do not guess addresses or use bare domains.
 - Return an empty list of conditions when the description names something none of these kinds can express. An empty list is a better answer than a wrong filter.
 - Set matchAll false only when the description asks for alternatives ("X or Y"). Default to true.

--- a/apps/web/utils/ai/split/prompt-to-split.ts
+++ b/apps/web/utils/ai/split/prompt-to-split.ts
@@ -137,13 +137,15 @@ ${prompt}
     schema: promptToSplitSchema,
   });
 
+  const filters = toFilters(result.object.conditions, options);
+  const allConditionsSupported =
+    filters.length === result.object.conditions.length &&
+    (supportsStarred ||
+      filters.every((filter) => filter.kind !== MailSplitFilterKind.STARRED));
   return {
     name: result.object.name,
     matchAll: result.object.matchAll,
-    filters: toFilters(result.object.conditions, options).filter(
-      (filter) =>
-        supportsStarred || filter.kind !== MailSplitFilterKind.STARRED,
-    ),
+    filters: allConditionsSupported ? filters : [],
   };
 }
 

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import type { Account } from "better-auth";
 import { cookies } from "next/headers";
 import { createReferral } from "@/utils/referral/referral-code";
@@ -399,8 +399,22 @@ describe("handleLinkAccount", () => {
     const upsert = prisma.emailAccount.upsert.mock.calls[0]?.[0];
     expect(upsert?.create.mailSplits).toEqual({
       create: [
-        { name: "All", kind: MailSplitKind.INBOX, values: [], order: 0 },
-        { name: "Unread", kind: MailSplitKind.UNREAD, values: [], order: 1 },
+        {
+          name: "All",
+          matchAll: true,
+          filters: { create: [] },
+          order: 0,
+        },
+        {
+          name: "Unread",
+          matchAll: true,
+          filters: {
+            create: [
+              { kind: MailSplitFilterKind.UNREAD, value: null, order: 0 },
+            ],
+          },
+          order: 1,
+        },
       ],
     });
     expect(upsert?.update).not.toHaveProperty("mailSplits");

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -17,8 +17,11 @@ describe("setDefaultMailSplits", () => {
     vi.clearAllMocks();
   });
 
-  it("seeds standard rule labels for an account without saved splits", async () => {
-    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
+  it("locks the account before changing standard rule splits", async () => {
+    prisma.$transaction.mockResolvedValue([
+      [{ locked: true }],
+      [{ missingCount: 1, availableCount: 14 }],
+    ] as never);
 
     await setDefaultMailSplits({
       emailAccountId: "account-id",

--- a/apps/web/utils/mail/default-splits.server.test.ts
+++ b/apps/web/utils/mail/default-splits.server.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ActionType,
-  MailSplitKind,
+  MailSplitFilterKind,
   SystemType,
 } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
@@ -12,9 +12,44 @@ import {
 
 vi.mock("@/utils/prisma");
 
-describe("default mail splits", () => {
+describe("setDefaultMailSplits", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("seeds standard rule labels for an account without saved splits", async () => {
+    prisma.$transaction.mockResolvedValue([[{ locked: true }], 1] as never);
+
+    await setDefaultMailSplits({
+      emailAccountId: "account-id",
+      defaultSplits: [
+        {
+          name: "Receipt",
+          labelId: "receipt-label",
+          filters: [
+            { kind: MailSplitFilterKind.LABEL, value: "receipt-label" },
+          ],
+        },
+      ],
+      enabled: true,
+    });
+
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining("pg_advisory_xact_lock"),
+      ]),
+      "account-id",
+    );
+  });
+
+  it("does not access the database when no rule can produce an inbox split", async () => {
+    await setDefaultMailSplits({
+      emailAccountId: "account-id",
+      defaultSplits: [],
+      enabled: true,
+    });
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("loads the enabled standard rules that can provide default splits", async () => {
@@ -27,8 +62,8 @@ describe("default mail splits", () => {
     ).resolves.toEqual([
       {
         name: "Receipt",
-        kind: MailSplitKind.LABEL,
-        values: ["receipt-label"],
+        labelId: "receipt-label",
+        filters: [{ kind: MailSplitFilterKind.LABEL, value: "receipt-label" }],
       },
     ]);
     expect(prisma.rule.findMany).toHaveBeenCalledWith({
@@ -42,67 +77,6 @@ describe("default mail splits", () => {
         actions: { select: { type: true, labelId: true } },
       },
     });
-  });
-
-  it("removes every split backed by a default rule label", async () => {
-    prisma.$transaction.mockResolvedValue([
-      [{ locked: true }],
-      { count: 2 },
-    ] as never);
-
-    await setDefaultMailSplits({
-      emailAccountId: "account-id",
-      defaultSplits: [
-        {
-          name: "Receipt",
-          kind: MailSplitKind.LABEL,
-          values: ["receipt-label"],
-        },
-        {
-          name: "Newsletter",
-          kind: MailSplitKind.LABEL,
-          values: ["newsletter-label"],
-        },
-      ],
-      enabled: false,
-    });
-
-    expect(prisma.mailSplit.deleteMany).toHaveBeenCalledWith({
-      where: {
-        emailAccountId: "account-id",
-        kind: MailSplitKind.LABEL,
-        OR: [
-          { values: { equals: ["receipt-label"] } },
-          { values: { equals: ["newsletter-label"] } },
-        ],
-      },
-    });
-  });
-
-  it("does not partially add defaults when the account has too few slots", async () => {
-    prisma.$transaction.mockResolvedValue([
-      [{ locked: true }],
-      [{ availableCount: 1, missingCount: 2 }],
-    ] as never);
-
-    await expect(
-      setDefaultMailSplits({
-        emailAccountId: "account-id",
-        defaultSplits: [
-          {
-            name: "Receipt",
-            kind: MailSplitKind.LABEL,
-            values: ["receipt-label"],
-          },
-          {
-            name: "Newsletter",
-            kind: MailSplitKind.LABEL,
-            values: ["newsletter-label"],
-          },
-        ],
-        enabled: true,
-      }),
-    ).resolves.toEqual({ status: "limit" });
   });
 });
 

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -33,7 +33,7 @@ export async function setDefaultMailSplits({
   defaultSplits: ReturnType<typeof getDefaultMailSplitDrafts>;
   enabled: boolean;
 }) {
-  if (!defaultSplits.length) return;
+  if (!defaultSplits.length) return { status: "success" as const };
   if (!enabled) {
     await prisma.$transaction([
       lockMailSplits(emailAccountId),
@@ -49,16 +49,16 @@ export async function setDefaultMailSplits({
         },
       }),
     ]);
-    return;
+    return { status: "success" as const };
   }
   const rows = defaultSplits.map((split, order) => ({
     ...split,
     id: randomUUID(),
     order,
   }));
-  await prisma.$transaction([
+  const [, results] = await prisma.$transaction([
     lockMailSplits(emailAccountId),
-    prisma.$executeRaw`
+    prisma.$queryRaw<Array<{ missingCount: number; availableCount: number }>>`
       WITH existing AS (
         SELECT COUNT(*)::integer AS count, COALESCE(MAX("order"), -1)::integer + 1 AS next_order
         FROM "MailSplit" WHERE "emailAccountId" = ${emailAccountId}
@@ -79,10 +79,22 @@ export async function setDefaultMailSplits({
         FROM missing CROSS JOIN existing
         WHERE (SELECT COUNT(*) FROM missing) <= GREATEST(${MAX_MAIL_SPLITS} - existing.count, 0)
         ON CONFLICT DO NOTHING RETURNING "id"
-      )
+      ), inserted_filters AS (
       INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
       SELECT missing."id" || '-filter', 'LABEL'::"MailSplitFilterKind", missing."labelId", 0, missing."id"
       FROM missing JOIN inserted ON inserted."id" = missing."id"
+      RETURNING "id"
+      )
+      SELECT (SELECT COUNT(*)::integer FROM missing) AS "missingCount",
+        GREATEST(${MAX_MAIL_SPLITS} - existing.count, 0)::integer AS "availableCount"
+      FROM existing
     `,
   ]);
+  const result = results[0];
+  return {
+    status:
+      result && result.missingCount > result.availableCount
+        ? ("limit" as const)
+        : ("success" as const),
+  };
 }

--- a/apps/web/utils/mail/default-splits.server.ts
+++ b/apps/web/utils/mail/default-splits.server.ts
@@ -1,9 +1,9 @@
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import { randomUUID } from "node:crypto";
-import { MailSplitKind } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
 import { lockMailSplits } from "@/utils/mail/split-lock";
-import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import { STANDARD_CATEGORY_SYSTEM_TYPES } from "@/utils/rule/consts";
 
 export async function getDefaultMailSplitDraftsForAccount(
@@ -33,107 +33,56 @@ export async function setDefaultMailSplits({
   defaultSplits: ReturnType<typeof getDefaultMailSplitDrafts>;
   enabled: boolean;
 }) {
-  if (defaultSplits.length === 0) return;
-
+  if (!defaultSplits.length) return;
   if (!enabled) {
     await prisma.$transaction([
       lockMailSplits(emailAccountId),
       prisma.mailSplit.deleteMany({
         where: {
           emailAccountId,
-          kind: MailSplitKind.LABEL,
-          // Exact match so a split the user widened to more labels survives.
           OR: defaultSplits.map((split) => ({
-            values: { equals: split.values },
+            filters: {
+              some: {},
+              every: { kind: MailSplitFilterKind.LABEL, value: split.labelId },
+            },
           })),
         },
       }),
     ]);
-    return { status: "success" as const };
+    return;
   }
-
   const rows = defaultSplits.map((split, order) => ({
-    id: randomUUID(),
     ...split,
+    id: randomUUID(),
     order,
   }));
-
-  const [, results] = await prisma.$transaction([
+  await prisma.$transaction([
     lockMailSplits(emailAccountId),
-    prisma.$queryRaw<Array<{ availableCount: number; missingCount: number }>>`
-      WITH split_state AS (
-        SELECT
-          COUNT(*)::integer AS count,
-          COALESCE(MAX("order"), -1)::integer + 1 AS next_order
-        FROM "MailSplit"
-        WHERE "emailAccountId" = ${emailAccountId}
-      ),
-      missing_defaults AS (
-        SELECT
-          defaults.*,
-          (ROW_NUMBER() OVER (ORDER BY defaults."order") - 1)::integer AS offset
-        FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb) AS defaults(
-          "id" text,
-          "name" text,
-          "kind" text,
-          "values" text[],
-          "order" integer
-        )
+    prisma.$executeRaw`
+      WITH existing AS (
+        SELECT COUNT(*)::integer AS count, COALESCE(MAX("order"), -1)::integer + 1 AS next_order
+        FROM "MailSplit" WHERE "emailAccountId" = ${emailAccountId}
+      ), missing AS (
+        SELECT defaults.*, ROW_NUMBER() OVER (ORDER BY defaults."order") - 1 AS offset
+        FROM jsonb_to_recordset(${JSON.stringify(rows)}::jsonb)
+          AS defaults("id" text, "name" text, "labelId" text, "order" integer)
         WHERE NOT EXISTS (
-          SELECT 1
-          FROM "MailSplit" AS existing
-          WHERE existing."emailAccountId" = ${emailAccountId}
-            AND (
-              existing."name" = defaults."name"
-              OR (
-                existing."kind" = 'LABEL'::"MailSplitKind"
-                AND existing."values" = defaults."values"
-              )
-            )
+          SELECT 1 FROM "MailSplit" split WHERE split."emailAccountId" = ${emailAccountId}
+          AND (split."name" = defaults."name" OR (
+            EXISTS (SELECT 1 FROM "MailSplitFilter" filter WHERE filter."mailSplitId" = split."id" AND filter."kind" = 'LABEL' AND filter."value" = defaults."labelId")
+            AND NOT EXISTS (SELECT 1 FROM "MailSplitFilter" filter WHERE filter."mailSplitId" = split."id" AND (filter."kind" <> 'LABEL' OR filter."value" IS DISTINCT FROM defaults."labelId"))
+          ))
         )
-        ORDER BY defaults."order"
-      ),
-      inserted_defaults AS (
-        INSERT INTO "MailSplit" (
-          "id",
-          "createdAt",
-          "updatedAt",
-          "name",
-          "kind",
-          "values",
-          "order",
-          "emailAccountId"
-        )
-        SELECT
-          missing_defaults."id",
-          CURRENT_TIMESTAMP,
-          CURRENT_TIMESTAMP,
-          missing_defaults."name",
-          missing_defaults."kind"::"MailSplitKind",
-          missing_defaults."values",
-          split_state.next_order + missing_defaults.offset,
-          ${emailAccountId}
-        FROM missing_defaults
-        CROSS JOIN split_state
-        WHERE (
-          SELECT COUNT(*) FROM missing_defaults
-        ) <= GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)
-        ON CONFLICT DO NOTHING
-        RETURNING "id"
+      ), inserted AS (
+        INSERT INTO "MailSplit" ("id", "createdAt", "updatedAt", "name", "matchAll", "order", "emailAccountId")
+        SELECT missing."id", NOW(), NOW(), missing."name", true, existing.next_order + missing.offset, ${emailAccountId}
+        FROM missing CROSS JOIN existing
+        WHERE (SELECT COUNT(*) FROM missing) <= GREATEST(${MAX_MAIL_SPLITS} - existing.count, 0)
+        ON CONFLICT DO NOTHING RETURNING "id"
       )
-      SELECT
-        (SELECT COUNT(*)::integer FROM missing_defaults) AS "missingCount",
-        GREATEST(${MAX_MAIL_SPLITS} - split_state.count, 0)::integer
-          AS "availableCount"
-      FROM split_state
+      INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
+      SELECT missing."id" || '-filter', 'LABEL'::"MailSplitFilterKind", missing."labelId", 0, missing."id"
+      FROM missing JOIN inserted ON inserted."id" = missing."id"
     `,
   ]);
-
-  const result = results[0];
-  return {
-    status:
-      result && result.missingCount > result.availableCount
-        ? ("limit" as const)
-        : ("success" as const),
-  };
 }

--- a/apps/web/utils/mail/default-splits.test.ts
+++ b/apps/web/utils/mail/default-splits.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ActionType,
-  MailSplitKind,
+  MailSplitFilterKind,
   SystemType,
 } from "@/generated/prisma/enums";
 import { getDefaultMailSplitDrafts } from "@/utils/mail/default-splits";
@@ -19,18 +19,20 @@ describe("getDefaultMailSplitDrafts", () => {
     expect(getDefaultMailSplitDrafts(rules)).toEqual([
       {
         name: "To Reply",
-        kind: MailSplitKind.LABEL,
-        values: ["reply-label"],
+        labelId: "reply-label",
+        filters: [{ kind: MailSplitFilterKind.LABEL, value: "reply-label" }],
       },
       {
         name: "Newsletter",
-        kind: MailSplitKind.LABEL,
-        values: ["newsletter-label"],
+        labelId: "newsletter-label",
+        filters: [
+          { kind: MailSplitFilterKind.LABEL, value: "newsletter-label" },
+        ],
       },
       {
         name: "Receipt",
-        kind: MailSplitKind.LABEL,
-        values: ["receipt-label"],
+        labelId: "receipt-label",
+        filters: [{ kind: MailSplitFilterKind.LABEL, value: "receipt-label" }],
       },
     ]);
   });
@@ -52,8 +54,10 @@ describe("getDefaultMailSplitDrafts", () => {
     expect(getDefaultMailSplitDrafts(rules)).toEqual([
       {
         name: "Notification",
-        kind: MailSplitKind.LABEL,
-        values: ["notification-label"],
+        labelId: "notification-label",
+        filters: [
+          { kind: MailSplitFilterKind.LABEL, value: "notification-label" },
+        ],
       },
     ]);
   });

--- a/apps/web/utils/mail/default-splits.ts
+++ b/apps/web/utils/mail/default-splits.ts
@@ -1,6 +1,6 @@
 import {
   ActionType,
-  MailSplitKind,
+  MailSplitFilterKind,
   type SystemType,
 } from "@/generated/prisma/enums";
 import {
@@ -38,8 +38,8 @@ export function getDefaultMailSplitDrafts(rules: RuleForDefaultSplit[]) {
       ? [
           {
             name: getRuleLabel(systemType),
-            kind: MailSplitKind.LABEL,
-            values: [labelId],
+            labelId,
+            filters: [{ kind: MailSplitFilterKind.LABEL, value: labelId }],
           },
         ]
       : [];

--- a/apps/web/utils/mail/initial-splits.ts
+++ b/apps/web/utils/mail/initial-splits.ts
@@ -1,14 +1,12 @@
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 
 export const INITIAL_MAIL_SPLITS = [
-  {
-    name: "All",
-    kind: MailSplitKind.INBOX,
-    values: [] as string[],
-  },
+  { name: "All", matchAll: true, filters: { create: [] } },
   {
     name: "Unread",
-    kind: MailSplitKind.UNREAD,
-    values: [] as string[],
+    matchAll: true,
+    filters: {
+      create: [{ kind: MailSplitFilterKind.UNREAD, value: null, order: 0 }],
+    },
   },
-] as const;
+];

--- a/apps/web/utils/mail/split-filters.ts
+++ b/apps/web/utils/mail/split-filters.ts
@@ -18,9 +18,12 @@ export const mailSplitFilterSchema = z
     value: z.string().trim().min(1).max(320).nullish(),
   })
   .refine(
-    (filter) => !KINDS_REQUIRING_VALUE.has(filter.kind) || !!filter.value,
+    (filter) =>
+      KINDS_REQUIRING_VALUE.has(filter.kind)
+        ? !!filter.value
+        : filter.value == null,
     {
-      message: "This condition needs a value",
+      message: "Provide a value only for conditions that require one",
       path: ["value"],
     },
   )

--- a/apps/web/utils/mail/split-filters.ts
+++ b/apps/web/utils/mail/split-filters.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
+
+/** UNREAD and STARRED are whole conditions on their own; the rest name a target. */
+const KINDS_REQUIRING_VALUE = new Set<MailSplitFilterKind>([
+  MailSplitFilterKind.LABEL,
+  MailSplitFilterKind.CATEGORY,
+  MailSplitFilterKind.FROM,
+  MailSplitFilterKind.OLDER_THAN,
+]);
+
+const OLDER_THAN_VALUES = OLDER_THAN_OPTIONS.map((option) => option.value);
+
+export const mailSplitFilterSchema = z
+  .object({
+    kind: z.nativeEnum(MailSplitFilterKind),
+    value: z.string().trim().min(1).max(320).nullish(),
+  })
+  .refine(
+    (filter) => !KINDS_REQUIRING_VALUE.has(filter.kind) || !!filter.value,
+    {
+      message: "This condition needs a value",
+      path: ["value"],
+    },
+  )
+  .refine(
+    (filter) =>
+      filter.kind !== MailSplitFilterKind.FROM ||
+      z.email().safeParse(filter.value).success,
+    { message: "Enter a sender email address", path: ["value"] },
+  )
+  .refine(
+    (filter) =>
+      filter.kind !== MailSplitFilterKind.OLDER_THAN ||
+      OLDER_THAN_VALUES.includes(filter.value ?? ""),
+    { message: "Unknown age", path: ["value"] },
+  );
+
+export type MailSplitFilterDraft = z.infer<typeof mailSplitFilterSchema>;
+
+/** One condition row per filter, so the cap matches what the builder can show. */
+export const MAX_SPLIT_FILTERS = 10;
+
+export const mailSplitFiltersSchema = z
+  .array(mailSplitFilterSchema)
+  .max(MAX_SPLIT_FILTERS);
+
+export const mailSplitNameSchema = z.string().trim().min(1).max(60);

--- a/apps/web/utils/mail/split-library.ts
+++ b/apps/web/utils/mail/split-library.ts
@@ -1,0 +1,241 @@
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
+
+/**
+ * A condition in the prepared library, written against label *names* so one
+ * catalogue works for every account — ids are resolved per account at render.
+ */
+type LibraryCondition =
+  | { kind: "LABEL"; labelName: string }
+  | { kind: "CATEGORY"; categoryName: string }
+  | { kind: "FROM"; sender: string }
+  | { kind: "UNREAD" }
+  | { kind: "STARRED" };
+
+export type SplitLibraryEntry = {
+  name: string;
+  description: string;
+  category: string;
+  conditions: LibraryCondition[];
+  /** Prepared splits ask for every condition unless they list alternatives. */
+  matchAll?: boolean;
+};
+
+export const SPLIT_LIBRARY: SplitLibraryEntry[] = [
+  {
+    name: "To reply",
+    category: "General",
+    description:
+      "Conversations waiting on your answer, labelled by Reply Zero.",
+    conditions: [{ kind: "LABEL", labelName: "To reply" }],
+  },
+  {
+    name: "Starred",
+    category: "General",
+    description: "Everything you have starred, in one place.",
+    conditions: [{ kind: "STARRED" }],
+  },
+  {
+    name: "Awaiting reply",
+    category: "General",
+    description: "You answered — they have not. Nudge-worthy threads.",
+    conditions: [{ kind: "LABEL", labelName: "Awaiting Reply" }],
+  },
+  {
+    name: "Calendar",
+    category: "General",
+    description: "Invitations, reschedules and meeting notifications.",
+    conditions: [{ kind: "LABEL", labelName: "Calendar" }],
+  },
+  {
+    name: "Receipts",
+    category: "General",
+    description: "Payments, payouts and invoices.",
+    conditions: [{ kind: "LABEL", labelName: "Receipt" }],
+  },
+  {
+    name: "Newsletters",
+    category: "General",
+    description: "Bulk mail you subscribed to — read when you have time.",
+    conditions: [{ kind: "LABEL", labelName: "Newsletter" }],
+  },
+  {
+    name: "Notifications",
+    category: "General",
+    description: "Tool alerts and digests, out of the main inbox.",
+    conditions: [{ kind: "LABEL", labelName: "Notification" }],
+  },
+  {
+    name: "Cold email",
+    category: "General",
+    description: "Unsolicited outreach from senders you have no history with.",
+    conditions: [{ kind: "LABEL", labelName: "Cold email" }],
+  },
+  {
+    name: "Unread",
+    category: "General",
+    description: "Everything you have not opened yet.",
+    conditions: [{ kind: "UNREAD" }],
+  },
+  {
+    name: "GitHub",
+    category: "Apps",
+    description: "Pull requests, reviews and issue activity.",
+    conditions: [
+      { kind: "FROM", sender: "mentions@noreply.github.com" },
+      { kind: "FROM", sender: "notifications@github.com" },
+    ],
+    matchAll: false,
+  },
+  {
+    name: "Stripe",
+    category: "Apps",
+    description: "Payouts, disputes and invoice receipts from Stripe.",
+    conditions: [{ kind: "FROM", sender: "receipts@stripe.com" }],
+  },
+  {
+    name: "Linear",
+    category: "Apps",
+    description: "Issue assignments, comments and mentions from Linear.",
+    conditions: [
+      { kind: "FROM", sender: "notifications@linear.app" },
+      { kind: "FROM", sender: "notifications@mail.linear.app" },
+    ],
+    matchAll: false,
+  },
+  {
+    name: "Figma",
+    category: "Apps",
+    description: "Comments and file updates from your team.",
+    conditions: [{ kind: "FROM", sender: "no-reply@figma.com" }],
+  },
+  {
+    name: "Notion",
+    category: "Apps",
+    description: "Comments, mentions, and updates to your documents.",
+    conditions: [{ kind: "FROM", sender: "notify@mail.notion.so" }],
+  },
+  {
+    name: "Asana",
+    category: "Apps",
+    description: "Task assignments, deadlines, and project updates.",
+    conditions: [{ kind: "FROM", sender: "no-reply@asana.com" }],
+  },
+  {
+    name: "Trello",
+    category: "Apps",
+    description: "Board invitations and task notifications.",
+    conditions: [{ kind: "FROM", sender: "do-not-reply@trello.com" }],
+  },
+  {
+    name: "HubSpot",
+    category: "Apps",
+    description: "Lead activity, form submissions, and CRM notifications.",
+    conditions: [
+      { kind: "FROM", sender: "noreply@notifications.hubspot.com" },
+      { kind: "FROM", sender: "no-reply@hubspot.com" },
+      { kind: "FROM", sender: "noreply@hubspot.com" },
+    ],
+    matchAll: false,
+  },
+  {
+    name: "Salesforce",
+    category: "Apps",
+    description: "Opportunity updates and sales activity.",
+    conditions: [
+      { kind: "FROM", sender: "info@salesforce.com" },
+      { kind: "FROM", sender: "support@salesforce.com" },
+      { kind: "FROM", sender: "email@mail.salesforce.com" },
+      { kind: "FROM", sender: "noreply@salesforce.com" },
+      { kind: "FROM", sender: "no-reply@salesforce.com" },
+      { kind: "FROM", sender: "notifications@salesforce.com" },
+    ],
+    matchAll: false,
+  },
+  {
+    name: "Pipedrive",
+    category: "Apps",
+    description: "Deal updates, follow-ups, and pipeline activity.",
+    conditions: [
+      { kind: "FROM", sender: "notifications@pipedrive.com" },
+      { kind: "FROM", sender: "info@pipedrive.com" },
+      { kind: "FROM", sender: "notifier@pipedrive.com" },
+      { kind: "FROM", sender: "support@pipedrive.com" },
+      { kind: "FROM", sender: "noreply@pipedrive.com" },
+    ],
+    matchAll: false,
+  },
+];
+
+export const SPLIT_LIBRARY_CATEGORIES = [
+  ...new Set(SPLIT_LIBRARY.map((entry) => entry.category)),
+];
+
+/**
+ * Resolves an entry's label and category names against this account. Returns
+ * null when the account has no such label, so the library never offers a split
+ * that would come back empty for a reason the reader can't see.
+ */
+export function resolveLibraryEntry(
+  entry: SplitLibraryEntry,
+  {
+    labelsByName,
+    categoriesByName,
+  }: {
+    labelsByName: Map<string, string>;
+    categoriesByName: Map<string, string>;
+  },
+): MailSplitFilterDraft[] | null {
+  const filters: MailSplitFilterDraft[] = [];
+
+  for (const condition of entry.conditions) {
+    switch (condition.kind) {
+      case "UNREAD":
+        filters.push({ kind: MailSplitFilterKind.UNREAD, value: null });
+        break;
+      case "STARRED":
+        filters.push({ kind: MailSplitFilterKind.STARRED, value: null });
+        break;
+      case "FROM":
+        filters.push({
+          kind: MailSplitFilterKind.FROM,
+          value: condition.sender,
+        });
+        break;
+      case "LABEL": {
+        const labelId = labelsByName.get(condition.labelName.toLowerCase());
+        if (!labelId) return null;
+        filters.push({ kind: MailSplitFilterKind.LABEL, value: labelId });
+        break;
+      }
+      case "CATEGORY": {
+        const category = categoriesByName.get(
+          condition.categoryName.toLowerCase(),
+        );
+        if (!category) return null;
+        filters.push({ kind: MailSplitFilterKind.CATEGORY, value: category });
+        break;
+      }
+    }
+  }
+
+  return filters;
+}
+
+/** The human-readable "Definition" rows shown on a library entry's detail view. */
+export function libraryDefinition(entry: SplitLibraryEntry) {
+  return entry.conditions.map((condition) => {
+    switch (condition.kind) {
+      case "UNREAD":
+        return { key: "Is", value: "unread" };
+      case "STARRED":
+        return { key: "Is", value: "starred" };
+      case "FROM":
+        return { key: "From", value: condition.sender };
+      case "LABEL":
+        return { key: "Label", value: condition.labelName };
+      case "CATEGORY":
+        return { key: "Category", value: condition.categoryName };
+    }
+  });
+}

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -1,109 +1,170 @@
 import { describe, expect, it } from "vitest";
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import {
   getPortableLabelSplits,
   mailSplitToThreadsQuery,
+  type MailSplit,
 } from "@/utils/mail/split-query";
 
+const NOW = new Date("2026-09-09T12:00:00.000Z");
+
 function split(
-  kind: MailSplitKind,
-  ...values: string[]
-): Parameters<typeof mailSplitToThreadsQuery>[0] {
-  return { id: "split-1", name: "Test split", kind, values };
+  filters: { kind: MailSplitFilterKind; value?: string | null }[],
+  matchAll = true,
+): MailSplit {
+  return {
+    id: "split-1",
+    name: "Test split",
+    matchAll,
+    filters: filters.map((filter) => ({
+      kind: filter.kind,
+      value: filter.value ?? null,
+    })),
+  };
 }
 
 describe("mailSplitToThreadsQuery", () => {
-  it("scopes the default split to the inbox", () => {
-    expect(mailSplitToThreadsQuery(split(MailSplitKind.INBOX))).toEqual({
-      type: "inbox",
-    });
+  it("scopes a split with no conditions to the inbox", () => {
+    expect(mailSplitToThreadsQuery(split([]), NOW)).toEqual({ type: "inbox" });
   });
 
   it("asks the server for unread rather than filtering loaded pages", () => {
-    expect(mailSplitToThreadsQuery(split(MailSplitKind.UNREAD))).toEqual({
-      type: "inbox",
-      isUnread: true,
-    });
+    expect(
+      mailSplitToThreadsQuery(
+        split([{ kind: MailSplitFilterKind.UNREAD }]),
+        NOW,
+      ),
+    ).toEqual({ isUnread: true, labelIds: ["INBOX"] });
   });
 
   it("limits label splits to matching inbox mail", () => {
     expect(
-      mailSplitToThreadsQuery(split(MailSplitKind.LABEL, "Label_42")),
-    ).toEqual({ labelIds: ["Label_42", "INBOX"] });
+      mailSplitToThreadsQuery(
+        split([{ kind: MailSplitFilterKind.LABEL, value: "Label_42" }]),
+        NOW,
+      ),
+    ).toEqual({ labelIds: ["INBOX", "Label_42"] });
   });
 
-  it("limits provider category splits to matching inbox mail", () => {
+  it("queries Outlook's focused section inside the inbox", () => {
     expect(
       mailSplitToThreadsQuery(
-        split(MailSplitKind.CATEGORY, "CATEGORY_PERSONAL"),
+        split([{ kind: MailSplitFilterKind.CATEGORY, value: "focused" }]),
+        NOW,
       ),
-    ).toEqual({ labelIds: ["CATEGORY_PERSONAL", "INBOX"] });
+    ).toEqual({ inboxSection: "focused", type: "inbox" });
+  });
+
+  it("combines every condition into one query when matching all", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split([
+          { kind: MailSplitFilterKind.UNREAD },
+          { kind: MailSplitFilterKind.LABEL, value: "Label_42" },
+          { kind: MailSplitFilterKind.FROM, value: "priya@northwind.co" },
+          { kind: MailSplitFilterKind.OLDER_THAN, value: "1w" },
+        ]),
+        NOW,
+      ),
+    ).toEqual({
+      isUnread: true,
+      fromEmail: "priya@northwind.co",
+      before: new Date("2026-09-02T12:00:00.000Z"),
+      labelIds: ["INBOX", "Label_42"],
+    });
+  });
+
+  it("keeps two labels as separate conditions rather than overwriting one", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split([
+          { kind: MailSplitFilterKind.LABEL, value: "Label_1" },
+          { kind: MailSplitFilterKind.LABEL, value: "Label_2" },
+        ]),
+        NOW,
+      ),
+    ).toEqual({ labelIds: ["INBOX", "Label_1", "Label_2"] });
+  });
+
+  it("turns each condition into its own branch when matching any", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split(
+          [
+            {
+              kind: MailSplitFilterKind.FROM,
+              value: "notifications@linear.app",
+            },
+            { kind: MailSplitFilterKind.FROM, value: "mentions@linear.app" },
+          ],
+          false,
+        ),
+        NOW,
+      ),
+    ).toEqual({
+      labelIds: ["INBOX"],
+      anyOf: [
+        { fromEmail: "notifications@linear.app" },
+        { fromEmail: "mentions@linear.app" },
+      ],
+    });
+  });
+
+  it("keeps a starred condition on the provider rather than filtering locally", () => {
+    expect(
+      mailSplitToThreadsQuery(
+        split([{ kind: MailSplitFilterKind.STARRED }]),
+        NOW,
+      ),
+    ).toEqual({ labelIds: ["INBOX", "STARRED"] });
   });
 
   it.each([
-    "focused",
-    "other",
-  ] as const)("queries Outlook's %s section inside the inbox", (inboxSection) => {
-    expect(
-      mailSplitToThreadsQuery(split(MailSplitKind.CATEGORY, inboxSection)),
-    ).toEqual({ type: "inbox", inboxSection });
-  });
-
-  it("merges a multi-label split into one inbox query", () => {
-    expect(
-      mailSplitToThreadsQuery(
-        split(MailSplitKind.LABEL, "Label_42", "Label_43"),
-      ),
-    ).toEqual({ labelIds: ["INBOX"], anyLabelIds: ["Label_42", "Label_43"] });
-  });
-
-  it.each([
-    MailSplitKind.LABEL,
-    MailSplitKind.CATEGORY,
-  ])("throws rather than silently querying the whole inbox when %s has no value", (kind) => {
-    expect(() => mailSplitToThreadsQuery(split(kind))).toThrow(
-      /has no (label|category)/,
+    [MailSplitFilterKind.LABEL, /has no label/],
+    [MailSplitFilterKind.CATEGORY, /has no category/],
+    [MailSplitFilterKind.FROM, /has no sender/],
+  ])("throws rather than silently querying the whole inbox when %s has no value", (kind, message) => {
+    expect(() => mailSplitToThreadsQuery(split([{ kind }]), NOW)).toThrow(
+      message,
     );
+  });
+
+  it("throws rather than guessing when the age token is unknown", () => {
+    expect(() =>
+      mailSplitToThreadsQuery(
+        split([{ kind: MailSplitFilterKind.OLDER_THAN, value: "7y" }]),
+        NOW,
+      ),
+    ).toThrow(/unknown age/);
   });
 });
 
 describe("getPortableLabelSplits", () => {
-  it("uses the source label name as the cross-account identity", () => {
+  it("uses the source label names as the cross-account identity", () => {
     const labelSplit = {
-      ...split(MailSplitKind.LABEL, "source-label-id"),
+      ...split([{ kind: MailSplitFilterKind.LABEL, value: "source-label-id" }]),
       name: "Custom tab title",
     };
 
     expect(
       getPortableLabelSplits(
-        [labelSplit, split(MailSplitKind.CATEGORY, "CATEGORY_UPDATES")],
+        [
+          labelSplit,
+          split([
+            { kind: MailSplitFilterKind.CATEGORY, value: "CATEGORY_UPDATES" },
+          ]),
+        ],
         { "source-label-id": { name: "Receipts" } },
       ),
     ).toEqual([{ ...labelSplit, labelNames: ["Receipts"] }]);
   });
 
-  it("omits label splits whose source label no longer exists", () => {
+  it("omits splits whose source label no longer exists", () => {
     expect(
-      getPortableLabelSplits([split(MailSplitKind.LABEL, "missing-label")], {}),
-    ).toEqual([]);
-  });
-
-  it("carries every label name of a multi-label split", () => {
-    const labelSplit = split(MailSplitKind.LABEL, "one", "two");
-
-    expect(
-      getPortableLabelSplits([labelSplit], {
-        one: { name: "One" },
-        two: { name: "Two" },
-      }),
-    ).toEqual([{ ...labelSplit, labelNames: ["One", "Two"] }]);
-  });
-
-  it("omits a multi-label split when one of its labels is gone", () => {
-    expect(
-      getPortableLabelSplits([split(MailSplitKind.LABEL, "one", "missing")], {
-        one: { name: "One" },
-      }),
+      getPortableLabelSplits(
+        [split([{ kind: MailSplitFilterKind.LABEL, value: "missing-label" }])],
+        {},
+      ),
     ).toEqual([]);
   });
 });

--- a/apps/web/utils/mail/split-query.test.ts
+++ b/apps/web/utils/mail/split-query.test.ts
@@ -168,3 +168,20 @@ describe("getPortableLabelSplits", () => {
     ).toEqual([]);
   });
 });
+
+it.each([
+  ["3d", "1m"],
+  ["1m", "3d"],
+])("uses the stricter age when matching all conditions: %s, %s", (first, second) => {
+  expect(
+    mailSplitToThreadsQuery(
+      split(
+        [first, second].map((value) => ({
+          kind: MailSplitFilterKind.OLDER_THAN,
+          value,
+        })),
+      ),
+      NOW,
+    ).before,
+  ).toEqual(new Date("2026-08-10T12:00:00.000Z"));
+});

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -1,5 +1,8 @@
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
-import type { ThreadsQuery } from "@/utils/threads/validation";
+import type {
+  ThreadsQuery,
+  ThreadsQueryLeaf,
+} from "@/utils/threads/validation";
 import { isOutlookInboxSection } from "@/utils/mail/outlook-inbox";
 
 export type MailSplitFilter = {
@@ -128,7 +131,7 @@ function matchAllQuery(split: MailSplit, now: Date): ThreadsQuery {
  * condition becomes its own leaf and the provider ORs them inside the inbox.
  */
 function matchAnyQuery(split: MailSplit, now: Date): ThreadsQuery {
-  const anyOf = split.filters.map((filter) => {
+  const anyOf = split.filters.map<ThreadsQueryLeaf>((filter) => {
     switch (filter.kind) {
       case MailSplitFilterKind.UNREAD:
         return { isUnread: true };

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -1,40 +1,49 @@
-import { MailSplitKind } from "@/generated/prisma/enums";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { isOutlookInboxSection } from "@/utils/mail/outlook-inbox";
+
+export type MailSplitFilter = {
+  kind: MailSplitFilterKind;
+  value: string | null;
+};
 
 export type MailSplit = {
   id: string;
   name: string;
-  kind: MailSplitKind;
-  values: string[];
+  /** False means "show mail matching any of these conditions". */
+  matchAll: boolean;
+  filters: MailSplitFilter[];
 };
 
 export type PortableLabelSplit = MailSplit & { labelNames: string[] };
 
+/** Tokens the "Older than" condition offers, and how far back each one reaches. */
+const OLDER_THAN_DAYS: Record<string, number> = {
+  "3d": 3,
+  "1w": 7,
+  "1m": 30,
+};
+
+export const OLDER_THAN_OPTIONS = [
+  { value: "3d", name: "3 days" },
+  { value: "1w", name: "a week" },
+  { value: "1m", name: "a month" },
+];
+
 /**
  * Every split is its own server query. Filtering a paginated list client-side would
  * only ever search the pages already loaded, which silently under-reports.
+ *
+ * `now` is injected so the "older than" window is testable.
  */
-export function mailSplitToThreadsQuery(split: MailSplit): ThreadsQuery {
-  switch (split.kind) {
-    case MailSplitKind.INBOX:
-      return { type: "inbox" };
-    case MailSplitKind.UNREAD:
-      return { type: "inbox", isUnread: true };
-    case MailSplitKind.LABEL: {
-      if (!split.values.length)
-        throw new Error(`Split "${split.name}" has no label`);
-      return labelIdsToThreadsQuery(split.values);
-    }
-    case MailSplitKind.CATEGORY: {
-      const [category] = split.values;
-      if (!category) throw new Error(`Split "${split.name}" has no category`);
-      if (isOutlookInboxSection(category)) {
-        return mailTypeToThreadsQuery(category);
-      }
-      return { labelIds: [category, "INBOX"] };
-    }
-  }
+export function mailSplitToThreadsQuery(
+  split: MailSplit,
+  now: Date = new Date(),
+): ThreadsQuery {
+  // A split with no conditions is the plain inbox — that's what "All" is.
+  if (!split.filters.length) return { type: "inbox" };
+
+  return split.matchAll ? matchAllQuery(split, now) : matchAnyQuery(split, now);
 }
 
 export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
@@ -44,25 +53,120 @@ export function mailTypeToThreadsQuery(type: string): ThreadsQuery {
   return { type };
 }
 
-/**
- * Splits the combined mailbox can run. It matches by label name because each
- * account has its own label ids, so a split whose labels no longer resolve is
- * dropped rather than silently run against fewer labels.
- */
 export function getPortableLabelSplits(
   splits: MailSplit[],
   labelsById: Record<string, { name: string }>,
 ): PortableLabelSplit[] {
   return splits.flatMap((split) => {
-    if (split.kind !== MailSplitKind.LABEL) return [];
-    const labelNames = split.values.flatMap((labelId) => {
-      const labelName = labelsById[labelId]?.name.trim();
-      return labelName ? [labelName] : [];
-    });
-    return labelNames.length && labelNames.length === split.values.length
-      ? [{ ...split, labelNames }]
-      : [];
+    const labelFilters = split.filters.filter(
+      (filter) => filter.kind === MailSplitFilterKind.LABEL,
+    );
+    if (
+      !labelFilters.length ||
+      labelFilters.length !== split.filters.length ||
+      (split.matchAll && labelFilters.length > 1)
+    )
+      return [];
+
+    const labelNames = labelFilters.map(
+      (filter) => labelsById[filter.value ?? ""]?.name.trim() ?? "",
+    );
+    // A split that leans on a label the account no longer has can't be
+    // reproduced elsewhere, so it's dropped rather than silently widened.
+    if (labelNames.some((name) => !name)) return [];
+
+    return [{ ...split, labelNames }];
   });
+}
+
+/** Everything ANDs into a single provider query. */
+function matchAllQuery(split: MailSplit, now: Date): ThreadsQuery {
+  const labelIds = ["INBOX"];
+  const query: ThreadsQuery = {};
+
+  for (const filter of split.filters) {
+    switch (filter.kind) {
+      case MailSplitFilterKind.UNREAD:
+        query.isUnread = true;
+        break;
+      case MailSplitFilterKind.STARRED:
+        labelIds.push("STARRED");
+        break;
+      case MailSplitFilterKind.LABEL:
+        labelIds.push(requireValue(filter, split, "label"));
+        break;
+      case MailSplitFilterKind.CATEGORY: {
+        const category = requireValue(filter, split, "category");
+        if (isOutlookInboxSection(category)) query.inboxSection = category;
+        else labelIds.push(category);
+        break;
+      }
+      case MailSplitFilterKind.FROM:
+        query.fromEmail = requireValue(filter, split, "sender");
+        break;
+      case MailSplitFilterKind.OLDER_THAN: {
+        const before = olderThanDate(
+          requireValue(filter, split, "age"),
+          split,
+          now,
+        );
+        if (!query.before || before < query.before) query.before = before;
+        break;
+      }
+    }
+  }
+
+  // `inboxSection` only narrows Outlook's inbox when nothing else pins the
+  // folder, so it carries the inbox scope itself rather than a label id.
+  if (query.inboxSection && labelIds.length === 1)
+    return { ...query, type: "inbox" };
+  return { ...query, labelIds };
+}
+
+/**
+ * "Match any" is a disjunction, which a single flat query can't express, so each
+ * condition becomes its own leaf and the provider ORs them inside the inbox.
+ */
+function matchAnyQuery(split: MailSplit, now: Date): ThreadsQuery {
+  const anyOf = split.filters.map((filter) => {
+    switch (filter.kind) {
+      case MailSplitFilterKind.UNREAD:
+        return { isUnread: true };
+      case MailSplitFilterKind.STARRED:
+        return { labelId: "STARRED" };
+      case MailSplitFilterKind.LABEL:
+        return { labelId: requireValue(filter, split, "label") };
+      case MailSplitFilterKind.CATEGORY: {
+        const category = requireValue(filter, split, "category");
+        return isOutlookInboxSection(category)
+          ? { inboxSection: category }
+          : { labelId: category };
+      }
+      case MailSplitFilterKind.FROM:
+        return { fromEmail: requireValue(filter, split, "sender") };
+      case MailSplitFilterKind.OLDER_THAN:
+        return {
+          before: olderThanDate(requireValue(filter, split, "age"), split, now),
+        };
+    }
+  });
+
+  return { labelIds: ["INBOX"], anyOf };
+}
+
+function requireValue(
+  filter: MailSplitFilter,
+  split: MailSplit,
+  what: string,
+): string {
+  if (!filter.value) throw new Error(`Split "${split.name}" has no ${what}`);
+  return filter.value;
+}
+
+function olderThanDate(token: string, split: MailSplit, now: Date): Date {
+  const days = OLDER_THAN_DAYS[token];
+  if (!days) throw new Error(`Split "${split.name}" has an unknown age`);
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 }
 
 export function labelIdsToThreadsQuery(labelIds: string[]): ThreadsQuery {

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -1,23 +1,30 @@
 import { randomUUID } from "node:crypto";
 import type { MailSplit } from "@/generated/prisma/client";
+import { MailSplitFilterKind } from "@/generated/prisma/enums";
+import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
 import prisma from "@/utils/prisma";
 import { lockMailSplits } from "@/utils/mail/split-lock";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 
-export type CreateMailSplitResult =
+type CreateMailSplitResult =
   | ({ status: "created" } & MailSplit)
   | { status: "duplicate" | "limit" };
 
-/**
- * Inserts a split only if the account is under its limit and the name is free,
- * so two concurrent creates can't race past either check.
- */
 export async function createMailSplit({
   emailAccountId,
   name,
-  kind,
-  values,
-}: Pick<MailSplit, "emailAccountId" | "name" | "kind" | "values">) {
+  matchAll,
+  filters,
+}: {
+  emailAccountId: string;
+  name: string;
+  matchAll: boolean;
+  filters: MailSplitFilterDraft[];
+}) {
+  // The id is chosen up front so the split and its conditions can be written in
+  // one transaction without a round trip in between.
+  const splitId = randomUUID();
+
   const [, results] = await prisma.$transaction([
     lockMailSplits(emailAccountId),
     prisma.$queryRaw<CreateMailSplitResult[]>`
@@ -40,18 +47,16 @@ export async function createMailSplit({
           "createdAt",
           "updatedAt",
           "name",
-          "kind",
-          "values",
+          "matchAll",
           "order",
           "emailAccountId"
         )
         SELECT
-          ${randomUUID()},
+          ${splitId},
           CURRENT_TIMESTAMP,
           CURRENT_TIMESTAMP,
           ${name},
-          ${kind}::"MailSplitKind",
-          ${values},
+          ${matchAll},
           split_state.next_order,
           ${emailAccountId}
         FROM split_state
@@ -69,15 +74,36 @@ export async function createMailSplit({
       FROM split_state
       LEFT JOIN inserted ON TRUE
     `,
+    // Guarded on the split existing, so a rejected insert above (limit reached,
+    // duplicate name) can't leave conditions pointing at nothing.
+    prisma.$executeRaw`
+      INSERT INTO "MailSplitFilter" ("id", "kind", "value", "order", "mailSplitId")
+      SELECT
+        conditions."id",
+        conditions."kind"::"MailSplitFilterKind",
+        conditions."value",
+        conditions."order",
+        ${splitId}
+      FROM jsonb_to_recordset(${toFilterRows(filters)}::jsonb)
+        AS conditions("id" text, "kind" text, "value" text, "order" integer)
+      WHERE EXISTS (SELECT 1 FROM "MailSplit" WHERE "id" = ${splitId})
+    `,
   ]);
 
   return results[0];
 }
 
-/**
- * Keeps splits usable after a label is deleted: wider splits carry on without
- * it, and a split it was the only label of has nothing left to show.
- */
+export function toFilterRows(filters: MailSplitFilterDraft[]) {
+  return JSON.stringify(
+    filters.map((filter, order) => ({
+      id: randomUUID(),
+      kind: filter.kind,
+      value: filter.value ?? null,
+      order,
+    })),
+  );
+}
+
 export async function removeLabelFromMailSplits({
   emailAccountId,
   labelId,
@@ -85,24 +111,24 @@ export async function removeLabelFromMailSplits({
   emailAccountId: string;
   labelId: string;
 }) {
-  // PostgreSQL cannot update and delete the same row in one CTE statement.
-  // Delete emptied splits first, then narrow the remaining rows atomically.
   await prisma.$transaction([
     lockMailSplits(emailAccountId),
-    prisma.$executeRaw`
-      DELETE FROM "MailSplit"
-      WHERE "emailAccountId" = ${emailAccountId}
-        AND "kind" = 'LABEL'::"MailSplitKind"
-        AND ${labelId} = ANY("values")
-        AND cardinality(array_remove("values", ${labelId})) = 0
-    `,
-    prisma.$executeRaw`
-      UPDATE "MailSplit"
-      SET "values" = array_remove("values", ${labelId}), "updatedAt" = NOW()
-      WHERE "emailAccountId" = ${emailAccountId}
-        AND "kind" = 'LABEL'::"MailSplitKind"
-        AND ${labelId} = ANY("values")
-    `,
+    prisma.mailSplit.deleteMany({
+      where: {
+        emailAccountId,
+        filters: {
+          some: {},
+          every: { kind: MailSplitFilterKind.LABEL, value: labelId },
+        },
+      },
+    }),
+    prisma.mailSplitFilter.deleteMany({
+      where: {
+        kind: MailSplitFilterKind.LABEL,
+        value: labelId,
+        mailSplit: { emailAccountId },
+      },
+    }),
   ]);
 }
 

--- a/apps/web/utils/mail/splits.server.ts
+++ b/apps/web/utils/mail/splits.server.ts
@@ -122,6 +122,13 @@ export async function removeLabelFromMailSplits({
         },
       },
     }),
+    prisma.mailSplit.updateMany({
+      where: {
+        emailAccountId,
+        filters: { some: { kind: MailSplitFilterKind.LABEL, value: labelId } },
+      },
+      data: { updatedAt: new Date() },
+    }),
     prisma.mailSplitFilter.deleteMany({
       where: {
         kind: MailSplitFilterKind.LABEL,

--- a/apps/web/utils/threads/fetch-page.test.ts
+++ b/apps/web/utils/threads/fetch-page.test.ts
@@ -40,3 +40,44 @@ describe("fetchThreadsPage", () => {
     );
   });
 });
+
+describe("match-any pagination", () => {
+  it("keeps overflow and deduplicates threads across condition pages", async () => {
+    const thread = (id: string, date: number) => ({
+      id,
+      messages: [{ internalDate: String(date) }],
+    });
+    const emailProvider = {
+      getThreadsWithQuery: vi.fn(async ({ query }) => ({
+        threads: query.fromEmail
+          ? [thread("newest", 4000), thread("shared", 3000)]
+          : [thread("shared", 3000), thread("oldest", 1000)],
+      })),
+    };
+    const load = (pageToken?: string) =>
+      fetchThreadsPage({
+        emailAccountId: "account-1",
+        query: {
+          labelId: "INBOX",
+          anyOf: [{ fromEmail: "sender@example.com" }, { labelId: "STARRED" }],
+        },
+        emailProvider: emailProvider as never,
+        maxResults: 2,
+        pageToken,
+        messageFormat: "metadata",
+      });
+    const first = await load();
+    expect(first.threads.map(({ id }) => id)).toEqual(["newest", "shared"]);
+    expect(first.nextPageToken).toBeTruthy();
+    const second = await load(first.nextPageToken);
+    expect(second.threads.map(({ id }) => id)).toEqual(["oldest"]);
+    expect(second.nextPageToken).toBeUndefined();
+    expect(
+      emailProvider.getThreadsWithQuery.mock.calls.some(
+        ([{ query }]) =>
+          query.labelIds?.includes("STARRED") &&
+          query.labelIds.includes("INBOX"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -58,20 +58,18 @@ export async function fetchThreadsPage({
       loadPage: async ({ source, pageToken }) => {
         const { anyOf: _anyOf, ...base } = query;
         const { labelId, ...condition } = source.condition;
+        const requiredLabelIds = base.labelIds?.length
+          ? base.labelIds
+          : base.labelId
+            ? [base.labelId]
+            : ["INBOX"];
         const page = await emailProvider.getThreadsWithQuery({
           query: {
             ...base,
             ...condition,
             labelIds: labelId
-              ? [
-                  ...(base.labelIds?.length
-                    ? base.labelIds
-                    : base.labelId
-                      ? [base.labelId]
-                      : []),
-                  labelId,
-                ]
-              : base.labelIds,
+              ? [...requiredLabelIds, labelId]
+              : requiredLabelIds,
           },
           maxResults,
           pageToken,

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -58,11 +58,9 @@ export async function fetchThreadsPage({
       loadPage: async ({ source, pageToken }) => {
         const { anyOf: _anyOf, ...base } = query;
         const { labelId, ...condition } = source.condition;
-        const requiredLabelIds = base.labelIds?.length
-          ? base.labelIds
-          : base.labelId
-            ? [base.labelId]
-            : ["INBOX"];
+        let requiredLabelIds = ["INBOX"];
+        if (base.labelIds?.length) requiredLabelIds = base.labelIds;
+        else if (base.labelId) requiredLabelIds = [base.labelId];
         const page = await emailProvider.getThreadsWithQuery({
           query: {
             ...base,

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -35,6 +35,60 @@ export async function fetchThreadsPage({
     });
   }
 
+  if (query.anyOf?.length) {
+    const merged = await mergePaginatedSources({
+      sources: query.anyOf.map((condition, index) => ({
+        id: String(index),
+        condition,
+      })),
+      cursor: pageToken ?? null,
+      pageBuffer: createPageBuffer<EmailThread>({
+        kind: "labels",
+        emailAccountId,
+        messageFormat,
+        maxResults,
+        query,
+      }),
+      limit: maxResults,
+      concurrency: LABEL_CONCURRENCY,
+      compare: (left, right) =>
+        getThreadTimestamp(right) - getThreadTimestamp(left),
+      getItemId: (thread: EmailThread) => thread.id,
+      dedupeItemKey: (thread) => thread.id,
+      loadPage: async ({ source, pageToken }) => {
+        const { anyOf: _anyOf, ...base } = query;
+        const { labelId, ...condition } = source.condition;
+        const page = await emailProvider.getThreadsWithQuery({
+          query: {
+            ...base,
+            ...condition,
+            labelIds: labelId
+              ? [
+                  ...(base.labelIds?.length
+                    ? base.labelIds
+                    : base.labelId
+                      ? [base.labelId]
+                      : []),
+                  labelId,
+                ]
+              : base.labelIds,
+          },
+          maxResults,
+          pageToken,
+          messageFormat,
+        });
+        return { items: page.threads, nextPageToken: page.nextPageToken };
+      },
+      onSourceError: ({ error }) => {
+        throw error;
+      },
+    });
+    return {
+      threads: merged.items,
+      nextPageToken: merged.nextPageToken ?? undefined,
+    };
+  }
+
   // A repeated label would run the same query twice and collide in the cursor.
   const anyLabelIds = [...new Set(query.anyLabelIds ?? [])];
   let requiredLabelIds = query.labelIds ?? [];

--- a/apps/web/utils/threads/validation.test.ts
+++ b/apps/web/utils/threads/validation.test.ts
@@ -38,3 +38,14 @@ describe("threadsQueryToSearchParams", () => {
     expect(threadsQuery.safeParse({ anyOf: "not json" }).success).toBe(false);
   });
 });
+
+it.each([
+  { anyOf: [{}] },
+  { anyOf: [{ unknown: true }] },
+  { anyOf: [{ labelId: "" }] },
+  { anyOf: [{ labelId: "one", fromEmail: "sender@example.com" }] },
+  { q: "search", anyOf: [{ isUnread: true }] },
+  { type: "sent", anyOf: [{ isUnread: true }] },
+])("rejects ambiguous split queries: %j", (query) => {
+  expect(threadsQuery.safeParse(query).success).toBe(false);
+});

--- a/apps/web/utils/threads/validation.test.ts
+++ b/apps/web/utils/threads/validation.test.ts
@@ -34,7 +34,7 @@ describe("threadsQueryToSearchParams", () => {
     ).toBe(false);
   });
 
-  it("drops an unparseable value rather than failing the request", () => {
-    expect(threadsQuery.parse({ anyOf: "not json" }).anyOf).toBeUndefined();
+  it("rejects malformed conditions instead of showing the entire inbox", () => {
+    expect(threadsQuery.safeParse({ anyOf: "not json" }).success).toBe(false);
   });
 });

--- a/apps/web/utils/threads/validation.test.ts
+++ b/apps/web/utils/threads/validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  threadsQuery,
+  threadsQueryToSearchParams,
+} from "@/utils/threads/validation";
+
+describe("threadsQueryToSearchParams", () => {
+  it("survives a round trip through the query string", () => {
+    const anyOf = [
+      { fromEmail: "notifications@linear.app" },
+      { labelId: "Label_1" },
+    ];
+    const params = threadsQueryToSearchParams({
+      labelIds: ["INBOX"],
+      anyOf,
+    });
+
+    // String(anyOf) would silently send "[object Object]", which the route then
+    // drops — leaving a "match any" split showing the whole inbox.
+    expect(params.get("anyOf")).toBe(JSON.stringify(anyOf));
+    expect(threadsQuery.parse({ anyOf: params.get("anyOf") }).anyOf).toEqual(
+      anyOf,
+    );
+  });
+
+  it("omits the parameter entirely when there are no branches", () => {
+    expect(
+      threadsQueryToSearchParams({ labelIds: ["INBOX"] }).has("anyOf"),
+    ).toBe(false);
+    expect(
+      threadsQueryToSearchParams({ labelIds: ["INBOX"], anyOf: [] }).has(
+        "anyOf",
+      ),
+    ).toBe(false);
+  });
+
+  it("drops an unparseable value rather than failing the request", () => {
+    expect(threadsQuery.parse({ anyOf: "not json" }).anyOf).toBeUndefined();
+  });
+});

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -49,12 +49,12 @@ export type ThreadsQuery = z.infer<typeof threadsQuery>;
 // full response so a bad param can never drop data a caller depends on.
 export const threadsView = z.enum(["full", "list"]).catch("full");
 
-/** A malformed value is dropped rather than failing the whole request. */
+/** Preserve invalid input so validation rejects it instead of widening the query. */
 function parseAnyOf(value: string): unknown {
   try {
     return JSON.parse(value);
   } catch {
-    return;
+    return value;
   }
 }
 

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -8,41 +8,66 @@ import { createSearchParams } from "@/utils/url";
  * One branch of a "match any" split. Leaves are single conditions, so the
  * provider can OR them without having to interpret a nested expression.
  */
-const threadsQueryLeaf = z.object({
-  labelId: z.string().nullish(),
-  fromEmail: z.string().nullish(),
-  isUnread: z.coerce.boolean().nullish(),
-  before: z.coerce.date().nullish(),
-  inboxSection: z.enum(["focused", "other"]).nullish(),
-});
+const threadsQueryLeaf = z
+  .strictObject({
+    labelId: z.string().trim().min(1).nullish(),
+    fromEmail: z.string().trim().min(1).nullish(),
+    isUnread: z.literal(true).nullish(),
+    before: z.coerce.date().nullish(),
+    inboxSection: z.enum(["focused", "other"]).nullish(),
+  })
+  .refine(
+    (leaf) =>
+      Object.values(leaf).filter(
+        (value) =>
+          value !== null &&
+          value !== undefined &&
+          value !== "" &&
+          value !== false,
+      ).length === 1,
+    { message: "Each match-any branch must contain one condition" },
+  );
 export type ThreadsQueryLeaf = z.infer<typeof threadsQueryLeaf>;
 
-export const threadsQuery = z.object({
-  q: z.string().nullish(),
-  fromEmail: z.string().nullish(),
-  limit: z.coerce.number().max(100).nullish(),
-  type: z.string().nullish(),
-  folderId: z.string().nullish(), // For Outlook
-  inboxSection: z.enum(["focused", "other"]).nullish(),
-  nextPageToken: microsoftGraphPageTokenSchema,
-  labelId: z.string().nullish(), // For Google
-  labelIds: z.array(z.string()).nullish(), // For Google
-  // Threads matching any one of these labels, on top of `labelIds`, which all
-  // have to match. Served by fanning out one provider query per label.
-  anyLabelIds: z.array(z.string()).max(MAX_SPLIT_LABELS).nullish(),
-  excludeLabelNames: z.array(z.string()).nullish(), // For Google
-  after: z.coerce.date().nullish(),
-  before: z.coerce.date().nullish(),
-  isUnread: z.coerce.boolean().nullish(),
-  /**
-   * Match any one of these, ANDed with the rest of the query. Travels over the
-   * wire as JSON, since a list of objects has no natural query-string form.
-   */
-  anyOf: z.preprocess(
-    (value) => (typeof value === "string" ? parseAnyOf(value) : value),
-    z.array(threadsQueryLeaf).max(MAX_SPLIT_FILTERS).nullish(),
-  ),
-});
+export const threadsQuery = z
+  .object({
+    q: z.string().nullish(),
+    fromEmail: z.string().nullish(),
+    limit: z.coerce.number().max(100).nullish(),
+    type: z.string().nullish(),
+    folderId: z.string().nullish(), // For Outlook
+    inboxSection: z.enum(["focused", "other"]).nullish(),
+    nextPageToken: microsoftGraphPageTokenSchema,
+    labelId: z.string().nullish(), // For Google
+    labelIds: z.array(z.string()).nullish(), // For Google
+    // Threads matching any one of these labels, on top of `labelIds`, which all
+    // have to match. Served by fanning out one provider query per label.
+    anyLabelIds: z.array(z.string()).max(MAX_SPLIT_LABELS).nullish(),
+    excludeLabelNames: z.array(z.string()).nullish(), // For Google
+    after: z.coerce.date().nullish(),
+    before: z.coerce.date().nullish(),
+    isUnread: z.coerce.boolean().nullish(),
+    /**
+     * Match any one of these, ANDed with the rest of the query. Travels over the
+     * wire as JSON, since a list of objects has no natural query-string form.
+     */
+    anyOf: z.preprocess(
+      (value) => (typeof value === "string" ? parseAnyOf(value) : value),
+      z.array(threadsQueryLeaf).max(MAX_SPLIT_FILTERS).nullish(),
+    ),
+  })
+  .refine(
+    (query) =>
+      !query.anyOf?.length ||
+      (!query.q &&
+        !query.anyLabelIds?.length &&
+        !query.folderId &&
+        (!query.type || query.type === "inbox")),
+    {
+      message:
+        "Match-any conditions require an inbox query without search or label unions",
+    },
+  );
 export type ThreadsQuery = z.infer<typeof threadsQuery>;
 
 // Opt-in slim response for list rows. Anything unrecognised falls back to the

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -1,6 +1,21 @@
 import { z } from "zod";
+import { MAX_SPLIT_FILTERS } from "@/utils/mail/split-filters";
 import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
+import { createSearchParams } from "@/utils/url";
+
+/**
+ * One branch of a "match any" split. Leaves are single conditions, so the
+ * provider can OR them without having to interpret a nested expression.
+ */
+const threadsQueryLeaf = z.object({
+  labelId: z.string().nullish(),
+  fromEmail: z.string().nullish(),
+  isUnread: z.coerce.boolean().nullish(),
+  before: z.coerce.date().nullish(),
+  inboxSection: z.enum(["focused", "other"]).nullish(),
+});
+export type ThreadsQueryLeaf = z.infer<typeof threadsQueryLeaf>;
 
 export const threadsQuery = z.object({
   q: z.string().nullish(),
@@ -19,9 +34,37 @@ export const threadsQuery = z.object({
   after: z.coerce.date().nullish(),
   before: z.coerce.date().nullish(),
   isUnread: z.coerce.boolean().nullish(),
+  /**
+   * Match any one of these, ANDed with the rest of the query. Travels over the
+   * wire as JSON, since a list of objects has no natural query-string form.
+   */
+  anyOf: z.preprocess(
+    (value) => (typeof value === "string" ? parseAnyOf(value) : value),
+    z.array(threadsQueryLeaf).max(MAX_SPLIT_FILTERS).nullish(),
+  ),
 });
 export type ThreadsQuery = z.infer<typeof threadsQuery>;
 
 // Opt-in slim response for list rows. Anything unrecognised falls back to the
 // full response so a bad param can never drop data a caller depends on.
 export const threadsView = z.enum(["full", "list"]).catch("full");
+
+/** A malformed value is dropped rather than failing the whole request. */
+function parseAnyOf(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return;
+  }
+}
+
+/** Serialises a query for `/api/threads`, JSON-encoding the `anyOf` branches. */
+export function threadsQueryToSearchParams(
+  query: ThreadsQuery & Record<string, unknown>,
+) {
+  const { anyOf, ...rest } = query;
+  return createSearchParams({
+    ...rest,
+    ...(anyOf?.length ? { anyOf: JSON.stringify(anyOf) } : {}),
+  });
+}

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -19,11 +19,7 @@ const threadsQueryLeaf = z
   .refine(
     (leaf) =>
       Object.values(leaf).filter(
-        (value) =>
-          value !== null &&
-          value !== undefined &&
-          value !== "" &&
-          value !== false,
+        (value) => value !== null && value !== undefined,
       ).length === 1,
     { message: "Each match-any branch must contain one condition" },
   );


### PR DESCRIPTION
Split inboxes can now combine conditions and be edited in place. The library groups the default inbox examples under General and selected service presets under Apps, with GitHub and Stripe first.

- Add an all/any condition builder for labels, categories, senders, unread, starred, and message age, plus editable AI suggestions.
- Simplify split tabs and details, with tab actions in the context menu and corrected select spacing.
- Migrate saved splits while preserving existing inbox/unread rows and multi-label unions; reuse buffered pagination for match-any results.
- Validation: 63 focused unit tests, 7 real-database tests, successful migration on a disposable database, and 4 emulated browser checks and 6 live AI regression tests passed. Builder and library screenshots inspected.

Match-all uses one provider query. Match-any runs up to ten condition queries with concurrency limited to four and buffered, deduplicated pagination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned mail split creation and editing with custom conditions, match-all/match-any behavior, and support for unread, starred, labels, categories, senders, and message age.
  - Added a library of ready-to-use split presets, with account-specific matching and support-aware options.
  - AI-assisted split creation now interprets natural-language requests and presents generated conditions for review.
  - Improved results for splits combining multiple conditions, including match-any searches and pagination.

- **Bug Fixes**
  - Invalid or incomplete split and search conditions are now rejected instead of being silently ignored.
  - Improved handling of deleted labels and split limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->