### PR TITLE
Desktop: add unread badges and background mail notifications

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -26,7 +26,6 @@ New unread inbox mail produces a native notification while the app is in the bac
 
 The app must remain running; hiding the Mac window is supported, fully quitting stops updates. macOS notifications require a signed app and notification permission in System Settings. Use the OS notification settings to disable alerts or sounds. Both the desktop release and hosted web changes are needed; older desktop versions safely ignore the new integration.
 
-
 ## Package
 
 ```sh

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -18,6 +18,15 @@ INBOX_ZERO_APP_URL=http://localhost:3000 pnpm --filter @inboxzero/desktop dev
 
 Sign-in uses the system browser and returns through `inboxzero://`. The web app's `DESKTOP_AUTH_ORIGIN` defaults to this scheme.
 
+## Mail badge and notifications
+
+The macOS Dock badge shows the combined unread inbox count across connected accounts, refreshed about once a minute and on focus. Linux uses the supported launcher badge; Windows does not currently display a numeric badge.
+
+New unread inbox mail produces a native notification while the app is in the background. Clicking it opens that account's inbox. Alerts contain no sender or subject preview. Mail from before app startup or more than five minutes ago is suppressed, and repeated sync results do not replay alerts. Notifications follow the existing mailbox sync schedule (normally about a minute), rather than a server push channel.
+
+The app must remain running; hiding the Mac window is supported, fully quitting stops updates. macOS notifications require a signed app and notification permission in System Settings. Use the OS notification settings to disable alerts or sounds. Both the desktop release and hosted web changes are needed; older desktop versions safely ignore the new integration.
+
+
 ## Package
 
 ```sh

--- a/apps/desktop/src/mail-notifications.test.ts
+++ b/apps/desktop/src/mail-notifications.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createMailNotificationTracker } from "./mail-notifications";
+
+describe("mail notification tracker", () => {
+  it("ignores startup backlog, stale mail, and future timestamps", () => {
+    const track = createMailNotificationTracker(1_000_000);
+    expect(
+      track(
+        {
+          emailAccountId: "account",
+          messages: [
+            { id: "old", receivedAt: 999_999 },
+            { id: "stale", receivedAt: 1_000_001 },
+            { id: "future", receivedAt: 2_000_001 },
+            { id: "invalid", receivedAt: Number.NaN },
+          ],
+        },
+        2_000_000,
+      ),
+    ).toBeNull();
+  });
+
+  it("deduplicates sync replays while allowing new mail in the same account", () => {
+    const track = createMailNotificationTracker(1000);
+    const message = { id: "message", receivedAt: 1100 };
+    expect(
+      track({ emailAccountId: "account", messages: [message, message] }, 1200),
+    ).toEqual({ emailAccountId: "account", count: 1 });
+    expect(
+      track({ emailAccountId: "account", messages: [message] }, 1300),
+    ).toBeNull();
+    expect(
+      track({ emailAccountId: "other", messages: [message] }, 1300),
+    ).toEqual({ emailAccountId: "other", count: 1 });
+    expect(
+      track(
+        {
+          emailAccountId: "account",
+          messages: [message, { id: "reply", receivedAt: 1250 }],
+        },
+        1300,
+      ),
+    ).toEqual({ emailAccountId: "account", count: 1 });
+  });
+
+  it("rejects malformed IPC and account paths", () => {
+    const track = createMailNotificationTracker(1000);
+    for (const payload of [
+      null,
+      {},
+      { emailAccountId: "../../login", messages: [] },
+      { emailAccountId: "account", messages: "bad" },
+      { emailAccountId: "account", messages: new Array(101).fill({}) },
+      { emailAccountId: "account", messages: [null, {}, 42] },
+    ]) {
+      expect(track(payload, 1200)).toBeNull();
+    }
+  });
+});

--- a/apps/desktop/src/mail-notifications.ts
+++ b/apps/desktop/src/mail-notifications.ts
@@ -1,0 +1,43 @@
+const MAX_MESSAGE_AGE_MS = 5 * 60_000;
+
+// Keep the baseline in the main process so renderer reloads do not replay mail.
+export function createMailNotificationTracker(startedAt = Date.now()) {
+  const seen = new Map<string, number>();
+
+  return (payload: unknown, now = Date.now()) => {
+    if (!payload || typeof payload !== "object") return null;
+    if (!("emailAccountId" in payload) || !("messages" in payload)) return null;
+    const { emailAccountId, messages } = payload;
+    if (
+      typeof emailAccountId !== "string" ||
+      !/^[a-zA-Z0-9_-]{1,128}$/u.test(emailAccountId) ||
+      !Array.isArray(messages) ||
+      messages.length > 100
+    )
+      return null;
+
+    const cutoff = Math.max(startedAt, now - MAX_MESSAGE_AGE_MS);
+    for (const [key, receivedAt] of seen) {
+      if (receivedAt <= cutoff) seen.delete(key);
+    }
+    let count = 0;
+    for (const message of messages) {
+      if (
+        !message ||
+        typeof message.id !== "string" ||
+        !message.id ||
+        message.id.length > 1024 ||
+        typeof message.receivedAt !== "number" ||
+        !Number.isFinite(message.receivedAt) ||
+        message.receivedAt <= cutoff ||
+        message.receivedAt > now
+      )
+        continue;
+      const key = JSON.stringify([emailAccountId, message.id]);
+      if (seen.has(key)) continue;
+      seen.set(key, message.receivedAt);
+      count += 1;
+    }
+    return count ? { emailAccountId, count } : null;
+  };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,10 +6,12 @@ import {
   dialog,
   ipcMain,
   nativeTheme,
+  Notification,
   session,
   shell,
   type Session,
   type WebContents,
+  type IpcMainEvent,
 } from "electron";
 import { installDesktopLoadRecovery } from "./load-recovery";
 import { configureDesktopApplicationMenu } from "./application-menu";
@@ -35,6 +37,7 @@ import {
   parseDesktopAuthCallback,
   shouldPersistDesktopUrl,
 } from "./desktop";
+import { createMailNotificationTracker } from "./mail-notifications";
 
 const PARTITION = "persist:inbox-zero";
 const PENDING_CALLBACK_PATH_FILE = "pending-auth-callback-path";
@@ -46,6 +49,8 @@ let pendingCallbackPath: string | null = null;
 let isQuitting = false;
 const appOrigin = getDesktopAppOrigin();
 const homeUrl = getDesktopHomeUrl(appOrigin);
+const trackNewMail = createMailNotificationTracker();
+const mailNotifications = new Map<string, Notification>();
 
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -56,6 +61,42 @@ if (!gotTheLock) {
 
 function startDesktopApp() {
   nativeTheme.themeSource = "light";
+  app.setAppUserModelId("com.getinboxzero.desktop");
+
+  ipcMain.on("desktop:unread-count", (event, count: unknown) => {
+    if (!isTrustedMailEvent(event)) return;
+    if (typeof count !== "number" || !Number.isSafeInteger(count) || count < 0)
+      return;
+    setUnreadBadge(count);
+  });
+  ipcMain.on("desktop:new-mail", (event, payload: unknown) => {
+    if (!isTrustedMailEvent(event)) return;
+    const mail = trackNewMail(payload);
+    if (!mail || mainWindow?.isFocused() || !Notification.isSupported()) return;
+    const notification = new Notification({
+      title: "Inbox Zero",
+      body:
+        mail.count === 1
+          ? "You have a new email"
+          : `You have ${mail.count} new emails`,
+    });
+    mailNotifications.get(mail.emailAccountId)?.close();
+    mailNotifications.set(mail.emailAccountId, notification);
+    notification.on("click", () => {
+      focusMainWindow();
+      mainWindow
+        ?.loadURL(new URL(`/${mail.emailAccountId}/mail`, appOrigin).toString())
+        .catch(() => {});
+    });
+    const release = () => {
+      if (mailNotifications.get(mail.emailAccountId) === notification) {
+        mailNotifications.delete(mail.emailAccountId);
+      }
+    };
+    notification.on("close", release);
+    notification.on("failed", release);
+    notification.show();
+  });
 
   app.on("second-instance", (_event, argv) => {
     const protocolUrl = findDesktopProtocolUrl(argv);
@@ -150,6 +191,7 @@ function createMainWindow() {
       contextIsolation: true,
       sandbox: true,
       nodeIntegration: false,
+      backgroundThrottling: false,
     },
   });
 
@@ -180,6 +222,12 @@ function getStartUrl(): string {
 }
 
 function trackLastAppUrl(contents: WebContents) {
+  contents.on(
+    "did-start-navigation",
+    (_event, _url, isInPlace, isMainFrame) => {
+      if (isMainFrame && !isInPlace) clearMailIndicators();
+    },
+  );
   contents.on("did-navigate", (_event, url) => {
     persistLastAppUrl(url);
   });
@@ -193,6 +241,7 @@ function trackLastAppUrl(contents: WebContents) {
 function persistLastAppUrl(url: string) {
   // Local load recovery must not erase the last mailbox to restore.
   if (url.startsWith("data:") || url === "about:blank") return;
+  if (new URL(url).pathname === "/login") clearMailIndicators();
   const file = path.join(app.getPath("userData"), LAST_APP_URL_FILE);
   try {
     if (shouldPersistDesktopUrl(url, appOrigin)) {
@@ -205,6 +254,26 @@ function persistLastAppUrl(url: string) {
   } catch {
     // Restoring the last page is best-effort; never break navigation over it.
   }
+}
+
+function isTrustedMailEvent(event: IpcMainEvent) {
+  return (
+    event.sender === mainWindow?.webContents &&
+    event.senderFrame === event.sender.mainFrame &&
+    new URL(event.senderFrame.url).origin === appOrigin
+  );
+}
+
+function setUnreadBadge(count: number) {
+  if (process.platform === "darwin")
+    app.dock?.setBadge(count ? String(count) : "");
+  else if (process.platform === "linux") app.setBadgeCount(count);
+}
+
+function clearMailIndicators() {
+  setUnreadBadge(0);
+  for (const notification of mailNotifications.values()) notification.close();
+  mailNotifications.clear();
 }
 
 function readLastAppUrl(): string | null {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -222,12 +222,9 @@ function getStartUrl(): string {
 }
 
 function trackLastAppUrl(contents: WebContents) {
-  contents.on(
-    "did-start-navigation",
-    (_event, _url, isInPlace, isMainFrame) => {
-      if (isMainFrame && !isInPlace) clearMailIndicators();
-    },
-  );
+  contents.on("did-start-navigation", ({ isSameDocument, isMainFrame }) => {
+    if (isMainFrame && !isSameDocument) clearMailIndicators();
+  });
   contents.on("did-navigate", (_event, url) => {
     persistLastAppUrl(url);
   });
@@ -241,7 +238,7 @@ function trackLastAppUrl(contents: WebContents) {
 function persistLastAppUrl(url: string) {
   // Local load recovery must not erase the last mailbox to restore.
   if (url.startsWith("data:") || url === "about:blank") return;
-  if (new URL(url).pathname === "/login") clearMailIndicators();
+  if (URL.parse(url)?.pathname === "/login") clearMailIndicators();
   const file = path.join(app.getPath("userData"), LAST_APP_URL_FILE);
   try {
     if (shouldPersistDesktopUrl(url, appOrigin)) {
@@ -260,7 +257,7 @@ function isTrustedMailEvent(event: IpcMainEvent) {
   return (
     event.sender === mainWindow?.webContents &&
     event.senderFrame === event.sender.mainFrame &&
-    new URL(event.senderFrame.url).origin === appOrigin
+    event.senderFrame.origin === appOrigin
   );
 }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,6 +1,10 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("inboxZeroDesktop", {
+  setUnreadCount: (count: number) =>
+    ipcRenderer.send("desktop:unread-count", count),
+  notifyNewMail: (payload: unknown) =>
+    ipcRenderer.send("desktop:new-mail", payload),
   startAuth: (provider: string, options?: { callbackPath?: string }) =>
     ipcRenderer.invoke("desktop-auth:start", provider, options),
 });

--- a/apps/web/app/(app)/DesktopMailIndicators.tsx
+++ b/apps/web/app/(app)/DesktopMailIndicators.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect } from "react";
+import type { LabelCountsResponse } from "@/app/api/labels/counts/route";
+import { useAccounts } from "@/hooks/useAccounts";
+import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
+
+export function DesktopMailIndicators() {
+  const { data } = useAccounts();
+  const accountIds = JSON.stringify(
+    (data?.emailAccounts ?? [])
+      .filter((account) => !account.account.disconnectedAt)
+      .map((account) => account.id)
+      .sort(),
+  );
+
+  useEffect(() => {
+    const desktop = getInboxZeroDesktopApp();
+    if (!desktop?.setUnreadCount) return;
+    const ids: string[] = JSON.parse(accountIds);
+    const counts = new Map<string, number>();
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    let running = false;
+
+    async function refresh() {
+      if (running || controller.signal.aborted) return;
+      clearTimeout(timer);
+      running = true;
+      try {
+        // Bound provider traffic for users with many connected accounts.
+        for (const id of ids) {
+          if (controller.signal.aborted) return;
+          try {
+            const response = await fetch("/api/labels/counts", {
+              headers: { [EMAIL_ACCOUNT_HEADER]: id },
+              signal: AbortSignal.any([
+                controller.signal,
+                AbortSignal.timeout(20_000),
+              ]),
+            });
+            if (response.status === 401 || response.status === 403) {
+              counts.delete(id);
+              continue;
+            }
+            if (!response.ok) continue;
+            const result: LabelCountsResponse = await response.json();
+            const inbox = result.counts.find((count) => count.id === "INBOX");
+            if (
+              inbox &&
+              Number.isSafeInteger(inbox.unread) &&
+              inbox.unread >= 0
+            ) {
+              counts.set(id, inbox.unread);
+            }
+          } catch {
+            // Preserve the last successful count through temporary network failures.
+          }
+        }
+        if (!controller.signal.aborted) {
+          desktop?.setUnreadCount?.(
+            [...counts.values()].reduce((sum, count) => sum + count, 0),
+          );
+        }
+      } finally {
+        running = false;
+        if (!controller.signal.aborted) timer = setTimeout(refresh, 60_000);
+      }
+    }
+
+    refresh();
+    window.addEventListener("focus", refresh);
+    window.addEventListener("online", refresh);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+      window.removeEventListener("focus", refresh);
+      window.removeEventListener("online", refresh);
+      desktop.setUnreadCount?.(0);
+    };
+  }, [accountIds]);
+
+  return null;
+}

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -15,6 +15,7 @@ import { SentryIdentify } from "@/app/(app)/sentry-identify";
 import { AiAutomationStatusBanner } from "@/app/(app)/AiAutomationStatusBanner";
 import { ErrorMessages } from "@/app/(app)/ErrorMessages";
 import { MailboxSyncManager } from "@/app/(app)/MailboxSyncManager";
+import { DesktopMailIndicators } from "@/app/(app)/DesktopMailIndicators";
 import { MailMutationOutboxManager } from "@/app/(app)/MailMutationOutboxManager";
 import { ProviderRateLimitBanner } from "@/app/(app)/ProviderRateLimitBanner";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -93,6 +94,7 @@ export default async function AppLayout({
             }
           >
             <MailboxSyncManager />
+            <DesktopMailIndicators />
             <MailMutationOutboxManager />
             <AiAutomationStatusBanner />
             <ErrorMessages />

--- a/apps/web/utils/desktop-app.ts
+++ b/apps/web/utils/desktop-app.ts
@@ -3,6 +3,11 @@ export type DesktopAuthProvider = "apple" | "google" | "microsoft";
 export const DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
 
 export type InboxZeroDesktopApi = {
+  setUnreadCount?: (count: number) => void;
+  notifyNewMail?: (payload: {
+    emailAccountId: string;
+    messages: { id: string; receivedAt: number }[];
+  }) => void;
   startAuth: (
     provider: DesktopAuthProvider,
     options?: { callbackPath?: string },

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -1,5 +1,6 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
 import { clearEmailCache, getEmailCacheDatabase } from "./database";
 import { readMailboxSyncState } from "./mailbox";
 import {
@@ -8,15 +9,66 @@ import {
   syncMailboxPages,
 } from "./mailbox-sync";
 
+vi.mock("@/utils/desktop-app", () => ({ getInboxZeroDesktopApp: vi.fn() }));
+
 describe("mailbox sync coordinator", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.mocked(getInboxZeroDesktopApp).mockReturnValue(undefined);
     await clearEmailCache();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it("forwards only unread inbox arrivals to desktop notifications", async () => {
+    const notifyNewMail = vi.fn();
+    vi.mocked(getInboxZeroDesktopApp).mockReturnValue({
+      startAuth: vi.fn(),
+      notifyNewMail,
+    });
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: vi.fn().mockResolvedValue({
+        accountId: "account-1",
+        cursor: "cursor-1",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: [
+          {
+            id: "new",
+            threadId: "t1",
+            internalDate: "1000",
+            labelIds: ["INBOX", "UNREAD"],
+          },
+          {
+            id: "read",
+            threadId: "t2",
+            internalDate: "1000",
+            labelIds: ["INBOX"],
+          },
+          {
+            id: "archived",
+            threadId: "t3",
+            internalDate: "1000",
+            labelIds: ["UNREAD"],
+          },
+          {
+            id: "sent",
+            threadId: "t4",
+            internalDate: "1000",
+            labelIds: ["SENT"],
+          },
+        ],
+      }),
+    });
+    expect(notifyNewMail).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      messages: [{ id: "new", receivedAt: 1000 }],
+    });
   });
 
   it("starts with a recent snapshot and follows cursors to completion", async () => {

--- a/apps/web/utils/email-cache/mailbox-sync.test.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.test.ts
@@ -71,6 +71,37 @@ describe("mailbox sync coordinator", () => {
     });
   });
 
+  it("batches expanded history pages and normalizes ISO arrival timestamps", async () => {
+    const notifyNewMail = vi.fn();
+    vi.mocked(getInboxZeroDesktopApp).mockReturnValue({
+      startAuth: vi.fn(),
+      notifyNewMail,
+    });
+    const receivedAt = "2026-01-01T12:00:00.000Z";
+    await syncMailboxPages({
+      emailAccountId: "account-1",
+      fetchPage: vi.fn().mockResolvedValue({
+        accountId: "account-1",
+        cursor: "cursor-1",
+        deletedMessageIds: [],
+        hasMore: false,
+        reset: true,
+        upsertedMessages: Array.from({ length: 101 }, (_, index) => ({
+          id: `message-${index}`,
+          threadId: `thread-${index}`,
+          internalDate: receivedAt,
+          labelIds: ["INBOX", "UNREAD"],
+        })),
+      }),
+    });
+    expect(notifyNewMail).toHaveBeenCalledTimes(2);
+    expect(notifyNewMail.mock.calls[0][0].messages).toHaveLength(100);
+    expect(notifyNewMail.mock.calls[1][0]).toEqual({
+      emailAccountId: "account-1",
+      messages: [{ id: "message-100", receivedAt: Date.parse(receivedAt) }],
+    });
+  });
+
   it("starts with a recent snapshot and follows cursors to completion", async () => {
     const fetchPage = vi
       .fn()

--- a/apps/web/utils/email-cache/mailbox-sync.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.ts
@@ -1,6 +1,7 @@
 import type { MailboxSyncResponse } from "@/app/api/mobile/mailbox-sync/route";
 import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
 import { ONE_DAY_MS } from "@/utils/date";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
 import { captureEmailCacheEpoch, isEmailCacheEpochCurrent } from "./database";
 import { applyMailboxSyncPage, readMailboxSyncState } from "./mailbox";
 
@@ -85,6 +86,22 @@ export async function syncMailboxPages({
       now: now?.getTime() ?? Date.now(),
     });
     if (!applied) throw new Error("Mailbox sync page was not persisted");
+    if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
+      return { hasMore: false, pagesSynced };
+    }
+    getInboxZeroDesktopApp()?.notifyNewMail?.({
+      emailAccountId,
+      messages: page.upsertedMessages
+        .filter(
+          (message) =>
+            message.labelIds?.includes("INBOX") &&
+            message.labelIds.includes("UNREAD"),
+        )
+        .map((message) => ({
+          id: message.id,
+          receivedAt: Number(message.internalDate),
+        })),
+    });
     pagesSynced += 1;
     hasMore = page.hasMore;
     input = { cursor: page.cursor, limit: DEFAULT_PAGE_LIMIT };

--- a/apps/web/utils/email-cache/mailbox-sync.ts
+++ b/apps/web/utils/email-cache/mailbox-sync.ts
@@ -89,9 +89,9 @@ export async function syncMailboxPages({
     if (!isEmailCacheEpochCurrent(emailAccountId, epoch)) {
       return { hasMore: false, pagesSynced };
     }
-    getInboxZeroDesktopApp()?.notifyNewMail?.({
-      emailAccountId,
-      messages: page.upsertedMessages
+    const notifyNewMail = getInboxZeroDesktopApp()?.notifyNewMail;
+    if (notifyNewMail) {
+      const messages = page.upsertedMessages
         .filter(
           (message) =>
             message.labelIds?.includes("INBOX") &&
@@ -99,9 +99,18 @@ export async function syncMailboxPages({
         )
         .map((message) => ({
           id: message.id,
-          receivedAt: Number(message.internalDate),
-        })),
-    });
+          receivedAt: Number.isFinite(Number(message.internalDate))
+            ? Number(message.internalDate)
+            : Date.parse(message.internalDate ?? ""),
+        }));
+      // Provider history pages can expand beyond the desktop IPC batch limit.
+      for (let offset = 0; offset < messages.length; offset += 100) {
+        notifyNewMail({
+          emailAccountId,
+          messages: messages.slice(offset, offset + 100),
+        });
+      }
+    }
     pagesSynced += 1;
     hasMore = page.hasMore;
     input = { cursor: page.cursor, limit: DEFAULT_PAGE_LIMIT };


### PR DESCRIPTION
The desktop app now shows a combined unread inbox badge and native notifications for new unread inbox mail received while the app is in the background. Clicking a notification opens the relevant account's inbox; notifications omit sender and subject details and suppress startup backlog and duplicate sync results.

- Supports macOS Dock badges and supported Linux launcher badges, with account counts refreshed about once a minute and on focus.
- Uses existing mailbox sync for notifications and restricts desktop IPC to the trusted main frame.
- Includes notification and mailbox-sync regression coverage. Validation is delegated to CI; focused formatting checks passed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Dock badges showing unread inbox counts.
  * Added native notifications for newly received unread mail, with account-specific details and actions to open the mailbox.
  * Unread indicators refresh automatically and clear during sign-in or desktop app navigation.
* **Documentation**
  * Documented badge behavior, notifications, platform differences, and operational requirements.
* **Tests**
  * Added coverage for notification filtering, deduplication, validation, and unread-mail synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->