### PR TITLE
mail: Prevent crashes from outdated cached settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@
 - Never use dynamic Prisma transactions (`prisma.$transaction(async (tx) => ...)`).
 
 ## Change Philosophy
+- Keep resource-specific validation in the owning feature; shared infrastructure should stay resource-agnostic.
 - Prefer the simplest, most readable change; only keep backwards compatibility when explicitly requested.
 - Do not optimize for migration paths: refactor call sites directly, including larger coordinated changes when clarity improves.
 - This is a public repository. Never include non-public data or internal details from private repositories or services in repository content or GitHub metadata; describe related private work only generically (for example, “updated the marketing repository”).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@
 - Never use dynamic Prisma transactions (`prisma.$transaction(async (tx) => ...)`).
 
 ## Change Philosophy
-- Keep resource-specific validation in the owning feature; shared infrastructure should stay resource-agnostic.
+- Respect module boundaries: keep feature-specific logic in its owning feature and shared infrastructure generic.
 - Prefer the simplest, most readable change; only keep backwards compatibility when explicitly requested.
 - Do not optimize for migration paths: refactor call sites directly, including larger coordinated changes when clarity improves.
 - This is a public repository. Never include non-public data or internal details from private repositories or services in repository content or GitHub metadata; describe related private work only generically (for example, “updated the marketing repository”).

--- a/apps/web/__tests__/playwright/emulated/mail/cached-settings.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/cached-settings.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from "@playwright/test";
+import { getEmailAccountId } from "../account-test-helpers";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("opens mail with settings cached before the split condition upgrade", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await page.addInitScript((accountId) => {
+    localStorage.setItem(
+      `inbox-zero:swr:v2:${accountId}`,
+      JSON.stringify({
+        "/api/mail/settings": {
+          layout: "LIST",
+          expandedPreview: false,
+          splits: [
+            {
+              id: "old-split",
+              name: "Saved",
+              kind: "LABEL",
+              values: ["Label_project"],
+            },
+          ],
+        },
+      }),
+    );
+  }, emailAccountId);
+
+  let releaseSettings!: () => void;
+  const settingsReady = new Promise<void>((resolve) => {
+    releaseSettings = resolve;
+  });
+  await page.route("**/api/mail/settings", async (route) => {
+    await settingsReady;
+    await route.continue();
+  });
+
+  try {
+    const { conversations } = await openMail(page);
+    await expect(
+      conversationWithSubject(page, conversations, "Archive Action Message"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Something went wrong", { exact: true }),
+    ).toBeHidden();
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "mail-with-outdated-cached-settings",
+    );
+
+    const responsePromise = page.waitForResponse("**/api/mail/settings");
+    releaseSettings();
+    const response = await responsePromise;
+    expect(response.ok()).toBe(true);
+    const settings = await response.json();
+    expect(settings.splits.length).toBeGreaterThan(0);
+    for (const split of settings.splits) {
+      await expect(
+        page.getByRole("button", { name: split.name, exact: true }),
+      ).toBeVisible();
+    }
+    await capturePlaywrightCheckpoint(
+      page,
+      testInfo,
+      "mail-with-refreshed-split-settings",
+    );
+  } finally {
+    releaseSettings();
+    await page.unrouteAll({ behavior: "wait" });
+  }
+});

