### PR TITLE
mail: widen sender column and coarsen list date sections

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadRow.tsx
@@ -227,7 +227,7 @@ export const ThreadRow = memo(function ThreadRow({
 
       {isWide ? (
         <>
-          <div className="flex w-48 shrink-0 items-baseline gap-1 overflow-hidden whitespace-nowrap">
+          <div className="flex w-64 shrink-0 items-baseline gap-1 overflow-hidden whitespace-nowrap">
             {participantLine}
           </div>
           {expandedPreview ? (

--- a/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/thread-list-behavior.test.ts
@@ -312,6 +312,7 @@ describe("groupThreadsByDate", () => {
         createDatedThread("2025-09-05T11:00:00"),
         createDatedThread("2025-09-05T08:00:00"),
         createDatedThread("2025-09-04T18:00:00"),
+        createDatedThread("2025-09-01T18:00:00"),
         createDatedThread("2025-08-30T18:00:00"),
         createDatedThread("2025-08-02T18:00:00"),
       ],
@@ -327,7 +328,8 @@ describe("groupThreadsByDate", () => {
     ).toEqual([
       { label: "Today", startIndex: 0, count: 2 },
       { label: "Yesterday", startIndex: 2, count: 1 },
-      { label: "August", startIndex: 3, count: 2 },
+      { label: "Last 7 days", startIndex: 3, count: 2 },
+      { label: "August", startIndex: 5, count: 1 },
     ]);
   });
 

--- a/apps/web/utils/date.test.ts
+++ b/apps/web/utils/date.test.ts
@@ -263,6 +263,7 @@ describe("formatDateGroupLabel", () => {
 
   it.each([
     { name: "today", date: "2025-09-05T09:30:00", expected: "Today" },
+    { name: "later today", date: "2025-09-05T23:30:00", expected: "Today" },
     { name: "yesterday", date: "2025-09-04T23:59:00", expected: "Yesterday" },
     {
       name: "an earlier day this week",
@@ -283,6 +284,11 @@ describe("formatDateGroupLabel", () => {
       name: "a day in a previous year",
       date: "2024-08-22T08:00:00",
       expected: "August 2024",
+    },
+    {
+      name: "a day ahead of today",
+      date: "2025-09-20T08:00:00",
+      expected: "September 20th, 2025",
     },
   ])("labels $name", ({ date, expected }) => {
     expect(formatDateGroupLabel(new Date(date), now)).toBe(expected);

--- a/apps/web/utils/date.test.ts
+++ b/apps/web/utils/date.test.ts
@@ -265,9 +265,14 @@ describe("formatDateGroupLabel", () => {
     { name: "today", date: "2025-09-05T09:30:00", expected: "Today" },
     { name: "yesterday", date: "2025-09-04T23:59:00", expected: "Yesterday" },
     {
-      name: "an earlier day this month",
+      name: "an earlier day this week",
       date: "2025-09-01T08:00:00",
-      expected: "September 1st",
+      expected: "Last 7 days",
+    },
+    {
+      name: "the oldest day of the past week",
+      date: "2025-08-30T00:00:00",
+      expected: "Last 7 days",
     },
     {
       name: "a day last month",
@@ -290,5 +295,14 @@ describe("formatDateGroupLabel", () => {
         new Date("2025-09-01T09:00:00"),
       ),
     ).toBe("Yesterday");
+  });
+
+  it("labels days older than a week but still in this month", () => {
+    expect(
+      formatDateGroupLabel(
+        new Date("2025-09-05T08:00:00"),
+        new Date("2025-09-20T09:00:00"),
+      ),
+    ).toBe("Earlier this month");
   });
 });

--- a/apps/web/utils/date.ts
+++ b/apps/web/utils/date.ts
@@ -4,6 +4,7 @@ import { isSameDay } from "date-fns/isSameDay";
 import { isSameMonth } from "date-fns/isSameMonth";
 import { isSameYear } from "date-fns/isSameYear";
 import { isWeekend } from "date-fns/isWeekend";
+import { startOfDay } from "date-fns/startOfDay";
 import { subDays } from "date-fns/subDays";
 import { TZDate } from "@date-fns/tz";
 import { createScopedLogger } from "@/utils/logger";
@@ -61,15 +62,18 @@ export function formatShortDate(
 }
 
 /**
- * Labels a date for grouping an email list into sections.
+ * Labels a date for grouping an email list into sections. The sections are
+ * deliberately coarse so a list only ever carries a handful of headings.
  * - Today and yesterday get their own sections.
- * - Other days in the current month are labelled by day (e.g. "September 5th").
+ * - The rest of the past week is one "Last 7 days" section.
+ * - Older days in the current month are one "Earlier this month" section.
  * - Earlier dates are labelled by month (e.g. "August", or "August 2024").
  */
 export function formatDateGroupLabel(date: Date, now: Date = new Date()) {
   if (isSameDay(date, now)) return "Today";
   if (isSameDay(date, subDays(now, 1))) return "Yesterday";
-  if (isSameMonth(date, now)) return format(date, "MMMM do");
+  if (date >= startOfDay(subDays(now, 6))) return "Last 7 days";
+  if (isSameMonth(date, now)) return "Earlier this month";
   if (isSameYear(date, now)) return format(date, "MMMM");
   return format(date, "MMMM yyyy");
 }

--- a/apps/web/utils/date.ts
+++ b/apps/web/utils/date.ts
@@ -68,10 +68,13 @@ export function formatShortDate(
  * - The rest of the past week is one "Last 7 days" section.
  * - Older days in the current month are one "Earlier this month" section.
  * - Earlier dates are labelled by month (e.g. "August", or "August 2024").
+ * - A date ahead of today keeps its own day, so a sender with a skewed clock
+ *   is never filed under a section that has already passed.
  */
 export function formatDateGroupLabel(date: Date, now: Date = new Date()) {
   if (isSameDay(date, now)) return "Today";
   if (isSameDay(date, subDays(now, 1))) return "Yesterday";
+  if (date > now) return format(date, "MMMM do, yyyy");
   if (date >= startOfDay(subDays(now, 6))) return "Last 7 days";
   if (isSameMonth(date, now)) return "Earlier this month";
   if (isSameYear(date, now)) return format(date, "MMMM");


### PR DESCRIPTION
Makes the conversation list easier to scan by giving sender names more room and cutting the number of date headings a list carries.

- Widen the wide-list sender column so there is clear space between the sender name and the subject
- Replace per-day headings ("September 5th") with "Last 7 days" and "Earlier this month"; Today, Yesterday, and older months are unchanged
- Update the date-label and thread-grouping unit tests to cover the new sections

Verified in the emulated mail UI: the list renders the new "Last 7 days" heading and the wider sender column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Widened the participant column in the mail thread list for improved readability.
  - Updated date grouping so messages from the past seven days appear together under “Last 7 days.”
  - Older messages within the current month are now grouped under “Earlier this month,” with clearer monthly sections beyond that range.

- **Tests**
  - Added coverage for date grouping across week and month boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->