### PR TITLE
ci: Report startup failures promptly and preserve server diagnostics

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -96,8 +96,8 @@ checks are still running is a report of nothing:
 "$(git rev-parse --show-toplevel)/.claude/skills/pr-watch/pr-digest" --watch
 ```
 
-That call blocks until the checks on this commit are terminal and then prints a
-digest ending in a `VERDICT` line. Read `.claude/skills/pr-watch/SKILL.md` for
+That call reports a failure or timeout immediately, or waits for the checks
+on this commit to settle, then prints a digest ending in a `VERDICT` line. Read `.claude/skills/pr-watch/SKILL.md` for
 how to act on each verdict, triage a failing job, and answer review comments.
 
 Starting the command matters more than remembering the skill: once it is

--- a/.claude/skills/pr-watch/SKILL.md
+++ b/.claude/skills/pr-watch/SKILL.md
@@ -30,9 +30,11 @@ PRD="$(git rev-parse --show-toplevel)/.claude/skills/pr-watch/pr-digest"
 
 ## The cycle
 
-1. Run `"$PRD" --watch` with **`run_in_background: true`**. It blocks until
-   every check run and commit status on the exact head SHA is terminal, then
-   prints the digest. You are re-invoked when it exits.
+1. Run `"$PRD" --watch` with **`run_in_background: true`**. It reports a failed,
+   cancelled or timed-out check on the exact head SHA
+   immediately, even while other checks are pending. Otherwise it waits for
+   checks to settle. At its wait deadline it prints `WAIT_LIMIT` and names
+   the pending checks; that deadline is not itself a CI failure. You are re-invoked when it exits.
 
    Never wait in the foreground. `sleep` is blocked and an `until` loop is
    killed at the execution tool's timeout, costing an error round-trip plus a
@@ -53,13 +55,18 @@ PRD="$(git rev-parse --show-toplevel)/.claude/skills/pr-watch/pr-digest"
 
 ## Failures
 
-Each `FAIL` line names the job and the step that broke. A step that failed or
-was cancelled with *"later steps skipped, tests did not run"* is infrastructure,
-not your diff — `gh run rerun <run-id> --failed` and go back to 1.
+Each `FAIL` line names the job and the step that broke. Report a timeout or
+failure promptly; do not keep saying checks are merely running. Skipped later
+steps do not prove infrastructure failure: compilation errors also skip steps.
 
-Otherwise `"$PRD" --logs <job-id>` for the assertion and code frame. Raw CI
-logs prefix every line with job name, step name, and a timestamp, and a
-Playwright job can exceed two megabytes; the flag strips all of that.
+Use `"$PRD" --logs <job-id>` for the assertion and code frame. Raw CI
+logs can be large; the flag reads the completed job directly, even while
+sibling jobs run, and retains relevant server-startup diagnostics.
+
+For a Playwright webServer timeout, identify the named service and inspect its
+startup output before classifying the cause. If the logs do not establish why
+it stalled, say so. Retry only confirmed transient infrastructure failures, and
+do not repeatedly retry the same startup timeout without investigating it.
 
 Before calling a failure unrelated, prove it: restore the base branch's version
 of the touched paths, rerun that one spec, and report the result. Do not sync

--- a/.claude/skills/pr-watch/pr-digest
+++ b/.claude/skills/pr-watch/pr-digest
@@ -48,11 +48,15 @@ commit_statuses() {
 
 logs() {
   local job=$1 repo raw cleaned out startup
+  local log_flag=""
+  if gh api --help 2>/dev/null | grep -- --allow-escape-sequences >/dev/null; then
+    log_flag=--allow-escape-sequences
+  fi
   repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || die "not a GitHub repo"
   # The completed job's endpoint works while sibling jobs are still running.
-  raw=$(api "repos/$repo/actions/jobs/$job/logs") || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
+  raw=$(api "repos/$repo/actions/jobs/$job/logs" ${log_flag:+"$log_flag"}) || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
   [ -n "${raw//[[:space:]]/}" ] || die "job $job logs unavailable; no log content was returned"
-  cleaned=$(printf '%s\n' "$raw" | perl -pe 's/\e\[[0-9;]*m//g; s/^[^\t]*\t[^\t]*\t\S+\s//; s/^\d{4}-\d\d-\d\dT\S+\s//')
+  cleaned=$(printf '%s\n' "$raw" | perl -0777 -pe 's/\e\][^\a\e]*(?:\a|\e\\)//g; s/\e[P^_X].*?\e\\//sg; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\e[ -\/]*[@-~]//g; s/[\x00-\x08\x0b-\x1f\x7f]//g; s/^[^\t\n]*\t[^\t\n]*\t\S+[^\S\n]//mg; s/^\d{4}-\d\d-\d\dT\S+[^\S\n]//mg')
   out=$(printf '%s\n' "$cleaned" |
     grep -E -A 3 -B 2 '(^|[^a-zA-Z])(Error|TimeoutError|AssertionError|Type error|error TS[0-9]+|ERR_|EADDRINUSE|ECONNREFUSED|timed out|Timed out|timeout|failed|Failed|FAIL|Cannot find|Cannot resolve|Cannot connect)|config\.webServer|^ *[0-9]+\) |^ *(Locator|Expected|Received|Call log):|^ *>? *[0-9]+ \| |^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (passed|flaky|skipped)|^##\[error\]' |
     tail -n "${PR_DIGEST_LOG_LINES:-80}")

--- a/.claude/skills/pr-watch/pr-digest
+++ b/.claude/skills/pr-watch/pr-digest
@@ -55,8 +55,8 @@ logs() {
   repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || die "not a GitHub repo"
   # The completed job's endpoint works while sibling jobs are still running.
   raw=$(api "repos/$repo/actions/jobs/$job/logs" ${log_flag:+"$log_flag"}) || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
-  grep '[^[:space:]]' <<<"$raw" >/dev/null || die "job $job logs unavailable; no log content was returned"
   cleaned=$(printf '%s\n' "$raw" | perl -0777 -pe 's/\e\][^\a\e]*(?:\a|\e\\)//g; s/\e[P^_X].*?\e\\//sg; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\e[ -\/]*[@-~]//g; s/[\x00-\x08\x0b-\x1f\x7f]//g; s/^[^\t\n]*\t[^\t\n]*\t\S+[^\S\n]//mg; s/^\d{4}-\d\d-\d\dT\S+[^\S\n]//mg')
+  grep '[^[:space:]]' <<<"$cleaned" >/dev/null || die "job $job logs unavailable; no log content was returned"
   out=$(printf '%s\n' "$cleaned" |
     grep -E -A 3 -B 2 '(^|[^a-zA-Z])(Error|TimeoutError|AssertionError|Type error|error TS[0-9]+|ERR_|EADDRINUSE|ECONNREFUSED|timed out|Timed out|timeout|failed|Failed|FAIL|Cannot find|Cannot resolve|Cannot connect)|config\.webServer|^ *[0-9]+\) |^ *(Locator|Expected|Received|Call log):|^ *>? *[0-9]+ \| |^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (passed|flaky|skipped)|^##\[error\]' |
     tail -n "${PR_DIGEST_LOG_LINES:-80}")

--- a/.claude/skills/pr-watch/pr-digest
+++ b/.claude/skills/pr-watch/pr-digest
@@ -55,7 +55,7 @@ logs() {
   repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || die "not a GitHub repo"
   # The completed job's endpoint works while sibling jobs are still running.
   raw=$(api "repos/$repo/actions/jobs/$job/logs" ${log_flag:+"$log_flag"}) || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
-  [ -n "${raw//[[:space:]]/}" ] || die "job $job logs unavailable; no log content was returned"
+  grep '[^[:space:]]' <<<"$raw" >/dev/null || die "job $job logs unavailable; no log content was returned"
   cleaned=$(printf '%s\n' "$raw" | perl -0777 -pe 's/\e\][^\a\e]*(?:\a|\e\\)//g; s/\e[P^_X].*?\e\\//sg; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\e[ -\/]*[@-~]//g; s/[\x00-\x08\x0b-\x1f\x7f]//g; s/^[^\t\n]*\t[^\t\n]*\t\S+[^\S\n]//mg; s/^\d{4}-\d\d-\d\dT\S+[^\S\n]//mg')
   out=$(printf '%s\n' "$cleaned" |
     grep -E -A 3 -B 2 '(^|[^a-zA-Z])(Error|TimeoutError|AssertionError|Type error|error TS[0-9]+|ERR_|EADDRINUSE|ECONNREFUSED|timed out|Timed out|timeout|failed|Failed|FAIL|Cannot find|Cannot resolve|Cannot connect)|config\.webServer|^ *[0-9]+\) |^ *(Locator|Expected|Received|Call log):|^ *>? *[0-9]+ \| |^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (passed|flaky|skipped)|^##\[error\]' |

--- a/.claude/skills/pr-watch/pr-digest
+++ b/.claude/skills/pr-watch/pr-digest
@@ -51,6 +51,7 @@ logs() {
   repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || die "not a GitHub repo"
   # The completed job's endpoint works while sibling jobs are still running.
   raw=$(api "repos/$repo/actions/jobs/$job/logs") || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
+  [ -n "${raw//[[:space:]]/}" ] || die "job $job logs unavailable; no log content was returned"
   cleaned=$(printf '%s\n' "$raw" | perl -pe 's/\e\[[0-9;]*m//g; s/^[^\t]*\t[^\t]*\t\S+\s//; s/^\d{4}-\d\d-\d\dT\S+\s//')
   out=$(printf '%s\n' "$cleaned" |
     grep -E -A 3 -B 2 '(^|[^a-zA-Z])(Error|TimeoutError|AssertionError|Type error|error TS[0-9]+|ERR_|EADDRINUSE|ECONNREFUSED|timed out|Timed out|timeout|failed|Failed|FAIL|Cannot find|Cannot resolve|Cannot connect)|config\.webServer|^ *[0-9]+\) |^ *(Locator|Expected|Received|Call log):|^ *>? *[0-9]+ \| |^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (passed|flaky|skipped)|^##\[error\]' |

--- a/.claude/skills/pr-watch/pr-digest
+++ b/.claude/skills/pr-watch/pr-digest
@@ -2,7 +2,7 @@
 # Compact PR status for agents. Prints only what needs a decision.
 #
 #   pr-digest [PR]            one-shot digest
-#   pr-digest --watch [PR]    poll until checks settle, then digest
+#   pr-digest --watch [PR]    report failures immediately, otherwise wait for checks
 #   pr-digest --all [PR]      re-print findings already shown once
 #   pr-digest --logs JOB_ID   failing CI log, stripped of timestamp noise
 #   pr-digest --reply ID BODY reply to a review comment thread
@@ -38,7 +38,7 @@ api() {
 
 check_runs() {
   api --paginate "repos/$1/commits/$2/check-runs?per_page=100" \
-    --jq '.check_runs[] | {name, status, conclusion, html_url}' | jq -s .
+    --jq '.check_runs[] | {name, status, conclusion, html_url, started_at}' | jq -s .
 }
 
 commit_statuses() {
@@ -47,27 +47,22 @@ commit_statuses() {
 }
 
 logs() {
-  local job=$1 keep out
-  keep='^[0-9]+\) |^ *(Error|TimeoutError|AssertionError):|^ *(Locator|Expected|Received|Timeout|Call log):|^ *- (Expect|waiting for|locator resolved)|^ *>? *[0-9]+ \| |^ *\^|^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (failed|passed|flaky|skipped)|^ *(✘|✗|×) |^##\[error\]'
-  out=$(gh run view --job "$job" --log-failed 2>/dev/null |
-    perl -pe 's/^[^\t]*\t[^\t]*\t\S+\s//' |
-    grep -v '^\[WebServer\]' |
-    grep -E "$keep" |
-    perl -pe 's/\e\[[0-9;]*m//g' |
-    awk '!/^##\[error\]/ || !seen[$0]++' |
+  local job=$1 repo raw cleaned out startup
+  repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || die "not a GitHub repo"
+  # The completed job's endpoint works while sibling jobs are still running.
+  raw=$(api "repos/$repo/actions/jobs/$job/logs") || die "job $job logs unavailable; inspect the job URL and retry log retrieval when available"
+  cleaned=$(printf '%s\n' "$raw" | perl -pe 's/\e\[[0-9;]*m//g; s/^[^\t]*\t[^\t]*\t\S+\s//; s/^\d{4}-\d\d-\d\dT\S+\s//')
+  out=$(printf '%s\n' "$cleaned" |
+    grep -E -A 3 -B 2 '(^|[^a-zA-Z])(Error|TimeoutError|AssertionError|Type error|error TS[0-9]+|ERR_|EADDRINUSE|ECONNREFUSED|timed out|Timed out|timeout|failed|Failed|FAIL|Cannot find|Cannot resolve|Cannot connect)|config\.webServer|^ *[0-9]+\) |^ *(Locator|Expected|Received|Call log):|^ *>? *[0-9]+ \| |^ *at .*\.(spec|test)\.[jt]sx?:[0-9]|^ *[0-9]+ (passed|flaky|skipped)|^##\[error\]' |
     tail -n "${PR_DIGEST_LOG_LINES:-80}")
-  if [ -n "$out" ]; then
-    echo "$out"
-    return 0
+  if [ -z "$out" ]; then out=$(printf '%s\n' "$cleaned" | tail -n 40); fi
+  printf '%s\n' "$out"
+  if grep -q 'Timed out waiting.*config.webServer' <<<"$cleaned"; then
+    echo "Server output preceding the startup timeout:"
+    startup=$(printf '%s\n' "$cleaned" | sed -n '1,/Timed out waiting.*config.webServer/p' |
+      grep -E 'pw:webserver|\[Next\.js\]|\[WebServer|\[.*(emulator|app|server).*\]|Starting|Listening|Ready in' | tail -n 30)
+    printf '%s\n' "${startup:-No server output was retained before the timeout.}"
   fi
-  out=$(gh run view --job "$job" --log-failed 2>/dev/null |
-    perl -pe 's/^[^\t]*\t[^\t]*\t\S+\s//' |
-    grep -vE '^\s*$|^\[WebServer\]' | tail -n 40)
-  if [ -n "$out" ]; then
-    echo "$out"
-    return 0
-  fi
-  die "no failed log for job $job"
 }
 
 # The reply endpoint needs the pull number, which the comment itself carries.
@@ -121,11 +116,12 @@ digest() {
              $(jq '[.[] | select(.state | test("^(failure|error)$"))] | length' <<<"$statuses") ))
 
   jq -r '"checks " + (if length == 0 then "none"
-    else ([.[].conclusion // "pending"] | group_by(.) | map("\(length) \(.[0])") | join(" · ")) end)' <<<"$runs"
+    else ([.[] | .conclusion // "pending"] | group_by(.) | map("\(length) \(.[0])") | join(" · ")) end)' <<<"$runs"
   jq -r '.[] | select(.state != "success") | "STATUS \(.context) \(.state)"' <<<"$statuses"
 
-  # Failing checks, annotated with the step that broke so infra cancellations
-  # are distinguishable from real test failures without another round trip.
+  jq -r '.[] | select(.status != "completed") | "PENDING \(.name) [\(.status)] since \(.started_at // "not started")"' <<<"$runs"
+
+  # Skipped later steps do not identify the cause of the failed step.
   if [ "$failed" -gt 0 ]; then
     while IFS=$'\t' read -r name conclusion url; do
       local job step_info=""
@@ -133,11 +129,11 @@ digest() {
       if [[ $job =~ ^[0-9]+$ ]]; then
         step_info=$(gh api "repos/$repo/actions/jobs/$job" --jq '
           (.steps // []) as $s
-          | ([$s[] | select(.conclusion == "failure" or .conclusion == "cancelled")] | first) as $bad
+          | ([$s[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")] | first) as $bad
           | if $bad == null then ""
             else " · step \"\($bad.name)\" \($bad.conclusion)"
                  + (if ([$s[] | select(.number > $bad.number and .conclusion == "skipped")] | length) > 0
-                    then " (later steps skipped, tests did not run)" else "" end)
+                    then " (later steps skipped)" else "" end)
             end' 2>/dev/null)
       fi
       echo "FAIL $name [$conclusion]$step_info"
@@ -325,9 +321,13 @@ main() {
   if [ "$watch" -eq 1 ]; then
     local started=$SECONDS head runs statuses empty=0 left
     while :; do
-      head=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
+      head=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) || die "could not read PR head"
       runs=$(check_runs "$repo" "$head") || die "could not read check runs"
       statuses=$(commit_statuses "$repo" "$head") || die "could not read commit statuses"
+      if [ "$(jq '[.[] | select(.conclusion != null and (.conclusion | test("^(success|neutral|skipped)$") | not))] | length' <<<"$runs")" != "0" ] ||
+         [ "$(jq '[.[] | select(.state == "failure" or .state == "error")] | length' <<<"$statuses")" != "0" ]; then
+        break
+      fi
       if [ "$(jq '[.[] | select(.status != "completed")] | length' <<<"$runs")" = "0" ] &&
          [ "$(jq '[.[] | select(.state == "pending")] | length' <<<"$statuses")" = "0" ]; then
         # Nothing outstanding. Wait a few polls before believing a PR that has
@@ -340,7 +340,10 @@ main() {
         empty=$((empty + 1))
       fi
       left=$((DEADLINE - (SECONDS - started)))
-      [ "$left" -le 0 ] && break
+      if [ "$left" -le 0 ]; then
+        echo "WAIT_LIMIT reached after ${DEADLINE}s; CI is still pending (not a CI failure)"
+        break
+      fi
       sleep "$(( POLL < left ? POLL : left ))"
     done
   fi

--- a/.claude/skills/pr-watch/pr-digest.test.mjs
+++ b/.claude/skills/pr-watch/pr-digest.test.mjs
@@ -60,7 +60,7 @@ test("unavailable job logs produce an explicit error", () => {
   assert.match(result.stderr, /logs unavailable/);
 });
 
-for (const logs of ["", " \n\t"]) {
+for (const logs of ["", " \n\t", "\u001b[31m\u001b[0m\u001b]0;title\u0007"]) {
   test(`empty job logs are unavailable: ${JSON.stringify(logs)}`, () => {
     const result = run(["--logs", "42"], { logs });
     assert.equal(result.status, 1);

--- a/.claude/skills/pr-watch/pr-digest.test.mjs
+++ b/.claude/skills/pr-watch/pr-digest.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const script = fileURLToPath(new URL("./pr-digest", import.meta.url));
+const pending = { name: "Slow browser tests", status: "in_progress", conclusion: null, started_at: "2026-01-01T00:00:00Z" };
+const failed = { name: "Web E2E", status: "completed", conclusion: "failure", html_url: "https://github.com/example/repo/actions/runs/1/job/42" };
+
+for (const conclusion of ["failure", "timed_out", "cancelled"]) {
+  test(`reports ${conclusion} without waiting for another job`, () => {
+    const result = run(["--watch"], { checks: [pending, { ...failed, conclusion }] });
+    assert.equal(result.status, 10, result.stderr);
+    assert.match(result.stdout, /VERDICT failures/);
+    assert.match(result.stdout, /PENDING Slow browser tests/);
+    assert.doesNotMatch(result.stdout, /tests did not run/);
+  });
+}
+
+test("a failing commit status wakes the watch while checks run", () => {
+  const result = run(["--watch"], { checks: [pending], statuses: [{ context: "External gate", state: "error" }] });
+  assert.equal(result.status, 10, result.stderr);
+  assert.match(result.stdout, /STATUS External gate error/);
+});
+
+test("wait deadline reports pending jobs without claiming a CI failure", () => {
+  const result = run(["--watch"], { checks: [pending, { ...failed, conclusion: "success" }] }, { PR_DIGEST_DEADLINE: "0" });
+  assert.equal(result.status, 12, result.stderr);
+  assert.match(result.stdout, /WAIT_LIMIT/);
+  assert.match(result.stdout, /1 pending/);
+  assert.match(result.stdout, /Slow browser tests \[in_progress\]/);
+  assert.doesNotMatch(result.stdout, /VERDICT green|VERDICT failures/);
+});
+
+test("returns green for terminal passing checks", () => {
+  const result = run(["--watch"], { checks: [{ ...failed, conclusion: "success" }] });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /VERDICT green/);
+});
+
+test("reads completed-job logs directly and preserves startup and type errors", () => {
+  const result = run(["--logs", "42"], { logs: [
+    "2026-01-01T00:00:00Z \u001b[31m[WebServer] Error: listen EADDRINUSE: address already in use :3000\u001b[0m",
+    "2026-01-01T00:00:01Z Error: Timed out waiting 240000ms from config.webServer.",
+    "2026-01-01T00:00:02Z Type error: Type boolean is not assignable to true.",
+  ].join("\n") });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /EADDRINUSE/);
+  assert.match(result.stdout, /Timed out waiting 240000ms/);
+  assert.match(result.stdout, /Type error:/);
+  assert.doesNotMatch(result.stdout, /\u001b\[/);
+});
+
+test("unavailable job logs produce an explicit error", () => {
+  const result = run(["--logs", "42"], {});
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /logs unavailable/);
+});
+
+function run(args, fixture, env = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), "pr-digest-test-"));
+  try {
+    writeFileSync(path.join(dir, "gh"), `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const a = process.argv.slice(2);
+const f = JSON.parse(process.env.DIGEST_FIXTURE);
+const route = a.find(value => value.startsWith('repos/')) || '';
+let data;
+if (a[0] === 'repo') data = { nameWithOwner: 'example/repo' };
+else if (a[0] === 'pr') data = { number: 1, headRefOid: 'abc', headRefName: 'feature', state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: '' };
+else if (a.includes('graphql')) data = { data: { viewer: { login: 'owner' } } };
+else if (route.includes('/check-runs')) data = { check_runs: f.checks || [] };
+else if (route.includes('/status?')) data = { statuses: f.statuses || [] };
+else if (route.endsWith('/logs')) {
+  if (f.logs === undefined) { process.stderr.write('Logs not available'); process.exit(1); }
+  process.stdout.write(f.logs); process.exit(0);
+}
+else if (route.includes('/actions/jobs/')) data = { steps: [{ name: 'Build app', number: 1, conclusion: 'failure' }, { name: 'Upload', number: 2, conclusion: 'skipped' }] };
+else if (route.includes('/comments?') || route.includes('/reviews?')) data = [];
+else { process.stderr.write('Unexpected gh call: ' + a.join(' ')); process.exit(1); }
+const filter = a.indexOf('--jq');
+if (filter >= 0) {
+  const result = spawnSync('jq', ['-r', a[filter + 1]], { input: JSON.stringify(data), encoding: 'utf8' });
+  process.stdout.write(result.stdout); process.stderr.write(result.stderr); process.exit(result.status);
+}
+process.stdout.write(JSON.stringify(data));
+`, { mode: 0o755 });
+    writeFileSync(path.join(dir, "git"), "#!/bin/sh\nif [ \"$1\" = branch ]; then echo feature; else echo abc; fi\n", { mode: 0o755 });
+    return spawnSync("bash", [script, ...args], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH}`, DIGEST_FIXTURE: JSON.stringify(fixture), PR_DIGEST_SEEN_DIR: dir, PR_DIGEST_DEADLINE: "3600", ...env },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/.claude/skills/pr-watch/pr-digest.test.mjs
+++ b/.claude/skills/pr-watch/pr-digest.test.mjs
@@ -16,7 +16,7 @@ for (const conclusion of ["failure", "timed_out", "cancelled"]) {
     assert.equal(result.status, 10, result.stderr);
     assert.match(result.stdout, /VERDICT failures/);
     assert.match(result.stdout, /PENDING Slow browser tests/);
-    assert.doesNotMatch(result.stdout, /tests did not run/);
+    assert.ok(result.stdout.includes(`FAIL Web E2E [${conclusion}] · step "Build app" failure (later steps skipped)`), result.stdout);
   });
 }
 
