### PR TITLE
fix: improve inline reply text contrast

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -1088,7 +1088,8 @@ function ComposeEmailFormContent({
         isComposeWindow
           ? "flex h-full min-h-0 flex-col overflow-hidden [&_[data-email-editor-root]]:min-h-0 [&_[data-email-editor-root]]:flex-1"
           : "space-y-2",
-        isInlineReply && "space-y-2 border-t border-border pt-4",
+        isInlineReply &&
+          "space-y-2 border-t border-border pt-4 [&_[data-email-editor-root]]:text-neutral-900 dark:[&_[data-email-editor-root]]:text-neutral-100",
       )}
     >
       <div className={cn(isComposeWindow ? "shrink-0 px-4" : "contents")}>


### PR DESCRIPTION
Inline reply text now uses a slightly darker neutral color so it reads as active text, with higher contrast in dark mode as well.

- Scoped the color adjustment to inline reply editors.
- Biome and diff checks passed. The focused compose-and-reply browser suite was blocked during login by invalid local database credentials.
- Styling only; no additional runtime work, database queries, or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the inline-reply form layout with clearer spacing and a separating top border.
  - Adjusted editor text colors for better readability in light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->