### PR TITLE
fix: add safe Gmail send diagnostics

### DIFF
--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1108,10 +1108,14 @@ export class GmailProvider implements EmailProvider {
   }
 
   async sendEmailWithHtml(body: SendEmailBody) {
-    const result = await sendEmailWithHtml(this.client, {
-      ...body,
-      attachments: toMailerAttachments(body.attachments),
-    });
+    const result = await sendEmailWithHtml(
+      this.client,
+      {
+        ...body,
+        attachments: toMailerAttachments(body.attachments),
+      },
+      this.logger,
+    );
     return {
       messageId: result.data.id || "",
       threadId: result.data.threadId || "",

--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -20,6 +20,39 @@ const email = {
 };
 
 describe("sending a Gmail draft from the reader", () => {
+  it("adds the authenticated mailbox as sender when none is supplied", async () => {
+    const { gmail, messages } = createGmail();
+    await sendEmailWithHtml(gmail, { ...email, replyToEmail: undefined });
+    const raw = messages.send.mock.calls[0][0].requestBody.raw;
+    expect(Buffer.from(raw, "base64url").toString()).toContain(
+      "From: sender@example.com\r\n",
+    );
+  });
+
+  it("preserves an explicit sender without fetching the profile", async () => {
+    const { gmail, messages, getProfile } = createGmail();
+    await sendEmailWithHtml(gmail, {
+      ...email,
+      from: "Support <alias@example.com>",
+      replyToEmail: undefined,
+    });
+    const raw = messages.send.mock.calls[0][0].requestBody.raw;
+    expect(Buffer.from(raw, "base64url").toString()).toContain(
+      "From: Support <alias@example.com>\r\n",
+    );
+    expect(getProfile).not.toHaveBeenCalled();
+  });
+
+  it("does not send when the authenticated sender cannot be determined", async () => {
+    const { gmail, messages, drafts, getProfile } = createGmail();
+    getProfile.mockResolvedValue({ data: {} });
+    await expect(sendEmailWithHtml(gmail, email)).rejects.toBeInstanceOf(
+      SafeError,
+    );
+    expect(messages.send).not.toHaveBeenCalled();
+    expect(drafts.send).not.toHaveBeenCalled();
+  });
+
   it("consumes the existing draft and sends the edited content", async () => {
     const { gmail, drafts, messages } = createGmail();
 
@@ -38,6 +71,9 @@ describe("sending a Gmail draft from the reader", () => {
     const [request] = call;
     const raw = request.requestBody.message.raw;
     expect(Buffer.from(raw, "base64url").toString()).toContain("Edited reply");
+    expect(Buffer.from(raw, "base64url").toString()).toContain(
+      "From: sender@example.com\r\n",
+    );
     expect(messages.send).not.toHaveBeenCalled();
   });
 
@@ -135,8 +171,14 @@ function createGmail() {
       >()
       .mockResolvedValue(sent),
   };
+  const getProfile = vi
+    .fn<() => Promise<{ data: { emailAddress?: string } }>>()
+    .mockResolvedValue({ data: { emailAddress: "sender@example.com" } });
   return {
-    gmail: { users: { messages, drafts } } as unknown as gmail_v1.Gmail,
+    getProfile,
+    gmail: {
+      users: { messages, drafts, getProfile },
+    } as unknown as gmail_v1.Gmail,
     messages,
     drafts,
   };

--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -1,7 +1,8 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import { assert, describe, expect, it, vi } from "vitest";
+import { getMockMessage } from "@/__tests__/helpers";
 import { SafeError } from "@/utils/error";
-import { sendEmailWithHtml } from "./mail";
+import { forwardEmail, replyToEmail, sendEmailWithHtml } from "./mail";
 
 vi.mock("@/utils/mail", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/utils/mail")>()),
@@ -51,6 +52,27 @@ describe("sending a Gmail draft from the reader", () => {
     );
     expect(messages.send).not.toHaveBeenCalled();
     expect(drafts.send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "reply",
+    "forward",
+  ] as const)("adds a sender for a %s without an explicit sender", async (kind) => {
+    const { gmail, messages } = createGmail();
+    const message = getMockMessage();
+    if (kind === "reply") {
+      await replyToEmail(gmail, message, "Reply content");
+    } else {
+      await forwardEmail(
+        gmail,
+        { ...message, attachments: [] },
+        { to: "recipient@example.com" },
+      );
+    }
+    const raw = messages.send.mock.calls[0][0].requestBody.raw;
+    expect(Buffer.from(raw, "base64url").toString()).toContain(
+      "From: sender@example.com\r\n",
+    );
   });
 
   it("consumes the existing draft and sends the edited content", async () => {

--- a/apps/web/utils/gmail/mail-send.test.ts
+++ b/apps/web/utils/gmail/mail-send.test.ts
@@ -1,8 +1,8 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import { assert, describe, expect, it, vi } from "vitest";
-import { getMockMessage } from "@/__tests__/helpers";
+import { createScopedLogger } from "@/utils/logger";
 import { SafeError } from "@/utils/error";
-import { forwardEmail, replyToEmail, sendEmailWithHtml } from "./mail";
+import { sendEmailWithHtml } from "./mail";
 
 vi.mock("@/utils/mail", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/utils/mail")>()),
@@ -21,58 +21,40 @@ const email = {
 };
 
 describe("sending a Gmail draft from the reader", () => {
-  it("adds the authenticated mailbox as sender when none is supplied", async () => {
+  it("reports the actual MIME sender presence and failed send endpoint without message content", async () => {
     const { gmail, messages } = createGmail();
-    await sendEmailWithHtml(gmail, { ...email, replyToEmail: undefined });
-    const raw = messages.send.mock.calls[0][0].requestBody.raw;
-    expect(Buffer.from(raw, "base64url").toString()).toContain(
-      "From: sender@example.com\r\n",
+    messages.get.mockResolvedValue({ data: { labelIds: ["INBOX"] } });
+    const failure = Object.assign(new Error("Bad Gateway"), { code: 502 });
+    messages.send.mockRejectedValue(failure);
+    const logger = createScopedLogger("test");
+    const info = vi.spyOn(logger, "info");
+    const warn = vi.spyOn(logger, "warn");
+    await expect(sendEmailWithHtml(gmail, email, logger)).rejects.toBe(failure);
+    expect(info).toHaveBeenCalledWith(
+      "Prepared Gmail send",
+      expect.objectContaining({
+        hasExplicitFrom: false,
+        hasMimeFrom: false,
+        hasReplyMessageId: true,
+        hasThreadId: true,
+        mimeBytes: expect.any(Number),
+      }),
     );
-  });
-
-  it("preserves an explicit sender without fetching the profile", async () => {
-    const { gmail, messages, getProfile } = createGmail();
-    await sendEmailWithHtml(gmail, {
-      ...email,
-      from: "Support <alias@example.com>",
-      replyToEmail: undefined,
-    });
-    const raw = messages.send.mock.calls[0][0].requestBody.raw;
-    expect(Buffer.from(raw, "base64url").toString()).toContain(
-      "From: Support <alias@example.com>\r\n",
+    expect(warn).toHaveBeenCalledWith(
+      "Gmail send request failed",
+      expect.objectContaining({
+        gmailOperation: "messages.send",
+        status: 502,
+        durationMs: expect.any(Number),
+      }),
     );
-    expect(getProfile).not.toHaveBeenCalled();
-  });
-
-  it("does not send when the authenticated sender cannot be determined", async () => {
-    const { gmail, messages, drafts, getProfile } = createGmail();
-    getProfile.mockResolvedValue({ data: {} });
-    await expect(sendEmailWithHtml(gmail, email)).rejects.toBeInstanceOf(
-      SafeError,
-    );
-    expect(messages.send).not.toHaveBeenCalled();
-    expect(drafts.send).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    "reply",
-    "forward",
-  ] as const)("adds a sender for a %s without an explicit sender", async (kind) => {
-    const { gmail, messages } = createGmail();
-    const message = getMockMessage();
-    if (kind === "reply") {
-      await replyToEmail(gmail, message, "Reply content");
-    } else {
-      await forwardEmail(
-        gmail,
-        { ...message, attachments: [] },
-        { to: "recipient@example.com" },
-      );
-    }
-    const raw = messages.send.mock.calls[0][0].requestBody.raw;
-    expect(Buffer.from(raw, "base64url").toString()).toContain(
-      "From: sender@example.com\r\n",
-    );
+    expect(messages.send).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.stringify([...info.mock.calls, ...warn.mock.calls]),
+    ).not.toContain(email.to);
+    expect(
+      JSON.stringify([...info.mock.calls, ...warn.mock.calls]),
+    ).not.toContain(email.messageHtml);
   });
 
   it("consumes the existing draft and sends the edited content", async () => {
@@ -93,9 +75,6 @@ describe("sending a Gmail draft from the reader", () => {
     const [request] = call;
     const raw = request.requestBody.message.raw;
     expect(Buffer.from(raw, "base64url").toString()).toContain("Edited reply");
-    expect(Buffer.from(raw, "base64url").toString()).toContain(
-      "From: sender@example.com\r\n",
-    );
     expect(messages.send).not.toHaveBeenCalled();
   });
 
@@ -193,14 +172,8 @@ function createGmail() {
       >()
       .mockResolvedValue(sent),
   };
-  const getProfile = vi
-    .fn<() => Promise<{ data: { emailAddress?: string } }>>()
-    .mockResolvedValue({ data: { emailAddress: "sender@example.com" } });
   return {
-    getProfile,
-    gmail: {
-      users: { messages, drafts, getProfile },
-    } as unknown as gmail_v1.Gmail,
+    gmail: { users: { messages, drafts } } as unknown as gmail_v1.Gmail,
     messages,
     drafts,
   };

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -12,7 +12,7 @@ import {
 import type { ParsedMessage } from "@/utils/types";
 import { createReplyContent, formatEmailDate } from "@/utils/gmail/reply";
 import type { EmailForAction } from "@/utils/ai/types";
-import { createScopedLogger } from "@/utils/logger";
+import { createScopedLogger, type Logger } from "@/utils/logger";
 import {
   extractErrorInfo,
   withGmailNonIdempotentWriteRetry,
@@ -102,6 +102,7 @@ const createRawMailMessage = async ({
 export async function sendEmailWithHtml(
   gmail: gmail_v1.Gmail,
   body: MailSendEmailBody,
+  sendLogger: Logger = logger,
 ) {
   ensureEmailSendingEnabled();
 
@@ -110,12 +111,25 @@ export async function sendEmailWithHtml(
   try {
     messageText = convertEmailHtmlToText({ htmlText: body.messageHtml });
   } catch (error) {
-    logger.error("Error converting email html to text", { error });
+    sendLogger.error("Error converting email html to text", { error });
     messageText = stripHtmlTagsForPlainText(body.messageHtml).trim();
   }
 
-  const from = await resolveSender(gmail, body.from);
-  const raw = await createRawMailMessage({ ...body, from, messageText });
+  const raw = await createRawMailMessage({ ...body, messageText });
+  const mime = Buffer.from(raw, "base64url");
+  const headerEnd = mime.indexOf("\r\n\r\n");
+  const mimeHeaders = mime
+    .subarray(0, headerEnd < 0 ? mime.length : headerEnd)
+    .toString("utf8");
+  sendLogger.info("Prepared Gmail send", {
+    hasExplicitFrom: Boolean(body.from?.trim()),
+    hasMimeFrom: /^from:/im.test(mimeHeaders),
+    hasReplyMessageId: Boolean(body.replyToEmail?.messageId),
+    hasThreadId: Boolean(body.replyToEmail?.threadId),
+    hasInReplyTo: /^in-reply-to:/im.test(mimeHeaders),
+    mimeBytes: mime.length,
+    attachmentCount: body.attachments?.length ?? 0,
+  });
   const { replyToEmail } = body;
   if (replyToEmail?.messageId) {
     const message = await getMessage(
@@ -124,7 +138,7 @@ export async function sendEmailWithHtml(
       "metadata",
     ).catch((error: unknown) => {
       if (extractErrorInfo(error).status === 404) {
-        logger.warn("Reply source disappeared before sending", {
+        sendLogger.warn("Reply source disappeared before sending", {
           messageId: replyToEmail.messageId,
         });
         throw new SafeError(
@@ -147,7 +161,7 @@ export async function sendEmailWithHtml(
       }
 
       // Sending the existing draft consumes it and applies edits in one request.
-      return withGmailNonIdempotentWriteRetry(() =>
+      return trackGmailSend("drafts.send", sendLogger, () =>
         gmail.users.drafts.send({
           userId: "me",
           requestBody: {
@@ -158,7 +172,7 @@ export async function sendEmailWithHtml(
       );
     }
   }
-  const result = await withGmailNonIdempotentWriteRetry(() =>
+  const result = await trackGmailSend("messages.send", sendLogger, () =>
     gmail.users.messages.send({
       userId: "me",
       requestBody: {
@@ -205,7 +219,7 @@ export async function replyToEmail(
   // Only replying to the original sender
   const raw = await createRawMailMessage({
     to: message.headers["reply-to"] || message.headers.from,
-    from: await resolveSender(gmail, from),
+    from,
     replyTo: options?.replyTo,
     subject: formatReplySubject(message.headers.subject),
     messageText,
@@ -269,7 +283,7 @@ export async function forwardEmail(
 
   const raw = await createRawMailMessage({
     to: options.to,
-    from: await resolveSender(gmail, options.from),
+    from: options.from,
     cc: options.cc,
     bcc: options.bcc,
     subject: forwardEmailSubject(message.headers.subject),
@@ -472,18 +486,28 @@ function readHtmlTagName(value: string, start: number) {
   return tagName;
 }
 
-async function resolveSender(gmail: gmail_v1.Gmail, suppliedFrom?: string) {
-  const from = suppliedFrom?.trim();
-  if (from) return from;
-
-  const profile = await withGmailRetry(() =>
-    gmail.users.getProfile({ userId: "me" }),
-  );
-  const emailAddress = profile.data.emailAddress?.trim();
-  if (!emailAddress) {
-    throw new SafeError(
-      "Could not determine the sender address. Reconnect the account before sending.",
-    );
+async function trackGmailSend<T>(
+  gmailOperation: "messages.send" | "drafts.send",
+  logger: Logger,
+  send: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now();
+  logger.info("Gmail send request started", { gmailOperation });
+  try {
+    const result = await withGmailNonIdempotentWriteRetry(send, 5, { logger });
+    logger.info("Gmail send request accepted", {
+      gmailOperation,
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (error) {
+    const { status, googleErrorStatus } = extractErrorInfo(error);
+    logger.warn("Gmail send request failed", {
+      gmailOperation,
+      durationMs: Date.now() - startedAt,
+      status,
+      googleErrorStatus,
+    });
+    throw error;
   }
-  return emailAddress;
 }

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -114,7 +114,19 @@ export async function sendEmailWithHtml(
     messageText = stripHtmlTagsForPlainText(body.messageHtml).trim();
   }
 
-  const raw = await createRawMailMessage({ ...body, messageText });
+  let from = body.from?.trim();
+  if (!from) {
+    const profile = await withGmailRetry(() =>
+      gmail.users.getProfile({ userId: "me" }),
+    );
+    from = profile.data.emailAddress?.trim();
+    if (!from) {
+      throw new SafeError(
+        "Could not determine the sender address. Reconnect the account before sending.",
+      );
+    }
+  }
+  const raw = await createRawMailMessage({ ...body, from, messageText });
   const { replyToEmail } = body;
   if (replyToEmail?.messageId) {
     const message = await getMessage(

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -116,20 +116,7 @@ export async function sendEmailWithHtml(
   }
 
   const raw = await createRawMailMessage({ ...body, messageText });
-  const mime = Buffer.from(raw, "base64url");
-  const headerEnd = mime.indexOf("\r\n\r\n");
-  const mimeHeaders = mime
-    .subarray(0, headerEnd < 0 ? mime.length : headerEnd)
-    .toString("utf8");
-  sendLogger.info("Prepared Gmail send", {
-    hasExplicitFrom: Boolean(body.from?.trim()),
-    hasMimeFrom: /^from:/im.test(mimeHeaders),
-    hasReplyMessageId: Boolean(body.replyToEmail?.messageId),
-    hasThreadId: Boolean(body.replyToEmail?.threadId),
-    hasInReplyTo: /^in-reply-to:/im.test(mimeHeaders),
-    mimeBytes: mime.length,
-    attachmentCount: body.attachments?.length ?? 0,
-  });
+  sendLogger.info("Prepared Gmail send", getGmailSendMetadata(raw, body));
   const { replyToEmail } = body;
   if (replyToEmail?.messageId) {
     const message = await getMessage(
@@ -510,4 +497,21 @@ async function trackGmailSend<T>(
     });
     throw error;
   }
+}
+
+function getGmailSendMetadata(raw: string, body: MailSendEmailBody) {
+  const mime = Buffer.from(raw, "base64url");
+  const headerEnd = mime.indexOf("\r\n\r\n");
+  const mimeHeaders = mime
+    .subarray(0, headerEnd < 0 ? mime.length : headerEnd)
+    .toString("utf8");
+  return {
+    hasExplicitFrom: Boolean(body.from?.trim()),
+    hasMimeFrom: /^from:/im.test(mimeHeaders),
+    hasReplyMessageId: Boolean(body.replyToEmail?.messageId),
+    hasThreadId: Boolean(body.replyToEmail?.threadId),
+    hasInReplyTo: /^in-reply-to:/im.test(mimeHeaders),
+    mimeBytes: mime.length,
+    attachmentCount: body.attachments?.length ?? 0,
+  };
 }

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -114,18 +114,7 @@ export async function sendEmailWithHtml(
     messageText = stripHtmlTagsForPlainText(body.messageHtml).trim();
   }
 
-  let from = body.from?.trim();
-  if (!from) {
-    const profile = await withGmailRetry(() =>
-      gmail.users.getProfile({ userId: "me" }),
-    );
-    from = profile.data.emailAddress?.trim();
-    if (!from) {
-      throw new SafeError(
-        "Could not determine the sender address. Reconnect the account before sending.",
-      );
-    }
-  }
+  const from = await resolveSender(gmail, body.from);
   const raw = await createRawMailMessage({ ...body, from, messageText });
   const { replyToEmail } = body;
   if (replyToEmail?.messageId) {
@@ -216,7 +205,7 @@ export async function replyToEmail(
   // Only replying to the original sender
   const raw = await createRawMailMessage({
     to: message.headers["reply-to"] || message.headers.from,
-    from,
+    from: await resolveSender(gmail, from),
     replyTo: options?.replyTo,
     subject: formatReplySubject(message.headers.subject),
     messageText,
@@ -280,7 +269,7 @@ export async function forwardEmail(
 
   const raw = await createRawMailMessage({
     to: options.to,
-    from: options.from,
+    from: await resolveSender(gmail, options.from),
     cc: options.cc,
     bcc: options.bcc,
     subject: forwardEmailSubject(message.headers.subject),
@@ -481,4 +470,20 @@ function readHtmlTagName(value: string, start: number) {
   }
 
   return tagName;
+}
+
+async function resolveSender(gmail: gmail_v1.Gmail, suppliedFrom?: string) {
+  const from = suppliedFrom?.trim();
+  if (from) return from;
+
+  const profile = await withGmailRetry(() =>
+    gmail.users.getProfile({ userId: "me" }),
+  );
+  const emailAddress = profile.data.emailAddress?.trim();
+  if (!emailAddress) {
+    throw new SafeError(
+      "Could not determine the sender address. Reconnect the account before sending.",
+    );
+  }
+  return emailAddress;
 }

--- a/apps/web/utils/logger.test.ts
+++ b/apps/web/utils/logger.test.ts
@@ -59,6 +59,28 @@ describe("Logger", () => {
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
+  it("redacts encoded MIME in provider errors even when debug logging is enabled", () => {
+    mockedEnv.NODE_ENV = "production";
+    mockedEnv.AXIOM_TOKEN = "server-token";
+    mockedEnv.ENABLE_DEBUG_LOGS = true;
+    const raw = Buffer.from(
+      "To: recipient@example.com\r\n\r\nPrivate message",
+    ).toString("base64url");
+    createScopedLogger("test").error("Send failed", {
+      error: { message: "Bad Gateway", status: 502, config: { data: { raw } } },
+    });
+    expect(JSON.stringify(vi.mocked(log.error).mock.calls)).not.toContain(raw);
+    expect(log.error).toHaveBeenCalledWith(
+      "Send failed",
+      expect.objectContaining({
+        error: expect.objectContaining({
+          status: 502,
+          config: { data: { raw: true } },
+        }),
+      }),
+    );
+  });
+
   it("uses Axiom logging when the server token is configured", () => {
     mockedEnv.AXIOM_TOKEN = "server-token";
 

--- a/apps/web/utils/redact-fields.ts
+++ b/apps/web/utils/redact-fields.ts
@@ -10,7 +10,7 @@ export const SENSITIVE_FIELD_NAMES = new Set([
   "replyTo",
 ]);
 
-// Secrets that must never leave the process.
+// Secrets and encoded payloads that must never leave the process.
 export const REDACTED_FIELD_NAMES = new Set([
   "accessToken",
   "access_token",
@@ -22,6 +22,7 @@ export const REDACTED_FIELD_NAMES = new Set([
   "set-cookie",
   "authorization",
   "requestBodyValues",
+  "raw",
   "receivedState",
   "systemInstruction",
   "contents",


### PR DESCRIPTION
Add request-scoped Gmail send diagnostics to distinguish message preparation, provider submission, and provider acceptance or failure. Keep encoded message payloads redacted from telemetry.

- Record only sender/header presence, payload size, attachment count, send endpoint, status, and elapsed time; never message content or recipient addresses.
- Preserve existing sender handling and non-idempotent retry behavior. No profile lookup is added.
- Validation: 64 focused tests passed across Gmail sending, provider integration, durable sending, logging, and error scrubbing. A controlled local live test using the application send code confirmed that Gmail accepts a reply without an explicit sender and stores it in Sent.
- The intermittent provider error was not reproduced; this change adds diagnostics rather than claiming a root-cause fix.
- Performance: no additional database or provider calls. Adds local MIME inspection and three structured log events per submitted send.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail send reliability with automatic retry handling for failed non-idempotent requests.
  * Gmail draft and message sends now report clearer preparation, success, and failure status.

* **Privacy and Security**
  * Sensitive email content, including encoded message payloads and raw MIME data, is redacted from production logs.
  * Delivery diagnostics exclude recipient addresses and message HTML while retaining useful troubleshooting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->