### PR TITLE
meetings: Open related draft from Go to Drafts (INB-328 review fixes)

### DIFF
--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
@@ -42,12 +42,15 @@ describe("meeting follow-up draft route", () => {
     getEmailAccountMock.mockResolvedValue("user@gmail.com");
   });
 
-  it("opens the related Gmail draft using its embedded message ID", async () => {
+  it("opens the related Gmail draft's conversation in Drafts", async () => {
     prisma.meeting.findFirst.mockResolvedValue({
       followUpDraftId: "draft-resource-123",
       emailAccount: { account: { provider: "google" } },
     } as never);
-    emailProvider.getDraft.mockResolvedValue({ id: "draft-message-123" });
+    emailProvider.getDraft.mockResolvedValue({
+      id: "draft-message-123",
+      threadId: "thread-123",
+    });
 
     const response = await GET(new NextRequest(requestUrl), routeContext);
 
@@ -58,7 +61,29 @@ describe("meeting follow-up draft route", () => {
     );
     expect(emailProvider.getDraft).toHaveBeenCalledWith("draft-resource-123");
     expect(response.headers.get("location")).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/thread-123",
+    );
+  });
+
+  // The Graph webLink resolves the item without translating a REST id into the
+  // EWS id the compose deeplink expects.
+  it("opens the related Outlook draft through the link Graph supplied", async () => {
+    getEmailAccountMock.mockResolvedValue("user@contoso.com");
+    prisma.meeting.findFirst.mockResolvedValue({
+      followUpDraftId: "draft-resource-123",
+      emailAccount: { account: { provider: "microsoft" } },
+    } as never);
+    emailProvider.getDraft.mockResolvedValue({
+      id: "draft-message-123",
+      threadId: "thread-123",
+      externalUrl:
+        "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+    });
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(response.headers.get("location")).toBe(
+      "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
     );
   });
 

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts
@@ -87,6 +87,27 @@ describe("meeting follow-up draft route", () => {
     );
   });
 
+  it("returns an explicit error when Outlook has no trusted draft link", async () => {
+    getEmailAccountMock.mockResolvedValue("user@contoso.com");
+    prisma.meeting.findFirst.mockResolvedValue({
+      followUpDraftId: "draft-resource-123",
+      emailAccount: { account: { provider: "microsoft" } },
+    } as never);
+    emailProvider.getDraft.mockResolvedValue({
+      id: "draft-message-123",
+      threadId: "thread-123",
+    });
+
+    const response = await GET(new NextRequest(requestUrl), routeContext);
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      error:
+        "The draft exists, but no trusted provider link is available to open it.",
+    });
+    expect(response.headers.get("location")).toBeNull();
+  });
+
   it("rejects email accounts the user does not own", async () => {
     getEmailAccountMock.mockResolvedValue(null);
 

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
@@ -50,7 +50,7 @@ export const GET = withAuth(
 
     if (!draft) return draftNotFound();
 
-    return NextResponse.redirect(getEmailDraftUrl(draft.id, email, provider));
+    return NextResponse.redirect(getEmailDraftUrl(draft, email, provider));
   },
 );
 

--- a/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.ts
@@ -50,7 +50,22 @@ export const GET = withAuth(
 
     if (!draft) return draftNotFound();
 
-    return NextResponse.redirect(getEmailDraftUrl(draft, email, provider));
+    const draftUrl = getEmailDraftUrl(draft, email, provider);
+    if (!draftUrl) {
+      request.logger.warn(
+        "No safe provider draft URL available for meeting follow-up draft",
+        { meetingId, provider },
+      );
+      return NextResponse.json(
+        {
+          error:
+            "The draft exists, but no trusted provider link is available to open it.",
+        },
+        { status: 422 },
+      );
+    }
+
+    return NextResponse.redirect(draftUrl);
   },
 );
 

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -167,40 +167,79 @@ describe("getEmailUrl", () => {
 });
 
 describe("getEmailDraftUrl", () => {
+  // Graph resolves its own webLink without any id translation, so it wins over
+  // anything assembled from a Graph REST id.
+  it("uses the Outlook link the provider supplied", () => {
+    expect(
+      getEmailDraftUrl(
+        {
+          id: "draft-123",
+          externalUrl:
+            "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+        },
+        "user@contoso.com",
+        "microsoft",
+      ),
+    ).toBe(
+      "https://outlook.office365.com/owa/?ItemID=AAMkAG&exvsurl=1&viewmodel=ReadMessageItem",
+    );
+  });
+
   it.each([
     {
-      name: "Google account",
-      draftMessageId: "draft-message-123",
-      emailAddress: "user@gmail.com",
-      provider: "google",
-      expected:
-        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#inbox?compose=draft-message-123",
+      name: "an unexpected host",
+      externalUrl: "https://evil.example.com/mail",
     },
+    { name: "a non-https scheme", externalUrl: "http://outlook.office.com/x" },
+    { name: "an unparseable value", externalUrl: "not-a-url" },
+  ])("ignores a draft link with $name", ({ externalUrl }) => {
+    expect(
+      getEmailDraftUrl(
+        { id: "draft-123", externalUrl },
+        "user@outlook.com",
+        "microsoft",
+      ),
+    ).toBe("https://outlook.live.com/mail/0/drafts/id/draft-123");
+  });
+
+  it.each([
     {
       name: "personal Microsoft account",
-      draftMessageId: "draft-123",
+      draft: { id: "draft-123" },
       emailAddress: "user@outlook.com",
       provider: "microsoft",
-      expected:
-        "https://outlook.live.com/mail/0/deeplink/compose?itemid=draft-123&exvsurl=1",
+      expected: "https://outlook.live.com/mail/0/drafts/id/draft-123",
     },
     {
       name: "business Microsoft account",
-      draftMessageId: "draft+123/abc",
+      draft: { id: "draft+123/abc" },
       emailAddress: "user@contoso.com",
       provider: "microsoft",
+      expected: "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
+    },
+    {
+      name: "Google account",
+      draft: { id: "draft-message-123", threadId: "thread-123" },
+      emailAddress: "user@gmail.com",
+      provider: "google",
       expected:
-        "https://outlook.office.com/mail/deeplink/compose?itemid=draft%2B123%2Fabc&exvsurl=1",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/thread-123",
+    },
+    {
+      name: "Google account without a thread",
+      draft: { id: "draft-message-123" },
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#drafts/draft-message-123",
     },
   ])("opens the draft for a $name", ({
-    draftMessageId,
+    draft,
     emailAddress,
     provider,
     expected,
   }) => {
-    expect(getEmailDraftUrl(draftMessageId, emailAddress, provider)).toBe(
-      expected,
-    );
+    expect(getEmailDraftUrl(draft, emailAddress, provider)).toBe(expected);
   });
 });
 

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -167,8 +167,9 @@ describe("getEmailUrl", () => {
 });
 
 describe("getEmailDraftUrl", () => {
-  // Graph resolves its own webLink without any id translation, so it wins over
-  // anything assembled from a Graph REST id.
+  // Graph resolves its own webLink without any id translation; Graph REST ids
+  // cannot be substituted into OWA /drafts/id/ URLs, so untrusted or missing
+  // links yield null instead of a broken deeplink.
   it("uses the Outlook link the provider supplied", () => {
     expect(
       getEmailDraftUrl(
@@ -191,32 +192,23 @@ describe("getEmailDraftUrl", () => {
       externalUrl: "https://evil.example.com/mail",
     },
     { name: "a non-https scheme", externalUrl: "http://outlook.office.com/x" },
+    {
+      name: "a non-default port",
+      externalUrl: "https://outlook.live.com:8443/evil",
+    },
     { name: "an unparseable value", externalUrl: "not-a-url" },
-  ])("ignores a draft link with $name", ({ externalUrl }) => {
+    { name: "no provider link", externalUrl: undefined },
+  ])("returns null for a draft link with $name", ({ externalUrl }) => {
     expect(
       getEmailDraftUrl(
         { id: "draft-123", externalUrl },
         "user@outlook.com",
         "microsoft",
       ),
-    ).toBe("https://outlook.live.com/mail/0/drafts/id/draft-123");
+    ).toBeNull();
   });
 
   it.each([
-    {
-      name: "personal Microsoft account",
-      draft: { id: "draft-123" },
-      emailAddress: "user@outlook.com",
-      provider: "microsoft",
-      expected: "https://outlook.live.com/mail/0/drafts/id/draft-123",
-    },
-    {
-      name: "business Microsoft account",
-      draft: { id: "draft+123/abc" },
-      emailAddress: "user@contoso.com",
-      provider: "microsoft",
-      expected: "https://outlook.office.com/mail/drafts/id/draft%2B123%2Fabc",
-    },
     {
       name: "Google account",
       draft: { id: "draft-message-123", threadId: "thread-123" },

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -44,11 +44,39 @@ function getOutlookBaseUrl(emailAddress?: string | null) {
     : "https://outlook.office.com/mail";
 }
 
+// Only the fields a draft deeplink can be built from. `externalUrl` is the
+// provider's own link to the item, which beats anything assembled here.
+type DraftLinkTarget = {
+  id: string;
+  threadId?: string | null;
+  externalUrl?: string | null;
+};
+
+const MICROSOFT_MAIL_HOSTS = [
+  "outlook.live.com",
+  "outlook.office.com",
+  "outlook.office365.com",
+];
+
+// The link is redirected to, so treat it as untrusted until the host proves it
+// belongs to Outlook rather than forwarding wherever the payload points.
+function getTrustedMicrosoftLink(externalUrl?: string | null) {
+  if (!externalUrl) return null;
+
+  try {
+    const url = new URL(externalUrl);
+    if (url.protocol !== "https:") return null;
+    return MICROSOFT_MAIL_HOSTS.includes(url.hostname) ? externalUrl : null;
+  } catch {
+    return null;
+  }
+}
+
 type ProviderUrlConfig = {
   requiresMessageId: boolean;
   buildUrl: (messageOrThreadId: string, emailAddress?: string | null) => string;
   buildDraftUrl: (
-    draftMessageId: string,
+    draft: DraftLinkTarget,
     emailAddress?: string | null,
   ) => string;
   selectId: (messageId: string, threadId: string) => string;
@@ -59,9 +87,12 @@ const GOOGLE_CONFIG: ProviderUrlConfig = {
   requiresMessageId: false,
   buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
     getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
-  buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
+  // Gmail's compose deeplink takes an internal id that cannot be derived from
+  // an API id, so the draft itself cannot be opened. Its conversation can, and
+  // Drafts is the one label that holds it.
+  buildDraftUrl: (draft: DraftLinkTarget, emailAddress?: string | null) =>
     getGmailUrlForFragment(
-      `inbox?compose=${encodeURIComponent(draftMessageId)}`,
+      `drafts/${encodeURIComponent(draft.threadId || draft.id)}`,
       emailAddress,
     ),
   selectId: (messageId: string, _threadId: string) => messageId,
@@ -79,8 +110,12 @@ const PROVIDER_CONFIG: Record<string, ProviderUrlConfig> = {
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
-    buildDraftUrl: (draftMessageId: string, emailAddress?: string | null) =>
-      `${getOutlookBaseUrl(emailAddress)}/deeplink/compose?itemid=${encodeURIComponent(draftMessageId)}&exvsurl=1`,
+    // Graph hands back a webLink that resolves the item without any id
+    // translation. The deeplink built here needs an EWS id, which a Graph REST
+    // id is not, so it only stands in when the provider gave us no link.
+    buildDraftUrl: (draft: DraftLinkTarget, emailAddress?: string | null) =>
+      getTrustedMicrosoftLink(draft.externalUrl) ??
+      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draft.id)}`,
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
@@ -111,17 +146,21 @@ export function getEmailUrl(
 }
 
 /**
- * Takes the draft's underlying *message* id, not the draft resource id — on
- * Gmail those differ (and the message id changes on every draft edit), so
- * resolve it via `EmailProvider.getDraft` at link time.
+ * Takes the draft message itself rather than an id, because the fields that
+ * produce a working link differ by provider: Outlook resolves its own webLink,
+ * while Gmail needs the thread. Resolve the draft via `EmailProvider.getDraft`
+ * at link time — its message id changes on every edit.
+ *
+ * Outlook lands on the draft. Gmail lands on the draft's conversation in
+ * Drafts; opening its composer needs an internal id the API does not expose.
  */
 export function getEmailDraftUrl(
-  draftMessageId: string,
+  draft: DraftLinkTarget,
   emailAddress?: string | null,
   provider?: string,
 ): string {
   const config = getProviderConfig(provider);
-  return config.buildDraftUrl(draftMessageId, emailAddress);
+  return config.buildDraftUrl(draft, emailAddress);
 }
 
 /**

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -65,7 +65,9 @@ function getTrustedMicrosoftLink(externalUrl?: string | null) {
 
   try {
     const url = new URL(externalUrl);
-    if (url.protocol !== "https:") return null;
+    // Reject non-default ports: hostname alone would allow
+    // https://outlook.live.com:8443/... through the whitelist.
+    if (url.protocol !== "https:" || url.port !== "") return null;
     return MICROSOFT_MAIL_HOSTS.includes(url.hostname) ? externalUrl : null;
   } catch {
     return null;
@@ -78,7 +80,7 @@ type ProviderUrlConfig = {
   buildDraftUrl: (
     draft: DraftLinkTarget,
     emailAddress?: string | null,
-  ) => string;
+  ) => string | null;
   selectId: (messageId: string, threadId: string) => string;
   buildSearchUrl: (from: string, emailAddress?: string | null) => string;
 };
@@ -111,11 +113,10 @@ const PROVIDER_CONFIG: Record<string, ProviderUrlConfig> = {
       return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
     // Graph hands back a webLink that resolves the item without any id
-    // translation. The deeplink built here needs an EWS id, which a Graph REST
-    // id is not, so it only stands in when the provider gave us no link.
-    buildDraftUrl: (draft: DraftLinkTarget, emailAddress?: string | null) =>
-      getTrustedMicrosoftLink(draft.externalUrl) ??
-      `${getOutlookBaseUrl(emailAddress)}/drafts/id/${encodeURIComponent(draft.id)}`,
+    // translation. Assembling /drafts/id/<graphId> uses the wrong id space
+    // (REST vs EWS) and reproduces INB-328, so there is no Graph-id fallback.
+    buildDraftUrl: (draft: DraftLinkTarget, _emailAddress?: string | null) =>
+      getTrustedMicrosoftLink(draft.externalUrl),
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
@@ -151,14 +152,15 @@ export function getEmailUrl(
  * while Gmail needs the thread. Resolve the draft via `EmailProvider.getDraft`
  * at link time — its message id changes on every edit.
  *
- * Outlook lands on the draft. Gmail lands on the draft's conversation in
- * Drafts; opening its composer needs an internal id the API does not expose.
+ * Outlook returns the trusted provider webLink, or null when none is available.
+ * Gmail returns a Drafts conversation URL (composer deeplinks need an internal
+ * id the API does not expose).
  */
 export function getEmailDraftUrl(
   draft: DraftLinkTarget,
   emailAddress?: string | null,
   provider?: string,
-): string {
+): string | null {
   const config = getProviderConfig(provider);
   return config.buildDraftUrl(draft, emailAddress);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to fork PR #3506 (`bahmd` / `fix/inb-328-open-related-draft`). Could not push to the fork head (`bahmd/inbox-zero` has no write access from this agent), so this branch carries the rebased PR plus Cubic review fixes.

## Changes vs #3506

- Rebased onto latest `main`
- **Cubic P2:** Removed the Outlook `${base}/drafts/id/${graphId}` fallback (wrong id space). Outlook now only redirects via a trusted Graph `webLink`; otherwise the route returns **422** with a clear message and logs a warning
- **Cubic P3:** Trusted Microsoft link check also rejects non-default ports (e.g. `https://outlook.live.com:8443/...`)

## Validation

- `pnpm test utils/url.test.ts app/api/user/meeting-recorder/meetings/[meetingId]/draft/route.test.ts` — 53 passed

## Note

Please prefer this branch over #3506, or cherry-pick / retarget as needed. Do not merge #3506 as-is with the Graph-id fallback. Replied on both open Cubic review threads on #3506.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57d76a5a-92ab-423c-9c45-c782f246d415?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57d76a5a-92ab-423c-9c45-c782f246d415&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gmail draft links now open the relevant draft conversation using its thread when available.
  - Outlook drafts now open through trusted provider-supplied links.

- **Bug Fixes**
  - Invalid or unavailable Outlook draft links now return a clear error instead of redirecting to an unsafe or unusable destination.
  - Draft redirects now validate link safety before sending users onward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->