### PR TITLE
ui: Fix double focus outline on inputs, selects, and textareas

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
@@ -222,7 +222,7 @@ function TimeField({
       type="time"
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      className="w-[110px] rounded-md border border-input bg-background px-2.5 py-1.5 text-center text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="w-[110px] rounded-md border border-input bg-background px-2.5 py-1.5 text-center text-sm tabular-nums outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
     />
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -445,7 +445,7 @@ export function NewSplitDialog({
                 aria-label="Match all or any condition"
                 value={matchAll ? "all" : "any"}
                 onChange={(event) => setMatchAll(event.target.value === "all")}
-                className="h-7 rounded-lg border border-border bg-background py-0 pr-8 pl-1.5 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="h-7 rounded-lg border border-border bg-background py-0 pr-8 pl-1.5 text-foreground text-xs outline-none transition-[color,box-shadow] focus:border-ring focus:ring-[3px] focus:ring-ring/50"
               >
                 <option value="all">all</option>
                 <option value="any">any</option>
@@ -749,7 +749,7 @@ function ConditionRow({
         onChange={(event) =>
           onChangeField(event.target.value as MailSplitFilterKind)
         }
-        className="h-8 w-[132px] shrink-0 rounded-lg border border-border bg-background px-2 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="h-8 w-[132px] shrink-0 rounded-lg border border-border bg-background px-2 text-foreground text-xs outline-none transition-[color,box-shadow] focus:border-ring focus:ring-[3px] focus:ring-ring/50"
       >
         {fields.map((field) => (
           <option key={field.kind} value={field.kind}>
@@ -773,7 +773,7 @@ function ConditionRow({
           aria-label="Condition value"
           value={condition.value ?? ""}
           onChange={(event) => onChangeValue(event.target.value)}
-          className="h-8 min-w-0 flex-1 rounded-lg border border-border bg-background px-2 text-foreground text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="h-8 min-w-0 flex-1 rounded-lg border border-border bg-background px-2 text-foreground text-xs outline-none transition-[color,box-shadow] focus:border-ring focus:ring-[3px] focus:ring-ring/50"
         >
           {valueOptions.map((option) => (
             <option key={option.id} value={option.value}>

--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -38,6 +38,17 @@ import {
   useMultiSelectFilter,
 } from "@/components/MultiSelectFilter";
 import { TagInput } from "@/components/TagInput";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Select as NativeSelect } from "@/components/Select";
 import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { Suspense, useState } from "react";
 import { PremiumAiAssistantAlert } from "@/components/PremiumAlert";
@@ -81,6 +92,7 @@ export default function Components() {
   ]);
   const [joinRule, setJoinRule] = useState("all");
   const [notifyByEmail, setNotifyByEmail] = useState(true);
+  const [demoCategory, setDemoCategory] = useState("newsletters");
   return (
     <Container>
       <div className="space-y-8 py-8">
@@ -813,6 +825,55 @@ export default function Components() {
               ]}
               selectedValues={selectedValues}
               setSelectedValues={setSelectedValues}
+            />
+          </div>
+        </div>
+
+        <div>
+          <div className="underline">Form fields</div>
+          <MutedText className="mt-2">
+            Focus one of these to check the ring. The @tailwindcss/forms plugin
+            paints its own focus border on native fields, so anything styled
+            like these has to set a focus border color of its own or the two
+            outlines stack up.
+          </MutedText>
+          <div className="mt-4 max-w-md space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="demo-input">Input</Label>
+              <Input id="demo-input" placeholder="name@company.com" />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="demo-input-disabled">Input, disabled</Label>
+              <Input id="demo-input-disabled" placeholder="Disabled" disabled />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="demo-textarea">Textarea</Label>
+              <Textarea
+                id="demo-textarea"
+                placeholder="Describe what should land here…"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="demo-select">Select</Label>
+              <Select value={demoCategory} onValueChange={setDemoCategory}>
+                <SelectTrigger id="demo-select">
+                  <SelectValue placeholder="Pick a category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="receipts">Receipts</SelectItem>
+                  <SelectItem value="newsletters">Newsletters</SelectItem>
+                  <SelectItem value="updates">Updates</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <NativeSelect
+              name="demo-native-select"
+              label="Select, native"
+              options={[
+                { label: "Receipts", value: "receipts" },
+                { label: "Newsletters", value: "newsletters" },
+                { label: "Updates", value: "updates" },
+              ]}
             />
           </div>
         </div>

--- a/apps/web/app/book/[slug]/BookingPageClient.tsx
+++ b/apps/web/app/book/[slug]/BookingPageClient.tsx
@@ -250,7 +250,7 @@ function DetailsStep({
               value={name}
               onChange={(event) => setName(event.target.value)}
               required
-              className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
             />
           </FormField>
           <FormField label="Email" required>
@@ -259,7 +259,7 @@ function DetailsStep({
               value={email}
               onChange={(event) => setEmail(event.target.value)}
               required
-              className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
             />
           </FormField>
           <FormField label="What would you like to discuss?" optional>
@@ -267,7 +267,7 @@ function DetailsStep({
               value={note}
               onChange={(event) => setNote(event.target.value)}
               rows={4}
-              className="block w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="block w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
             />
           </FormField>
         </div>

--- a/apps/web/components/Select.tsx
+++ b/apps/web/components/Select.tsx
@@ -26,7 +26,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         <select
           id={props.name}
           className={cn(
-            "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            "block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus:border-ring focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
             label && "mt-1",
           )}
           disabled={props.disabled}

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex h-10 w-full min-w-0 rounded-md border border-input bg-background px-3 py-2 text-base outline-none transition-[color,box-shadow] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       ref={ref}

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-left text-sm outline-none transition-[color,box-shadow] data-[placeholder]:text-muted-foreground focus:border-ring focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:flex-1 [&>span]:text-left [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-left text-sm outline-none transition-[color,box-shadow] data-[placeholder]:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:flex-1 [&>span]:text-left [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-left text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:flex-1 [&>span]:text-left [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-left text-sm outline-none transition-[color,box-shadow] data-[placeholder]:text-muted-foreground focus:border-ring focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:flex-1 [&>span]:text-left [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <textarea
     className={cn(
-      "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-base ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300 md:text-sm",
+      "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
       className,
     )}
     ref={ref}


### PR DESCRIPTION
Focused form fields rendered two stacked outlines: the `@tailwindcss/forms` plugin paints its own blue focus border on native `input`/`select`/`textarea`, and our shadcn components layered a ring with a 2px offset on top without ever setting a focus border colour, leaving a white gap between the two.

- Switched the shadcn `Input`, `Textarea`, `Select` trigger and the native `Select` to the current shadcn focus treatment: `focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50`, no ring offset. Setting the border on focus overrides the plugin's blue, so one outline shows.
- Applied the same fix to the native selects in the split dialog, the time field in the calendar hours editor, and the booking page fields, which had the same bug.
- Native `select` uses `focus:` rather than `focus-visible:` because Chrome does not match `:focus-visible` on a mouse-clicked select, which would otherwise fall through to the plugin's style.
- `Textarea` also moved off hardcoded slate colours onto `border-input` / `bg-background` / `text-muted-foreground` so it follows the active theme. The older input style that already sets its own focus border is untouched.
- Added a "Form fields" section to `/components` demoing Input, Textarea and both Selects, so the focus ring is checkable in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated form-control focus states with clearer borders, 3px focus rings, softer contrast, and smoother transitions.
  * Focus indicators for select controls now appear specifically during keyboard-style interactions.
  * Improved input and textarea styling consistency across light and dark themes.
  * Added a minimum-width safeguard for input fields.

* **Documentation**
  * Expanded the Components demo page with examples of input, textarea, and select form fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->