@@ -59,6 +59,14 @@ test("unavailable job logs produce an explicit error", () => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /logs unavailable/);
 });
+
+for (const logs of ["", " \n\t"]) {
+  test(`empty job logs are unavailable: ${JSON.stringify(logs)}`, () => {
+    const result = run(["--logs", "42"], { logs });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /logs unavailable; no log content was returned/);
+  });
+}
 
 function run(args, fixture, env = {}) {
   const dir = mkdtempSync(path.join(tmpdir(), "pr-digest-test-"));

--- a/.claude/skills/pr-watch/pr-digest.test.mjs
+++ b/.claude/skills/pr-watch/pr-digest.test.mjs
@@ -45,13 +45,13 @@ test("reads completed-job logs directly and preserves startup and type errors", 
   const result = run(["--logs", "42"], { logs: [
     "2026-01-01T00:00:00Z \u001b[31m[WebServer] Error: listen EADDRINUSE: address already in use :3000\u001b[0m",
     "2026-01-01T00:00:01Z Error: Timed out waiting 240000ms from config.webServer.",
-    "2026-01-01T00:00:02Z Type error: Type boolean is not assignable to true.",
+    "\u001b]0;untrusted title\u0007\u001b[2J2026-01-01T00:00:02Z Type error: Type boolean is not assignable to true.",
   ].join("\n") });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /EADDRINUSE/);
   assert.match(result.stdout, /Timed out waiting 240000ms/);
   assert.match(result.stdout, /Type error:/);
-  assert.doesNotMatch(result.stdout, /\u001b\[/);
+  assert.doesNotMatch(result.stdout, /[\u0000-\u0008\u000b-\u001f\u007f]|untrusted title/);
 });
 
 test("unavailable job logs produce an explicit error", () => {
@@ -77,12 +77,14 @@ const a = process.argv.slice(2);
 const f = JSON.parse(process.env.DIGEST_FIXTURE);
 const route = a.find(value => value.startsWith('repos/')) || '';
 let data;
+if (a.includes('--help')) { process.stdout.write('--allow-escape-sequences'); process.exit(0); }
 if (a[0] === 'repo') data = { nameWithOwner: 'example/repo' };
 else if (a[0] === 'pr') data = { number: 1, headRefOid: 'abc', headRefName: 'feature', state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: '' };
 else if (a.includes('graphql')) data = { data: { viewer: { login: 'owner' } } };
 else if (route.includes('/check-runs')) data = { check_runs: f.checks || [] };
 else if (route.includes('/status?')) data = { statuses: f.statuses || [] };
 else if (route.endsWith('/logs')) {
+  if (!a.includes('--allow-escape-sequences')) { process.stderr.write('Escape sequences require opt-in'); process.exit(1); }
   if (f.logs === undefined) { process.stderr.write('Logs not available'); process.exit(1); }
   process.stdout.write(f.logs); process.exit(0);
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Check PR monitor failure reporting
+        if: matrix.shard == 1
+        run: node --test .claude/skills/pr-watch/pr-digest.test.mjs
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -127,6 +127,14 @@ for (const target of targets) {
         target.path,
       ],
       {
+        // Playwright's timeout omits the service; these logs show its command and readiness URL.
+        ...(process.env.CI
+          ? {
+              DEBUG: [process.env.DEBUG, "pw:webserver"]
+                .filter(Boolean)
+                .join(","),
+            }
+          : {}),
         PLAYWRIGHT_BLOB_REPORT_FILE: path.join(
           blobReportDir,
           `${target.name}.zip`,

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -109,12 +109,16 @@ export default defineConfig({
   ],
   webServer: [
     {
+      name: "Email emulator",
+      stdout: "pipe",
       command: `node __tests__/playwright/email-server.mjs ${emailPort}`,
       cwd: process.cwd(),
       url: emailBaseUrl,
       timeout: 30_000,
     },
     {
+      name: "Google emulator",
+      stdout: "pipe",
       command: emulateCommand,
       cwd: process.cwd(),
       url: `${emulateBaseUrl}/.well-known/openid-configuration`,
@@ -124,6 +128,8 @@ export default defineConfig({
     ...(todoistBaseUrl && todoistPort
       ? [
           {
+            name: "Todoist emulator",
+            stdout: "pipe",
             command: `pnpm exec tsx scripts/todoist-mcp-emulator.ts ${todoistPort}`,
             cwd: process.cwd(),
             url: `${todoistBaseUrl}/health`,
@@ -133,6 +139,8 @@ export default defineConfig({
         ]
       : []),
     {
+      name: "Next.js",
+      stdout: "pipe",
       command: `pnpm exec next dev --turbopack --port ${basePort}`,
       cwd: process.cwd(),
       url: `${baseURL}/api/auth/ok`,

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -134,6 +134,7 @@ const env = process.env;
 fs.appendFileSync(env.CALL_LOG, JSON.stringify({
   args: process.argv.slice(2),
   runId: env.PLAYWRIGHT_RUN_ID,
+  debug: env.DEBUG,
   blob: env.PLAYWRIGHT_BLOB_REPORT_FILE,
   output: env.PLAYWRIGHT_OUTPUT_DIR,
   todoist: env.PLAYWRIGHT_TODOIST_ENABLED,
@@ -159,6 +160,7 @@ if (process.argv.includes("test")) {
       PATH: `${bin}${path.delimiter}${process.env.PATH}`,
       CALL_LOG: callLog,
       CI: "true",
+      DEBUG: "pw:api",
       GITHUB_STEP_SUMMARY: summary,
       PLAYWRIGHT_DRY_RUN: "",
       PLAYWRIGHT_SKIP_REPORT_MERGE: "",
@@ -186,6 +188,7 @@ if (process.argv.includes("test")) {
   ]);
   for (const run of runs) {
     expect(run.args).toContain("--global-timeout=480000");
+    expect(run.debug).toBe("pw:api,pw:webserver");
     expect(existsSync(run.blob)).toBe(true);
     expect(existsSync(path.join(run.output, "evidence.json"))).toBe(true);
   }


### PR DESCRIPTION
CI startup failures can remain hidden while unrelated jobs run, and Playwright previously discarded the stdout needed to identify the stalled service. Report failures promptly and retain named server startup/readiness diagnostics.

- Wake the PR monitor on failed, cancelled, or timed-out checks; distinguish its own wait deadline and list pending jobs.
- Read completed-job logs directly while sibling jobs run, preserving timeout and compilation errors plus startup context.
- Name Playwright servers, pipe stdout, and enable CI lifecycle/readiness logging without changing startup timeouts.
- Remove the assumption that skipped later steps prove an infrastructure failure.
- Add mocked monitor regression coverage to CI and extend the existing batch-runner regression. No local tests or builds run; validation is delegated to CI.

The observed failures occurred while starting the second target in a batch; surrounding targets and a later retry passed. Existing logs do not establish which service stalled, so this change improves detection and diagnosis without claiming a speculative root-cause fix.

Runtime impact is limited to CI diagnostics and monitor polling; application runtime and database behavior are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR monitoring now reports failed, cancelled, or timed-out checks immediately.
  * Pending checks show start times and clear deadline messages when they remain unsettled.
  * Log viewing provides improved job output and server-startup diagnostics, including Playwright web-server details.
  * Empty or unavailable logs now report a clear diagnostic.

* **Documentation**
  * Guidance distinguishes confirmed infrastructure failures from skipped steps and avoids unnecessary retries.

* **Tests**
  * Added coverage for monitoring outcomes, deadlines, logs, exit statuses, and Playwright diagnostics.
  * CI now verifies PR monitoring failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->