### PR TITLE
test: add opt-in email loading simulation

### DIFF
--- a/apps/web/__tests__/playwright/mail-simulation/README.md
+++ b/apps/web/__tests__/playwright/mail-simulation/README.md
@@ -63,6 +63,9 @@ Sources, checked 2026-09-10:
 - https://developers.google.com/workspace/gmail/api/guides/handle-errors
 - https://developers.google.com/workspace/gmail/api/guides/batch
 
+The dedicated config requires a loopback HTTP provider URL with an explicit port;
+remote providers and HTTPS are not supported. OAuth callback URLs are normalized.
+
 The published schedule uses 6,000 units per user/project/minute and 1,200,000 per
 project/minute; `threads.get` costs 40. Existing Cloud projects can retain older
 quotas. Configure the ledger with the actual project's settings before drawing
@@ -72,6 +75,9 @@ The proxy uses a rolling 60-second window, counts every admitted attempt, and
 meters GET batch parts individually. Batches can return HTTP 200 with individual
 403/429 failures. Rejected admissions do not consume the simulated quota. This
 is an explicit model, not Google's undisclosed window/admission algorithm.
+Quota rejections return the delay until sufficient weighted capacity expires;
+concurrency rejections use a one-second backoff. A budget smaller than one request
+requires a manual reset and uses the configured window as its retry interval.
 
 Latency defaults to 250 ms and transfer delay to 2 MB/s per response. Concurrent
 batch parts count separately. The main profiles set the concurrency threshold to 100 to isolate quota and

--- a/apps/web/__tests__/playwright/mail-simulation/README.md
+++ b/apps/web/__tests__/playwright/mail-simulation/README.md
@@ -1,0 +1,91 @@
+# Mail loading simulation
+
+Runs the unchanged email client in Chromium, through the real application routes
+and Gmail provider, against emulate.dev with a local quota/latency proxy. Opt-in:
+the dedicated config is only used by `test:mail-loading`. Normal Playwright and
+Vitest discovery exclude these scenarios; no CI workflow invokes the command.
+
+```sh
+pnpm install
+# Use a disposable local Postgres database with this repository's migrations.
+# PREVIEW_DATABASE_URL_UNPOOLED takes precedence over other Prisma URLs.
+PREVIEW_DATABASE_URL_UNPOOLED="$SIMULATION_DATABASE_URL" pnpm -F inbox-zero-ai exec prisma migrate deploy
+DATABASE_URL="$SIMULATION_DATABASE_URL" \
+  UPSTASH_REDIS_URL="$SIMULATION_REDIS_URL" UPSTASH_REDIS_TOKEN="$SIMULATION_REDIS_TOKEN" \
+  pnpm -F inbox-zero-ai test:mail-loading
+node --test apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
+```
+
+The standard Playwright harness starts its development server. Run on an idle
+machine; first-route compilation is included in cold-view measurements. Supply
+local Redis to exercise account cooldowns; without it the application's shared
+rate-limit protection is disabled. Each run has a fresh synthetic account.
+
+## Workload and evidence
+
+The seed contains 1,000 threads: short messages, eight-message conversations, a
+150-message conversation, and a roughly 850 KB HTML newsletter. All/Unread splits
+overlap. Scenarios open arbitrary visible rows immediately, revisit a thread,
+navigate J/K rapidly, switch splits twelve times, scroll in both directions,
+and open another tab in the same browser context. A constrained phase exhausts
+quota during an uncached open and then restores capacity to observe recovery.
+
+Three profiles run the same baseline interactions: generous quota with latency,
+the currently published quota, and forced exhaustion after warmup. Each profile
+starts a fresh dev server, emulator, synthetic account and browser context, so
+pending requests, label mutations and Redis cooldowns do not leak between profiles.
+Artifacts for all three runs are preserved under `.tmp/mail-simulation/<run>/`.
+
+For one profile, run `pnpm -F inbox-zero-ai test:mail-loading latency`.
+The other profile names are `published-quota` and `constrained`; multiple names
+can be passed to run a subset. Reports are written directly into the simulation
+run folder, leaving normal Playwright reports untouched.
+
+Playwright attaches `mail-loading-summary.json`, `gmail-requests.json`, a screenshot,
+and its standard browser diagnostic evidence. The summary records action-to-body
+observations, application detail-request counts, accepted quota units, rejected
+provider calls, bytes, and peak concurrency. A body is ready only when its unique
+synthetic marker is visible in the actual reader or email iframe. Timings include
+Playwright action/polling overhead and are upper bounds, not precise paint timing
+or a statistically meaningful p95. `loaded: false` means the body was not visible
+within 12 seconds; it is a finding, not a successful load. When a reader error removes navigation, an annotation records that remaining
+scenarios were blocked. Other structural failures still fail the test, while
+slow/failed loads are recorded to keep a baseline
+usable before client fixes. Inspect the JSON and annotations even when Playwright passes.
+Provider counters are snapshots at action completion; unfinished admitted requests
+are reported separately, so byte totals can still be growing.
+
+## Quota model and limits of fidelity
+
+Sources, checked 2026-09-10:
+
+- https://developers.google.com/workspace/gmail/api/reference/quota
+- https://developers.google.com/workspace/gmail/api/guides/handle-errors
+- https://developers.google.com/workspace/gmail/api/guides/batch
+
+The published schedule uses 6,000 units per user/project/minute and 1,200,000 per
+project/minute; `threads.get` costs 40. Existing Cloud projects can retain older
+quotas. Configure the ledger with the actual project's settings before drawing
+production capacity conclusions.
+
+The proxy uses a rolling 60-second window, counts every admitted attempt, and
+meters GET batch parts individually. Batches can return HTTP 200 with individual
+403/429 failures. Rejected admissions do not consume the simulated quota. This
+is an explicit model, not Google's undisclosed window/admission algorithm.
+
+Latency defaults to 250 ms and transfer delay to 2 MB/s per response. Concurrent
+batch parts count separately. The main profiles set the concurrency threshold to 100 to isolate quota and
+latency behavior; forced exhaustion uses 2. The threshold is a stress parameter:
+Google documents the limit without specifying a numeric threshold. Transfer delay
+is not a model of Gmail's daily bandwidth cap or aggregate connection bandwidth.
+The single seeded mailbox shares one ledger identity across tabs and OAuth tokens;
+project sharing across users is covered by the ledger test, not a multi-user
+browser workload. The app's own mailbox sync runs normally and competes with foreground requests.
+External-client load and automation are not yet replayed.
+
+Only Gmail traffic is metered; OAuth/other services pass through. Unsupported
+Gmail methods or batch writes fail explicitly. The test-only control endpoint
+`/__simulation` reads the ledger or resets it once requests finish. Resets between
+phases are artificial quota restoration; they do not clear the application's
+Redis cooldown. All fixture content is synthetic. No production client, cache,
+prefetch, prompt, or tool behavior is changed.

