### PR TITLE
Mail: Add split tab reordering and simplify controls

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -1,3 +1,4 @@
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import { INITIAL_MAIL_SPLITS } from "@/utils/mail/initial-splits";
 import { expect } from "@playwright/test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
@@ -60,6 +61,19 @@ test("restores a deleted All tab and protects it from removal", async ({
       [emailAccountId, "All"],
     ),
   );
+  await withClient(async (client) => {
+    for (let index = 1; index < MAX_MAIL_SPLITS; index++) {
+      await client.query(
+        `WITH split AS (
+          INSERT INTO "MailSplit" (id, "updatedAt", "emailAccountId", name, "matchAll", "order")
+          VALUES (gen_random_uuid()::text, NOW(), $1, $2, true, $3) RETURNING id
+        )
+        INSERT INTO "MailSplitFilter" (id, "mailSplitId", kind, "order")
+        SELECT gen_random_uuid()::text, id, 'UNREAD', 0 FROM split`,
+        [emailAccountId, `Split ${index}`, index + 1],
+      );
+    }
+  });
   await openMail(page);
   const allTab = page
     .locator("button[data-split-tab]")
@@ -70,6 +84,33 @@ test("restores a deleted All tab and protects it from removal", async ({
     page.getByRole("menuitem", { name: "Turn off split" }),
   ).toBeHidden();
   await capturePlaywrightCheckpoint(page, testInfo, "mail-protected-all-split");
+  await page.getByRole("button", { name: "New split", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Move All down", exact: true }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Move Unread up", exact: true }),
+  ).toBeDisabled();
+  await expect(page.locator('[data-drag-split="all"]')).toHaveAttribute(
+    "draggable",
+    "false",
+  );
+  const tabs = page.locator("button[data-split-tab]");
+  const original = await tabs.allTextContents();
+  expect(original).toHaveLength(MAX_MAIL_SPLITS + 1);
+  await page
+    .getByRole("button", { name: "Move Unread down", exact: true })
+    .click();
+  const expected = [
+    original[0],
+    original[2],
+    original[1],
+    ...original.slice(3),
+  ];
+  await expect(tabs).toHaveText(expected);
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await page.reload();
+  await expect(tabs).toHaveText(expected);
 });
 
 test("moves focus with the active split when cycling by keyboard", async ({

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -186,3 +186,35 @@ test("turns a prepared split on from the library", async ({
   await page.getByRole("menuitem", { name: "Turn off split" }).click();
   await expect(starredSplit).toHaveCount(0);
 });
+
+test("reorders splits with arrows and dragging and persists tab order", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  const tabs = page.locator("button[data-split-tab]");
+  const original = await tabs.allTextContents();
+  expect(original.length).toBeGreaterThan(1);
+  await page.getByRole("button", { name: "New split", exact: true }).click();
+  const list = page.getByRole("list", { name: "Split order" });
+  await page
+    .getByRole("button", { name: `Move ${original[0]} down`, exact: true })
+    .click();
+  await expect(list).toHaveAttribute("aria-busy", "false");
+  const expected = [original[1], original[0], ...original.slice(2)];
+  await expect(tabs).toHaveText(expected);
+  await expect(
+    page.getByRole("button", { name: "Turn off the All split", exact: true }),
+  ).toBeDisabled();
+  await hideDevIndicator(page);
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-sortable-splits");
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await page.reload();
+  await expect(tabs).toHaveText(expected);
+  await page.getByRole("button", { name: "New split", exact: true }).click();
+  const rows = list.getByRole("listitem");
+  await rows.nth(0).locator("[data-drag-split]").dragTo(rows.nth(1));
+  await expect(tabs).toHaveText(original);
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await page.reload();
+  await expect(tabs).toHaveText(original);
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -99,6 +99,7 @@ import {
   buildMailSplitFromPromptAction,
   createMailSplitAction,
   deleteMailSplitAction,
+  reorderMailSplitsAction,
   updateMailSplitAction,
   updateMailPreferencesAction,
 } from "@/utils/actions/mail-split";
@@ -1181,6 +1182,20 @@ export function MailShell() {
     [emailAccountId, splitCategoryChoices, splitLabelChoices, splitSenders],
   );
 
+  const onReorderSplits = useCallback(
+    async (ids: string[]) => {
+      const result = await reorderMailSplitsAction(emailAccountId, { ids });
+      if (result?.serverError || result?.validationErrors) {
+        toast.error(getActionErrorMessage(result));
+        await mutateSettings();
+        return false;
+      }
+      await mutateSettings();
+      return true;
+    },
+    [emailAccountId, mutateSettings],
+  );
+
   const onDeleteSplit = useCallback(
     async (splitId: string) => {
       const result = await deleteMailSplitAction(emailAccountId, {
@@ -1588,6 +1603,8 @@ export function MailShell() {
           onCreate={onCreateSplit}
           onUpdate={onUpdateSplit}
           onDelete={onDeleteSplit}
+          onReorder={onReorderSplits}
+          onEdit={setEditingSplitId}
           onDescribe={onDescribeSplit}
         />
       )}

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CheckIcon,
+  GripVerticalIcon,
   ChevronLeftIcon,
   Loader2Icon,
   PlusIcon,
@@ -75,6 +79,8 @@ export type NewSplitDialogProps = {
     filters: MailSplitFilterDraft[];
   }) => Promise<boolean>;
   onDelete: (id: string) => Promise<boolean>;
+  onReorder: (ids: string[]) => Promise<boolean>;
+  onEdit: (id: string) => void;
   onDescribe: (prompt: string) => Promise<{
     filters: MailSplitFilterDraft[];
     name: string | null;
@@ -100,6 +106,8 @@ export function NewSplitDialog({
   onCreate,
   onUpdate,
   onDelete,
+  onReorder,
+  onEdit,
   onDescribe,
 }: NewSplitDialogProps) {
   const [mode, setMode] = useState<"library" | "build" | "describe">("library");
@@ -110,6 +118,34 @@ export function NewSplitDialog({
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [isBusy, setIsBusy] = useState(false);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+
+  const moveSplit = async (id: string, targetId: string) => {
+    if (isBusy || id === targetId) return;
+    const ids = existingSplits.map((split) => split.id);
+    const from = ids.indexOf(id);
+    const to = ids.indexOf(targetId);
+    if (from < 0 || to < 0) return;
+    ids.splice(from, 1);
+    ids.splice(to, 0, id);
+    setIsBusy(true);
+    try {
+      await onReorder(ids);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const removeSplit = async (id: string) => {
+    if (isBusy) return;
+    setIsBusy(true);
+    try {
+      await onDelete(id);
+    } finally {
+      setIsBusy(false);
+    }
+  };
 
   const fields = useMemo(
     () =>
@@ -390,27 +426,100 @@ export function NewSplitDialog({
 
               {category === YOUR_SPLITS ? (
                 existingSplits.length ? (
-                  <div className="grid grid-cols-2 gap-2">
-                    {existingSplits.map((split) => (
-                      <div
+                  <ul
+                    className="space-y-1"
+                    aria-label="Split order"
+                    aria-busy={isBusy}
+                  >
+                    {existingSplits.map((split, index) => (
+                      <li
                         key={split.id}
-                        className="flex min-w-0 items-center gap-2 rounded-xl border border-primary/25 bg-primary/5 px-3 py-2.5 text-primary"
+                        className={cn(
+                          "flex min-w-0 items-center gap-1 rounded-lg px-1 py-1.5",
+                          dropTargetId === split.id
+                            ? "bg-accent ring-1 ring-border"
+                            : "hover:bg-muted/50",
+                          draggedId === split.id && "opacity-50",
+                        )}
+                        onDragOver={(event) => {
+                          if (!draggedId || isBusy) return;
+                          event.preventDefault();
+                          event.dataTransfer.dropEffect = "move";
+                          setDropTargetId(split.id);
+                        }}
+                        onDragLeave={() => setDropTargetId(null)}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          if (draggedId) moveSplit(draggedId, split.id);
+                          setDraggedId(null);
+                          setDropTargetId(null);
+                        }}
                       >
-                        <span className="min-w-0 flex-1 truncate font-medium text-[13px]">
-                          {split.name}
+                        <span
+                          draggable={!isBusy}
+                          data-drag-split={split.id}
+                          aria-hidden="true"
+                          className="cursor-grab p-1 text-muted-foreground active:cursor-grabbing"
+                          onDragStart={(event) => {
+                            event.dataTransfer.setData("text/plain", split.id);
+                            event.dataTransfer.effectAllowed = "move";
+                            setDraggedId(split.id);
+                          }}
+                          onDragEnd={() => {
+                            setDraggedId(null);
+                            setDropTargetId(null);
+                          }}
+                        >
+                          <GripVerticalIcon className="size-3.5" />
                         </span>
                         <button
                           type="button"
-                          disabled={!split.filters.length}
-                          aria-label={`Turn off the ${split.name} split`}
-                          onClick={() => onDelete(split.id)}
-                          className="flex size-4.5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          disabled={isBusy || !split.filters.length}
+                          aria-label={`Edit the ${split.name} split`}
+                          onClick={() => onEdit(split.id)}
+                          className="min-w-0 flex-1 truncate rounded text-left font-medium text-[13px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                         >
-                          <XIcon className="size-2.5" />
+                          {split.name}
                         </button>
-                      </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7 text-muted-foreground"
+                          aria-label={`Move ${split.name} up`}
+                          disabled={isBusy || index === 0}
+                          onClick={() =>
+                            moveSplit(split.id, existingSplits[index - 1].id)
+                          }
+                        >
+                          <ArrowUpIcon className="size-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7 text-muted-foreground"
+                          aria-label={`Move ${split.name} down`}
+                          disabled={
+                            isBusy || index === existingSplits.length - 1
+                          }
+                          onClick={() =>
+                            moveSplit(split.id, existingSplits[index + 1].id)
+                          }
+                        >
+                          <ArrowDownIcon className="size-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7 text-muted-foreground"
+                          disabled={isBusy || !split.filters.length}
+                          aria-label={`Turn off the ${split.name} split`}
+                          onClick={() => removeSplit(split.id)}
+                        >
+                          <XIcon className="size-3.5" />
+                        </Button>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 ) : (
                   <p className="text-muted-foreground text-xs leading-relaxed">
                     Splits you build yourself land here.
@@ -683,13 +792,15 @@ function LibraryTile({
         onClick={onToggle}
         disabled={disabled}
         className={cn(
-          "flex size-4.5 shrink-0 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          on
-            ? "bg-primary text-primary-foreground hover:bg-destructive"
-            : "text-muted-foreground hover:bg-primary/10 hover:text-primary",
+          "flex size-6 shrink-0 items-center justify-center rounded-md hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          on ? "text-primary" : "text-muted-foreground hover:text-foreground",
         )}
       >
-        {on ? <CheckGlyph /> : <PlusIcon className="size-3" />}
+        {on ? (
+          <CheckIcon className="size-3.5" />
+        ) : (
+          <PlusIcon className="size-3.5" />
+        )}
       </button>
     </div>
   );
@@ -810,23 +921,6 @@ function InfoGlyph() {
       <circle cx="12" cy="12" r="9" />
       <path d="M12 11v5" />
       <path d="M12 8h.01" />
-    </svg>
-  );
-}
-
-function CheckGlyph() {
-  return (
-    <svg
-      aria-hidden
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-2.5"
-    >
-      <path d="m5 12 5 5L20 7" />
     </svg>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -122,8 +122,10 @@ export function NewSplitDialog({
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
 
   const moveSplit = async (id: string, targetId: string) => {
-    if (isBusy || id === targetId) return;
-    const ids = existingSplits.map((split) => split.id);
+    if (isBusy || id === targetId || id === "all" || targetId === "all") return;
+    const ids = existingSplits
+      .filter((split) => split.id !== "all")
+      .map((split) => split.id);
     const from = ids.indexOf(id);
     const to = ids.indexOf(targetId);
     if (from < 0 || to < 0) return;
@@ -442,7 +444,8 @@ export function NewSplitDialog({
                           draggedId === split.id && "opacity-50",
                         )}
                         onDragOver={(event) => {
-                          if (!draggedId || isBusy) return;
+                          if (!draggedId || isBusy || split.id === "all")
+                            return;
                           event.preventDefault();
                           event.dataTransfer.dropEffect = "move";
                           setDropTargetId(split.id);
@@ -456,10 +459,15 @@ export function NewSplitDialog({
                         }}
                       >
                         <span
-                          draggable={!isBusy}
+                          draggable={!isBusy && split.id !== "all"}
                           data-drag-split={split.id}
                           aria-hidden="true"
-                          className="cursor-grab p-1 text-muted-foreground active:cursor-grabbing"
+                          className={cn(
+                            "p-1 text-muted-foreground",
+                            split.id === "all"
+                              ? "invisible"
+                              : "cursor-grab active:cursor-grabbing",
+                          )}
                           onDragStart={(event) => {
                             event.dataTransfer.setData("text/plain", split.id);
                             event.dataTransfer.effectAllowed = "move";
@@ -486,7 +494,12 @@ export function NewSplitDialog({
                           size="icon"
                           className="size-7 text-muted-foreground"
                           aria-label={`Move ${split.name} up`}
-                          disabled={isBusy || index === 0}
+                          disabled={
+                            isBusy ||
+                            split.id === "all" ||
+                            index === 0 ||
+                            existingSplits[index - 1].id === "all"
+                          }
                           onClick={() =>
                             moveSplit(split.id, existingSplits[index - 1].id)
                           }
@@ -499,7 +512,9 @@ export function NewSplitDialog({
                           className="size-7 text-muted-foreground"
                           aria-label={`Move ${split.name} down`}
                           disabled={
-                            isBusy || index === existingSplits.length - 1
+                            isBusy ||
+                            split.id === "all" ||
+                            index === existingSplits.length - 1
                           }
                           onClick={() =>
                             moveSplit(split.id, existingSplits[index + 1].id)

--- a/apps/web/utils/actions/mail-split.test.ts
+++ b/apps/web/utils/actions/mail-split.test.ts
@@ -6,6 +6,7 @@ import {
   buildMailSplitFromPromptAction,
   createMailSplitAction,
   deleteMailSplitAction,
+  reorderMailSplitsAction,
   updateMailPreferencesAction,
   updateMailSplitAction,
 } from "@/utils/actions/mail-split";
@@ -41,6 +42,14 @@ describe("mail split actions", () => {
       email: "user@example.com",
       account: { userId: "user-1", provider: "google" },
     } as never);
+  });
+
+  it("rejects duplicate split IDs before attempting a reorder", async () => {
+    const result = await reorderMailSplitsAction(EMAIL_ACCOUNT_ID, {
+      ids: ["split-1", "split-1"],
+    });
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("only deletes filtered splits belonging to the account", async () => {

--- a/apps/web/utils/actions/mail-split.ts
+++ b/apps/web/utils/actions/mail-split.ts
@@ -9,13 +9,18 @@ import {
   buildMailSplitFromPromptBody,
   createMailSplitBody,
   deleteMailSplitBody,
+  reorderMailSplitsBody,
   updateMailPreferencesBody,
   updateMailSplitBody,
 } from "@/utils/actions/mail-split.validation";
 import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
 import { aiPromptToSplitFilters } from "@/utils/ai/split/prompt-to-split";
 import { getEmailAccountWithAi } from "@/utils/user/get";
-import { createMailSplit, toFilterRows } from "@/utils/mail/splits.server";
+import {
+  createMailSplit,
+  reorderMailSplits,
+  toFilterRows,
+} from "@/utils/mail/splits.server";
 import { lockMailSplits } from "@/utils/mail/split-lock";
 import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 
@@ -135,6 +140,13 @@ export const deleteMailSplitAction = actionClient
       }),
     ]);
     if (!count) throw new SafeError("Split not found or cannot be removed");
+  });
+
+export const reorderMailSplitsAction = actionClient
+  .metadata({ name: "reorderMailSplits" })
+  .inputSchema(reorderMailSplitsBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { ids } }) => {
+    await reorderMailSplits({ emailAccountId, ids });
   });
 
 export const updateMailPreferencesAction = actionClient

--- a/apps/web/utils/actions/mail-split.validation.ts
+++ b/apps/web/utils/actions/mail-split.validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MAX_MAIL_SPLITS } from "@/utils/mail/split-constants";
 import { MailLayout } from "@/generated/prisma/enums";
 import {
   mailSplitFiltersSchema,
@@ -50,6 +51,17 @@ export const buildMailSplitFromPromptBody = z.object({
 export type BuildMailSplitFromPromptBody = z.infer<
   typeof buildMailSplitFromPromptBody
 >;
+
+export const reorderMailSplitsBody = z.object({
+  ids: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_MAIL_SPLITS)
+    .refine(
+      (ids) => new Set(ids).size === ids.length,
+      "Split IDs must be unique",
+    ),
+});
 
 export const deleteMailSplitBody = z.object({ id: z.string() });
 export type DeleteMailSplitBody = z.infer<typeof deleteMailSplitBody>;


### PR DESCRIPTION
Split inbox tabs can now be reordered from “Your splits” using drag handles or move up/down buttons, with the order saved across reloads. Selected splits use a compact list with editable names and neutral remove buttons; the library keeps its two-column grid and uses simple checkmarks without destructive hover styling.

- Keeps the synthetic fallback All tab pinned and excludes it from reorder requests, including at the split limit.
- Reuses the existing account-scoped reorder transaction; no schema changes or additional work during normal mailbox rendering.
- Validation: focused action/validation tests, existing database tests, focused split-tab browser tests, screenshot inspection, and scoped Biome checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail split tabs can now be reordered using drag-and-drop or up/down controls.
  * The updated order is saved and remains consistent across sessions.
  * The built-in **All** tab stays protected from reordering.
  * Split management now supports clearer edit, disable, and delete interactions.

* **Bug Fixes**
  * The **Other** tab now correctly excludes messages matched by enabled splits and restores them when those splits are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->