### PR TITLE
ui: Fix components page crash and trim form fields copy

### DIFF
--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/components/ui/item";
 import { IconCircle } from "@/app/(app)/[emailAccountId]/onboarding/IconCircle";
 import { isValidEmail } from "@/utils/email";
+import { EmailAccountPreviewProvider } from "@/providers/EmailAccountProvider";
 import { ActionBadges } from "@/app/(app)/[emailAccountId]/assistant/Rules";
 import { DismissibleVideoCard } from "@/components/VideoCard";
 import { PremiumExpiredCardContent } from "@/components/PremiumCard";
@@ -82,6 +83,14 @@ import {
 export const maxDuration = 3;
 
 export default function Components() {
+  return (
+    <EmailAccountPreviewProvider>
+      <ComponentsDemo />
+    </EmailAccountPreviewProvider>
+  );
+}
+
+function ComponentsDemo() {
   const { selectedValues, setSelectedValues } = useMultiSelectFilter([
     "alerts",
   ]);
@@ -831,12 +840,6 @@ export default function Components() {
 
         <div>
           <div className="underline">Form fields</div>
-          <MutedText className="mt-2">
-            Focus one of these to check the ring. The @tailwindcss/forms plugin
-            paints its own focus border on native fields, so anything styled
-            like these has to set a focus border color of its own or the two
-            outlines stack up.
-          </MutedText>
           <div className="mt-4 max-w-md space-y-4">
             <div className="space-y-1.5">
               <Label htmlFor="demo-input">Input</Label>


### PR DESCRIPTION
The `/components` page threw `useEmailAccount must be used within an EmailAccountProvider` and rendered the error boundary instead of the page. It demos `ResultDisplayContent`, which calls `useAccount()`, so it needs that context. Wrapped the page in `EmailAccountPreviewProvider`, the same no-fetch context the `/components/tools` demo page already uses.

- Also dropped the explanatory paragraph from the Form fields section, which was more copy than a storybook page needs.
- Verified in a browser: the page threw before the change and renders clean after, and the focused Input shows a single 3px ring with no offset gap and no blue border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the Components landing page demos to render within the email account preview experience.
  - Simplified the form fields demo by removing the note about focus rings and the forms plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->