### PR TITLE
mail: Improve opt-in contact autocomplete

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -54,7 +54,7 @@ API_KEY_SALT= # openssl rand -hex 32
 CRON_SECRET= # openssl rand -hex 32 -note: cron disabled if not set
 
 NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
-# NEXT_PUBLIC_CONTACTS_ENABLED=false # Opt out of Gmail and Outlook contact suggestions (enabled by default)
+# NEXT_PUBLIC_CONTACTS_ENABLED=true # Opt in to Gmail and Outlook contact suggestions (disabled by default)
 # AUTO_JOIN_ORGANIZATION_ENABLED=true # Self-hosted: auto-add new users to the org
 # SSO_LOGIN_ENABLED=true # Show and allow SSO login
 # NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT= # Self-hosted: override the login footer notice. Set to none to hide it.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -54,7 +54,7 @@ API_KEY_SALT= # openssl rand -hex 32
 CRON_SECRET= # openssl rand -hex 32 -note: cron disabled if not set
 
 NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
-# NEXT_PUBLIC_CONTACTS_ENABLED=true # Suggest Gmail and Outlook contacts while composing
+# NEXT_PUBLIC_CONTACTS_ENABLED=false # Opt out of Gmail and Outlook contact suggestions (enabled by default)
 # AUTO_JOIN_ORGANIZATION_ENABLED=true # Self-hosted: auto-add new users to the org
 # SSO_LOGIN_ENABLED=true # Show and allow SSO login
 # NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT= # Self-hosted: override the login footer notice. Set to none to hide it.

--- a/apps/web/__tests__/playwright/emulated/mail/contact-autocomplete.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/contact-autocomplete.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail } from "./mail-test-helpers";
+
+test("suggests contacts in every recipient field and reuses cached searches", async ({
+  page,
+}, testInfo) => {
+  const queries: string[] = [];
+  await page.route("**/api/user/contacts?*", async (route) => {
+    const query =
+      new URL(route.request().url()).searchParams.get("query") ?? "";
+    queries.push(query);
+    await route.fulfill({
+      json: {
+        contacts:
+          query === "contact"
+            ? [
+                { name: "First Contact", emailAddress: "first@example.com" },
+                { name: "Second Contact", emailAddress: "second@example.com" },
+              ]
+            : [],
+      },
+    });
+  });
+  await openMail(page);
+  await page.getByRole("button", { name: /^Compose/ }).click();
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  const to = dialog.getByRole("combobox", { name: "To", exact: true });
+  await to.fill("contact");
+  await expect(
+    page.getByRole("option", { name: "First Contact" }),
+  ).toBeVisible();
+  await capturePlaywrightCheckpoint(page, testInfo, "contact-suggestions");
+  await to.press("ArrowDown");
+  await to.press("ArrowUp");
+  await to.press("Enter");
+  await expect(
+    dialog.getByRole("button", { name: "Remove first@example.com" }),
+  ).toBeVisible();
+  await expect(to).toHaveValue("");
+
+  await to.fill("contact");
+  await expect(
+    page.getByRole("option", { name: "Second Contact" }),
+  ).toBeVisible();
+  await expect(page.getByRole("option", { name: "First Contact" })).toHaveCount(
+    0,
+  );
+  await to.fill("unmatched");
+  await expect(
+    page.getByRole("option", { name: "Second Contact" }),
+  ).toHaveCount(0);
+  await to.fill("");
+
+  await dialog.getByRole("button", { name: "Cc/Bcc" }).click();
+  for (const name of ["Cc", "Bcc"]) {
+    const field = dialog.getByRole("combobox", { name, exact: true });
+    await field.fill("contact");
+    await page.getByRole("option", { name: "Second Contact" }).click();
+    await expect(field).toHaveValue("");
+  }
+  expect(queries.filter((query) => query === "contact")).toHaveLength(1);
+
+  const bcc = dialog.getByRole("combobox", { name: "Bcc", exact: true });
+  await bcc.fill("manual@example.com");
+  await bcc.press("Enter");
+  await expect(
+    dialog.getByRole("button", { name: "Remove manual@example.com" }),
+  ).toBeVisible();
+});

