### PR TITLE
fix: Protect and restore the default mail tab

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/calendar-invitation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/calendar-invitation.spec.ts
@@ -3,6 +3,11 @@ import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { getEmailAccountId } from "../account-test-helpers";
 import { test } from "../playwright-test";
 
+test.afterEach(async ({ page }) => {
+  // Background revalidation can still be fetching when the assertions finish.
+  await page.unrouteAll({ behavior: "wait" });
+});
+
 test("shows inline calendar responses with the current RSVP", async ({
   page,
 }, testInfo) => {

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -50,6 +50,28 @@ async function hideDevIndicator(page: Parameters<typeof openMail>[0]) {
   });
 }
 
+test("restores a deleted All tab and protects it from removal", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await withClient((client) =>
+    client.query(
+      'DELETE FROM "MailSplit" WHERE "emailAccountId" = $1 AND name = $2',
+      [emailAccountId, "All"],
+    ),
+  );
+  await openMail(page);
+  const allTab = page
+    .locator("button[data-split-tab]")
+    .filter({ hasText: /^All$/ });
+  await expect(allTab).toBeVisible();
+  await allTab.click({ button: "right" });
+  await expect(
+    page.getByRole("menuitem", { name: "Turn off split" }),
+  ).toBeHidden();
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-protected-all-split");
+});
+
 test("moves focus with the active split when cycling by keyboard", async ({
   page,
 }, testInfo) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1421,7 +1421,10 @@ export function MailShell() {
             />
             {!isScoped && !searchQuery && (
               <SplitTabs
-                splits={splits.map((split) => ({ ...split, deletable: true }))}
+                splits={splits.map((split) => ({
+                  ...split,
+                  deletable: split.filters.length > 0,
+                }))}
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ManageSplitsDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ManageSplitsDialog.tsx
@@ -132,7 +132,7 @@ export function ManageSplitsDialog({
                 size="icon"
                 className="size-8 text-muted-foreground hover:text-destructive"
                 aria-label={`Remove the ${split.name} split`}
-                disabled={isSaving}
+                disabled={isSaving || !split.deletable}
                 onClick={() => remove(split.id)}
               >
                 <Trash2Icon className="size-4" />

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -401,6 +401,7 @@ export function NewSplitDialog({
                         </span>
                         <button
                           type="button"
+                          disabled={!split.filters.length}
                           aria-label={`Turn off the ${split.name} split`}
                           onClick={() => onDelete(split.id)}
                           className="flex size-4.5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/apps/web/app/api/mail/settings/route.ts
+++ b/apps/web/app/api/mail/settings/route.ts
@@ -1,3 +1,4 @@
+import { ensureAllMailSplit } from "@/utils/mail/initial-splits";
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
@@ -30,7 +31,7 @@ async function getMailSettings({ emailAccountId }: { emailAccountId: string }) {
   return {
     layout: emailAccount?.mailLayout ?? null,
     expandedPreview: emailAccount?.mailExpandedPreview ?? false,
-    splits: emailAccount?.mailSplits ?? [],
+    splits: ensureAllMailSplit(emailAccount?.mailSplits ?? []),
   };
 }
 

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -5,6 +5,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import {
   buildMailSplitFromPromptAction,
   createMailSplitAction,
+  deleteMailSplitAction,
   updateMailPreferencesAction,
   updateMailSplitAction,
 } from "@/utils/actions/mail-split";
@@ -40,6 +41,27 @@ describe("mail split actions", () => {
       email: "user@example.com",
       account: { userId: "user-1", provider: "google" },
     } as never);
+  });
+
+  it("only deletes filtered splits belonging to the account", async () => {
+    prisma.$transaction.mockResolvedValue([[], { count: 1 }] as never);
+    const result = await deleteMailSplitAction(EMAIL_ACCOUNT_ID, {
+      id: "custom",
+    });
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.mailSplit.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "custom",
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        filters: { some: {} },
+      },
+    });
+  });
+
+  it("reports when a protected split cannot be removed", async () => {
+    prisma.$transaction.mockResolvedValue([[], { count: 0 }] as never);
+    const result = await deleteMailSplitAction(EMAIL_ACCOUNT_ID, { id: "all" });
+    expect(result?.serverError).toBe("Split not found or cannot be removed");
   });
 
   it("creates splits behind an account-scoped database lock", async () => {

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -128,10 +128,13 @@ export const deleteMailSplitAction = actionClient
   .inputSchema(deleteMailSplitBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { id } }) => {
     // deleteMany rather than delete so another account's id can never be removed
-    await prisma.$transaction([
+    const [, { count }] = await prisma.$transaction([
       lockMailSplits(emailAccountId),
-      prisma.mailSplit.deleteMany({ where: { id, emailAccountId } }),
+      prisma.mailSplit.deleteMany({
+        where: { id, emailAccountId, filters: { some: {} } },
+      }),
     ]);
+    if (!count) throw new SafeError("Split not found or cannot be removed");
   });
 
 export const updateMailPreferencesAction = actionClient

--- a/apps/web/utils/mail/initial-splits.test.ts
+++ b/apps/web/utils/mail/initial-splits.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ensureAllMailSplit } from "@/utils/mail/initial-splits";
+
+describe("ensureAllMailSplit", () => {
+  it("restores the unfiltered inbox when its tab was deleted", () => {
+    const unread = {
+      id: "unread",
+      name: "Unread",
+      order: 1,
+      matchAll: true,
+      filters: [{ kind: "UNREAD" as const, value: null }],
+    };
+    expect(ensureAllMailSplit([unread])).toEqual([
+      { id: "all", name: "All", order: -1, matchAll: true, filters: [] },
+      unread,
+    ]);
+  });
+
+  it("preserves an existing unfiltered tab and its position", () => {
+    const splits = [
+      {
+        id: "existing",
+        name: "Everything",
+        order: 2,
+        matchAll: true,
+        filters: [],
+      },
+    ];
+    expect(ensureAllMailSplit(splits)).toBe(splits);
+  });
+
+  it("keeps the inbox available with no saved splits", () => {
+    expect(ensureAllMailSplit([])).toHaveLength(1);
+  });
+});

--- a/apps/web/utils/mail/initial-splits.ts
+++ b/apps/web/utils/mail/initial-splits.ts
@@ -1,3 +1,4 @@
+import type { MailSplit } from "@/utils/mail/split-query";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 
 export const INITIAL_MAIL_SPLITS = [
@@ -10,3 +11,13 @@ export const INITIAL_MAIL_SPLITS = [
     },
   },
 ];
+
+export function ensureAllMailSplit(splits: (MailSplit & { order: number })[]) {
+  if (splits.some((split) => split.filters.length === 0)) return splits;
+
+  // Older accounts may have deleted All before the default tab was protected.
+  return [
+    { id: "all", name: "All", order: -1, matchAll: true, filters: [] },
+    ...splits,
+  ];
+}


### PR DESCRIPTION
Protect the default All mail tab from removal and restore its unfiltered view when it is missing.

- Disable removal controls and enforce deletion protection on the server.
- Add recovery and deletion regression coverage; all 15 focused unit tests and formatting checks passed.
- Browser verification was blocked during setup by local test database authentication.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail now always includes an available default “All” tab, even if it was previously removed.
* **Bug Fixes**
  * Protected, unfiltered mail tabs can no longer be deleted or turned off.
  * Split deletion now only removes eligible, filtered tabs and provides a clear error when removal is unavailable.
* **Tests**
  * Added coverage for restoring the default tab, enforcing split deletion rules, and completing background updates reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->