--- a/apps/web/__tests__/playwright/mail-simulation/loading.spec.ts
+++ b/apps/web/__tests__/playwright/mail-simulation/loading.spec.ts
@@ -44,6 +44,13 @@ test(`measures current client under ${profile}`, async ({
     bytesPerSecond: 2_000_000,
   });
   let detailRequests = 0;
+  const threadStatuses = new Map<string, number>();
+  page.on("response", (response) => {
+    const path = new URL(response.url()).pathname;
+    if (path.startsWith("/api/threads/sim_thread_"))
+      threadStatuses.set(path, response.status());
+  });
+  let scenarioFailed = false;
   page.on("request", (request) => {
     if (/\/api\/threads\/sim_thread_/.test(request.url())) detailRequests++;
   });
@@ -99,6 +106,7 @@ test(`measures current client under ${profile}`, async ({
     for (const key of ["j", "j", "j", "k", "j", "j", "k"]) {
       await page.keyboard.press(key);
     }
+    await expect(page).toHaveURL(/thread-id=sim_thread_3(?:&|$)/);
     const selectedId = new URL(page.url()).searchParams.get("thread-id");
     const selectedThread = Number(selectedId?.replace("sim_thread_", ""));
     expect(
@@ -118,12 +126,12 @@ test(`measures current client under ${profile}`, async ({
     const switchStart = performance.now();
     const switchRequests = detailRequests;
     for (let index = 0; index < 12; index++) {
-      await page
-        .getByRole("button", {
-          name: index % 2 === 0 ? "Unread" : "All",
-          exact: true,
-        })
-        .click();
+      const split = page.getByRole("button", {
+        name: index % 2 === 0 ? "Unread" : "All",
+        exact: true,
+      });
+      await split.click();
+      await expect(split).toHaveAttribute("aria-current", "true");
     }
     await expect(
       page.getByRole("button", { name: "All", exact: true }),
@@ -163,6 +171,7 @@ test(`measures current client under ${profile}`, async ({
         waitUntil: "domcontentloaded",
       });
       const loaded = await waitForBody(page, 30);
+      expect(threadStatuses.get("/api/threads/sim_thread_30")).toBe(429);
       samples.push({
         scenario: "uncached-open-during-quota-exhaustion",
         durationMs: performance.now() - started,
@@ -206,8 +215,24 @@ test(`measures current client under ${profile}`, async ({
         detailRequests: detailRequests - recoveryRequests,
       });
     }
+  } catch (error) {
+    scenarioFailed = true;
+    throw error;
   } finally {
-    await report(page, testInfo, samples, phases);
+    try {
+      await report(page, testInfo, samples, phases);
+    } catch (error) {
+      if (!scenarioFailed) {
+        expect
+          .soft(false, "Simulation reporting failed; inspect the test logs")
+          .toBe(true);
+      }
+      console.error("Simulation reporting failed", error);
+      testInfo.annotations.push({
+        type: "report-error",
+        description: "Simulation reporting failed; inspect the test logs.",
+      });
+    }
   }
 });
 

--- a/apps/web/__tests__/playwright/mail-simulation/loading.spec.ts
+++ b/apps/web/__tests__/playwright/mail-simulation/loading.spec.ts
@@ -1,0 +1,333 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+import { performance } from "node:perf_hooks";
+import { writeFile } from "node:fs/promises";
+import { Redis } from "@upstash/redis";
+import { test } from "../emulated/playwright-test";
+import {
+  openMail,
+  conversationWithSubject,
+} from "../emulated/mail/mail-test-helpers";
+
+type Sample = {
+  scenario: string;
+  durationMs: number;
+  loaded: boolean;
+  detailRequests: number;
+  threadId?: string | null;
+};
+type ProviderEvent = {
+  method: string;
+  cost: number;
+  reason: string | null;
+  bytes: number;
+  active: number;
+  status: number;
+};
+
+const profile = process.env.MAIL_SIMULATION_PROFILE ?? "latency";
+if (!["latency", "published-quota", "constrained"].includes(profile)) {
+  throw new Error("Unknown mail simulation profile");
+}
+test(`measures current client under ${profile}`, async ({
+  page,
+  context,
+}, testInfo) => {
+  test.setTimeout(240_000);
+  const samples: Sample[] = [];
+  const phases: { events: ProviderEvent[] }[] = [];
+  await configure({
+    userUnits: profile === "published-quota" ? 6000 : 120_000,
+    projectUnits: 1_200_000,
+    concurrency: 100,
+    latencyMs: 250,
+    windowMs: 60_000,
+    bytesPerSecond: 2_000_000,
+  });
+  let detailRequests = 0;
+  page.on("request", (request) => {
+    if (/\/api\/threads\/sim_thread_/.test(request.url())) detailRequests++;
+  });
+  try {
+    const start = performance.now();
+    const { conversations, emailAccountId } = await openMail(page);
+    samples.push({
+      scenario: "cold-view",
+      durationMs: performance.now() - start,
+      loaded: true,
+      detailRequests,
+    });
+    // No explicit idle period: click an arbitrary visible row as soon as the list exists.
+    for (const index of [4, 2, 0, 4]) {
+      const row = conversationWithSubject(
+        page,
+        conversations,
+        `Simulation thread ${String(index).padStart(4, "0")}`,
+      );
+      await expect(row).toBeVisible();
+      const before = detailRequests;
+      const started = performance.now();
+      await row.click();
+      const loaded = await waitForBody(page, index);
+      samples.push({
+        scenario: `open-${index}${index === 2 ? "-150-messages" : index === 4 ? "-large-html" : ""}`,
+        durationMs: performance.now() - started,
+        loaded,
+        detailRequests: detailRequests - before,
+      });
+      const back = page.getByRole("button", {
+        name: "Back to inbox",
+        exact: true,
+      });
+      if (!(await back.isVisible())) {
+        testInfo.annotations.push({
+          type: "blocked-scenarios",
+          description:
+            "Reader navigation disappeared after a load failure; remaining interactions could not run.",
+        });
+        return;
+      }
+      await back.click();
+    }
+    // J/K changes threads; ArrowUp/Down navigates messages inside the reader.
+    await conversationWithSubject(
+      page,
+      conversations,
+      "Simulation thread 0000",
+    ).click();
+    const navigationStart = performance.now();
+    const navigationRequests = detailRequests;
+    for (const key of ["j", "j", "j", "k", "j", "j", "k"]) {
+      await page.keyboard.press(key);
+    }
+    const selectedId = new URL(page.url()).searchParams.get("thread-id");
+    const selectedThread = Number(selectedId?.replace("sim_thread_", ""));
+    expect(
+      Number.isFinite(selectedThread) && selectedId?.startsWith("sim_thread_"),
+    ).toBe(true);
+    const navigationLoaded = await waitForBody(page, selectedThread);
+    samples.push({
+      scenario: "rapid-next-previous",
+      threadId: selectedId,
+      durationMs: performance.now() - navigationStart,
+      loaded: navigationLoaded,
+      detailRequests: detailRequests - navigationRequests,
+    });
+    await page
+      .getByRole("button", { name: "Back to inbox", exact: true })
+      .click();
+    const switchStart = performance.now();
+    const switchRequests = detailRequests;
+    for (let index = 0; index < 12; index++) {
+      await page
+        .getByRole("button", {
+          name: index % 2 === 0 ? "Unread" : "All",
+          exact: true,
+        })
+        .click();
+    }
+    await expect(
+      page.getByRole("button", { name: "All", exact: true }),
+    ).toHaveAttribute("aria-current", "true");
+    samples.push({
+      scenario: "12-rapid-split-switches",
+      durationMs: performance.now() - switchStart,
+      loaded: true,
+      detailRequests: detailRequests - switchRequests,
+    });
+    await conversations.hover();
+    await page.mouse.wheel(0, 3000);
+    await page.mouse.wheel(0, -3000);
+    // A second page shares persisted storage, but has its own in-memory cache.
+    const other = await context.newPage();
+    await other.goto(`/${emailAccountId}/mail`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      other.getByRole("listbox", { name: "Conversations" }),
+    ).toBeVisible();
+    await other.close();
+    if (profile === "constrained") {
+      phases.push(await snapshot());
+      // Exhaust quota after warming the UI, without replacing any application response.
+      await configure({
+        userUnits: 0,
+        projectUnits: 1_200_000,
+        concurrency: 2,
+        latencyMs: 250,
+        windowMs: 1000,
+        bytesPerSecond: 2_000_000,
+      });
+      const before = detailRequests;
+      const started = performance.now();
+      await page.goto(`/${emailAccountId}/mail?thread-id=sim_thread_30`, {
+        waitUntil: "domcontentloaded",
+      });
+      const loaded = await waitForBody(page, 30);
+      samples.push({
+        scenario: "uncached-open-during-quota-exhaustion",
+        durationMs: performance.now() - started,
+        loaded,
+        detailRequests: detailRequests - before,
+      });
+      if (process.env.UPSTASH_REDIS_URL && process.env.UPSTASH_REDIS_TOKEN) {
+        const state = await new Redis({
+          url: process.env.UPSTASH_REDIS_URL,
+          token: process.env.UPSTASH_REDIS_TOKEN,
+        }).get(`email-provider-rate-limit:${emailAccountId}`);
+        await testInfo.attach("account-cooldown.json", {
+          body: JSON.stringify({ recorded: state !== null }),
+          contentType: "application/json",
+        });
+      }
+      const rejected = await snapshot();
+      phases.push(rejected);
+      expect(rejected.events.some((event: ProviderEvent) => event.reason)).toBe(
+        true,
+      );
+      await testInfo.attach("quota-exhaustion.json", {
+        body: JSON.stringify(rejected, null, 2),
+        contentType: "application/json",
+      });
+      const recoveryStart = performance.now();
+      const recoveryRequests = detailRequests;
+      await configure({
+        userUnits: 6000,
+        concurrency: 100,
+        windowMs: 60_000,
+      });
+      await page.goto(`/${emailAccountId}/mail?thread-id=sim_thread_30`, {
+        waitUntil: "domcontentloaded",
+      });
+      const recoveryLoaded = await waitForBody(page, 30);
+      samples.push({
+        scenario: "open-after-quota-restored",
+        durationMs: performance.now() - recoveryStart,
+        loaded: recoveryLoaded,
+        detailRequests: detailRequests - recoveryRequests,
+      });
+    }
+  } finally {
+    await report(page, testInfo, samples, phases);
+  }
+});
+
+async function waitForBody(page: Page, thread: number) {
+  const last = thread === 2 ? 149 : thread % 10 === 0 ? 7 : 0;
+  const marker = `Simulation body ${thread} message ${last}`;
+  try {
+    await expect
+      .poll(
+        async () => {
+          for (const frame of page.frames()) {
+            if (
+              await frame
+                .getByText(marker, { exact: true })
+                .first()
+                .isVisible()
+                .catch(() => false)
+            )
+              return true;
+          }
+          return false;
+        },
+        { timeout: 12_000, intervals: [25, 50, 100] },
+      )
+      .toBe(true);
+    return true;
+  } catch {
+    const testInfo = test.info();
+    await testInfo.attach(`body-timeout-${thread}.json`, {
+      body: JSON.stringify({
+        expectedThread: thread,
+        actualThread: new URL(page.url()).searchParams.get("thread-id"),
+        renderedMessages: await page
+          .locator("li[data-thread-message-id]")
+          .evaluateAll((elements) =>
+            elements.map((element) =>
+              element.getAttribute("data-thread-message-id"),
+            ),
+          ),
+      }),
+      contentType: "application/json",
+    });
+    await page.screenshot({
+      path: testInfo.outputPath(`body-timeout-${thread}.png`),
+    });
+    return false;
+  }
+}
+
+async function configure(options: Record<string, number>) {
+  await expect
+    .poll(
+      async () => {
+        const result = await fetch(
+          `${process.env.GOOGLE_BASE_URL}/__simulation`,
+          {
+            method: "POST",
+            body: JSON.stringify(options),
+            headers: { "content-type": "application/json" },
+          },
+        );
+        return result.status;
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(200);
+}
+
+async function snapshot() {
+  const response = await fetch(`${process.env.GOOGLE_BASE_URL}/__simulation`);
+  if (!response.ok) throw new Error("Could not read simulation ledger");
+  return response.json();
+}
+
+async function report(
+  page: Page,
+  testInfo: TestInfo,
+  samples: Sample[],
+  phases: { events: ProviderEvent[] }[],
+) {
+  const provider = await snapshot();
+  const allPhases: { events: ProviderEvent[] }[] = [...phases, provider];
+  const events = allPhases.flatMap((phase) => phase.events);
+  const summary = {
+    samples,
+    provider: {
+      requests: events.length,
+      rejected: events.filter((event) => event.reason).length,
+      acceptedUnits: events
+        .filter((event) => !event.reason)
+        .reduce((sum, event) => sum + event.cost, 0),
+      bytes: events.reduce((sum, event) => sum + event.bytes, 0),
+      peakConcurrency: Math.max(0, ...events.map((event) => event.active)),
+      uncompleted: events.filter((event) => event.status === 0).length,
+    },
+    config: provider.config,
+  };
+  console.log(`MAIL_SIMULATION ${JSON.stringify(summary)}`);
+  await writeFile(
+    testInfo.outputPath("mail-loading-summary.json"),
+    JSON.stringify(summary, null, 2),
+  );
+  await writeFile(
+    testInfo.outputPath("gmail-requests.json"),
+    JSON.stringify(allPhases, null, 2),
+  );
+  await testInfo.attach("mail-loading-summary.json", {
+    body: JSON.stringify(summary, null, 2),
+    contentType: "application/json",
+  });
+  await testInfo.attach("gmail-requests.json", {
+    body: JSON.stringify(allPhases, null, 2),
+    contentType: "application/json",
+  });
+  expect(
+    provider.harnessErrors,
+    "Simulation proxy must support all exercised endpoints",
+  ).toEqual([]);
+  await page.screenshot({
+    path: testInfo.outputPath("simulation.png"),
+    fullPage: true,
+  });
+}

--- a/apps/web/__tests__/playwright/mail-simulation/playwright.config.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/playwright.config.mjs
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { defineConfig } from "@playwright/test";
+import baseConfig from "../../../playwright.config.mjs";
+
+const providerUrl = process.env.GOOGLE_BASE_URL;
+
+export default defineConfig({
+  ...baseConfig,
+  outputDir:
+    process.env.PLAYWRIGHT_OUTPUT_DIR ?? ".tmp/mail-simulation/test-results",
+  testDir: path.resolve("__tests__/playwright"),
+  projects: [
+    baseConfig.projects[0],
+    {
+      name: "mail-simulation",
+      dependencies: ["emulated-setup"],
+      testDir: path.resolve("__tests__/playwright/mail-simulation"),
+      testMatch: "loading.spec.ts",
+      use: { storageState: process.env.PLAYWRIGHT_AUTH_FILE },
+    },
+  ],
+  reporter: [
+    ["list"],
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder:
+          process.env.MAIL_SIMULATION_REPORT_DIR ??
+          ".tmp/mail-simulation/report",
+      },
+    ],
+  ],
+  webServer: baseConfig.webServer.map((server) => ({
+    ...server,
+    reuseExistingServer: false,
+    ...(server.url === `${providerUrl}/.well-known/openid-configuration`
+      ? {
+          command: `node __tests__/playwright/mail-simulation/server.mjs ${new URL(providerUrl).port}`,
+        }
+      : {}),
+  })),
+});

--- a/apps/web/__tests__/playwright/mail-simulation/playwright.config.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/playwright.config.mjs
@@ -3,6 +3,16 @@ import { defineConfig } from "@playwright/test";
 import baseConfig from "../../../playwright.config.mjs";
 
 const providerUrl = process.env.GOOGLE_BASE_URL;
+const providerAddress = new URL(providerUrl);
+if (
+  providerAddress.protocol !== "http:" ||
+  !["127.0.0.1", "localhost"].includes(providerAddress.hostname) ||
+  !providerAddress.port
+) {
+  throw new Error(
+    "Mail simulation requires a local HTTP GOOGLE_BASE_URL with an explicit port",
+  );
+}
 
 export default defineConfig({
   ...baseConfig,
@@ -36,7 +46,7 @@ export default defineConfig({
     reuseExistingServer: false,
     ...(server.url === `${providerUrl}/.well-known/openid-configuration`
       ? {
-          command: `node __tests__/playwright/mail-simulation/server.mjs ${new URL(providerUrl).port}`,
+          command: `node __tests__/playwright/mail-simulation/server.mjs ${providerAddress.port}`,
         }
       : {}),
   })),

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
@@ -1,0 +1,284 @@
+import { createServer } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
+
+// Published May 2026 schedule. Existing projects may have different quotas.
+// https://developers.google.com/workspace/gmail/api/reference/quota
+export const QUOTA_COSTS = {
+  "threads.list": 10,
+  "threads.get": 40,
+  "threads.modify": 10,
+  "threads.trash": 20,
+  "threads.untrash": 10,
+  "threads.delete": 20,
+  "messages.list": 5,
+  "messages.get": 20,
+  "messages.modify": 5,
+  "messages.batchModify": 50,
+  "messages.batchDelete": 50,
+  "messages.trash": 20,
+  "messages.untrash": 5,
+  "messages.delete": 10,
+  "messages.send": 100,
+  "messages.attachments.get": 20,
+  "drafts.list": 5,
+  "drafts.get": 20,
+  "drafts.create": 10,
+  "drafts.update": 15,
+  "drafts.delete": 10,
+  "drafts.send": 100,
+  "labels.list": 1,
+  "labels.get": 1,
+  "labels.create": 5,
+  "labels.update": 5,
+  "labels.delete": 5,
+  "history.list": 2,
+  getProfile: 1,
+  watch: 100,
+  stop: 50,
+  "settings.sendAs.list": 1,
+  "settings.filters.list": 1,
+  "settings.forwardingAddresses.list": 1,
+};
+
+export function gmailMethod(method, path) {
+  const parts = new URL(path, "http://localhost").pathname.split("/");
+  const userIndex = parts.indexOf("users");
+  if (userIndex < 0 || !parts.includes("gmail")) return null;
+  const [resource, id, action, attachmentId] = parts.slice(userIndex + 2);
+  if (resource === "profile") return "getProfile";
+  if (["watch", "stop"].includes(resource)) return resource;
+  if (
+    resource === "settings" &&
+    ["sendAs", "filters", "forwardingAddresses"].includes(id) &&
+    !action
+  )
+    return `settings.${id}.list`;
+  if (resource === "history") return "history.list";
+  if (action === "attachments" && attachmentId)
+    return "messages.attachments.get";
+  if (action) return `${resource}.${action}`;
+  if (["batchModify", "batchDelete", "send"].includes(id))
+    return `${resource}.${id}`;
+  let operation = "create";
+  if (method === "GET") operation = id ? "get" : "list";
+  else if (method === "DELETE") operation = "delete";
+  else if (["PUT", "PATCH"].includes(method)) operation = "update";
+  return `${resource}.${operation}`;
+}
+
+export function createQuotaLedger(options = {}, now = Date.now) {
+  const config = {
+    userUnits: 6000,
+    projectUnits: 1_200_000,
+    windowMs: 60_000,
+    concurrency: 8,
+    latencyMs: 250,
+    bytesPerSecond: 2_000_000,
+    ...options,
+  };
+  let usage = [];
+  const activeByUser = new Map();
+  const events = [];
+  return {
+    config,
+    events,
+    admit(method, user = "mailbox") {
+      const time = now();
+      usage = usage.filter((entry) => entry.time > time - config.windowMs);
+      const cost = QUOTA_COSTS[method];
+      if (cost === undefined)
+        throw new Error(`Unmodelled Gmail method: ${method}`);
+      const userUsage = usage
+        .filter((entry) => entry.user === user)
+        .reduce((sum, entry) => sum + entry.cost, 0);
+      const projectUsage = usage.reduce((sum, entry) => sum + entry.cost, 0);
+      const active = activeByUser.get(user) ?? 0;
+      let reason = null;
+      let status = 0;
+      if (active >= config.concurrency) {
+        reason = "concurrentLimitExceeded";
+        status = 429;
+      } else if (userUsage + cost > config.userUnits) {
+        reason = "userRateLimitExceeded";
+        status = 403;
+      } else if (projectUsage + cost > config.projectUnits) {
+        reason = "rateLimitExceeded";
+        status = 403;
+      }
+      const event = {
+        time,
+        method,
+        user,
+        cost,
+        reason,
+        active,
+        bytes: 0,
+        status,
+      };
+      events.push(event);
+      if (reason) return { event, release() {} };
+      usage.push({ time, cost, user });
+      activeByUser.set(user, active + 1);
+      event.active = active + 1;
+      let released = false;
+      return {
+        event,
+        release() {
+          if (!released) {
+            activeByUser.set(user, activeByUser.get(user) - 1);
+            released = true;
+          }
+        },
+      };
+    },
+    reset(options = {}) {
+      if ([...activeByUser.values()].some((count) => count > 0))
+        throw new Error("Wait for in-flight Gmail requests before resetting");
+      Object.assign(config, options);
+      usage = [];
+      events.length = 0;
+    },
+  };
+}
+
+export async function createQuotaProxy({ upstream, port = 0, options }) {
+  if (
+    !["127.0.0.1", "localhost", "[::1]"].includes(new URL(upstream).hostname)
+  ) {
+    throw new Error("Simulation upstream must be local");
+  }
+  const ledger = createQuotaLedger(options);
+  const harnessErrors = [];
+  const server = createServer(async (req, res) => {
+    try {
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      const body = Buffer.concat(chunks);
+      if (req.url === "/__simulation") {
+        if (req.method === "POST")
+          ledger.reset(JSON.parse(body.toString() || "{}"));
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            config: ledger.config,
+            events: ledger.events,
+            harnessErrors,
+          }),
+        );
+        return;
+      }
+      const headers = { ...req.headers };
+      for (const key of [
+        "host",
+        "content-length",
+        "connection",
+        "accept-encoding",
+      ])
+        delete headers[key];
+      const response = req.url.startsWith("/batch")
+        ? await batch(body.toString(), headers)
+        : await forward(req.method, req.url, headers, body);
+      res.writeHead(response.status, response.headers);
+      res.end(response.body);
+    } catch (error) {
+      if (req.url === "/__simulation") {
+        res.writeHead(409, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: String(error) }));
+        return;
+      }
+      harnessErrors.push(String(error));
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: String(error) }));
+    }
+  });
+  async function forward(method, path, headers, body) {
+    const target = new URL(path, upstream);
+    if (target.origin !== new URL(upstream).origin) {
+      throw new Error("Simulation requests must stay on the local upstream");
+    }
+    const name = gmailMethod(method, path);
+    const admission = name ? ledger.admit(name) : null;
+    const event = admission?.event;
+    if (event?.reason) {
+      const seconds = Math.ceil(ledger.config.windowMs / 1000);
+      return {
+        status: event.status,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": String(seconds),
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            error: {
+              code: event.status,
+              message: `${event.reason}. Retry after ${new Date(Date.now() + seconds * 1000).toISOString()}`,
+              errors: [{ domain: "usageLimits", reason: event.reason }],
+            },
+          }),
+        ),
+      };
+    }
+    try {
+      if (name) await delay(ledger.config.latencyMs);
+      const response = await fetch(target, {
+        method,
+        headers,
+        body:
+          ["GET", "HEAD"].includes(method) || !body?.length ? undefined : body,
+        redirect: "manual",
+      });
+      const bytes = Buffer.from(await response.arrayBuffer());
+      if (event) {
+        event.bytes = bytes.length;
+        event.status = response.status;
+        await delay((bytes.length / ledger.config.bytesPerSecond) * 1000);
+        event.durationMs = Date.now() - event.time;
+      }
+      const responseHeaders = Object.fromEntries(response.headers);
+      for (const key of [
+        "content-encoding",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+      ])
+        delete responseHeaders[key];
+      return { status: response.status, headers: responseHeaders, body: bytes };
+    } finally {
+      admission?.release();
+    }
+  }
+  async function batch(body, headers) {
+    const requests = [
+      ...body.matchAll(
+        /^(GET|POST|PUT|PATCH|DELETE) (\S+)(?: HTTP\/1\.[01])?\r?$/gm,
+      ),
+    ];
+    if (!requests.length) throw new Error("Unrecognized Gmail batch body");
+    // The app currently batches GETs only. Fail rather than silently mis-model writes.
+    if (requests.some((match) => match[1] !== "GET"))
+      throw new Error("Simulation only supports GET batch parts");
+    const responses = await Promise.all(
+      requests.map((match) => forward(match[1], match[2], headers)),
+    );
+    const boundary = "simulation_batch";
+    const parts = responses.map(
+      (response, index) =>
+        `--${boundary}\r\nContent-Type: application/http\r\nContent-ID: <response-${index}>\r\n\r\nHTTP/1.1 ${response.status} ${response.status === 200 ? "OK" : "Error"}\r\nContent-Type: application/json\r\n${response.headers["retry-after"] ? `Retry-After: ${response.headers["retry-after"]}\r\n` : ""}\r\n${response.body.toString()}\r\n`,
+    );
+    return {
+      status: 200,
+      headers: { "content-type": `multipart/mixed; boundary=${boundary}` },
+      body: Buffer.from(`${parts.join("")}--${boundary}--\r\n`),
+    };
+  }
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${server.address().port}`,
+    ledger,
+    close: () =>
+      new Promise((resolve) => {
+        server.close(resolve);
+        server.closeAllConnections();
+      }),
+  };
+}

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
@@ -183,19 +183,23 @@ export async function createQuotaProxy({ upstream, port = 0, options }) {
     } catch (error) {
       if (req.url === "/__simulation") {
         res.writeHead(409, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: String(error) }));
+        res.end(JSON.stringify({ error: "Simulation reset is not available" }));
         return;
       }
-      harnessErrors.push(String(error));
+      harnessErrors.push("Simulation request failed; inspect the server logs");
+      console.error("Simulation request failed", error);
       res.writeHead(500, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: String(error) }));
+      res.end(JSON.stringify({ error: "Simulation request failed" }));
     }
   });
   async function forward(method, path, headers, body) {
-    const target = new URL(path, upstream);
-    if (target.origin !== new URL(upstream).origin) {
+    const requested = new URL(path, upstream);
+    const target = new URL(upstream);
+    if (requested.origin !== target.origin) {
       throw new Error("Simulation requests must stay on the local upstream");
     }
+    target.pathname = requested.pathname;
+    target.search = requested.search;
     const name = gmailMethod(method, path);
     const admission = name ? ledger.admit(name) : null;
     const event = admission?.event;

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.mjs
@@ -95,15 +95,35 @@ export function createQuotaLedger(options = {}, now = Date.now) {
       const active = activeByUser.get(user) ?? 0;
       let reason = null;
       let status = 0;
+      let retryAfterMs = 0;
       if (active >= config.concurrency) {
         reason = "concurrentLimitExceeded";
         status = 429;
+        retryAfterMs = 1000;
       } else if (userUsage + cost > config.userUnits) {
         reason = "userRateLimitExceeded";
         status = 403;
       } else if (projectUsage + cost > config.projectUnits) {
         reason = "rateLimitExceeded";
         status = 403;
+      }
+      if (status === 403) {
+        retryAfterMs = Math.max(
+          quotaRetryDelay(
+            usage.filter((entry) => entry.user === user),
+            config.userUnits,
+            cost,
+            config.windowMs,
+            time,
+          ),
+          quotaRetryDelay(
+            usage,
+            config.projectUnits,
+            cost,
+            config.windowMs,
+            time,
+          ),
+        );
       }
       const event = {
         time,
@@ -114,6 +134,7 @@ export function createQuotaLedger(options = {}, now = Date.now) {
         active,
         bytes: 0,
         status,
+        retryAfterMs,
       };
       events.push(event);
       if (reason) return { event, release() {} };
@@ -204,7 +225,7 @@ export async function createQuotaProxy({ upstream, port = 0, options }) {
     const admission = name ? ledger.admit(name) : null;
     const event = admission?.event;
     if (event?.reason) {
-      const seconds = Math.ceil(ledger.config.windowMs / 1000);
+      const seconds = Math.max(1, Math.ceil(event.retryAfterMs / 1000));
       return {
         status: event.status,
         headers: {
@@ -281,8 +302,24 @@ export async function createQuotaProxy({ upstream, port = 0, options }) {
     ledger,
     close: () =>
       new Promise((resolve) => {
-        server.close(resolve);
-        server.closeAllConnections();
+        const deadline = setTimeout(() => server.closeAllConnections(), 1000);
+        deadline.unref();
+        server.close(() => {
+          clearTimeout(deadline);
+          resolve();
+        });
       }),
   };
+}
+
+function quotaRetryDelay(entries, limit, cost, windowMs, now) {
+  let remaining = entries.reduce((sum, entry) => sum + entry.cost, 0);
+  if (remaining + cost <= limit) return 0;
+  for (const entry of entries) {
+    remaining -= entry.cost;
+    if (remaining + cost <= limit)
+      return Math.max(1, entry.time + windowMs - now);
+  }
+  // A deliberately undersized test budget cannot recover without a reset.
+  return windowMs;
 }

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
@@ -109,7 +109,13 @@ test("batch request targets cannot escape the local upstream", async () => {
       body: "--batch\nContent-Type: application/http\n\nGET https://example.com/gmail/v1/users/me/threads/a\n\n--batch--",
     });
     assert.equal(response.status, 500);
-    assert.match(await response.text(), /must stay on the local upstream/);
+    assert.deepEqual(await response.json(), {
+      error: "Simulation request failed",
+    });
+    const diagnostics = await fetch(`${proxy.url}/__simulation`).then(
+      (result) => result.json(),
+    );
+    assert.equal(diagnostics.harnessErrors.length, 1);
     assert.equal(proxy.ledger.events.length, 0);
   } finally {
     await proxy.close();

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
@@ -121,3 +121,26 @@ test("batch request targets cannot escape the local upstream", async () => {
     await proxy.close();
   }
 });
+
+test("quota retries wait only until sufficient weighted capacity expires", () => {
+  let now = 0;
+  const ledger = createQuotaLedger(
+    { userUnits: 60, projectUnits: 80 },
+    () => now,
+  );
+  ledger.admit("messages.get").release();
+  now = 10_000;
+  ledger.admit("threads.get").release();
+  ledger.admit("messages.get", "other").release();
+  now = 55_000;
+  assert.equal(ledger.admit("messages.get").event.retryAfterMs, 5000);
+  assert.equal(ledger.admit("threads.get").event.retryAfterMs, 15_000);
+  assert.equal(ledger.admit("threads.get", "third").event.retryAfterMs, 15_000);
+});
+
+test("concurrency retries do not impose a full quota window", () => {
+  const ledger = createQuotaLedger({ concurrency: 1 });
+  const active = ledger.admit("threads.get");
+  assert.equal(ledger.admit("threads.get").event.retryAfterMs, 1000);
+  active.release();
+});

--- a/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/quota-proxy.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import {
+  createQuotaLedger,
+  createQuotaProxy,
+  gmailMethod,
+} from "./quota-proxy.mjs";
+
+test("weighted quota expires and accounts share the project budget", () => {
+  let now = 0;
+  const ledger = createQuotaLedger(
+    { userUnits: 40, projectUnits: 60 },
+    () => now,
+  );
+  const first = ledger.admit("threads.get", "one");
+  first.release();
+  assert.equal(
+    ledger.admit("labels.list", "one").event.reason,
+    "userRateLimitExceeded",
+  );
+  ledger.admit("messages.get", "two").release();
+  assert.equal(
+    ledger.admit("labels.list", "three").event.reason,
+    "rateLimitExceeded",
+  );
+  now = 60_000;
+  assert.equal(ledger.admit("threads.get", "one").event.reason, null);
+});
+
+test("concurrency is held until completion and failed admissions do not spend quota", () => {
+  const ledger = createQuotaLedger({ concurrency: 1, userUnits: 80 });
+  const first = ledger.admit("threads.get");
+  assert.equal(ledger.admit("threads.get").event.status, 429);
+  first.release();
+  first.release();
+  const next = ledger.admit("threads.get");
+  assert.equal(next.event.reason, null);
+  next.release();
+  assert.equal(
+    ledger.admit("threads.get").event.reason,
+    "userRateLimitExceeded",
+  );
+});
+
+test("HTTP batch meters each part, returns partial errors, and counts response bytes", async () => {
+  const upstream = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ id: "thread", messages: [] }));
+  });
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  const proxy = await createQuotaProxy({
+    upstream: `http://127.0.0.1:${upstream.address().port}`,
+    options: { userUnits: 40, latencyMs: 0 },
+  });
+  try {
+    const response = await fetch(`${proxy.url}/batch/gmail/v1`, {
+      method: "POST",
+      body: "--batch\nContent-Type: application/http\n\nGET /gmail/v1/users/me/threads/a\n\n--batch\nContent-Type: application/http\n\nGET /gmail/v1/users/me/threads/b\n\n--batch--",
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(body, /HTTP\/1.1 200 OK/);
+    assert.match(body, /HTTP\/1.1 403 Error/);
+    assert.match(body, /userRateLimitExceeded/);
+    assert.equal(proxy.ledger.events.length, 2);
+    assert.ok(proxy.ledger.events[0].bytes > 0);
+    assert.equal(proxy.ledger.events[1].bytes, 0);
+  } finally {
+    await proxy.close();
+    await new Promise((resolve) => upstream.close(resolve));
+  }
+});
+
+test("concurrency belongs to a mailbox, not the whole project", () => {
+  const ledger = createQuotaLedger({ concurrency: 1 });
+  const first = ledger.admit("threads.get", "one");
+  const second = ledger.admit("threads.get", "two");
+  assert.equal(second.event.reason, null);
+  assert.equal(ledger.admit("threads.get", "one").event.status, 429);
+  first.release();
+  second.release();
+});
+
+test("classifies settings, attachments and query-bearing batch requests", () => {
+  assert.equal(
+    gmailMethod("GET", "/gmail/v1/users/me/settings/filters"),
+    "settings.filters.list",
+  );
+  assert.equal(
+    gmailMethod("GET", "/gmail/v1/users/me/messages/a/attachments/b"),
+    "messages.attachments.get",
+  );
+  assert.equal(
+    gmailMethod("GET", "/gmail/v1/users/me/threads/a?format=metadata"),
+    "threads.get",
+  );
+  assert.equal(
+    gmailMethod("POST", "/gmail/v1/users/me/messages/batchModify"),
+    "messages.batchModify",
+  );
+});
+
+test("batch request targets cannot escape the local upstream", async () => {
+  const proxy = await createQuotaProxy({ upstream: "http://127.0.0.1:1" });
+  try {
+    const response = await fetch(`${proxy.url}/batch/gmail/v1`, {
+      method: "POST",
+      body: "--batch\nContent-Type: application/http\n\nGET https://example.com/gmail/v1/users/me/threads/a\n\n--batch--",
+    });
+    assert.equal(response.status, 500);
+    assert.match(await response.text(), /must stay on the local upstream/);
+    assert.equal(proxy.ledger.events.length, 0);
+  } finally {
+    await proxy.close();
+  }
+});