--- a/apps/web/__tests__/playwright/emulated/mail/contact-autocomplete.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/contact-autocomplete.spec.ts
@@ -7,10 +7,15 @@ test("suggests contacts in every recipient field and reuses cached searches", as
   page,
 }, testInfo) => {
   const queries: string[] = [];
+  let releaseSearch: () => void = () => {};
+  const pendingSearch = new Promise<void>((resolve) => {
+    releaseSearch = resolve;
+  });
   await page.route("**/api/user/contacts?*", async (route) => {
     const query =
       new URL(route.request().url()).searchParams.get("query") ?? "";
     queries.push(query);
+    if (query === "unmatched") await pendingSearch;
     await route.fulfill({
       json: {
         contacts:
@@ -47,10 +52,21 @@ test("suggests contacts in every recipient field and reuses cached searches", as
   await expect(page.getByRole("option", { name: "First Contact" })).toHaveCount(
     0,
   );
+  const unmatchedRequest = page.waitForRequest((request) =>
+    request.url().includes("/api/user/contacts?query=unmatched"),
+  );
   await to.fill("unmatched");
+  await unmatchedRequest;
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
   await expect(
     page.getByRole("option", { name: "Second Contact" }),
   ).toHaveCount(0);
+  releaseSearch();
   await to.fill("");
 
   await dialog.getByRole("button", { name: "Cc/Bcc" }).click();

--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -13,6 +13,9 @@
     "store/command-palette.ts",
     "app/(app)/[emailAccountId]/mail/snooze-command-palette.ts"
   ],
+  "contact-autocomplete.spec.ts": [
+    "app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx"
+  ],
   "compose-and-reply.spec.ts": [
     "app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx",
     "components/email-list/EmailThread.tsx"

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -133,6 +133,9 @@ for (const target of targets) {
         ),
         PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, target.name),
         PLAYWRIGHT_RUN_ID: targetRunId,
+        ...(target.path.endsWith("contact-autocomplete.spec.ts")
+          ? { NEXT_PUBLIC_CONTACTS_ENABLED: "true" }
+          : {}),
         ...(isIntegrationsTarget(target.path)
           ? { NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true" }
           : {}),

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -1578,7 +1578,8 @@ function ComposeContactRecipientField({
         ],
     {
       dedupingInterval: 5 * 60 * 1000,
-      revalidateOnFocus: false,
+      keepPreviousData: false,
+      revalidateOnFocus: true,
       onError(error) {
         if (error.info?.reconnectRequired) onReconnectRequired();
       },

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -22,7 +22,6 @@ import {
   ComboboxOptions,
 } from "@headlessui/react";
 import {
-  CheckCircleIcon,
   ChevronDownIcon,
   ImageIcon,
   PaperclipIcon,
@@ -74,6 +73,7 @@ import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { sendEmailAction, updateDraftAction } from "@/utils/actions/mail";
 import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import {
+  extractEmailAddress,
   extractNameFromEmail,
   isValidEmail,
   splitRecipientList,
@@ -1564,23 +1564,44 @@ function ComposeContactRecipientField({
   selectedRecipients: string;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const normalizedQuery = searchQuery.trim().toLowerCase();
   const label = RECIPIENT_LABELS[name];
   const selectedEmailAddresses = splitRecipientList(selectedRecipients);
 
   const { data: contacts } = useSWR<ContactsResponse, ContactsFetchError>(
-    reconnectRequired
+    reconnectRequired || !active
       ? null
       : [
-          `/api/user/contacts?query=${encodeURIComponent(searchQuery)}`,
+          `/api/user/contacts?query=${encodeURIComponent(debouncedQuery)}`,
           emailAccountId,
         ],
     {
-      keepPreviousData: true,
+      dedupingInterval: 5 * 60 * 1000,
+      revalidateOnFocus: false,
       onError(error) {
         if (error.info?.reconnectRequired) onReconnectRequired();
       },
     },
   );
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedQuery(normalizedQuery), 200);
+    return () => clearTimeout(timeout);
+  }, [normalizedQuery]);
+
+  const selectedAddresses = new Set(
+    selectedEmailAddresses.map((address) =>
+      extractEmailAddress(address).toLowerCase(),
+    ),
+  );
+  const suggestions =
+    normalizedQuery && normalizedQuery === debouncedQuery
+      ? (contacts?.contacts ?? []).filter(
+          (contact) =>
+            !selectedAddresses.has(contact.emailAddress.toLowerCase()),
+        )
+      : [];
 
   // The local input state resets on unmount (e.g. hiding Cc/Bcc), so the
   // parent's pending entry must reset with it or hidden text would still send.
@@ -1688,47 +1709,39 @@ function ComposeContactRecipientField({
             </div>
           )}
 
-          {active && !!contacts?.contacts.length && (
-            <ComboboxOptions className="absolute z-10 mt-1 max-h-60 overflow-auto rounded-md bg-popover py-1 text-base shadow-lg ring-1 ring-border focus:outline-none sm:text-sm">
-              <ComboboxOption
-                className="h-0 w-0 overflow-hidden"
-                value={searchQuery}
-              />
-              {contacts.contacts.map((contact) => (
+          {active && !!suggestions.length && (
+            <ComboboxOptions className="absolute z-20 mt-1 max-h-72 w-max min-w-full max-w-[min(28rem,calc(100vw-3rem))] overflow-auto rounded-md border bg-popover py-1 text-sm shadow-lg focus:outline-none">
+              {suggestions.map((contact) => (
                 <ComboboxOption
                   className={({ focus }) =>
-                    `cursor-default select-none px-4 py-1 text-foreground ${focus ? "bg-accent" : ""}`
+                    `cursor-pointer select-none px-3 py-1 text-foreground ${focus ? "bg-accent" : ""}`
                   }
                   key={contact.emailAddress}
                   value={contact.emailAddress}
                 >
-                  {({ selected }: { selected: boolean }) => (
-                    <div className="my-2 flex items-center">
-                      {selected ? (
-                        <div className="flex h-12 w-12 items-center justify-center rounded-full">
-                          <CheckCircleIcon className="h-6 w-6" />
+                  <div className="my-2 flex items-center">
+                    <Avatar className="shrink-0">
+                      <AvatarImage
+                        alt={contact.name ?? contact.emailAddress}
+                        src={contact.profilePictureUrl ?? undefined}
+                      />
+                      <AvatarFallback>
+                        {(contact.name || contact.emailAddress)
+                          .at(0)
+                          ?.toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="ml-3 flex min-w-0 flex-col justify-center">
+                      {contact.name && (
+                        <div className="truncate font-medium text-foreground">
+                          {contact.name}
                         </div>
-                      ) : (
-                        <Avatar>
-                          <AvatarImage
-                            alt={contact.emailAddress}
-                            src={contact.profilePictureUrl ?? undefined}
-                          />
-                          <AvatarFallback>
-                            {contact.emailAddress.at(0) || "A"}
-                          </AvatarFallback>
-                        </Avatar>
                       )}
-                      <div className="ml-4 flex flex-col justify-center">
-                        {contact.name && (
-                          <div className="text-foreground">{contact.name}</div>
-                        )}
-                        <div className="text-sm font-semibold text-muted-foreground">
-                          {contact.emailAddress}
-                        </div>
+                      <div className="truncate text-sm text-muted-foreground">
+                        {contact.emailAddress}
                       </div>
                     </div>
-                  )}
+                  </div>
                 </ComboboxOption>
               ))}
             </ComboboxOptions>

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -402,7 +402,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_BRAND_ICON_URL: z.string().optional().default("/icon.png"),
     NEXT_PUBLIC_SLACK_BOT_NAME: z.string().trim().min(1).default("Inbox Zero"),
     NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT: z.string().optional(),
-    NEXT_PUBLIC_CONTACTS_ENABLED: booleanString.optional().default(true),
+    NEXT_PUBLIC_CONTACTS_ENABLED: booleanString.optional().default(false),
     NEXT_PUBLIC_EMAIL_SEND_ENABLED: booleanString.default(true),
     NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: booleanString.optional().default(true),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -402,7 +402,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_BRAND_ICON_URL: z.string().optional().default("/icon.png"),
     NEXT_PUBLIC_SLACK_BOT_NAME: z.string().trim().min(1).default("Inbox Zero"),
     NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT: z.string().optional(),
-    NEXT_PUBLIC_CONTACTS_ENABLED: booleanString.optional().default(false),
+    NEXT_PUBLIC_CONTACTS_ENABLED: booleanString.optional().default(true),
     NEXT_PUBLIC_EMAIL_SEND_ENABLED: booleanString.default(true),
     NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: booleanString.optional().default(true),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -183,7 +183,8 @@ export default defineConfig({
         NEXT_PUBLIC_POSTHOG_API_HOST: "",
         NEXT_PUBLIC_DUB_REFER_DOMAIN: "",
         NEXT_PUBLIC_IS_RESEND_CONFIGURED: "",
-        NEXT_PUBLIC_CONTACTS_ENABLED: "false",
+        NEXT_PUBLIC_CONTACTS_ENABLED:
+          process.env.NEXT_PUBLIC_CONTACTS_ENABLED ?? "false",
         NEXT_PUBLIC_EMAIL_SEND_ENABLED: "true",
         NEXT_PUBLIC_MEETING_RECORDER_ENABLED: "true",
         PLAYWRIGHT_TEST_EMAIL: playwrightTestEmail,


### PR DESCRIPTION
Improve opt-in contact autocomplete for To, Cc, and Bcc, with clearer suggestions and keyboard selection.

- Debounce searches by 200 ms, deduplicate account-scoped requests for five minutes, refresh on focus, and hide stale matches and already-selected recipients.
- Keep contact suggestions disabled by default and add focused browser coverage for selection, manual entry, cache reuse, and pending searches.
- Validated with 24 focused unit tests, emulated browser tests, formatting checks, screenshot inspection, and passing CI before restoring the opt-in default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added contact suggestions while composing emails in the To, Cc, and Bcc fields.
  - Suggestions support delayed searching, keyboard navigation, selection, and manual email entry.
  - Previously selected addresses are excluded from suggestion results.
  - Contact avatars and refreshed dropdown styling improve the suggestion experience.

- **Bug Fixes**
  - Prevented stale suggestions from appearing while a new search is pending.
  - Reused recent search results to avoid unnecessary repeat requests.

- **Tests**
  - Added end-to-end coverage for recipient autocomplete interactions and pending searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->