--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -1,4 +1,5 @@
 {
+  "cached-settings.spec.ts": ["utils/swr-persistence.ts"],
   "archive-reconciliation.spec.ts": ["app/(app)/MailMutationOutboxManager.tsx"],
   "account-selection.spec.ts": [
     "app/(app)/[emailAccountId]/mail/MailSidebar.tsx",

--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -1,5 +1,5 @@
 {
-  "cached-settings.spec.ts": ["utils/swr-persistence.ts"],
+  "cached-settings.spec.ts": ["hooks/useMailSettings.ts"],
   "archive-reconciliation.spec.ts": ["app/(app)/MailMutationOutboxManager.tsx"],
   "account-selection.spec.ts": [
     "app/(app)/[emailAccountId]/mail/MailSidebar.tsx",

--- a/apps/web/hooks/useMailSettings.test.tsx
+++ b/apps/web/hooks/useMailSettings.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig, useSWRConfig } from "swr";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
+import { useMailSettings } from "./useMailSettings";
+
+const settings: MailSettingsResponse = {
+  layout: "LIST",
+  expandedPreview: false,
+  splits: [
+    {
+      id: "split-1",
+      name: "Unread",
+      order: 0,
+      matchAll: true,
+      filters: [{ kind: "UNREAD", value: null }],
+    },
+  ],
+};
+
+afterEach(cleanup);
+
+describe("useMailSettings", () => {
+  it.each([
+    { kind: "LABEL", value: "label-1" },
+    { kind: "LABEL", values: ["label-1"] },
+    { matchAll: true, filters: null },
+    { matchAll: true, filters: [null] },
+  ])("withholds incompatible cached settings until revalidation: %j", async (split) => {
+    const response = Promise.withResolvers<MailSettingsResponse>();
+    const fetcher = vi.fn(() => response.promise);
+    const cache = new Map();
+    const { result } = renderHook(
+      () => ({ settings: useMailSettings(), hydrate: useSWRConfig().mutate }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <SWRConfig
+            value={{
+              provider: () => cache,
+              fetcher,
+            }}
+          >
+            {children}
+          </SWRConfig>
+        ),
+      },
+    );
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledOnce());
+    await act(async () => {
+      await result.current.hydrate(
+        "/api/mail/settings",
+        {
+          ...settings,
+          splits: [{ id: "split-1", name: "Saved", order: 0, ...split }],
+        },
+        { revalidate: false },
+      );
+    });
+    expect(result.current.settings.data).toBeUndefined();
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    await act(async () => response.resolve(settings));
+    await waitFor(() => expect(result.current.settings.data).toEqual(settings));
+
+    await act(async () => {
+      await result.current.settings.mutate(
+        { ...settings, expandedPreview: true },
+        { revalidate: false },
+      );
+    });
+    expect(result.current.settings.data?.expandedPreview).toBe(true);
+  });
+});

--- a/apps/web/hooks/useMailSettings.ts
+++ b/apps/web/hooks/useMailSettings.ts
@@ -1,6 +1,46 @@
+import { useEffect, useMemo } from "react";
 import useSWR from "swr";
+import { z } from "zod";
 import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
+import { MailLayout, MailSplitFilterKind } from "@/generated/prisma/enums";
+
+const mailSettingsSchema = z.object({
+  layout: z.enum(MailLayout).nullable(),
+  expandedPreview: z.boolean(),
+  splits: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      order: z.number(),
+      matchAll: z.boolean(),
+      filters: z.array(
+        z.object({
+          kind: z.enum(MailSplitFilterKind),
+          value: z.string().nullable(),
+        }),
+      ),
+    }),
+  ),
+}) satisfies z.ZodType<MailSettingsResponse>;
 
 export function useMailSettings() {
-  return useSWR<MailSettingsResponse>("/api/mail/settings");
+  const swr = useSWR<MailSettingsResponse>("/api/mail/settings");
+  // Persisted responses can predate the current settings format. Wait for
+  // revalidation rather than exposing incompatible settings to consumers.
+  const data = useMemo(
+    () =>
+      mailSettingsSchema.safeParse(swr.data).success ? swr.data : undefined,
+    [swr.data],
+  );
+
+  const { mutate } = swr;
+  const hasIncompatibleData = swr.data !== undefined && data === undefined;
+  useEffect(() => {
+    if (!hasIncompatibleData) return;
+    // Hydration mutates SWR and can discard an in-flight request. Clear the
+    // incompatible entry and explicitly start a fresh request.
+    mutate(undefined, { revalidate: true, throwOnError: false });
+  }, [hasIncompatibleData, mutate]);
+
+  return { ...swr, data };
 }

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
 import {
   accountIdFromSnapshotKey,
   clearPersistedSwrCache,
@@ -62,20 +63,53 @@ describe("swr-persistence", () => {
     expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
   });
 
+  it.each([
+    { kind: "LABEL", value: "label-1" },
+    { kind: "LABEL", values: ["label-1"] },
+    { matchAll: true, filters: null },
+    { matchAll: true, filters: [null] },
+  ])("discards incompatible settings while keeping other cached data: %j", (split) => {
+    window.localStorage.setItem(
+      `inbox-zero:swr:v2:${ACCOUNT_A}`,
+      JSON.stringify({
+        "/api/mail/settings": {
+          layout: "LIST",
+          expandedPreview: false,
+          splits: [{ id: "split-1", name: "Saved", order: 0, ...split }],
+        },
+        "/api/labels": { labels: [] },
+      }),
+    );
+
+    const restored = readPersistedSwrEntries(ACCOUNT_A);
+    expect(restored.has("/api/mail/settings")).toBe(false);
+    expect(restored.get("/api/labels")?.data).toEqual({ labels: [] });
+
+    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(`inbox-zero:swr:v2:${ACCOUNT_A}`) ?? "{}",
+      ),
+    ).not.toHaveProperty("/api/mail/settings");
+  });
+
   it("preserves valid cached mail settings including split filters", () => {
-    const settings = {
+    const settings: MailSettingsResponse = {
       layout: "SPLIT",
       expandedPreview: true,
       splits: [
         {
           id: "split-1",
           name: "Saved",
-          kind: "LABEL",
-          values: ["label-1", "label-2"],
+          order: 0,
+          matchAll: false,
+          filters: [
+            { kind: "LABEL", value: "label-1" },
+            { kind: "LABEL", value: "label-2" },
+          ],
         },
-        { id: "split-2", name: "Inbox", kind: "INBOX", values: [] },
+        { id: "split-2", name: "Inbox", order: 1, matchAll: true, filters: [] },
       ],
-      defaultSplits: [{ name: "Default", kind: "LABEL", values: ["label-3"] }],
     };
     persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/mail/settings": settings }));
     expect(

--- a/apps/web/utils/swr-persistence.test.ts
+++ b/apps/web/utils/swr-persistence.test.ts
@@ -63,36 +63,6 @@ describe("swr-persistence", () => {
     expect(readPersistedSwrEntries(ACCOUNT_A).size).toBe(0);
   });
 
-  it.each([
-    { kind: "LABEL", value: "label-1" },
-    { kind: "LABEL", values: ["label-1"] },
-    { matchAll: true, filters: null },
-    { matchAll: true, filters: [null] },
-  ])("discards incompatible settings while keeping other cached data: %j", (split) => {
-    window.localStorage.setItem(
-      `inbox-zero:swr:v2:${ACCOUNT_A}`,
-      JSON.stringify({
-        "/api/mail/settings": {
-          layout: "LIST",
-          expandedPreview: false,
-          splits: [{ id: "split-1", name: "Saved", order: 0, ...split }],
-        },
-        "/api/labels": { labels: [] },
-      }),
-    );
-
-    const restored = readPersistedSwrEntries(ACCOUNT_A);
-    expect(restored.has("/api/mail/settings")).toBe(false);
-    expect(restored.get("/api/labels")?.data).toEqual({ labels: [] });
-
-    persistSwrEntries(ACCOUNT_A, cacheWith({ "/api/labels": { labels: [] } }));
-    expect(
-      JSON.parse(
-        window.localStorage.getItem(`inbox-zero:swr:v2:${ACCOUNT_A}`) ?? "{}",
-      ),
-    ).not.toHaveProperty("/api/mail/settings");
-  });
-
   it("preserves valid cached mail settings including split filters", () => {
     const settings: MailSettingsResponse = {
       layout: "SPLIT",

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -1,3 +1,26 @@
+import { z } from "zod";
+import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
+import { MailLayout, MailSplitFilterKind } from "@/generated/prisma/enums";
+
+const mailSettingsCacheSchema = z.object({
+  layout: z.enum(MailLayout).nullable(),
+  expandedPreview: z.boolean(),
+  splits: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      order: z.number(),
+      matchAll: z.boolean(),
+      filters: z.array(
+        z.object({
+          kind: z.enum(MailSplitFilterKind),
+          value: z.string().nullable(),
+        }),
+      ),
+    }),
+  ),
+}) satisfies z.ZodType<MailSettingsResponse>;
+
 const STORAGE_PREFIX = "inbox-zero:swr:v2:";
 
 // These hooks use plain-string SWR keys that are not account-scoped (the
@@ -118,7 +141,16 @@ function readRawSnapshot(emailAccountId: string): Record<string, unknown> {
     }
     for (const key of PERSISTED_SWR_KEYS) {
       const data = (parsed as Record<string, unknown>)[key];
-      if (data !== undefined) snapshot[key] = data;
+      if (data === undefined) continue;
+      // Cached API responses can outlive the code that wrote them. Reject old
+      // split shapes before hydration so SWR can fetch the current settings.
+      if (
+        key === "/api/mail/settings" &&
+        !mailSettingsCacheSchema.safeParse(data).success
+      ) {
+        continue;
+      }
+      snapshot[key] = data;
     }
   } catch {
     // A corrupt snapshot must never break the app.

--- a/apps/web/utils/swr-persistence.ts
+++ b/apps/web/utils/swr-persistence.ts
@@ -1,26 +1,3 @@
-import { z } from "zod";
-import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
-import { MailLayout, MailSplitFilterKind } from "@/generated/prisma/enums";
-
-const mailSettingsCacheSchema = z.object({
-  layout: z.enum(MailLayout).nullable(),
-  expandedPreview: z.boolean(),
-  splits: z.array(
-    z.object({
-      id: z.string(),
-      name: z.string(),
-      order: z.number(),
-      matchAll: z.boolean(),
-      filters: z.array(
-        z.object({
-          kind: z.enum(MailSplitFilterKind),
-          value: z.string().nullable(),
-        }),
-      ),
-    }),
-  ),
-}) satisfies z.ZodType<MailSettingsResponse>;
-
 const STORAGE_PREFIX = "inbox-zero:swr:v2:";
 
 // These hooks use plain-string SWR keys that are not account-scoped (the
@@ -141,16 +118,7 @@ function readRawSnapshot(emailAccountId: string): Record<string, unknown> {
     }
     for (const key of PERSISTED_SWR_KEYS) {
       const data = (parsed as Record<string, unknown>)[key];
-      if (data === undefined) continue;
-      // Cached API responses can outlive the code that wrote them. Reject old
-      // split shapes before hydration so SWR can fetch the current settings.
-      if (
-        key === "/api/mail/settings" &&
-        !mailSettingsCacheSchema.safeParse(data).success
-      ) {
-        continue;
-      }
-      snapshot[key] = data;
+      if (data !== undefined) snapshot[key] = data;
     }
   } catch {
     // A corrupt snapshot must never break the app.


### PR DESCRIPTION
Prevents the mail page from crashing on outdated cached split settings by validating them in the owning settings hook and refreshing incompatible entries.

- Keeps shared persistence resource-agnostic and records that boundary in AGENTS.md.
- Adds coverage for cache hydration during an in-flight request, stale settings, and restored split tabs; corrects the valid-settings fixture.
- Validated with 21 focused unit tests, the emulated browser regression, screenshot inspection, and Biome checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mail now safely handles outdated or incompatible saved settings.
  - Invalid cached settings are temporarily withheld while current settings are refreshed, preventing errors and ensuring updated split filters appear correctly.
  - Mail conversations continue loading successfully during settings revalidation.

- **Tests**
  - Added coverage for cached-settings upgrades, incompatible filter formats, refreshed settings, and optimistic updates.

- **Documentation**
  - Clarified guidance for keeping feature-specific logic within its owning area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->