--- a/apps/web/__tests__/playwright/mail-simulation/run.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/run.mjs
@@ -14,7 +14,7 @@ for (const profile of profiles) {
   const destination = path.join(output, profile);
   mkdirSync(destination, { recursive: true });
   const result = spawnSync(
-    "pnpm",
+    process.platform === "win32" ? "pnpm.cmd" : "pnpm",
     [
       "exec",
       "playwright",
@@ -25,6 +25,7 @@ for (const profile of profiles) {
     ],
     {
       stdio: "inherit",
+      shell: process.platform === "win32",
       env: {
         ...process.env,
         MAIL_SIMULATION_PROFILE: profile,

--- a/apps/web/__tests__/playwright/mail-simulation/run.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/run.mjs
@@ -1,0 +1,48 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const availableProfiles = ["latency", "published-quota", "constrained"];
+const profiles =
+  process.argv.length > 2 ? process.argv.slice(2) : availableProfiles;
+if (profiles.some((profile) => !availableProfiles.includes(profile))) {
+  throw new Error(`Choose profiles from: ${availableProfiles.join(", ")}`);
+}
+const output = path.resolve(".tmp/mail-simulation", String(Date.now()));
+let failed = false;
+for (const profile of profiles) {
+  const destination = path.join(output, profile);
+  mkdirSync(destination, { recursive: true });
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "playwright",
+      "test",
+      "--config",
+      "__tests__/playwright/mail-simulation/playwright.config.mjs",
+      "--project=mail-simulation",
+    ],
+    {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        MAIL_SIMULATION_PROFILE: profile,
+        MAIL_SIMULATION_REPORT_DIR: path.join(destination, "playwright-report"),
+        PLAYWRIGHT_OUTPUT_DIR: path.join(destination, "test-results"),
+        PLAYWRIGHT_RUN_ID: `${process.pid}-${profile}-${Date.now()}`,
+      },
+    },
+  );
+  writeFileSync(
+    path.join(destination, "run.json"),
+    JSON.stringify(
+      { profile, status: result.status, error: result.error?.message },
+      null,
+      2,
+    ),
+  );
+  if (result.status !== 0) failed = true;
+}
+console.log(`Mail simulation artifacts: ${output}`);
+process.exitCode = failed ? 1 : 0;

--- a/apps/web/__tests__/playwright/mail-simulation/server.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/server.mjs
@@ -43,7 +43,10 @@ const emulator = await createEmulator({
           client_id: "client_id",
           client_secret: "client_secret",
           redirect_uris: [
-            `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/oauth2/callback/google`,
+            new URL(
+              "/api/auth/oauth2/callback/google",
+              process.env.NEXT_PUBLIC_BASE_URL,
+            ).href,
           ],
         },
       ],
@@ -63,7 +66,12 @@ for (const signal of ["SIGINT", "SIGTERM"])
   process.on(signal, async () => {
     const deadline = setTimeout(() => process.exit(0), 5000);
     deadline.unref();
-    await proxy.close();
-    await emulator.close();
+    for (const close of [() => proxy.close(), () => emulator.close()]) {
+      try {
+        await close();
+      } catch (error) {
+        console.error("Simulation shutdown failed", error);
+      }
+    }
     process.exit(0);
   });

--- a/apps/web/__tests__/playwright/mail-simulation/server.mjs
+++ b/apps/web/__tests__/playwright/mail-simulation/server.mjs
@@ -1,0 +1,69 @@
+import { createServer } from "node:net";
+import { createEmulator } from "emulate";
+import { createQuotaProxy } from "./quota-proxy.mjs";
+
+const port = Number(process.argv[2]);
+const email = process.env.PLAYWRIGHT_TEST_EMAIL;
+if (!email || !port)
+  throw new Error("Simulation requires a port and PLAYWRIGHT_TEST_EMAIL");
+const messages = [];
+for (let thread = 0; thread < 1000; thread++) {
+  const count = thread === 2 ? 150 : thread % 10 === 0 ? 8 : 1;
+  for (let message = 0; message < count; message++) {
+    const marker = `Simulation body ${thread} message ${message}`;
+    messages.push({
+      id: `sim_${thread}_${message}`,
+      thread_id: `sim_thread_${thread}`,
+      user_email: email,
+      from: "sender@example.com",
+      to: email,
+      subject: `Simulation thread ${String(thread).padStart(4, "0")}`,
+      body_text: marker,
+      body_html: `<p>${marker}</p>${thread === 4 ? "<p>Large newsletter paragraph with a synthetic update.</p>".repeat(15_000) : ""}`,
+      label_ids: ["INBOX", ...(thread % 2 === 0 ? ["UNREAD"] : [])],
+      internal_date: String(
+        Date.now() - thread * 60_000 - (count - message) * 100,
+      ),
+    });
+  }
+}
+const allocator = createServer();
+await new Promise((resolve) => allocator.listen(0, "127.0.0.1", resolve));
+const upstreamPort = allocator.address().port;
+await new Promise((resolve) => allocator.close(resolve));
+const emulator = await createEmulator({
+  service: "google",
+  port: upstreamPort,
+  baseUrl: `http://127.0.0.1:${port}`,
+  seed: {
+    google: {
+      users: [{ email, name: "Simulation User" }],
+      oauth_clients: [
+        {
+          client_id: "client_id",
+          client_secret: "client_secret",
+          redirect_uris: [
+            `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/oauth2/callback/google`,
+          ],
+        },
+      ],
+      messages,
+    },
+  },
+});
+const proxy = await createQuotaProxy({
+  upstream: `http://127.0.0.1:${upstreamPort}`,
+  port,
+  options: { latencyMs: 0, concurrency: 100, bytesPerSecond: 100_000_000 },
+});
+console.log(
+  `Mail simulation ready at ${proxy.url}; ${messages.length} synthetic messages`,
+);
+for (const signal of ["SIGINT", "SIGTERM"])
+  process.on(signal, async () => {
+    const deadline = setTimeout(() => process.exit(0), 5000);
+    deadline.unref();
+    await proxy.close();
+    await emulator.close();
+    process.exit(0);
+  });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,8 @@
     "test-db": "cross-env RUN_DB_TESTS=true vitest --run --dir __tests__/db",
     "test-e2e": "cross-env RUN_E2E_TESTS=true vitest --run",
     "test-e2e:flows": "cross-env RUN_E2E_FLOW_TESTS=true vitest --run --dir __tests__/e2e/flows --no-file-parallelism",
-    "test-integration": "cross-env RUN_INTEGRATION_TESTS=true vitest --run --dir __tests__/integration"
+    "test-integration": "cross-env RUN_INTEGRATION_TESTS=true vitest --run --dir __tests__/integration",
+    "test:mail-loading": "node __tests__/playwright/mail-simulation/run.mjs"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "4.0.128",


### PR DESCRIPTION
Adds a manual browser simulation for measuring email loading under Gmail latency and quota pressure. The harness exercises large conversations, rapid navigation, split switching, multiple tabs, and quota exhaustion/recovery using synthetic mailbox data.

- Uses a dedicated Playwright configuration excluded from normal test discovery and CI execution, with separate reports for each profile.
- Meters provider requests and batch parts through a local-only proxy; production client behavior and runtime database/network work are unchanged.
- Validated all three browser profiles, reran the latency and constrained profiles after harness updates, reviewed screenshots, and passed eight proxy checks plus formatting checks.

Observed loading failures are captured as baseline evidence rather than treated as a passing performance target. The README documents quota assumptions and measurement limitations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added an opt-in mail-loading simulation for measuring email client performance across latency, quota, concurrency, navigation, thread, split-view, and multi-page scenarios.
  - Added constrained-quota testing, recovery checks, request metrics, screenshots, diagnostics, and JSON result artifacts.
  - Added validation for quota accounting, batching, concurrency limits, request costs, and local upstream restrictions.
  - Added a runner for executing standard simulation profiles and a command to launch the simulation suite.

- **Documentation**
  - Documented setup, profiles, seeded workloads, artifacts, quota behavior, and simulation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->