### PR TITLE
feat(mail): add important and catch-all inbox splits

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -242,5 +242,21 @@ test("Other excludes enabled splits and restores mail when a split is disabled",
     .getByRole("button", { name: "Promos", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Turn off split" }).click();
+  await page.getByRole("button", { name: "Other", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Other", exact: true }),
+  ).toHaveAttribute("aria-current", "true");
   await expect(promotion).toBeVisible();
+
+  await page.getByRole("button", { name: "New split" }).click();
+  await page.getByRole("button", { name: "Build your own" }).click();
+  await page.getByLabel("Condition field").first().selectOption("STARRED");
+  await page.getByLabel("Split name").fill("Other");
+  await page.getByRole("button", { name: "Add split" }).click();
+  await expect(
+    page.getByRole("button", { name: "Other (custom)", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Other", exact: true }),
+  ).toBeVisible();
 });

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -164,3 +164,61 @@ test("turns a prepared split on from the library", async ({
   await page.getByRole("menuitem", { name: "Turn off split" }).click();
   await expect(starredSplit).toHaveCount(0);
 });
+
+test("Other excludes enabled splits and restores mail when a split is disabled", async ({
+  page,
+}, testInfo) => {
+  const { conversations } = await openMail(page);
+  // Remove Unread so category membership alone determines this partition.
+  await page
+    .getByRole("button", { name: "Unread", exact: true })
+    .click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Turn off split" }).click();
+  await page.getByRole("button", { name: "Other", exact: true }).click();
+  const promotion = conversationWithSubject(
+    page,
+    conversations,
+    "Promotion Category Message",
+  );
+  await expect(promotion).toBeVisible();
+
+  await page.getByRole("button", { name: "New split" }).click();
+  await page.getByRole("button", { name: "General", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Turn on the Important split", exact: true })
+    .click();
+  await expect(
+    page.getByRole("button", {
+      name: "Turn off the Important split",
+      exact: true,
+    }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(
+    page.getByRole("button", { name: "Important", exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "New split" }).click();
+  await page.getByRole("button", { name: "Build your own" }).click();
+  await page.getByLabel("Condition field").first().selectOption("CATEGORY");
+  await page
+    .getByLabel("Condition value")
+    .first()
+    .selectOption({ label: "Promotions" });
+  await page.getByLabel("Split name").fill("Promos");
+  await page.getByRole("button", { name: "Add split" }).click();
+  await expect(promotion).toBeVisible();
+  await page.getByRole("button", { name: "Other", exact: true }).click();
+  await expect(promotion).toHaveCount(0);
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-other-excludes-enabled-splits",
+  );
+
+  await page
+    .getByRole("button", { name: "Promos", exact: true })
+    .click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Turn off split" }).click();
+  await expect(promotion).toBeVisible();
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GmailLabel } from "@/utils/gmail/label";
 import { isThreadStarred } from "@/app/(app)/[emailAccountId]/mail/star-state";
 import {
   type CSSProperties,
@@ -111,6 +112,8 @@ import {
 } from "@/utils/actions/mail";
 import {
   getPortableLabelSplits,
+  OTHER_SPLIT_ID,
+  otherMailSplitQuery,
   mailSplitToThreadsQuery,
   mailTypeToThreadsQuery,
 } from "@/utils/mail/split-query";
@@ -310,7 +313,19 @@ export function MailShell() {
 
   const splits = useMemo(
     () =>
-      (settings?.splits ?? []).filter(
+      [
+        ...(settings?.splits ?? []),
+        ...(isGoogle && !isAllAccounts
+          ? [
+              {
+                id: OTHER_SPLIT_ID,
+                name: "Other",
+                matchAll: true,
+                filters: [],
+              },
+            ]
+          : []),
+      ].filter(
         (split) =>
           !isAllAccounts ||
           split.filters.every(
@@ -318,7 +333,7 @@ export function MailShell() {
           ) ||
           combinedLabelSplits.some((portable) => portable.id === split.id),
       ),
-    [settings?.splits, isAllAccounts, combinedLabelSplits],
+    [settings?.splits, isAllAccounts, combinedLabelSplits, isGoogle],
   );
   const activeSplit =
     splits.find((split) => split.id === activeSplitId) ?? splits[0];
@@ -332,10 +347,11 @@ export function MailShell() {
     if (searchQuery) return { q: searchQuery };
     if (scopeQuery) return scopeQuery;
 
+    if (activeSplit?.id === OTHER_SPLIT_ID) return otherMailSplitQuery(splits);
     return activeSplit
       ? mailSplitToThreadsQuery(activeSplit)
       : { type: "inbox" };
-  }, [searchQuery, scopeQuery, activeSplit]);
+  }, [searchQuery, scopeQuery, activeSplit, splits]);
 
   const accountThreadState = useMailThreads({
     emailAccountId,
@@ -1062,12 +1078,15 @@ export function MailShell() {
 
   const splitLabelChoices = useMemo(
     () =>
-      visibleLabels.map((label) => ({
+      [
+        ...visibleLabels,
+        ...(isGoogle ? [{ id: GmailLabel.IMPORTANT, name: "Important" }] : []),
+      ].map((label) => ({
         id: `label:${label.id}`,
         name: label.name,
         value: label.id,
       })),
-    [visibleLabels],
+    [visibleLabels, isGoogle],
   );
   const splitCategoryChoices = useMemo(
     () =>
@@ -1421,7 +1440,10 @@ export function MailShell() {
             />
             {!isScoped && !searchQuery && (
               <SplitTabs
-                splits={splits.map((split) => ({ ...split, deletable: true }))}
+                splits={splits.map((split) => ({
+                  ...split,
+                  deletable: split.id !== OTHER_SPLIT_ID,
+                }))}
                 activeSplitId={displayedActiveSplitId}
                 onSelect={setActiveSplitId}
                 onDelete={onDeleteSplit}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadList.tsx
@@ -132,7 +132,7 @@ export function ThreadList({
         className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
         ref={setScrollRoot}
       >
-        {threads.length === 0 ? (
+        {threads.length === 0 && !showLoadMore ? (
           <div className="px-6 py-12 text-center text-muted-foreground text-sm">
             No emails in this view
           </div>

--- a/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/use-mail-threads.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { createOtherSplitFilter } from "@/utils/mail/thread-matches-split";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 import useSWRInfinite from "swr/infinite";
@@ -252,14 +253,17 @@ export function useMailThreads({
       mutations: mailMutations,
       threads: sourceThreads ?? [],
     });
-    return query.isUnread
-      ? overlaidThreads.filter((thread) => isThreadUnread(thread.messages))
-      : overlaidThreads;
+    const isOther = createOtherSplitFilter(query.excludeSplits ?? []);
+    return overlaidThreads.filter(
+      (thread) =>
+        (!query.isUnread || isThreadUnread(thread.messages)) && isOther(thread),
+    );
   }, [
     emailAccountId,
     mailMutations,
     mutationOverlayReady,
     query.isUnread,
+    query.excludeSplits,
     sourceThreads,
   ]);
 

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -49,6 +49,7 @@ export const GET = withEmailProvider(
       before,
       isUnread,
       anyOf,
+      excludeSplits: searchParams.get("excludeSplits"),
     });
 
     try {

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -57,6 +57,22 @@ describe("synced mailbox cache", () => {
     expect(result?.threads.map(({ id }) => id)).toEqual(["other"]);
   });
 
+  it("falls back when a cached exclusion filter is malformed", async () => {
+    const result = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: {
+        type: "inbox",
+        excludeSplits: [
+          {
+            matchAll: true,
+            filters: [{ kind: "OLDER_THAN", value: "invalid" }],
+          },
+        ],
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
   it("invalidates all detail variants for changed threads and deleted cached drafts", async () => {
     const database = await getEmailCacheDatabase();
     if (!database) throw new Error("Database unavailable");

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -23,6 +23,40 @@ describe("synced mailbox cache", () => {
     await clearEmailCache();
   });
 
+  it("excludes named splits from cached Other results", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2020-01-01"),
+      page: {
+        cursor: "complete",
+        reset: true,
+        hasMore: false,
+        deletedMessageIds: [],
+        upsertedMessages: [
+          getMessage({
+            id: "important",
+            threadId: "important",
+            labelIds: ["INBOX", "IMPORTANT"],
+          }),
+          getMessage({ id: "other", threadId: "other", labelIds: ["INBOX"] }),
+        ],
+      },
+    });
+    const result = await readSyncedMailboxThreads({
+      emailAccountId: "account-1",
+      query: {
+        type: "inbox",
+        excludeSplits: [
+          {
+            matchAll: true,
+            filters: [{ kind: "LABEL", value: "IMPORTANT" }],
+          },
+        ],
+      },
+    });
+    expect(result?.threads.map(({ id }) => id)).toEqual(["other"]);
+  });
+
   it("invalidates all detail variants for changed threads and deleted cached drafts", async () => {
     const database = await getEmailCacheDatabase();
     if (!database) throw new Error("Database unavailable");

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -186,10 +186,10 @@ export async function readSyncedMailboxThreads({
   limit?: number;
 }): Promise<SyncedMailboxSnapshot | undefined> {
   if (!isSupportedMailboxQuery(query)) return;
-  const isOther = createOtherSplitFilter(query.excludeSplits ?? []);
   const epoch = captureEmailCacheEpoch(emailAccountId);
 
   try {
+    const isOther = createOtherSplitFilter(query.excludeSplits ?? []);
     const database = await getEmailCacheDatabase();
     if (!database || !isEmailCacheEpochCurrent(emailAccountId, epoch)) return;
     const transaction = database.transaction(

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -1,3 +1,4 @@
+import { createOtherSplitFilter } from "@/utils/mail/thread-matches-split";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { internalDateToDate, sortByInternalDate } from "@/utils/date";
 import { canonicalizeEmailAddress } from "@/utils/email";
@@ -185,6 +186,7 @@ export async function readSyncedMailboxThreads({
   limit?: number;
 }): Promise<SyncedMailboxSnapshot | undefined> {
   if (!isSupportedMailboxQuery(query)) return;
+  const isOther = createOtherSplitFilter(query.excludeSplits ?? []);
   const epoch = captureEmailCacheEpoch(emailAccountId);
 
   try {
@@ -288,7 +290,10 @@ export async function readSyncedMailboxThreads({
           const threadMessages = threadRecords
             .map((record) => record.data)
             .filter((message) => !isIgnoredSender(message.headers.from));
-          if (threadMatchesQuery(threadMessages, query)) {
+          if (
+            isOther({ messages: threadMessages }) &&
+            threadMatchesQuery(threadMessages, query)
+          ) {
             selectedRecords.push(threadRecords);
             if (selectedRecords.length >= limit + 1) break;
           }
@@ -308,7 +313,10 @@ export async function readSyncedMailboxThreads({
         .filter((message) => !isIgnoredSender(message.headers.from)),
     );
     const matchingThreads = [...messagesByThread.entries()]
-      .filter(([, messages]) => threadMatchesQuery(messages, query))
+      .filter(
+        ([, messages]) =>
+          isOther({ messages }) && threadMatchesQuery(messages, query),
+      )
       .sort(
         ([, left], [, right]) =>
           getMessageTimestamp(right.at(-1)) - getMessageTimestamp(left.at(-1)),
@@ -555,6 +563,7 @@ function isCompleteMailboxQuery(query: ThreadsQuery) {
 function isRecentInboxQuery(query: ThreadsQuery) {
   return (
     query.type === "inbox" &&
+    !query.excludeSplits?.length &&
     !query.fromEmail &&
     !query.folderId &&
     !query.isUnread &&

--- a/apps/web/utils/mail/split-library.ts
+++ b/apps/web/utils/mail/split-library.ts
@@ -1,3 +1,4 @@
+import { GmailLabel } from "@/utils/gmail/label";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
 
@@ -22,6 +23,12 @@ export type SplitLibraryEntry = {
 };
 
 export const SPLIT_LIBRARY: SplitLibraryEntry[] = [
+  {
+    name: "Important",
+    category: "General",
+    description: "Based on Gmail’s importance markers.",
+    conditions: [{ kind: "LABEL", labelName: GmailLabel.IMPORTANT }],
+  },
   {
     name: "To reply",
     category: "General",

--- a/apps/web/utils/mail/split-library.ts
+++ b/apps/web/utils/mail/split-library.ts
@@ -1,4 +1,3 @@
-import { GmailLabel } from "@/utils/gmail/label";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
 
@@ -27,7 +26,7 @@ export const SPLIT_LIBRARY: SplitLibraryEntry[] = [
     name: "Important",
     category: "General",
     description: "Based on Gmail’s importance markers.",
-    conditions: [{ kind: "LABEL", labelName: GmailLabel.IMPORTANT }],
+    conditions: [{ kind: "LABEL", labelName: "Important" }],
   },
   {
     name: "To reply",

--- a/apps/web/utils/mail/split-query.ts
+++ b/apps/web/utils/mail/split-query.ts
@@ -18,6 +18,22 @@ export type MailSplit = {
   filters: MailSplitFilter[];
 };
 
+type QuerySplit = Pick<MailSplit, "matchAll" | "filters"> & { name?: string };
+
+export const OTHER_SPLIT_ID = "other-inbox";
+
+export function otherMailSplitQuery(splits: MailSplit[]): ThreadsQuery {
+  return {
+    type: "inbox",
+    excludeSplits: splits
+      .filter((split) => split.filters.length > 0)
+      .map(({ matchAll, filters }) => ({
+        matchAll,
+        filters: filters.map(({ kind, value }) => ({ kind, value })),
+      })),
+  };
+}
+
 export type PortableLabelSplit = MailSplit & { labelNames: string[] };
 
 /** Tokens the "Older than" condition offers, and how far back each one reaches. */
@@ -40,7 +56,7 @@ export const OLDER_THAN_OPTIONS = [
  * `now` is injected so the "older than" window is testable.
  */
 export function mailSplitToThreadsQuery(
-  split: MailSplit,
+  split: QuerySplit,
   now: Date = new Date(),
 ): ThreadsQuery {
   // A split with no conditions is the plain inbox — that's what "All" is.
@@ -83,7 +99,7 @@ export function getPortableLabelSplits(
 }
 
 /** Everything ANDs into a single provider query. */
-function matchAllQuery(split: MailSplit, now: Date): ThreadsQuery {
+function matchAllQuery(split: QuerySplit, now: Date): ThreadsQuery {
   const labelIds = ["INBOX"];
   const query: ThreadsQuery = {};
 
@@ -130,7 +146,7 @@ function matchAllQuery(split: MailSplit, now: Date): ThreadsQuery {
  * "Match any" is a disjunction, which a single flat query can't express, so each
  * condition becomes its own leaf and the provider ORs them inside the inbox.
  */
-function matchAnyQuery(split: MailSplit, now: Date): ThreadsQuery {
+function matchAnyQuery(split: QuerySplit, now: Date): ThreadsQuery {
   const anyOf = split.filters.map<ThreadsQueryLeaf>((filter) => {
     switch (filter.kind) {
       case MailSplitFilterKind.UNREAD:
@@ -159,16 +175,18 @@ function matchAnyQuery(split: MailSplit, now: Date): ThreadsQuery {
 
 function requireValue(
   filter: MailSplitFilter,
-  split: MailSplit,
+  split: QuerySplit,
   what: string,
 ): string {
-  if (!filter.value) throw new Error(`Split "${split.name}" has no ${what}`);
+  if (!filter.value)
+    throw new Error(`Split "${split.name ?? "Other"}" has no ${what}`);
   return filter.value;
 }
 
-function olderThanDate(token: string, split: MailSplit, now: Date): Date {
+function olderThanDate(token: string, split: QuerySplit, now: Date): Date {
   const days = OLDER_THAN_DAYS[token];
-  if (!days) throw new Error(`Split "${split.name}" has an unknown age`);
+  if (!days)
+    throw new Error(`Split "${split.name ?? "Other"}" has an unknown age`);
   return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 }
 

--- a/apps/web/utils/mail/thread-matches-split.test.ts
+++ b/apps/web/utils/mail/thread-matches-split.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { EmailThread } from "@/utils/email/types";
+import { otherMailSplitQuery, type MailSplit } from "@/utils/mail/split-query";
+import { createOtherSplitFilter } from "@/utils/mail/thread-matches-split";
+
+const now = new Date("2026-01-10T12:00:00Z");
+const important: MailSplit = {
+  id: "important",
+  name: "Important",
+  matchAll: true,
+  filters: [{ kind: "LABEL", value: "IMPORTANT" }],
+};
+
+describe("Other inbox membership", () => {
+  it("excludes a conversation when an earlier inbox message matches a split", () => {
+    expect(
+      threadMatchesSplit(
+        thread(["INBOX", "IMPORTANT"], ["INBOX"]),
+        important,
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      threadMatchesSplit(thread(["IMPORTANT"], ["INBOX"]), important, now),
+    ).toBe(false);
+  });
+
+  it("keeps AND conditions on the same message and allows OR across conditions", () => {
+    const split: MailSplit = {
+      ...important,
+      filters: [...important.filters, { kind: "STARRED", value: null }],
+    };
+    const conversation = thread(["INBOX", "IMPORTANT"], ["INBOX", "STARRED"]);
+    expect(threadMatchesSplit(conversation, split, now)).toBe(false);
+    expect(
+      threadMatchesSplit(conversation, { ...split, matchAll: false }, now),
+    ).toBe(true);
+  });
+
+  it("ignores All and stops excluding a split once it is removed", () => {
+    const all = { ...important, id: "all", name: "All", filters: [] };
+    expect(otherMailSplitQuery([all, important]).excludeSplits).toEqual([
+      { matchAll: important.matchAll, filters: important.filters },
+    ]);
+    expect(otherMailSplitQuery([all]).excludeSplits).toEqual([]);
+    expect(threadMatchesSplit(thread(["INBOX"]), all, now)).toBe(false);
+  });
+
+  it("matches sender, read state, category and age together", () => {
+    const split: MailSplit = {
+      ...important,
+      filters: [
+        { kind: "FROM", value: "sender@example.com" },
+        { kind: "UNREAD", value: null },
+        { kind: "CATEGORY", value: "CATEGORY_UPDATES" },
+        { kind: "OLDER_THAN", value: "3d" },
+      ],
+    };
+    const conversation = thread(["INBOX", "UNREAD", "CATEGORY_UPDATES"]);
+    expect(threadMatchesSplit(conversation, split, now)).toBe(true);
+    conversation.messages[0].internalDate = String(now.getTime());
+    expect(threadMatchesSplit(conversation, split, now)).toBe(false);
+  });
+});
+
+function thread(...labels: string[][]): EmailThread {
+  return {
+    id: "thread",
+    snippet: "",
+    messages: labels.map((labelIds, index) => ({
+      id: String(index),
+      labelIds,
+      headers: { from: "Sender <SENDER@example.com>" },
+      internalDate: String(new Date("2026-01-01T12:00:00Z").getTime()),
+    })),
+  } as EmailThread;
+}
+
+function threadMatchesSplit(thread: EmailThread, split: MailSplit, now: Date) {
+  return !createOtherSplitFilter([split], now)(thread);
+}

--- a/apps/web/utils/mail/thread-matches-split.test.ts
+++ b/apps/web/utils/mail/thread-matches-split.test.ts
@@ -46,6 +46,34 @@ describe("Other inbox membership", () => {
     expect(threadMatchesSplit(thread(["INBOX"]), all, now)).toBe(false);
   });
 
+  it.each([
+    undefined,
+    null,
+    "",
+    "invalid",
+    "2026-01-10T12:00:00Z",
+  ])("keeps mail with a non-old timestamp in Other: %s", (internalDate) => {
+    const conversation = thread(["INBOX"]);
+    conversation.messages[0].internalDate = internalDate;
+    expect(
+      createOtherSplitFilter(
+        [{ matchAll: true, filters: [{ kind: "OLDER_THAN", value: "3d" }] }],
+        now,
+      )(conversation),
+    ).toBe(true);
+  });
+
+  it("recognizes old ISO timestamps", () => {
+    const conversation = thread(["INBOX"]);
+    conversation.messages[0].internalDate = "2026-01-01T12:00:00Z";
+    expect(
+      createOtherSplitFilter(
+        [{ matchAll: true, filters: [{ kind: "OLDER_THAN", value: "3d" }] }],
+        now,
+      )(conversation),
+    ).toBe(false);
+  });
+
   it("matches sender, read state, category and age together", () => {
     const split: MailSplit = {
       ...important,

--- a/apps/web/utils/mail/thread-matches-split.ts
+++ b/apps/web/utils/mail/thread-matches-split.ts
@@ -1,0 +1,71 @@
+import { isSameEmailAddress } from "@/utils/email";
+import type { ParsedMessage } from "@/utils/types";
+import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
+import type {
+  ThreadsQuery,
+  ThreadsQueryLeaf,
+} from "@/utils/threads/validation";
+
+type SplitMessage = Pick<
+  ParsedMessage,
+  "labelIds" | "headers" | "internalDate"
+>;
+
+export function createOtherSplitFilter(
+  splits: NonNullable<ThreadsQuery["excludeSplits"]>,
+  now: Date = new Date(),
+) {
+  const queries = splits
+    .filter((split) => split.filters.length)
+    .map((split) =>
+      mailSplitToThreadsQuery(
+        {
+          ...split,
+          filters: split.filters.map((filter) => ({
+            ...filter,
+            value: filter.value ?? null,
+          })),
+        },
+        now,
+      ),
+    );
+  // Gmail matches all AND conditions on the same message. Inspect the full
+  // conversation so mixed-label threads cannot also leak into Other.
+  return (thread: { messages: SplitMessage[] }): boolean =>
+    !queries.some((query) =>
+      thread.messages.some(
+        (message) =>
+          matchesMessage(message, query) &&
+          (!query.anyOf?.length ||
+            query.anyOf.some((condition) =>
+              matchesMessage(message, condition),
+            )),
+      ),
+    );
+}
+
+function matchesMessage(
+  message: SplitMessage,
+  query: ThreadsQuery | ThreadsQueryLeaf,
+): boolean {
+  const labels = message.labelIds ?? [];
+  if (
+    "labelIds" in query &&
+    query.labelIds?.some((label) => !labels.includes(label))
+  )
+    return false;
+  if (query.labelId && !labels.includes(query.labelId)) return false;
+  if (query.isUnread && !labels.includes("UNREAD")) return false;
+  if (
+    query.fromEmail &&
+    !isSameEmailAddress(message.headers.from, query.fromEmail)
+  )
+    return false;
+  if (
+    query.before &&
+    Number(message.internalDate) >=
+      Math.floor(query.before.getTime() / 1000) * 1000
+  )
+    return false;
+  return true;
+}

--- a/apps/web/utils/mail/thread-matches-split.ts
+++ b/apps/web/utils/mail/thread-matches-split.ts
@@ -1,3 +1,4 @@
+import { internalDateToDate } from "@/utils/date";
 import { isSameEmailAddress } from "@/utils/email";
 import type { ParsedMessage } from "@/utils/types";
 import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
@@ -61,11 +62,15 @@ function matchesMessage(
     !isSameEmailAddress(message.headers.from, query.fromEmail)
   )
     return false;
-  if (
-    query.before &&
-    Number(message.internalDate) >=
-      Math.floor(query.before.getTime() / 1000) * 1000
-  )
-    return false;
+  if (query.before) {
+    const timestamp = internalDateToDate(message.internalDate, {
+      fallbackToNow: false,
+    }).getTime();
+    if (
+      !Number.isFinite(timestamp) ||
+      timestamp >= Math.floor(query.before.getTime() / 1000) * 1000
+    )
+      return false;
+  }
   return true;
 }

--- a/apps/web/utils/threads/fetch-page.test.ts
+++ b/apps/web/utils/threads/fetch-page.test.ts
@@ -81,3 +81,65 @@ describe("match-any pagination", () => {
     ).toBe(true);
   });
 });
+
+describe("Other pagination", () => {
+  const excludeSplits = [
+    {
+      matchAll: true,
+      filters: [{ kind: "LABEL" as const, value: "newsletter" }],
+    },
+  ];
+  const thread = (id: string, labels: string[]) => ({
+    id,
+    messages: [{ labelIds: ["INBOX", ...labels] }],
+  });
+
+  it("fills pages past excluded conversations without losing the continuation", async () => {
+    const emailProvider = {
+      name: "google",
+      getThreadsWithQuery: vi
+        .fn()
+        .mockResolvedValueOnce({
+          threads: [thread("excluded", ["newsletter"])],
+          nextPageToken: "second",
+        })
+        .mockResolvedValueOnce({
+          threads: [thread("kept", [])],
+          nextPageToken: "third",
+        }),
+    };
+    const result = await fetchThreadsPage({
+      query: { type: "inbox", excludeSplits },
+      emailProvider: emailProvider as never,
+      emailAccountId: "account",
+      maxResults: 1,
+      messageFormat: "metadata",
+    });
+    expect(result.threads.map(({ id }) => id)).toEqual(["kept"]);
+    expect(result.nextPageToken).toBe("third");
+    expect(emailProvider.getThreadsWithQuery.mock.calls[1][0].pageToken).toBe(
+      "second",
+    );
+  });
+
+  it("bounds empty scans and preserves the next page for sparse inboxes", async () => {
+    let page = 0;
+    const emailProvider = {
+      name: "google",
+      getThreadsWithQuery: vi.fn(async () => ({
+        threads: [thread("excluded", ["newsletter"])],
+        nextPageToken: String(++page),
+      })),
+    };
+    const result = await fetchThreadsPage({
+      query: { type: "inbox", excludeSplits },
+      emailProvider: emailProvider as never,
+      emailAccountId: "account",
+      maxResults: 1,
+      messageFormat: "metadata",
+    });
+    expect(result.threads).toEqual([]);
+    expect(result.nextPageToken).toBe("5");
+    expect(emailProvider.getThreadsWithQuery).toHaveBeenCalledTimes(5);
+  });
+});

--- a/apps/web/utils/threads/fetch-page.test.ts
+++ b/apps/web/utils/threads/fetch-page.test.ts
@@ -117,19 +117,22 @@ describe("Other pagination", () => {
     });
     expect(result.threads.map(({ id }) => id)).toEqual(["kept"]);
     expect(result.nextPageToken).toBe("third");
-    expect(emailProvider.getThreadsWithQuery.mock.calls[1][0].pageToken).toBe(
-      "second",
-    );
+    expect(
+      emailProvider.getThreadsWithQuery.mock.calls.at(1)?.at(0)?.pageToken,
+    ).toBe("second");
   });
 
   it("bounds empty scans and preserves the next page for sparse inboxes", async () => {
     let page = 0;
     const emailProvider = {
       name: "google",
-      getThreadsWithQuery: vi.fn(async () => ({
-        threads: [thread("excluded", ["newsletter"])],
-        nextPageToken: String(++page),
-      })),
+      getThreadsWithQuery: vi.fn(async () => {
+        page += 1;
+        return {
+          threads: [thread("excluded", ["newsletter"])],
+          nextPageToken: String(page),
+        };
+      }),
     };
     const result = await fetchThreadsPage({
       query: { type: "inbox", excludeSplits },

--- a/apps/web/utils/threads/fetch-page.ts
+++ b/apps/web/utils/threads/fetch-page.ts
@@ -4,6 +4,8 @@ import { createPageBuffer } from "@/utils/redis/thread-page-buffer";
 import { getThreadTimestamp } from "@/utils/threads/sort";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 
+import { createOtherSplitFilter } from "@/utils/mail/thread-matches-split";
+
 const LABEL_CONCURRENCY = 4;
 
 /**
@@ -26,6 +28,31 @@ export async function fetchThreadsPage({
   pageToken?: string;
   messageFormat: "full" | "metadata";
 }): Promise<{ threads: EmailThread[]; nextPageToken?: string }> {
+  if (query.excludeSplits?.length) {
+    if (emailProvider.name !== "google")
+      throw new Error("Other split exclusions are only supported for Gmail");
+    const { excludeSplits, ...base } = query;
+    const isOther = createOtherSplitFilter(excludeSplits);
+    const threads: EmailThread[] = [];
+    let nextPageToken = pageToken;
+    // Bound sparse-inbox scans per request. Returning the continuation, even
+    // with an empty page, lets the reader keep going without losing messages.
+    for (let page = 0; page < 5; page++) {
+      const result = await fetchThreadsPage({
+        query: base,
+        emailProvider,
+        emailAccountId,
+        maxResults: maxResults - threads.length,
+        pageToken: nextPageToken,
+        messageFormat,
+      });
+      threads.push(...result.threads.filter(isOther));
+      nextPageToken = result.nextPageToken;
+      if (!nextPageToken || threads.length >= maxResults) break;
+    }
+    return { threads, nextPageToken };
+  }
+
   if (query.q) {
     return emailProvider.searchThreads({
       query: query.q,

--- a/apps/web/utils/threads/validation.test.ts
+++ b/apps/web/utils/threads/validation.test.ts
@@ -75,3 +75,21 @@ it("round-trips Other exclusions and rejects unsupported query combinations", ()
       .success,
   ).toBe(false);
 });
+
+it.each([
+  { isUnread: true },
+  { labelIds: ["STARRED"] },
+  { labelId: "STARRED" },
+  { fromEmail: "sender@example.com" },
+  { after: new Date() },
+  { before: new Date() },
+  { excludeLabelNames: ["Newsletter"] },
+])("rejects extra predicates in Other queries: %j", (predicate) => {
+  expect(
+    threadsQuery.safeParse({
+      type: "inbox",
+      excludeSplits: [{ matchAll: true, filters: [{ kind: "UNREAD" }] }],
+      ...predicate,
+    }).success,
+  ).toBe(false);
+});

--- a/apps/web/utils/threads/validation.test.ts
+++ b/apps/web/utils/threads/validation.test.ts
@@ -49,3 +49,29 @@ it.each([
 ])("rejects ambiguous split queries: %j", (query) => {
   expect(threadsQuery.safeParse(query).success).toBe(false);
 });
+
+it("round-trips Other exclusions and rejects unsupported query combinations", () => {
+  const excludeSplits = [
+    {
+      matchAll: true,
+      filters: [{ kind: "LABEL" as const, value: "newsletter" }],
+    },
+  ];
+  const params = threadsQueryToSearchParams({ type: "inbox", excludeSplits });
+  expect(
+    threadsQuery.parse({
+      type: "inbox",
+      excludeSplits: params.get("excludeSplits"),
+    }).excludeSplits,
+  ).toEqual(excludeSplits);
+  expect(
+    threadsQuery.safeParse({ type: "inbox", excludeSplits: "invalid" }).success,
+  ).toBe(false);
+  expect(threadsQuery.safeParse({ type: "sent", excludeSplits }).success).toBe(
+    false,
+  );
+  expect(
+    threadsQuery.safeParse({ type: "inbox", q: "search", excludeSplits })
+      .success,
+  ).toBe(false);
+});

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -83,6 +83,13 @@ export const threadsQuery = z
       !query.excludeSplits?.length ||
       (query.type === "inbox" &&
         !query.q &&
+        !query.fromEmail &&
+        !query.labelId &&
+        !query.labelIds?.length &&
+        !query.excludeLabelNames?.length &&
+        !query.after &&
+        !query.before &&
+        !query.isUnread &&
         !query.folderId &&
         !query.inboxSection &&
         !query.anyOf?.length &&

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
-import { MAX_SPLIT_FILTERS } from "@/utils/mail/split-filters";
-import { MAX_SPLIT_LABELS } from "@/utils/mail/split-constants";
+import {
+  MAX_SPLIT_FILTERS,
+  mailSplitFiltersSchema,
+} from "@/utils/mail/split-filters";
+import {
+  MAX_MAIL_SPLITS,
+  MAX_SPLIT_LABELS,
+} from "@/utils/mail/split-constants";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 import { createSearchParams } from "@/utils/url";
 
@@ -27,6 +33,26 @@ export type ThreadsQueryLeaf = z.infer<typeof threadsQueryLeaf>;
 
 export const threadsQuery = z
   .object({
+    excludeSplits: z.preprocess(
+      (value) => (typeof value === "string" ? parseAnyOf(value) : value),
+      z
+        .array(
+          z.object({
+            matchAll: z.boolean(),
+            filters: mailSplitFiltersSchema.refine(
+              (filters) =>
+                filters.every(
+                  (filter) =>
+                    filter.kind !== "CATEGORY" ||
+                    !["focused", "other"].includes(filter.value ?? ""),
+                ),
+              { message: "Other split exclusions require Gmail conditions" },
+            ),
+          }),
+        )
+        .max(MAX_MAIL_SPLITS)
+        .nullish(),
+    ),
     q: z.string().nullish(),
     fromEmail: z.string().nullish(),
     limit: z.coerce.number().max(100).nullish(),
@@ -52,6 +78,17 @@ export const threadsQuery = z
       z.array(threadsQueryLeaf).max(MAX_SPLIT_FILTERS).nullish(),
     ),
   })
+  .refine(
+    (query) =>
+      !query.excludeSplits?.length ||
+      (query.type === "inbox" &&
+        !query.q &&
+        !query.folderId &&
+        !query.inboxSection &&
+        !query.anyOf?.length &&
+        !query.anyLabelIds?.length),
+    { message: "Other split exclusions require a plain inbox query" },
+  )
   .refine(
     (query) =>
       !query.anyOf?.length ||
@@ -83,9 +120,12 @@ function parseAnyOf(value: string): unknown {
 export function threadsQueryToSearchParams(
   query: ThreadsQuery & Record<string, unknown>,
 ) {
-  const { anyOf, ...rest } = query;
+  const { anyOf, excludeSplits, ...rest } = query;
   return createSearchParams({
     ...rest,
+    ...(excludeSplits?.length
+      ? { excludeSplits: JSON.stringify(excludeSplits) }
+      : {}),
     ...(anyOf?.length ? { anyOf: JSON.stringify(anyOf) } : {}),
   });
 }


### PR DESCRIPTION
Adds an optional Important split based on Gmail importance markers and a catch-all Other tab for inbox conversations that match none of the enabled splits. Disabling a split returns its conversations to Other; All remains available.

- Applies the same exclusion logic to provider pages, cached mailbox views, and optimistic updates, with bounded pagination for sparse results.
- Validated 90 focused unit tests and the split-inbox browser checks in CI; inspected the CI screenshots and passed Biome checks.

Performance: exclusion filters compile once per scan. Other can fetch up to five provider pages per request; it adds no database query or AI call. Available for individual Gmail accounts.
