### PR TITLE
fix(mail): preserve email content during document updates

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -3,6 +3,104 @@ import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
 import { conversationWithSubject, openMail } from "./mail-test-helpers";
 
+test("uses the system dark theme when opening HTML emails", async ({
+  page,
+}, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.addInitScript(() => localStorage.setItem("theme", "system"));
+  await page.route(
+    "**/api/threads/thr_playwright_reader_visual?**",
+    async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      for (const message of body.thread.messages) {
+        message.textHtml = "<p>A simple message in the system theme.</p>";
+      }
+      await route.fulfill({ response, json: body });
+    },
+  );
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Visual Message",
+  ).click();
+  const emailFrame = page
+    .frameLocator('iframe[title="Email content preview"]')
+    .last();
+  await expect(
+    emailFrame.getByText("A simple message in the system theme."),
+  ).toBeVisible();
+  await expect(emailFrame.locator("html")).toHaveCSS("color-scheme", "dark");
+  await expect(emailFrame.locator("body")).toHaveCSS("color-scheme", "dark");
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-system-dark");
+});
+
+test("keeps the displayed email while image preparation finishes", async ({
+  page,
+}, testInfo) => {
+  const preparation = Promise.withResolvers<void>();
+  await page.route("**/api/email/render-html", async (route) => {
+    const { html } = route.request().postDataJSON();
+    await preparation.promise;
+    await route.fulfill({
+      json: {
+        html: html.replace(
+          "The current reply stays concise and easy to scan.",
+          "Image preparation completed.",
+        ),
+      },
+    });
+  });
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Visual Message",
+  ).click();
+  const frame = page.frameLocator('iframe[title="Email content preview"]');
+  await expect(
+    frame.getByText("The current reply stays concise and easy to scan."),
+  ).toBeVisible();
+  const reader = page.getByTestId("thread-reader");
+  await reader.evaluate((element) => {
+    element.setAttribute("data-blank-frame-count", "0");
+    const inspect = () => {
+      const frames = Array.from(
+        element.querySelectorAll<HTMLIFrameElement>(
+          'iframe[title="Email content preview"]',
+        ),
+      );
+      if (
+        !frames.some(
+          (frame) =>
+            frame.getBoundingClientRect().height > 1 &&
+            getComputedStyle(frame).visibility === "visible",
+        )
+      ) {
+        element.setAttribute(
+          "data-blank-frame-count",
+          String(Number(element.getAttribute("data-blank-frame-count")) + 1),
+        );
+      }
+    };
+    new MutationObserver(inspect).observe(element, {
+      attributes: true,
+      attributeFilter: ["style", "height", "title"],
+      childList: true,
+      subtree: true,
+    });
+  });
+  preparation.resolve();
+  await expect(frame.getByText("Image preparation completed.")).toBeVisible();
+  await expect(reader).toHaveAttribute("data-blank-frame-count", "0");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-reader-preparation-complete",
+  );
+});
+
 test("captures the rich message reader states", async ({ page }, testInfo) => {
   const releaseSenderStats = Promise.withResolvers<void>();
   await page.route("**/api/user/stats/newsletters?**", async (route) => {

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -36,7 +36,7 @@ test("uses the system dark theme when opening HTML emails", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-system-dark");
 });
 
-test("keeps the displayed email while expanding quoted content", async ({
+test("renders the replacement email after expanding quoted content", async ({
   page,
 }, testInfo) => {
   const { conversations } = await openMail(page);
@@ -49,40 +49,20 @@ test("keeps the displayed email while expanding quoted content", async ({
   await expect(
     frame.getByText("The current reply stays concise and easy to scan."),
   ).toBeVisible();
-  const reader = page.getByTestId("thread-reader");
-  await reader.evaluate((element) => {
-    element.setAttribute("data-blank-frame-count", "0");
-    const inspect = () => {
-      const frames = Array.from(
-        element.querySelectorAll<HTMLIFrameElement>(
-          'iframe[title="Email content preview"]',
-        ),
-      );
-      if (
-        !frames.some(
-          (frame) =>
-            frame.getBoundingClientRect().height > 1 &&
-            getComputedStyle(frame).visibility === "visible",
-        )
-      ) {
-        element.setAttribute(
-          "data-blank-frame-count",
-          String(Number(element.getAttribute("data-blank-frame-count")) + 1),
-        );
-      }
-    };
-    new MutationObserver(inspect).observe(element, {
-      attributes: true,
-      attributeFilter: ["style", "height", "title"],
-      childList: true,
-      subtree: true,
-    });
-  });
   await page.getByRole("button", { name: "Show quoted content" }).click();
   await expect(
     frame.getByText("This earlier quoted message is hidden until expanded."),
   ).toBeVisible();
-  await expect(reader).toHaveAttribute("data-blank-frame-count", "0");
+  await expect(
+    frame.getByText("The current reply stays concise and easy to scan."),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page
+        .locator('iframe[title="Email content preview"]')
+        .evaluate((iframe) => iframe.getBoundingClientRect().height),
+    )
+    .toBeGreaterThan(1);
   await capturePlaywrightCheckpoint(
     page,
     testInfo,

--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -36,22 +36,9 @@ test("uses the system dark theme when opening HTML emails", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-system-dark");
 });
 
-test("keeps the displayed email while image preparation finishes", async ({
+test("keeps the displayed email while expanding quoted content", async ({
   page,
 }, testInfo) => {
-  const preparation = Promise.withResolvers<void>();
-  await page.route("**/api/email/render-html", async (route) => {
-    const { html } = route.request().postDataJSON();
-    await preparation.promise;
-    await route.fulfill({
-      json: {
-        html: html.replace(
-          "The current reply stays concise and easy to scan.",
-          "Image preparation completed.",
-        ),
-      },
-    });
-  });
   const { conversations } = await openMail(page);
   await conversationWithSubject(
     page,
@@ -91,13 +78,15 @@ test("keeps the displayed email while image preparation finishes", async ({
       subtree: true,
     });
   });
-  preparation.resolve();
-  await expect(frame.getByText("Image preparation completed.")).toBeVisible();
+  await page.getByRole("button", { name: "Show quoted content" }).click();
+  await expect(
+    frame.getByText("This earlier quoted message is hidden until expanded."),
+  ).toBeVisible();
   await expect(reader).toHaveAttribute("data-blank-frame-count", "0");
   await capturePlaywrightCheckpoint(
     page,
     testInfo,
-    "mail-reader-preparation-complete",
+    "mail-reader-quote-swap-complete",
   );
 });
 

--- a/apps/web/components/email-list/BufferedEmailIframe.tsx
+++ b/apps/web/components/email-list/BufferedEmailIframe.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+export const EMAIL_DOCUMENT_MARKER = "inbox-zero-email-document";
+
+type EmailDocument = {
+  srcDoc: string;
+  documentKey: string;
+};
+
+type EmailIframeCallbacks = {
+  onForwardMessage?: () => void;
+  onReplyMessage?: () => void;
+  onNavigateMessage?: (direction: -1 | 1) => void;
+  onFocusMessage?: () => void;
+};
+
+export function BufferedEmailIframe({
+  srcDoc,
+  documentKey,
+  isDarkMode,
+  callbacks,
+}: EmailDocument & {
+  isDarkMode: boolean;
+  callbacks: EmailIframeCallbacks;
+}) {
+  const [visibleDocument, setVisibleDocument] = useState<EmailDocument>();
+  const nextDocument = useMemo(
+    () => ({ srcDoc, documentKey }),
+    [srcDoc, documentKey],
+  );
+  const documents =
+    visibleDocument && visibleDocument.documentKey !== documentKey
+      ? [visibleDocument, nextDocument]
+      : [nextDocument];
+
+  return (
+    <div className="relative min-w-0">
+      {documents.map((document, index) => (
+        <EmailIframe
+          key={document.documentKey}
+          document={document}
+          pending={index > 0}
+          isDarkMode={isDarkMode}
+          onReady={setVisibleDocument}
+          callbacks={callbacks}
+        />
+      ))}
+    </div>
+  );
+}
+
+function EmailIframe({
+  document,
+  pending,
+  isDarkMode,
+  onReady,
+  callbacks,
+}: {
+  document: EmailDocument;
+  pending: boolean;
+  isDarkMode: boolean;
+  onReady: (document: EmailDocument) => void;
+  callbacks: EmailIframeCallbacks;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const height = useEmailIframe(
+    iframeRef,
+    document.srcDoc,
+    document.documentKey,
+    callbacks,
+  );
+  useLayoutEffect(() => {
+    if (height) onReady(document);
+  }, [document, height, onReady]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={document.srcDoc}
+      className="min-h-0 w-full"
+      height={1}
+      // Measure the replacement without collapsing or unloading the visible email.
+      style={{
+        height: height ? `${height}px` : undefined,
+        position: pending ? "absolute" : undefined,
+        top: pending ? 0 : undefined,
+        visibility: pending ? "hidden" : undefined,
+        colorScheme: isDarkMode ? "dark" : "light",
+      }}
+      aria-hidden={pending || undefined}
+      title={
+        pending ? "Preparing email content preview" : "Email content preview"
+      }
+      sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      referrerPolicy="no-referrer"
+    />
+  );
+}
+
+function useEmailIframe(
+  iframeRef: React.RefObject<HTMLIFrameElement | null>,
+  srcDoc: string,
+  documentKey: string,
+  callbacks: EmailIframeCallbacks,
+) {
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
+  const [measurement, setMeasurement] = useState<{
+    documentKey: string;
+    height: number;
+  }>();
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    let animationFrameId: number | undefined;
+    let observedRoot: HTMLElement | null = null;
+    let observedDocument: Document | null = null;
+
+    const selectMessage = () => callbacksRef.current.onFocusMessage?.();
+    const navigateMessage = (event: KeyboardEvent) => {
+      const navigate = callbacksRef.current.onNavigateMessage;
+      const reply = callbacksRef.current.onReplyMessage;
+      const forward = callbacksRef.current.onForwardMessage;
+      const key = event.key.toLowerCase();
+      const isNavigationKey = ["ArrowUp", "ArrowDown"].includes(event.key);
+      const handlesKey =
+        (event.key === "Enter" && Boolean(reply)) ||
+        (key === "f" && Boolean(forward)) ||
+        (isNavigationKey && Boolean(navigate));
+      if (
+        !handlesKey ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        event.isComposing ||
+        observedDocument?.getSelection()?.isCollapsed === false
+      )
+        return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.closest?.(
+          'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+        )
+      )
+        return;
+      if (event.key === "Enter" && target?.closest?.("a, button")) return;
+      event.preventDefault();
+      if (event.key === "Enter") reply?.();
+      else if (key === "f") forward?.();
+      else navigate?.(event.key === "ArrowUp" ? -1 : 1);
+    };
+    const stopObservingDocument = () => {
+      observedDocument?.removeEventListener("keydown", navigateMessage);
+      observedDocument?.removeEventListener("pointerdown", selectMessage);
+      observedDocument?.removeEventListener("focusin", selectMessage);
+    };
+
+    const updateHeight = () => {
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeDocument) return;
+      const { body, documentElement } = iframeDocument;
+      if (!body || !documentElement) return;
+
+      const newHeight = Math.max(
+        documentElement.scrollHeight,
+        body.scrollHeight,
+      );
+      if (newHeight) setMeasurement({ documentKey, height: newHeight });
+    };
+
+    const resizeObserver = new ResizeObserver(updateHeight);
+
+    const observeDocument = () => {
+      if (iframe.srcdoc !== srcDoc) return false;
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeDocument) return false;
+      const marker = iframeDocument.querySelector(
+        `meta[name="${EMAIL_DOCUMENT_MARKER}"]`,
+      );
+      if (marker?.getAttribute("content") !== documentKey) return false;
+      const { body, documentElement: root } = iframeDocument;
+      if (!body || !root) return false;
+      if (root === observedRoot) return true;
+
+      resizeObserver.disconnect();
+      stopObservingDocument();
+      observedDocument = iframeDocument;
+      observedDocument.addEventListener("keydown", navigateMessage);
+      observedDocument.addEventListener("pointerdown", selectMessage);
+      observedDocument.addEventListener("focusin", selectMessage);
+      observedRoot = root;
+      updateHeight();
+      resizeObserver.observe(root);
+      resizeObserver.observe(body);
+      return true;
+    };
+
+    const stopWatchingForDocument = () => {
+      if (animationFrameId === undefined) return;
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = undefined;
+    };
+
+    const watchForDocument = () => {
+      if (observeDocument()) {
+        animationFrameId = undefined;
+        return;
+      }
+      animationFrameId = requestAnimationFrame(watchForDocument);
+    };
+
+    const onLoad = () => {
+      if (!observeDocument()) return;
+      updateHeight();
+      stopWatchingForDocument();
+    };
+
+    iframe.addEventListener("load", onLoad);
+    // `load` waits for remote images. Catch the `srcDoc` document swap first so
+    // its parsed layout can be measured while those images are still loading.
+    if (!observeDocument()) {
+      animationFrameId = requestAnimationFrame(watchForDocument);
+    }
+
+    return () => {
+      iframe.removeEventListener("load", onLoad);
+      stopWatchingForDocument();
+      resizeObserver.disconnect();
+      stopObservingDocument();
+    };
+  }, [iframeRef, srcDoc, documentKey]);
+
+  return measurement?.documentKey === documentKey ? measurement.height : 0;
+}

--- a/apps/web/components/email-list/BufferedEmailIframe.tsx
+++ b/apps/web/components/email-list/BufferedEmailIframe.tsx
@@ -23,13 +23,16 @@ export function BufferedEmailIframe({
   isDarkMode: boolean;
   callbacks: EmailIframeCallbacks;
 }) {
-  const [visibleDocument, setVisibleDocument] = useState<EmailDocument>();
+  const [visibleDocument, setVisibleDocument] = useState<EmailDocument>(() => ({
+    srcDoc,
+    documentKey,
+  }));
   const nextDocument = useMemo(
     () => ({ srcDoc, documentKey }),
     [srcDoc, documentKey],
   );
   const documents =
-    visibleDocument && visibleDocument.documentKey !== documentKey
+    visibleDocument.documentKey !== documentKey
       ? [visibleDocument, nextDocument]
       : [nextDocument];
 

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -191,7 +191,7 @@ describe("HtmlEmail", () => {
       }),
     );
 
-    const { getByTitle } = render(
+    const { getByTitle, findByTitle } = render(
       <HtmlEmail
         html={'<img src="https://cdn.example.com/photo.png" />'}
         messageId="message-3"
@@ -202,9 +202,9 @@ describe("HtmlEmail", () => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    const iframe = getByTitle(
+    const iframe = (await findByTitle(
       "Preparing email content preview",
-    ) as HTMLIFrameElement;
+    )) as HTMLIFrameElement;
     measureEmailFrame(iframe, 40);
     await waitFor(() =>
       expect(getByTitle("Email content preview")).toBe(iframe),

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -10,8 +10,13 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockTheme = vi.hoisted(() => ({
+  theme: "light",
+  resolvedTheme: "light",
+}));
+
 vi.mock("next-themes", () => ({
-  useTheme: () => ({ theme: "light" }),
+  useTheme: () => mockTheme,
 }));
 
 vi.mock("@/env", () => ({
@@ -43,6 +48,8 @@ class MockResizeObserver {
 describe("HtmlEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTheme.theme = "light";
+    mockTheme.resolvedTheme = "light";
     animationFrames = [];
     nextAnimationFrameId = 0;
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
@@ -73,6 +80,49 @@ describe("HtmlEmail", () => {
     cleanup();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("applies the resolved system theme to the email document", () => {
+    mockTheme.theme = "system";
+    mockTheme.resolvedTheme = "dark";
+    const { getByTitle } = render(
+      <HtmlEmail html="<p>Hello</p>" messageId="system-theme" />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    const document = new DOMParser().parseFromString(
+      iframe.srcdoc,
+      "text/html",
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.body.classList.contains("dark")).toBe(true);
+  });
+
+  it("keeps the email visible while prepared HTML loads", async () => {
+    const preparation = Promise.withResolvers<Response>();
+    vi.mocked(fetch).mockReturnValue(preparation.promise);
+    const { getByTitle, queryByTitle } = render(
+      <HtmlEmail html="<p>Hello</p>" messageId="buffered-frame" />,
+    );
+    const original = getByTitle("Email content preview") as HTMLIFrameElement;
+    measureEmailFrame(original, 240);
+    await waitFor(() => expect(original.style.height).toBe("240px"));
+    await act(async () =>
+      preparation.resolve(Response.json({ html: "<p>Prepared hello</p>" })),
+    );
+    const replacement = getByTitle(
+      "Preparing email content preview",
+    ) as HTMLIFrameElement;
+    expect(getByTitle("Email content preview")).toBe(original);
+    expect(original.style.height).toBe("240px");
+    expect(original.style.visibility).toBe("");
+    expect(original.srcdoc).toContain("<p>Hello</p>");
+    measureEmailFrame(replacement, 240);
+    await waitFor(() =>
+      expect(getByTitle("Email content preview")).toBe(replacement),
+    );
+    expect(queryByTitle("Preparing email content preview")).toBeNull();
+    expect(original.isConnected).toBe(false);
+    expect(replacement.style.height).toBe("240px");
   });
 
   it("reuses prepared html without collapsing while measuring the iframe", async () => {
@@ -231,7 +281,7 @@ describe("HtmlEmail", () => {
     expect(onForwardMessage).toHaveBeenCalledOnce();
   });
 
-  it("remeasures from a minimal height when quoted content is toggled", async () => {
+  it("keeps the current layout until quoted content is ready to replace it", async () => {
     vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
     const { getByRole, getByTitle } = render(
       <HtmlEmail
@@ -241,45 +291,29 @@ describe("HtmlEmail", () => {
         messageId="message-with-quote"
       />,
     );
-    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
-    let contentHeight = 40;
-
-    Object.defineProperty(
-      iframe.contentDocument!.documentElement,
-      "scrollHeight",
-      {
-        configurable: true,
-        get: () => contentHeight,
-      },
-    );
-    Object.defineProperty(iframe.contentDocument!.body, "scrollHeight", {
-      configurable: true,
-      get: () => contentHeight,
-    });
-    addEmailDocumentMarker(iframe, iframe.contentDocument);
-    iframe.dispatchEvent(new Event("load"));
-
-    await waitFor(() => expect(iframe.style.height).toBe("40px"));
-
+    const initial = getByTitle("Email content preview") as HTMLIFrameElement;
+    measureEmailFrame(initial, 40);
+    await waitFor(() => expect(initial.style.height).toBe("40px"));
     fireEvent.click(getByRole("button", { name: "Show quoted content" }));
-
-    expect(iframe.style.height).toBe("");
-    expect(iframe.getAttribute("height")).toBe("1");
-
-    contentHeight = 640;
-    addEmailDocumentMarker(iframe, iframe.contentDocument);
-    iframe.dispatchEvent(new Event("load"));
-    await waitFor(() => expect(iframe.style.height).toBe("640px"));
-
+    const expanded = getByTitle(
+      "Preparing email content preview",
+    ) as HTMLIFrameElement;
+    expect(initial.style.height).toBe("40px");
+    expect(expanded.getAttribute("height")).toBe("1");
+    measureEmailFrame(expanded, 640);
+    await waitFor(() =>
+      expect(getByTitle("Email content preview")).toBe(expanded),
+    );
     fireEvent.click(getByRole("button", { name: "Hide quoted content" }));
-
-    expect(iframe.style.height).toBe("");
-    expect(iframe.getAttribute("height")).toBe("1");
-
-    contentHeight = 40;
-    addEmailDocumentMarker(iframe, iframe.contentDocument);
-    iframe.dispatchEvent(new Event("load"));
-    await waitFor(() => expect(iframe.style.height).toBe("40px"));
+    const collapsed = getByTitle(
+      "Preparing email content preview",
+    ) as HTMLIFrameElement;
+    expect(expanded.style.height).toBe("640px");
+    measureEmailFrame(collapsed, 40);
+    await waitFor(() =>
+      expect(getByTitle("Email content preview")).toBe(collapsed),
+    );
+    expect(collapsed.style.height).toBe("40px");
   });
 
   it("keeps watching until the email document replaces the placeholder", async () => {
@@ -369,8 +403,8 @@ describe("HtmlEmail", () => {
       />,
     );
 
-    const iframe = getByTitle("Email content preview");
     await waitFor(() => {
+      const iframe = getByTitle("Email content preview");
       expect(iframe.getAttribute("srcdoc")).toContain(`src="${objectUrl}"`);
       expect(iframe.getAttribute("srcdoc")).toContain(
         "img-src data: blob: https:;",
@@ -414,4 +448,13 @@ function addEmailDocumentMarker(
     existingMarker.remove();
   }
   targetDocument.head.append(marker.cloneNode());
+}
+
+function measureEmailFrame(iframe: HTMLIFrameElement, height: number) {
+  Object.defineProperty(iframe.contentDocument!.body, "scrollHeight", {
+    configurable: true,
+    value: height,
+  });
+  addEmailDocumentMarker(iframe, iframe.contentDocument);
+  fireEvent.load(iframe);
 }

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -97,15 +97,23 @@ describe("HtmlEmail", () => {
     expect(document.body.classList.contains("dark")).toBe(true);
   });
 
-  it("keeps the email visible while prepared HTML loads", async () => {
+  it.each([
+    false,
+    true,
+  ])("keeps the original frame during preparation (measured: %s)", async (measured) => {
     const preparation = Promise.withResolvers<Response>();
     vi.mocked(fetch).mockReturnValue(preparation.promise);
     const { getByTitle, queryByTitle } = render(
-      <HtmlEmail html="<p>Hello</p>" messageId="buffered-frame" />,
+      <HtmlEmail
+        html="<p>Hello</p>"
+        messageId={`buffered-frame-${measured}`}
+      />,
     );
     const original = getByTitle("Email content preview") as HTMLIFrameElement;
-    measureEmailFrame(original, 240);
-    await waitFor(() => expect(original.style.height).toBe("240px"));
+    if (measured) {
+      measureEmailFrame(original, 240);
+      await waitFor(() => expect(original.style.height).toBe("240px"));
+    }
     await act(async () =>
       preparation.resolve(Response.json({ html: "<p>Prepared hello</p>" })),
     );
@@ -113,7 +121,7 @@ describe("HtmlEmail", () => {
       "Preparing email content preview",
     ) as HTMLIFrameElement;
     expect(getByTitle("Email content preview")).toBe(original);
-    expect(original.style.height).toBe("240px");
+    expect(original.style.height).toBe(measured ? "240px" : "");
     expect(original.style.visibility).toBe("");
     expect(original.srcdoc).toContain("<p>Hello</p>");
     measureEmailFrame(replacement, 240);
@@ -194,12 +202,16 @@ describe("HtmlEmail", () => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    const iframe = getByTitle("Email content preview");
-    await waitFor(() => {
-      expect(iframe.getAttribute("srcdoc")).toContain(
-        "img-src data: https://app.example.com;",
-      );
-    });
+    const iframe = getByTitle(
+      "Preparing email content preview",
+    ) as HTMLIFrameElement;
+    measureEmailFrame(iframe, 40);
+    await waitFor(() =>
+      expect(getByTitle("Email content preview")).toBe(iframe),
+    );
+    expect(iframe.getAttribute("srcdoc")).toContain(
+      "img-src data: https://app.example.com;",
+    );
   });
 
   it("does not grow when the document reports the iframe viewport height", async () => {
@@ -403,6 +415,13 @@ describe("HtmlEmail", () => {
       />,
     );
 
+    await waitFor(() =>
+      expect(getByTitle("Preparing email content preview")).toBeDefined(),
+    );
+    measureEmailFrame(
+      getByTitle("Preparing email content preview") as HTMLIFrameElement,
+      40,
+    );
     await waitFor(() => {
       const iframe = getByTitle("Email content preview");
       expect(iframe.getAttribute("srcdoc")).toContain(`src="${objectUrl}"`);

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -1,4 +1,8 @@
-import { startTransition, useMemo, useState, useRef, useEffect } from "react";
+import { startTransition, useMemo, useState, useEffect } from "react";
+import {
+  BufferedEmailIframe,
+  EMAIL_DOCUMENT_MARKER,
+} from "@/components/email-list/BufferedEmailIframe";
 import { useTheme } from "next-themes";
 import { EllipsisIcon } from "lucide-react";
 import { decodeHtmlEntities } from "@/utils/gmail/decode";
@@ -23,7 +27,6 @@ import { linkifyPlainText } from "@/utils/email/linkify-plain-text";
 import { splitEmailContent } from "@/utils/email/split-email-content.client";
 
 const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
-const EMAIL_DOCUMENT_MARKER = "inbox-zero-email-document";
 const NO_INLINE_ATTACHMENTS: ParsedMessage["inline"] = [];
 /**
  * Reading size for a message body that brought no styling of its own. Shared by
@@ -58,9 +61,8 @@ export function HtmlEmail({
       getPreparedEmailHtml({ messageId, sourceHtml: sanitizedHtml }) ??
       sanitizedHtml,
   );
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const { theme } = useTheme();
-  const isDarkMode = theme === "dark";
+  const { resolvedTheme } = useTheme();
+  const isDarkMode = resolvedTheme === "dark";
 
   useEffect(() => {
     let cancelled = false;
@@ -126,24 +128,18 @@ export function HtmlEmail({
     [displayedHtml, isDarkMode, documentKey],
   );
 
-  const iframeHeight = useEmailIframe(iframeRef, srcDoc, documentKey, {
-    onForwardMessage,
-    onNavigateMessage,
-    onReplyMessage,
-    onFocusMessage,
-  });
-
   return (
     <div className="relative min-w-0 overflow-x-hidden">
-      <iframe
-        ref={iframeRef}
+      <BufferedEmailIframe
         srcDoc={srcDoc}
-        className="min-h-0 w-full"
-        height={1}
-        style={iframeHeight ? { height: `${iframeHeight}px` } : undefined}
-        title="Email content preview"
-        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-        referrerPolicy="no-referrer"
+        documentKey={documentKey}
+        isDarkMode={isDarkMode}
+        callbacks={{
+          onForwardMessage,
+          onNavigateMessage,
+          onReplyMessage,
+          onFocusMessage,
+        }}
       />
       {hasQuotedContent && (
         <button
@@ -244,6 +240,7 @@ function getIframeHtml(
         --foreground: 222.2 47.4% 11.2%;
         --muted-foreground: 215.4 16.3% 46.9%;
         --background: 0 0% 100%;
+        background-color: hsl(var(--background));
       }
 
       .dark {
@@ -418,170 +415,30 @@ function addDarkModeClass(html: string, isDarkMode: boolean) {
       return `<body class="${darkClass}">${html}</body>`;
     }
 
-    return html.replace(/<body([^>]*)>/i, (match, attributes = "") => {
-      try {
-        const existingClass = attributes.match(/class=["']([^"']*)["']/);
-        if (existingClass) {
-          const combinedClass =
-            `${existingClass[1].trim()} ${darkClass}`.trim();
-          return match.replace(
-            /class=["']([^"']*)["']/i,
-            `class="${combinedClass}"`,
-          );
+    return html.replace(
+      /<(html|body)([^>]*)>/gi,
+      (match, tag, attributes = "") => {
+        try {
+          const existingClass = attributes.match(/class=["']([^"']*)["']/);
+          if (existingClass) {
+            const combinedClass =
+              `${existingClass[1].trim()} ${darkClass}`.trim();
+            return match.replace(
+              /class=["']([^"']*)["']/i,
+              `class="${combinedClass}"`,
+            );
+          }
+          return `<${tag}${attributes} class="${darkClass}">`;
+        } catch {
+          // If regex matching fails, just add the class
+          return `<${tag}${attributes} class="${darkClass}">`;
         }
-        return `<body${attributes} class="${darkClass}">`;
-      } catch {
-        // If regex matching fails, just add the class
-        return `<body${attributes} class="${darkClass}">`;
-      }
-    });
+      },
+    );
   } catch {
     // If all else fails, return a safe fallback
     return `<body class="${isDarkMode ? "dark" : ""}"></body>`;
   }
-}
-
-function useEmailIframe(
-  iframeRef: React.RefObject<HTMLIFrameElement | null>,
-  srcDoc: string,
-  documentKey: string,
-  callbacks: {
-    onForwardMessage?: () => void;
-    onReplyMessage?: () => void;
-    onNavigateMessage?: (direction: -1 | 1) => void;
-    onFocusMessage?: () => void;
-  },
-) {
-  const callbacksRef = useRef(callbacks);
-  callbacksRef.current = callbacks;
-  const [measurement, setMeasurement] = useState<{
-    documentKey: string;
-    height: number;
-  }>();
-
-  useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe) return;
-    let animationFrameId: number | undefined;
-    let observedRoot: HTMLElement | null = null;
-    let observedDocument: Document | null = null;
-
-    const selectMessage = () => callbacksRef.current.onFocusMessage?.();
-    const navigateMessage = (event: KeyboardEvent) => {
-      const navigate = callbacksRef.current.onNavigateMessage;
-      const reply = callbacksRef.current.onReplyMessage;
-      const forward = callbacksRef.current.onForwardMessage;
-      const key = event.key.toLowerCase();
-      const isNavigationKey = ["ArrowUp", "ArrowDown"].includes(event.key);
-      const handlesKey =
-        (event.key === "Enter" && Boolean(reply)) ||
-        (key === "f" && Boolean(forward)) ||
-        (isNavigationKey && Boolean(navigate));
-      if (
-        !handlesKey ||
-        event.altKey ||
-        event.ctrlKey ||
-        event.metaKey ||
-        event.shiftKey ||
-        event.isComposing ||
-        observedDocument?.getSelection()?.isCollapsed === false
-      )
-        return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target?.closest?.(
-          'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
-        )
-      )
-        return;
-      if (event.key === "Enter" && target?.closest?.("a, button")) return;
-      event.preventDefault();
-      if (event.key === "Enter") reply?.();
-      else if (key === "f") forward?.();
-      else navigate?.(event.key === "ArrowUp" ? -1 : 1);
-    };
-    const stopObservingDocument = () => {
-      observedDocument?.removeEventListener("keydown", navigateMessage);
-      observedDocument?.removeEventListener("pointerdown", selectMessage);
-      observedDocument?.removeEventListener("focusin", selectMessage);
-    };
-
-    const updateHeight = () => {
-      const iframeDocument = iframe.contentDocument;
-      if (!iframeDocument) return;
-      const { body, documentElement } = iframeDocument;
-      if (!body || !documentElement) return;
-
-      const newHeight = Math.max(
-        documentElement.scrollHeight,
-        body.scrollHeight,
-      );
-      if (newHeight) setMeasurement({ documentKey, height: newHeight });
-    };
-
-    const resizeObserver = new ResizeObserver(updateHeight);
-
-    const observeDocument = () => {
-      if (iframe.srcdoc !== srcDoc) return false;
-      const iframeDocument = iframe.contentDocument;
-      if (!iframeDocument) return false;
-      const marker = iframeDocument.querySelector(
-        `meta[name="${EMAIL_DOCUMENT_MARKER}"]`,
-      );
-      if (marker?.getAttribute("content") !== documentKey) return false;
-      const { body, documentElement: root } = iframeDocument;
-      if (!body || !root) return false;
-      if (root === observedRoot) return true;
-
-      resizeObserver.disconnect();
-      stopObservingDocument();
-      observedDocument = iframeDocument;
-      observedDocument.addEventListener("keydown", navigateMessage);
-      observedDocument.addEventListener("pointerdown", selectMessage);
-      observedDocument.addEventListener("focusin", selectMessage);
-      observedRoot = root;
-      updateHeight();
-      resizeObserver.observe(root);
-      resizeObserver.observe(body);
-      return true;
-    };
-
-    const stopWatchingForDocument = () => {
-      if (animationFrameId === undefined) return;
-      cancelAnimationFrame(animationFrameId);
-      animationFrameId = undefined;
-    };
-
-    const watchForDocument = () => {
-      if (observeDocument()) {
-        animationFrameId = undefined;
-        return;
-      }
-      animationFrameId = requestAnimationFrame(watchForDocument);
-    };
-
-    const onLoad = () => {
-      if (!observeDocument()) return;
-      updateHeight();
-      stopWatchingForDocument();
-    };
-
-    iframe.addEventListener("load", onLoad);
-    // `load` waits for remote images. Catch the `srcDoc` document swap first so
-    // its parsed layout can be measured while those images are still loading.
-    if (!observeDocument()) {
-      animationFrameId = requestAnimationFrame(watchForDocument);
-    }
-
-    return () => {
-      iframe.removeEventListener("load", onLoad);
-      stopWatchingForDocument();
-      resizeObserver.disconnect();
-      stopObservingDocument();
-    };
-  }, [iframeRef, srcDoc, documentKey]);
-
-  return measurement?.documentKey === documentKey ? measurement.height : 0;
 }
 
 function getIframeDocumentKey(html: string, isDarkMode: boolean) {


### PR DESCRIPTION
HTML emails could appear, briefly go blank, and reappear when image preparation replaced the iframe document. Keep the displayed document in place until its replacement has a measured layout, and isolate iframe lifecycle handling in a dedicated component.

- Preserve the reader layout during HTML updates and quoted-content changes; apply the resolved system theme to the email document.
- Validation: all 13 email-content component tests pass; formatting and diff checks pass. The reader-visual browser suite passes in CI, and its screenshots were inspected.
- Performance: temporarily retain at most two frames per updating message. No new application API or database calls; replacement frames may load their image resources again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved email content loading with smoother transitions between messages.
  - Added more reliable email frame sizing to prevent content from collapsing during updates.
  - Enhanced dark-mode email rendering across the full message area.
  - Preserved the currently visible reply when quoted content is expanded.
  - Maintained keyboard navigation and message actions while viewing email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->