### PR TITLE
Gmail: Reuse shared fields for tracing logs

### DIFF
--- a/apps/web/app/api/google/webhook/route.ts
+++ b/apps/web/app/api/google/webhook/route.ts
@@ -49,11 +49,10 @@ export const POST = withError("google/webhook", async (request) => {
     historyId: decodedData.historyId,
     queueMessageId: body.message?.messageId,
     subscriptionId: body.subscription,
-  });
-
-  logger.info("Received webhook - acknowledging immediately", {
     sentAt: body.message?.publishTime,
   });
+
+  logger.info("Received webhook - acknowledging immediately");
 
   const emailAccount = await getWebhookEmailAccount(
     { email: decodedData.emailAddress.toLowerCase() },

--- a/apps/web/app/api/google/webhook/route.ts
+++ b/apps/web/app/api/google/webhook/route.ts
@@ -47,12 +47,13 @@ export const POST = withError("google/webhook", async (request) => {
   logger = logger.with({
     email: decodedData.emailAddress,
     historyId: decodedData.historyId,
-    pubsubMessageId: body.message?.messageId,
-    pubsubPublishTime: body.message?.publishTime,
-    pubsubSubscription: body.subscription,
+    queueMessageId: body.message?.messageId,
+    subscriptionId: body.subscription,
   });
 
-  logger.info("Received webhook - acknowledging immediately");
+  logger.info("Received webhook - acknowledging immediately", {
+    sentAt: body.message?.publishTime,
+  });
 
   const emailAccount = await getWebhookEmailAccount(
     { email: decodedData.emailAddress.toLowerCase() },

--- a/apps/web/utils/gmail/watch.ts
+++ b/apps/web/utils/gmail/watch.ts
@@ -43,9 +43,9 @@ async function startGmailWatch(gmail: gmail_v1.Gmail, logger: Logger) {
   );
 
   logger.info("Gmail watch registered", {
-    watchHistoryId: res.data.historyId,
-    watchExpiration: res.data.expiration,
-    topicName: env.GOOGLE_PUBSUB_TOPIC_NAME,
+    gmailHistoryId: res.data.historyId,
+    expirationDate: res.data.expiration,
+    topic: env.GOOGLE_PUBSUB_TOPIC_NAME,
   });
 
   return res.data;

--- a/apps/web/utils/gmail/watch.ts
+++ b/apps/web/utils/gmail/watch.ts
@@ -44,7 +44,9 @@ async function startGmailWatch(gmail: gmail_v1.Gmail, logger: Logger) {
 
   logger.info("Gmail watch registered", {
     gmailHistoryId: res.data.historyId,
-    expirationDate: res.data.expiration,
+    expirationDate: res.data.expiration
+      ? new Date(Number(res.data.expiration)).toISOString()
+      : undefined,
     topic: env.GOOGLE_PUBSUB_TOPIC_NAME,
   });
 


### PR DESCRIPTION
New Gmail tracing fields can cause log ingestion to be rejected when a dataset has reached its field limit. Reuse established logging fields for watch registration and Pub/Sub delivery so these events remain ingestible without expanding the schema.

- Preserve history ID, expiration, topic, message ID, subscription, and publish-time metadata.
- Validation: nine focused watch and webhook tests pass; formatting checks pass; synthetic ingestion checks accept both corrected event shapes.

No additional database or network calls and no changes to email processing behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging consistency for Google webhook processing and Gmail watch registration.
  * Updated log fields to use clearer identifiers for message IDs, subscriptions, history IDs, expiration dates, topics, and message timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->