### PR TITLE
Fix Outlook scoped cleanup and deletion completion

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -220,7 +220,7 @@ describe("aiProcessAssistantChat", () => {
   }, 30_000);
 
   it.each([
-    ["web", 240_000],
+    ["web", 720_000],
     ["messaging", 60_000],
   ] as const)(
     "continues %s tool calls without a step cap and reserves time for a final response",

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -192,7 +192,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
               cacheKeyParts: [{ model, provider: "microsoft", messages }],
             },
             async () => {
-              const { toolCalls, actual } = await runAssistantChat({
+              const { toolCalls, actual, finalText } = await runAssistantChat({
                 emailAccount: cloneEmailAccountForProvider(
                   emailAccount,
                   "microsoft",
@@ -203,12 +203,18 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
               const listCall = toolCalls.find(
                 (toolCall) => toolCall.toolName === "listFolders",
               );
-              const outputText = JSON.stringify(listCall?.output ?? {});
+              const output = listCall?.output as
+                | { folders: Array<{ id: string }> }
+                | undefined;
+              const outputText = JSON.stringify(output ?? {});
+              const folderIds =
+                output?.folders.map((folder) => folder.id) ?? [];
               const pass =
                 !!listCall &&
                 outputText.includes(`Operations${FOLDER_SEPARATOR}Reports`) &&
-                !outputText.includes("folder-operations") &&
-                !outputText.includes("folder-vendor-updates") &&
+                folderIds.length > 0 &&
+                finalText.trim().length > 0 &&
+                folderIds.every((id) => !finalText.includes(id)) &&
                 !toolCalls.some(
                   (toolCall) =>
                     toolCall.toolName === "listCategories" ||
@@ -217,7 +223,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
 
               return {
                 pass,
-                actual: `${actual} | output=${outputText}`,
+                actual: `${actual} | output=${outputText} | finalText=${finalText}`,
               };
             },
           );

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -214,7 +214,12 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
                 outputText.includes(`Operations${FOLDER_SEPARATOR}Reports`) &&
                 folderIds.length > 0 &&
                 finalText.trim().length > 0 &&
-                folderIds.every((id) => !finalText.includes(id)) &&
+                folderIds.every(
+                  (id) =>
+                    typeof id === "string" &&
+                    id.trim().length > 0 &&
+                    !finalText.includes(id),
+                ) &&
                 !toolCalls.some(
                   (toolCall) =>
                     toolCall.toolName === "listCategories" ||

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -44,7 +44,7 @@ import {
 import { getToolFailureWarning } from "@/utils/ai/assistant/chat-response-guard";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 
-export const maxDuration = 300;
+export const maxDuration = 800;
 
 export const POST = withEmailAccount("chat", async (request) => {
   const emailAccountId = request.auth.emailAccountId;

--- a/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
@@ -28,7 +28,7 @@ describe("chat folder tools", () => {
     vi.clearAllMocks();
   });
 
-  it("lists nested Outlook folders without exposing folder IDs", async () => {
+  it("lists nested Outlook folders with IDs for scoped searches", async () => {
     const folders: OutlookFolder[] = [
       {
         id: "folder-1",
@@ -59,19 +59,19 @@ describe("chat folder tools", () => {
       count: 2,
       folders: [
         {
+          id: "folder-1",
           name: "Operations",
           path: "Operations",
           childFolderCount: 1,
         },
         {
+          id: "folder-2",
           name: "Reports",
           path: `Operations${FOLDER_SEPARATOR}Reports`,
           childFolderCount: 0,
         },
       ],
     });
-    expect(JSON.stringify(result)).not.toContain("folder-1");
-    expect(JSON.stringify(result)).not.toContain("folder-2");
   });
 
   it("reuses an existing Outlook folder by normalized name", async () => {

--- a/apps/web/utils/ai/assistant/chat-folder-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.ts
@@ -35,7 +35,7 @@ export const listFoldersTool = ({
 }: FolderToolOptions) =>
   tool({
     description:
-      "List Outlook mail folders for this account. Use this before moving threads to a folder when the exact folder name is unclear. Returns folder names and paths only; internal folder IDs are not shown.",
+      "List Outlook mail folders for this account. Use this to find folders before searching or moving threads. Returns names, paths, and IDs; use a folder ID in searchInbox categoryName when names are ambiguous.",
     inputSchema: z.object({}),
     execute: async () => {
       trackToolCall({ tool: "list_folders", email, logger });
@@ -47,7 +47,7 @@ export const listFoldersTool = ({
           logger,
         });
         const folders = await emailProvider.getFolders();
-        const flattenedFolders = flattenFolders(folders).map(toVisibleFolder);
+        const flattenedFolders = flattenFolders(folders);
 
         return {
           folders: flattenedFolders,

--- a/apps/web/utils/ai/assistant/chat-folder-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.ts
@@ -2,7 +2,11 @@ import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { Logger } from "@/utils/logger";
-import { FOLDER_SEPARATOR, type OutlookFolder } from "@/utils/outlook/folders";
+import {
+  FOLDER_SEPARATOR,
+  flattenOutlookFolders,
+  type OutlookFolder,
+} from "@/utils/outlook/folders";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
 type FolderToolOptions = {
@@ -221,24 +225,13 @@ type FolderReference = FlattenedFolder & {
   id: string;
 };
 
-function flattenFolders(
-  folders: OutlookFolder[],
-  parentPath?: string,
-): FolderReference[] {
-  return folders.flatMap((folder) => {
-    const path = parentPath
-      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
-      : folder.displayName;
-    return [
-      {
-        id: folder.id,
-        name: folder.displayName,
-        path,
-        childFolderCount: folder.childFolderCount ?? folder.childFolders.length,
-      },
-      ...flattenFolders(folder.childFolders, path),
-    ];
-  });
+function flattenFolders(folders: OutlookFolder[]): FolderReference[] {
+  return flattenOutlookFolders(folders).map((folder) => ({
+    id: folder.id,
+    name: folder.displayName,
+    path: folder.path,
+    childFolderCount: folder.childFolderCount ?? folder.childFolders.length,
+  }));
 }
 
 function toVisibleFolder(folder: FolderReference): FlattenedFolder {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -1450,7 +1450,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     );
   });
 
-  it("searchInbox normalizes simple Outlook scope queries before provider search", async () => {
+  it("searchInbox keeps bare Outlook text queries as text", async () => {
     const searchMessages = vi.fn().mockResolvedValue({
       messages: [],
       nextPageToken: undefined,
@@ -1474,11 +1474,11 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     expect(searchMessages).toHaveBeenNthCalledWith(1, {
-      query: "",
+      query: "Operations folder",
       maxResults: 20,
       pageToken: undefined,
       readState: "unread",
-      labelName: "Operations",
+      labelName: undefined,
     });
   });
 
@@ -1507,11 +1507,11 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     expect(searchMessages).toHaveBeenCalledWith({
-      query: "",
+      query: "newsletter",
       maxResults: 20,
       pageToken: undefined,
       readState: "unread",
-      labelName: "newsletter",
+      labelName: undefined,
     });
   });
 
@@ -1613,7 +1613,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     expect(result.hasMore).toBe(false);
   });
 
-  it("searchInbox falls back to Outlook text search when a normalized scope is conclusively empty", async () => {
+  it("searchInbox preserves an empty Outlook folder scope", async () => {
     const searchMessages = vi
       .fn()
       .mockResolvedValueOnce({
@@ -1638,7 +1638,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     const result: any = await (toolInstance.execute as any)({
-      query: "invoice",
+      query: 'folder:"invoice"',
       limit: 20,
     });
 
@@ -1649,15 +1649,11 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       readState: undefined,
       labelName: "invoice",
     });
-    expect(searchMessages).toHaveBeenNthCalledWith(2, {
-      query: "invoice",
-      maxResults: 20,
-      readState: undefined,
-    });
-    expect(result.queryUsed).toBe("invoice");
+    expect(searchMessages).toHaveBeenCalledTimes(1);
+    expect(result.queryUsed).toBe("");
   });
 
-  it("searchInbox falls back to Outlook text search after empty structured pages end", async () => {
+  it("searchInbox preserves Outlook scope after empty structured pages end", async () => {
     const searchMessages = vi
       .fn()
       .mockResolvedValueOnce({
@@ -1686,7 +1682,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     const result: any = await (toolInstance.execute as any)({
-      query: "invoice",
+      query: 'folder:"invoice"',
       limit: 20,
     });
 
@@ -1704,12 +1700,8 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       readState: undefined,
       labelName: "invoice",
     });
-    expect(searchMessages).toHaveBeenNthCalledWith(3, {
-      query: "invoice",
-      maxResults: 20,
-      readState: undefined,
-    });
-    expect(result.queryUsed).toBe("invoice");
+    expect(searchMessages).toHaveBeenCalledTimes(2);
+    expect(result.queryUsed).toBe("");
   });
 
   it("searchInbox does not pass structured Outlook filters to Google", async () => {
@@ -1849,7 +1841,10 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       limit: 20,
     });
 
-    expect(result.microsoftSearchFeedback.retryQueries).toContain(
+    expect(searchMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ query: String.raw`"Folder \\ Review"` }),
+    );
+    expect(result.microsoftSearchFeedback.retryQueries).not.toContain(
       String.raw`"Folder \\ Review"`,
     );
   });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -60,29 +60,6 @@ import { SafeError } from "@/utils/error";
 const SEARCH_INBOX_MAX_RESULTS = 20;
 const OUTLOOK_EMPTY_PAGE_AUTOPAGINATION_LIMIT = 5;
 const MAX_SENDER_CATEGORIZATION_WAIT_MS = 1500;
-const OUTLOOK_SCOPE_SUFFIX_TERMS = new Set([
-  "category",
-  "folder",
-  "mailbox",
-  "email",
-  "emails",
-  "message",
-  "messages",
-  "mail",
-]);
-const OUTLOOK_BOOLEAN_OPERATORS = new Set(["AND", "OR", "NOT"]);
-const OUTLOOK_TEMPORAL_SEARCH_TERMS = new Set([
-  "today",
-  "yesterday",
-  "tomorrow",
-  "week",
-  "month",
-  "year",
-  "morning",
-  "afternoon",
-  "evening",
-]);
-
 const recipientListSchema = z
   .string()
   .trim()
@@ -558,7 +535,7 @@ const outlookSearchInboxInputSchema = z
       .min(1)
       .nullish()
       .describe(
-        "Outlook category or folder scope for a scoped inbox search or cleanup request.",
+        "Outlook category or folder name, folder path, or folder/category ID for a scoped inbox search or cleanup request.",
       ),
   })
   .refine(
@@ -1734,7 +1711,7 @@ async function runOutlookSearch({
     }
   }
 
-  let queryUsed = formatQueryWithFromEmail(
+  const queryUsed = formatQueryWithFromEmail(
     executedQuery,
     normalizedInput.fromEmail,
   );
@@ -1752,20 +1729,6 @@ async function runOutlookSearch({
     categoryName: normalizedInput.categoryName,
     fromEmail: normalizedInput.fromEmail,
   });
-
-  if (
-    normalizedInput.fallbackQuery &&
-    !pageToken &&
-    result.messages.length === 0 &&
-    !result.nextPageToken
-  ) {
-    result = await emailProvider.searchMessages({
-      query: normalizedInput.fallbackQuery,
-      maxResults: limit ?? SEARCH_INBOX_MAX_RESULTS,
-      readState: normalizedInput.readState ?? undefined,
-    });
-    queryUsed = normalizedInput.fallbackQuery;
-  }
 
   return { result, queryUsed, failures };
 }
@@ -1814,7 +1777,6 @@ type NormalizedOutlookSearchInput = {
   fromEmail?: string | null;
   readState?: OutlookReadState | null;
   categoryName?: string | null;
-  fallbackQuery?: string | null;
 };
 
 function normalizeOutlookSearchInput({
@@ -1872,14 +1834,12 @@ function normalizeOutlookSearchInput({
     };
   }
 
-  const scopeCandidate =
-    getOutlookFieldScopeCandidate(queryWithoutState) ??
-    getOutlookScopeCandidate(queryWithoutState);
+  const scopeCandidate = getOutlookFieldScopeCandidate(queryWithoutState);
 
   if (!scopeCandidate) {
     return {
-      query: normalizedQuery,
-      readState,
+      query: queryWithoutState,
+      readState: inferredReadState,
     };
   }
 
@@ -1887,7 +1847,6 @@ function normalizeOutlookSearchInput({
     query: "",
     readState: inferredReadState,
     categoryName: scopeCandidate,
-    fallbackQuery: normalizedQuery,
   };
 }
 
@@ -1925,52 +1884,7 @@ function getOutlookFieldScopeCandidate(query: string) {
   const field = normalizedQuery.slice(0, colonIndex).trim().toLowerCase();
   if (field !== "category" && field !== "folder") return null;
 
-  return stripOutlookScopeDecorators(normalizedQuery.slice(colonIndex + 1));
-}
-
-function getOutlookScopeCandidate(query: string) {
-  const normalizedQuery = query.trim();
-  if (!normalizedQuery) return null;
-  if (hasOutlookTextSearchSyntax(normalizedQuery)) return null;
-  if (hasOutlookTemporalSearchTerm(normalizedQuery)) return null;
-
-  const candidate = stripOutlookScopeDecorators(normalizedQuery);
-  if (!candidate) return null;
-
-  return candidate;
-}
-
-function hasOutlookTemporalSearchTerm(query: string) {
-  return splitOutlookScopeWords(query).some((word) =>
-    OUTLOOK_TEMPORAL_SEARCH_TERMS.has(word.toLowerCase()),
-  );
-}
-
-function hasOutlookTextSearchSyntax(query: string) {
-  return (
-    hasOutlookSearchOperatorCharacters(query) ||
-    splitOutlookScopeWords(query).some((word) =>
-      OUTLOOK_BOOLEAN_OPERATORS.has(word.toUpperCase()),
-    ) ||
-    getOutlookComparisonFilters(query).length > 0
-  );
-}
-
-function hasOutlookSearchOperatorCharacters(query: string) {
-  return Array.from(query).some((char) =>
-    ["@", ":", "<", ">", "=", "{", "}", "[", "]", "|"].includes(char),
-  );
-}
-
-function stripOutlookScopeDecorators(value: string) {
-  const words = splitOutlookScopeWords(stripWrappingQuotes(value));
-  const lastWord = words.at(-1)?.toLowerCase();
-
-  if (lastWord && OUTLOOK_SCOPE_SUFFIX_TERMS.has(lastWord)) {
-    words.pop();
-  }
-
-  return words.join(" ").trim();
+  return stripWrappingQuotes(normalizedQuery.slice(colonIndex + 1));
 }
 
 function stripWrappingQuotes(value: string) {
@@ -1988,14 +1902,6 @@ function stripWrappingQuotes(value: string) {
   }
 
   return normalized;
-}
-
-function splitOutlookScopeWords(value: string) {
-  return value
-    .trim()
-    .split(/\s+/)
-    .map((word) => word.replace(/^[()]+|[()]+$/g, ""))
-    .filter(Boolean);
 }
 
 async function runThreadActionsInParallel({

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -49,11 +49,11 @@ import { getAssistantChatProvider } from "./chat-provider-shared";
 import { LlmUseCase } from "@/utils/llms/use-cases";
 import { isIntegrationActionEnabledForUserId } from "@/utils/integration-action.server";
 
-export const maxDuration = 300;
+export const maxDuration = 800;
 // Increment when chat prompts, tools, or routing change so run quality remains attributable.
-export const ASSISTANT_CHAT_PIPELINE_VERSION = 8;
+export const ASSISTANT_CHAT_PIPELINE_VERSION = 9;
 const ASSISTANT_CHAT_TOOL_BUDGET_MS = {
-  web: 240_000,
+  web: 720_000,
   messaging: 60_000,
 } satisfies Record<"web" | "messaging", number>;
 

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -192,6 +192,9 @@ describe("OutlookProvider.searchMessages", () => {
     await expect(
       provider.searchMessages({ query: "", labelName: "Receipts" }),
     ).rejects.toThrow("ambiguous");
+    vi.spyOn(provider, "getLabels").mockRejectedValue(
+      new Error("Categories unavailable"),
+    );
     await provider.searchMessages({ query: "", labelName: "folder-1" });
     expect(query).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -4,6 +4,7 @@ import * as outlookMessageModule from "@/utils/outlook/message";
 import * as outlookLabelModule from "@/utils/outlook/label";
 import { createTestLogger } from "@/__tests__/helpers";
 import { OutlookProvider } from "./microsoft";
+import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 
 const { envMock, outlookMailMock, getFolderIdsMock } = vi.hoisted(() => ({
   envMock: {
@@ -57,6 +58,147 @@ afterEach(() => {
     deleteditems: "trash-folder-id",
     junkemail: "spam-folder-id",
     sentitems: "sent-folder-id",
+  });
+});
+
+describe("OutlookProvider.searchMessages", () => {
+  it("resolves a nested folder and searches its messages without a category filter", async () => {
+    const message = createMessage({
+      id: "matching-message",
+      parentFolderId: "nested-folder",
+    });
+    const client = createMockOutlookClient([message]);
+    const provider = new OutlookProvider(client, createTestLogger());
+    vi.spyOn(provider, "getFolders").mockResolvedValue([
+      {
+        id: "parent",
+        displayName: "Parent",
+        childFolders: [
+          { id: "nested-folder", displayName: "Receipts", childFolders: [] },
+        ],
+      },
+    ]);
+    vi.spyOn(provider, "getLabels").mockResolvedValue([]);
+
+    const result = await provider.searchMessages({
+      query: "invoice",
+      labelName: "receipts",
+    });
+
+    expect(result.messages.map((message) => message.id)).toEqual([
+      "matching-message",
+    ]);
+    expect(client.getRequestLog()).toContainEqual({
+      apiPath: "/me/mailFolders/nested-folder/messages",
+      search: '"invoice"',
+      filter: undefined,
+    });
+  });
+
+  it("resolves a full folder path when leaf names are duplicated", async () => {
+    const query = vi
+      .spyOn(outlookMessageModule, "queryBatchMessages")
+      .mockResolvedValue({ messages: [] });
+    const provider = new OutlookProvider(
+      createMockOutlookClient([]),
+      createTestLogger(),
+    );
+    vi.spyOn(provider, "getFolders").mockResolvedValue([
+      {
+        id: "parent",
+        displayName: "Parent",
+        childFolders: [
+          { id: "nested", displayName: "Receipts", childFolders: [] },
+        ],
+      },
+      { id: "root", displayName: "Receipts", childFolders: [] },
+    ]);
+    vi.spyOn(provider, "getLabels").mockResolvedValue([]);
+    await provider.searchMessages({
+      query: "",
+      labelName: `Parent${FOLDER_SEPARATOR}Receipts`,
+    });
+    expect(query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ folderId: "nested", categoryNames: [] }),
+      expect.anything(),
+    );
+    query.mockRestore();
+  });
+
+  it("preserves categories as category filters", async () => {
+    const query = vi
+      .spyOn(outlookMessageModule, "queryBatchMessages")
+      .mockResolvedValueOnce({ messages: [] });
+    const provider = new OutlookProvider(
+      createMockOutlookClient([]),
+      createTestLogger(),
+    );
+    vi.spyOn(provider, "getFolders").mockResolvedValue([]);
+    vi.spyOn(provider, "getLabels").mockResolvedValue([
+      { id: "category-1", name: "Receipts", type: "user" },
+    ]);
+
+    await provider.searchMessages({ query: "", labelName: "receipts" });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        categoryNames: ["Receipts"],
+        folderId: undefined,
+      }),
+      expect.anything(),
+    );
+    query.mockRestore();
+  });
+
+  it("rejects ambiguous names and unknown scopes before searching", async () => {
+    const query = vi.spyOn(outlookMessageModule, "queryBatchMessages");
+    const provider = new OutlookProvider(
+      createMockOutlookClient([]),
+      createTestLogger(),
+    );
+    vi.spyOn(provider, "getFolders").mockResolvedValue([
+      { id: "folder-1", displayName: "Receipts", childFolders: [] },
+      { id: "folder-2", displayName: "Receipts", childFolders: [] },
+    ]);
+    vi.spyOn(provider, "getLabels").mockResolvedValue([]);
+
+    await expect(
+      provider.searchMessages({ query: "", labelName: "Receipts" }),
+    ).rejects.toThrow("ambiguous");
+    await expect(
+      provider.searchMessages({ query: "", labelName: "Missing" }),
+    ).rejects.toThrow("not found");
+    expect(query).not.toHaveBeenCalled();
+    query.mockRestore();
+  });
+
+  it("accepts an exact folder ID when folder and category names collide", async () => {
+    const query = vi
+      .spyOn(outlookMessageModule, "queryBatchMessages")
+      .mockResolvedValue({ messages: [] });
+    const provider = new OutlookProvider(
+      createMockOutlookClient([]),
+      createTestLogger(),
+    );
+    vi.spyOn(provider, "getFolders").mockResolvedValue([
+      { id: "folder-1", displayName: "Receipts", childFolders: [] },
+    ]);
+    vi.spyOn(provider, "getLabels").mockResolvedValue([
+      { id: "category-1", name: "Receipts", type: "user" },
+    ]);
+
+    await expect(
+      provider.searchMessages({ query: "", labelName: "Receipts" }),
+    ).rejects.toThrow("ambiguous");
+    await provider.searchMessages({ query: "", labelName: "folder-1" });
+    expect(query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ folderId: "folder-1", categoryNames: [] }),
+      expect.anything(),
+    );
+    query.mockRestore();
   });
 });
 

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -93,6 +93,7 @@ import {
 import {
   getOrCreateOutlookFolderIdByName,
   getOutlookFolderTree,
+  FOLDER_SEPARATOR,
   addOutlookSystemFolderTypes,
   deleteOutlookFolder,
   renameOutlookFolder,
@@ -1274,6 +1275,49 @@ export class OutlookProvider implements EmailProvider {
     readState?: "read" | "unread";
     labelName?: string;
   }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
+    let folderId: string | undefined;
+    let categoryNames: string[] = [];
+    if (options.labelName) {
+      const scope = options.labelName.trim();
+      const [folderTree, categories] = await Promise.all([
+        this.getFolders(),
+        this.getLabels(),
+      ]);
+      const folders = flattenOutlookFolders(folderTree);
+      const folderById = folders.find((folder) => folder.id === scope);
+      const categoryById = categories.find((category) => category.id === scope);
+      const matchingFolders = folderById
+        ? [folderById]
+        : folders.filter(
+            (folder) =>
+              folder.displayName.toLowerCase() === scope.toLowerCase() ||
+              folder.path.toLowerCase() === scope.toLowerCase(),
+          );
+      const matchingCategories = categoryById
+        ? [categoryById]
+        : categories.filter(
+            (category) => category.name.toLowerCase() === scope.toLowerCase(),
+          );
+
+      if (folderById) {
+        folderId = folderById.id;
+      } else if (categoryById) {
+        categoryNames = [categoryById.name];
+      } else if (matchingFolders.length + matchingCategories.length > 1) {
+        throw new Error(
+          "Outlook search scope is ambiguous. Use a folder path or ID from listFolders, or a category ID.",
+        );
+      } else if (matchingFolders.length === 1) {
+        folderId = matchingFolders[0].id;
+      } else if (matchingCategories.length === 1) {
+        categoryNames = [matchingCategories[0].name];
+      } else {
+        throw new Error(
+          "Outlook folder or category not found. List available folders and categories before retrying.",
+        );
+      }
+    }
+
     const response = await queryBatchMessages(
       this.client,
       {
@@ -1282,7 +1326,8 @@ export class OutlookProvider implements EmailProvider {
         pageToken: options.pageToken,
         fromEmail: options.fromEmail,
         readState: options.readState,
-        categoryNames: options.labelName ? [options.labelName] : [],
+        folderId,
+        categoryNames,
       },
       this.logger,
     );
@@ -2326,11 +2371,19 @@ function resolveOutlookFolderId(
 
 function flattenOutlookFolders(
   folders: Awaited<ReturnType<OutlookProvider["getFolders"]>>,
-): Awaited<ReturnType<OutlookProvider["getFolders"]>> {
-  return folders.flatMap((folder) => [
-    folder,
-    ...flattenOutlookFolders(folder.childFolders),
-  ]);
+  parentPath = "",
+): Array<
+  Awaited<ReturnType<OutlookProvider["getFolders"]>>[number] & { path: string }
+> {
+  return folders.flatMap((folder) => {
+    const path = parentPath
+      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
+      : folder.displayName;
+    return [
+      { ...folder, path },
+      ...flattenOutlookFolders(folder.childFolders, path),
+    ];
+  });
 }
 
 function filterMessagesForParticipant(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -85,6 +85,7 @@ import type { SendEmailBody } from "@/utils/types/mail";
 import { getOutlookCategoryPreset } from "@/utils/outlook/category-colors";
 import { unwatchOutlook, watchOutlook } from "@/utils/outlook/watch";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
+import { resolveOutlookSearchScope } from "@/utils/outlook/search-scope";
 import {
   extractEmailAddress,
   getSearchTermForSender,
@@ -93,7 +94,7 @@ import {
 import {
   getOrCreateOutlookFolderIdByName,
   getOutlookFolderTree,
-  FOLDER_SEPARATOR,
+  flattenOutlookFolders,
   addOutlookSystemFolderTypes,
   deleteOutlookFolder,
   renameOutlookFolder,
@@ -1275,48 +1276,10 @@ export class OutlookProvider implements EmailProvider {
     readState?: "read" | "unread";
     labelName?: string;
   }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
-    let folderId: string | undefined;
-    let categoryNames: string[] = [];
-    if (options.labelName) {
-      const scope = options.labelName.trim();
-      const [folderTree, categories] = await Promise.all([
-        this.getFolders(),
-        this.getLabels(),
-      ]);
-      const folders = flattenOutlookFolders(folderTree);
-      const folderById = folders.find((folder) => folder.id === scope);
-      const categoryById = categories.find((category) => category.id === scope);
-      const matchingFolders = folderById
-        ? [folderById]
-        : folders.filter(
-            (folder) =>
-              folder.displayName.toLowerCase() === scope.toLowerCase() ||
-              folder.path.toLowerCase() === scope.toLowerCase(),
-          );
-      const matchingCategories = categoryById
-        ? [categoryById]
-        : categories.filter(
-            (category) => category.name.toLowerCase() === scope.toLowerCase(),
-          );
-
-      if (folderById) {
-        folderId = folderById.id;
-      } else if (categoryById) {
-        categoryNames = [categoryById.name];
-      } else if (matchingFolders.length + matchingCategories.length > 1) {
-        throw new Error(
-          "Outlook search scope is ambiguous. Use a folder path or ID from listFolders, or a category ID.",
-        );
-      } else if (matchingFolders.length === 1) {
-        folderId = matchingFolders[0].id;
-      } else if (matchingCategories.length === 1) {
-        categoryNames = [matchingCategories[0].name];
-      } else {
-        throw new Error(
-          "Outlook folder or category not found. List available folders and categories before retrying.",
-        );
-      }
-    }
+    const { folderId, categoryNames } = await resolveOutlookSearchScope({
+      emailProvider: this,
+      scope: options.labelName,
+    });
 
     const response = await queryBatchMessages(
       this.client,
@@ -2367,23 +2330,6 @@ function resolveOutlookFolderId(
 ): string | undefined {
   const folderKey = LABEL_TO_FOLDER_KEY[labelId.toUpperCase()];
   return folderKey ? folderIds[folderKey] : undefined;
-}
-
-function flattenOutlookFolders(
-  folders: Awaited<ReturnType<OutlookProvider["getFolders"]>>,
-  parentPath = "",
-): Array<
-  Awaited<ReturnType<OutlookProvider["getFolders"]>>[number] & { path: string }
-> {
-  return folders.flatMap((folder) => {
-    const path = parentPath
-      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
-      : folder.displayName;
-    return [
-      { ...folder, path },
-      ...flattenOutlookFolders(folder.childFolders, path),
-    ];
-  });
 }
 
 function filterMessagesForParticipant(

--- a/apps/web/utils/outlook/folders.ts
+++ b/apps/web/utils/outlook/folders.ts
@@ -275,3 +275,18 @@ export async function deleteOutlookFolder(
     logger,
   );
 }
+
+export function flattenOutlookFolders(
+  folders: OutlookFolder[],
+  parentPath = "",
+): Array<OutlookFolder & { path: string }> {
+  return folders.flatMap((folder) => {
+    const path = parentPath
+      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
+      : folder.displayName;
+    return [
+      { ...folder, path },
+      ...flattenOutlookFolders(folder.childFolders, path),
+    ];
+  });
+}

--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -223,6 +223,52 @@ describe("queryBatchMessages", () => {
     expect(api).not.toHaveBeenCalled();
   });
 
+  it("queries the requested folder directly for folder-only cleanup", async () => {
+    const request = createMockMessagesRequest();
+    const api = vi.fn().mockReturnValue(request);
+    await queryBatchMessages(
+      createCachedOutlookClient(api),
+      { folderId: "folder/id", searchQuery: "" },
+      createTestLogger(),
+    );
+    expect(api).toHaveBeenCalledWith("/me/mailFolders/folder%2Fid/messages");
+    expect(request.search).not.toHaveBeenCalled();
+    expect(request.filter).not.toHaveBeenCalled();
+  });
+
+  it("preserves folder scope on continuation pages", async () => {
+    const request = createMockMessagesRequest();
+    request.get.mockResolvedValue({
+      value: [
+        {
+          id: "inside",
+          conversationId: "thread-1",
+          parentFolderId: "folder-1",
+        },
+        {
+          id: "outside",
+          conversationId: "thread-2",
+          parentFolderId: "folder-2",
+        },
+      ],
+      "@odata.nextLink":
+        "https://graph.microsoft.com/v1.0/me/messages?$skip=40",
+    });
+    const api = vi.fn().mockReturnValue(request);
+    const result = await queryBatchMessages(
+      createCachedOutlookClient(api),
+      {
+        folderId: "folder-1",
+        pageToken: "https://graph.microsoft.com/v1.0/me/messages?$skip=20",
+      },
+      createTestLogger(),
+    );
+    expect(result.messages.map((message) => message.id)).toEqual(["inside"]);
+    expect(result.nextPageToken).toBe(
+      "https://graph.microsoft.com/v1.0/me/messages?$skip=40",
+    );
+  });
+
   it("uses metadata filters for unread category searches", async () => {
     const request = createMockMessagesRequest();
     const api = vi.fn().mockReturnValue(request);

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -566,7 +566,7 @@ export async function queryBatchMessages(
   });
 
   // Build the base request
-  let request = createMessagesRequest(client).top(maxResults);
+  let request = createMessagesRequest(client, folderId).top(maxResults);
 
   let nextPageToken: string | undefined;
 
@@ -624,11 +624,6 @@ export async function queryBatchMessages(
   } else {
     // Filter path - use $filter parameter for date filters or folder-only queries
     const filters: string[] = [];
-
-    // Add folder filter if a specific folder is requested
-    if (folderFilter) {
-      filters.push(folderFilter);
-    }
 
     if (metadataSearch.odataFilters.length) {
       filters.push(...metadataSearch.odataFilters);
@@ -949,10 +944,17 @@ export async function getMessages(
  * Helper to create a request for fetching multiple messages with standard fields selected.
  * Returns a typed request builder that can be chained with .filter(), .top(), etc.
  */
-export function createMessagesRequest(client: OutlookClient) {
+export function createMessagesRequest(
+  client: OutlookClient,
+  folderId?: string,
+) {
   return client
     .getClient()
-    .api("/me/messages")
+    .api(
+      folderId
+        ? `/me/mailFolders/${encodeURIComponent(folderId)}/messages`
+        : "/me/messages",
+    )
     .select(MESSAGE_SELECT_FIELDS)
     .expand(MESSAGE_EXPAND_ATTACHMENTS);
 }

--- a/apps/web/utils/outlook/search-scope.ts
+++ b/apps/web/utils/outlook/search-scope.ts
@@ -1,0 +1,53 @@
+import type { EmailProvider } from "@/utils/email/types";
+import { flattenOutlookFolders } from "@/utils/outlook/folders";
+
+export async function resolveOutlookSearchScope({
+  emailProvider,
+  scope,
+}: {
+  emailProvider: Pick<EmailProvider, "getFolders" | "getLabels">;
+  scope?: string;
+}): Promise<{ folderId?: string; categoryNames: string[] }> {
+  if (!scope) return { categoryNames: [] };
+
+  const trimmedScope = scope.trim();
+  const [folderTree, categories] = await Promise.all([
+    emailProvider.getFolders(),
+    emailProvider.getLabels(),
+  ]);
+  const folders = flattenOutlookFolders(folderTree);
+
+  const folderById = folders.find((folder) => folder.id === trimmedScope);
+  if (folderById) return { folderId: folderById.id, categoryNames: [] };
+
+  const categoryById = categories.find(
+    (category) => category.id === trimmedScope,
+  );
+  if (categoryById) return { categoryNames: [categoryById.name] };
+
+  const normalizedScope = trimmedScope.toLowerCase();
+  const matchingFolders = folders.filter(
+    (folder) =>
+      folder.displayName.toLowerCase() === normalizedScope ||
+      folder.path.toLowerCase() === normalizedScope,
+  );
+  const matchingCategories = categories.filter(
+    (category) => category.name.toLowerCase() === normalizedScope,
+  );
+
+  if (matchingFolders.length + matchingCategories.length > 1) {
+    throw new Error(
+      "Outlook search scope is ambiguous. Use a folder path or ID from listFolders, or a category ID.",
+    );
+  }
+
+  const [folder] = matchingFolders;
+  if (folder) return { folderId: folder.id, categoryNames: [] };
+
+  const [category] = matchingCategories;
+  if (category) return { categoryNames: [category.name] };
+
+  throw new Error(
+    "Outlook folder or category not found. List available folders and categories before retrying.",
+  );
+}

--- a/apps/web/utils/outlook/search-scope.ts
+++ b/apps/web/utils/outlook/search-scope.ts
@@ -11,15 +11,13 @@ export async function resolveOutlookSearchScope({
   if (!scope) return { categoryNames: [] };
 
   const trimmedScope = scope.trim();
-  const [folderTree, categories] = await Promise.all([
-    emailProvider.getFolders(),
-    emailProvider.getLabels(),
-  ]);
+  const folderTree = await emailProvider.getFolders();
   const folders = flattenOutlookFolders(folderTree);
 
   const folderById = folders.find((folder) => folder.id === trimmedScope);
   if (folderById) return { folderId: folderById.id, categoryNames: [] };
 
+  const categories = await emailProvider.getLabels();
   const categoryById = categories.find(
     (category) => category.id === trimmedScope,
   );

--- a/apps/web/utils/outlook/trash.test.ts
+++ b/apps/web/utils/outlook/trash.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { publishDelete } from "@inboxzero/tinybird";
+import { createTestLogger } from "@/__tests__/helpers";
+import type { OutlookClient } from "@/utils/outlook/client";
+import { trashThread } from "./trash";
+
+vi.mock("@inboxzero/tinybird", () => ({ publishDelete: vi.fn() }));
+vi.mock("@/utils/microsoft/retry", () => ({
+  withMicrosoftGraphRetry: (fn: () => Promise<unknown>) => fn(),
+  withMicrosoftGraphWriteRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+const nextLink = "https://graph.microsoft.com/v1.0/me/messages?$skip=10";
+
+describe("trashThread", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("enumerates all pages before moving messages and deduplicates messages", async () => {
+    const { options, get, post } = setup();
+    get.mockResolvedValueOnce({
+      value: [{ id: "a" }],
+      "@odata.nextLink": nextLink,
+    });
+    get.mockResolvedValueOnce({ value: [], "@odata.nextLink": `${nextLink}0` });
+    get.mockImplementationOnce(async () => {
+      expect(post).not.toHaveBeenCalled();
+      return { value: [{ id: "a" }, { id: "b" }] };
+    });
+
+    await expect(trashThread(options)).resolves.toEqual({ status: 200 });
+    expect(post.mock.calls.map(([path]) => path)).toEqual([
+      "/me/messages/a/move",
+      "/me/messages/b/move",
+    ]);
+    expect(publishDelete).toHaveBeenCalledOnce();
+  });
+
+  it("rejects partial move failures without publishing successful deletion", async () => {
+    const { options, get, post } = setup();
+    get.mockResolvedValue({ value: [{ id: "a" }, { id: "b" }] });
+    post.mockImplementation(async (path: string) => {
+      if (path.includes("/b/")) throw new Error("Access denied");
+    });
+
+    await expect(trashThread(options)).rejects.toThrow("Access denied");
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(publishDelete).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back or mutate when a later page fails", async () => {
+    const { options, get, post } = setup();
+    get.mockResolvedValueOnce({
+      value: [{ id: "a" }],
+      "@odata.nextLink": nextLink,
+    });
+    get.mockRejectedValueOnce(new Error("Requested entity was not found"));
+    get.mockResolvedValue({ value: [] });
+
+    await expect(trashThread(options)).rejects.toThrow(
+      "Requested entity was not found",
+    );
+    expect(post).not.toHaveBeenCalled();
+    expect(publishDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects repeated pagination before moving any messages", async () => {
+    const { options, get, post } = setup();
+    get.mockResolvedValue({
+      value: [{ id: "a" }],
+      "@odata.nextLink": nextLink,
+    });
+
+    await expect(trashThread(options)).rejects.toThrow("pagination");
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful deletion successful when analytics fails", async () => {
+    const { options, get } = setup();
+    get.mockResolvedValue({ value: [{ id: "a" }] });
+    vi.mocked(publishDelete).mockRejectedValueOnce(
+      new Error("Analytics unavailable"),
+    );
+    await expect(trashThread(options)).resolves.toEqual({ status: 200 });
+  });
+});
+
+function setup() {
+  const get = vi.fn();
+  const post = vi.fn().mockResolvedValue({});
+  const api = vi.fn((path: string) => ({
+    filter: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    get,
+    post: (body: unknown) => post(path, body),
+  }));
+  return {
+    get,
+    post,
+    options: {
+      client: { getClient: () => ({ api }) } as unknown as OutlookClient,
+      threadId: "conversation",
+      ownerEmail: "user@example.com",
+      actionSource: "user" as const,
+      logger: createTestLogger(),
+    },
+  };
+}

--- a/apps/web/utils/outlook/trash.ts
+++ b/apps/web/utils/outlook/trash.ts
@@ -1,11 +1,12 @@
 import type { OutlookClient } from "@/utils/outlook/client";
 import { publishDelete, type TinybirdEmailAction } from "@inboxzero/tinybird";
 import type { Logger } from "@/utils/logger";
-import { runWithBoundedConcurrency } from "@/utils/async";
-import { withMicrosoftGraphWriteRetry } from "@/utils/microsoft/retry";
-import { processThreadMessagesFallback } from "@/utils/outlook/thread-helpers";
-
-const THREAD_TRASH_CONCURRENCY = 2;
+import {
+  withMicrosoftGraphRetry,
+  withMicrosoftGraphWriteRetry,
+} from "@/utils/microsoft/retry";
+import { runThreadMessageMutation } from "@/utils/outlook/thread-helpers";
+import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 
 export async function trashThread(options: {
   client: OutlookClient;
@@ -15,130 +16,66 @@ export async function trashThread(options: {
   logger: Logger;
 }) {
   const { client, threadId, ownerEmail, actionSource, logger } = options;
+  const escapedThreadId = threadId.replace(/'/g, "''");
+  let page: { value: { id: string }[]; "@odata.nextLink"?: string } =
+    await withMicrosoftGraphRetry(
+      () =>
+        client
+          .getClient()
+          .api("/me/messages")
+          .filter(`conversationId eq '${escapedThreadId}'`)
+          .select("id")
+          .get(),
+      logger,
+    );
+
+  // Finish enumeration before moving messages changes the paginated result set.
+  const messageIds = new Set<string>();
+  const visitedPages = new Set<string>();
+  while (true) {
+    for (const message of page.value) messageIds.add(message.id);
+    if (!page["@odata.nextLink"]) break;
+
+    const nextLink = resolveMicrosoftGraphNextLink(page["@odata.nextLink"]);
+    if (!nextLink || visitedPages.has(nextLink)) {
+      throw new Error("Unable to complete Outlook thread pagination");
+    }
+    visitedPages.add(nextLink);
+    page = await withMicrosoftGraphRetry(
+      () => client.getClient().api(nextLink).get(),
+      logger,
+    );
+  }
+
+  await runThreadMessageMutation({
+    messageIds: [...messageIds],
+    threadId,
+    logger,
+    failureMessage: "Failed to move message to trash",
+    messageHandler: (messageId) =>
+      withMicrosoftGraphWriteRetry(
+        () =>
+          client.getClient().api(`/me/messages/${messageId}/move`).post({
+            destinationId: "deleteditems",
+          }),
+        logger,
+      ),
+  });
 
   try {
-    // In Outlook, trashing is moving to the Deleted Items folder
-    // We need to move each message in the thread individually
-    // Escape single quotes in threadId for the filter
-    const escapedThreadId = threadId.replace(/'/g, "''");
-    const messages = await client
-      .getClient()
-      .api("/me/messages")
-      .filter(`conversationId eq '${escapedThreadId}'`)
-      .get();
-
-    const trashPromise = runWithBoundedConcurrency({
-      items: messages.value.map((message: { id: string }) => message.id),
-      concurrency: THREAD_TRASH_CONCURRENCY,
-      run: async (messageId) => {
-        try {
-          return await withMicrosoftGraphWriteRetry(
-            () =>
-              client.getClient().api(`/me/messages/${messageId}/move`).post({
-                destinationId: "deleteditems",
-              }),
-            logger,
-          );
-        } catch (error) {
-          logger.warn("Failed to move message to trash", {
-            messageId,
-            threadId,
-            error,
-          });
-          return null;
-        }
-      },
-    });
-
-    const publishPromise = publishDelete({
+    await publishDelete({
       ownerEmail,
       threadId,
       actionSource,
       timestamp: Date.now(),
     });
-
-    const [trashResult, publishResult] = await Promise.allSettled([
-      trashPromise,
-      publishPromise,
-    ]);
-
-    if (trashResult.status === "rejected") {
-      const error = trashResult.reason as Error;
-      if (error.message?.includes("Requested entity was not found")) {
-        // thread doesn't exist, so it's already been deleted
-        logger.warn("Failed to trash non-existent thread", {
-          email: ownerEmail,
-          threadId,
-          error,
-        });
-        return { status: 200 };
-      } else {
-        logger.error("Failed to trash thread", {
-          email: ownerEmail,
-          threadId,
-          error,
-        });
-        throw error;
-      }
-    }
-
-    if (publishResult.status === "rejected") {
-      logger.error("Failed to publish delete action", {
-        email: ownerEmail,
-        threadId,
-        error: publishResult.reason,
-      });
-    }
-
-    return { status: 200 };
   } catch (error) {
-    // If the filter fails, try a different approach
-    logger.warn("Filter failed, trying alternative approach", {
+    logger.error("Failed to publish delete action", {
+      email: ownerEmail,
       threadId,
       error,
     });
-
-    try {
-      await processThreadMessagesFallback({
-        client,
-        threadId,
-        logger,
-        messageHandler: (messageId) =>
-          withMicrosoftGraphWriteRetry(
-            () =>
-              client
-                .getClient()
-                .api(`/me/messages/${messageId}/move`)
-                .post({ destinationId: "deleteditems" }),
-            logger,
-          ),
-        noMessagesMessage:
-          "No messages found for conversationId, skipping trash move",
-      });
-
-      // Publish the delete action
-      try {
-        await publishDelete({
-          ownerEmail,
-          threadId,
-          actionSource,
-          timestamp: Date.now(),
-        });
-      } catch (publishError) {
-        logger.error("Failed to publish delete action", {
-          email: ownerEmail,
-          threadId,
-          error: publishError,
-        });
-      }
-
-      return { status: 200 };
-    } catch (directError) {
-      logger.error("Failed to trash thread", {
-        threadId,
-        error: directError,
-      });
-      throw directError;
-    }
   }
+
+  return { status: 200 };
 }

--- a/apps/web/utils/outlook/trash.ts
+++ b/apps/web/utils/outlook/trash.ts
@@ -16,6 +16,50 @@ export async function trashThread(options: {
   logger: Logger;
 }) {
   const { client, threadId, ownerEmail, actionSource, logger } = options;
+  const messageIds = await getThreadMessageIds({ client, threadId, logger });
+
+  await runThreadMessageMutation({
+    messageIds,
+    threadId,
+    logger,
+    failureMessage: "Failed to move message to trash",
+    messageHandler: (messageId) =>
+      withMicrosoftGraphWriteRetry(
+        () =>
+          client.getClient().api(`/me/messages/${messageId}/move`).post({
+            destinationId: "deleteditems",
+          }),
+        logger,
+      ),
+  });
+
+  try {
+    await publishDelete({
+      ownerEmail,
+      threadId,
+      actionSource,
+      timestamp: Date.now(),
+    });
+  } catch (error) {
+    logger.error("Failed to publish delete action", {
+      email: ownerEmail,
+      threadId,
+      error,
+    });
+  }
+
+  return { status: 200 };
+}
+
+async function getThreadMessageIds({
+  client,
+  threadId,
+  logger,
+}: {
+  client: OutlookClient;
+  threadId: string;
+  logger: Logger;
+}): Promise<string[]> {
   const escapedThreadId = threadId.replace(/'/g, "''");
   let page: { value: { id: string }[]; "@odata.nextLink"?: string } =
     await withMicrosoftGraphRetry(
@@ -47,35 +91,5 @@ export async function trashThread(options: {
     );
   }
 
-  await runThreadMessageMutation({
-    messageIds: [...messageIds],
-    threadId,
-    logger,
-    failureMessage: "Failed to move message to trash",
-    messageHandler: (messageId) =>
-      withMicrosoftGraphWriteRetry(
-        () =>
-          client.getClient().api(`/me/messages/${messageId}/move`).post({
-            destinationId: "deleteditems",
-          }),
-        logger,
-      ),
-  });
-
-  try {
-    await publishDelete({
-      ownerEmail,
-      threadId,
-      actionSource,
-      timestamp: Date.now(),
-    });
-  } catch (error) {
-    logger.error("Failed to publish delete action", {
-      email: ownerEmail,
-      threadId,
-      error,
-    });
-  }
-
-  return { status: 200 };
+  return [...messageIds];
 }


### PR DESCRIPTION
Outlook chat now resolves folder names, paths, and IDs separately from categories, keeps empty searches within their requested scope, and exposes folder IDs internally for disambiguation. Conversation deletion enumerates every page before moving messages and reports partial failures instead of silently succeeding.

- Increase web chat tool time from 4 to 12 minutes, with an 800-second request limit.
- Remove guessed folder scopes and unsafe fallback searches; update existing tool descriptions and chat attribution.
- Retry transient deletion reads, deduplicate message IDs, and reject repeated pagination tokens.
- Keep provider orchestration small with a dedicated scope resolver, shared folder-path traversal, and a deletion enumeration helper.

Validation: 347 focused provider/Outlook/chat-tool tests passed after helper extraction on Node 24; 121 provider and assistant lifecycle tests passed after CI/review fixes; the focused live Outlook folder-listing eval passed; targeted Biome checks passed. Regression tests cover scoped search, empty pages, paginated deletion, and partial failures.

Folder resolution adds metadata reads, and deletion retains conversation message IDs until enumeration completes. Durable background cleanup remains separate follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Outlook folder listings now provide identifiers for more precise folder-scoped searches.
  - Searches can resolve nested folder paths, folder identifiers, and categories, including duplicate folder names.

- **Bug Fixes**
  - Improved folder-scoped message retrieval and pagination for Outlook searches.
  - Thread deletion now processes paginated messages more reliably and avoids partial operations when retrieval fails.
  - Increased available processing time for longer assistant chat requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->