### PR TITLE
mail: Apply sidebar colors and raised active rows

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailSidebar.tsx
@@ -225,7 +225,7 @@ export function MailSidebar({
           <Link
             href={backToAppHref}
             data-desktop-mac-end
-            className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground text-xs hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <ArrowLeftIcon className="size-3.5 shrink-0" />
             <span className="flex-1 truncate" data-hide-on-desktop-mac>
@@ -440,7 +440,7 @@ export function MailSidebar({
             type="button"
             onClick={onOpenShortcuts}
             aria-label="Keyboard shortcuts"
-            className="mt-2 flex size-10 shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="mt-2 flex size-10 shrink-0 items-center justify-center self-center rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <KeyboardIcon className="size-4" />
           </button>
@@ -449,7 +449,7 @@ export function MailSidebar({
         <button
           type="button"
           onClick={onOpenShortcuts}
-          className="mt-2 flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground text-xs hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="mt-2 flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground text-xs hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <KeyboardIcon className="size-3.5 shrink-0" />
           <span className="flex-1 text-left">Keyboard shortcuts</span>
@@ -647,8 +647,8 @@ function NavRow({
       : "gap-2.5 px-2.5 py-1.5",
     nested && "pl-7",
     active
-      ? "bg-primary/10 font-medium text-foreground"
-      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+      ? "bg-card font-medium text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.04),0_0_0_1px_rgba(17,24,39,0.05)]"
+      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
   );
   const content = collapsed ? (
     <>
@@ -669,7 +669,7 @@ function NavRow({
             "shrink-0 text-xs",
             emphasizeCount
               ? "rounded-full bg-primary/10 px-1.5 py-px font-medium text-primary"
-              : "text-muted-foreground",
+              : "text-sidebar-muted-foreground",
           )}
         >
           {count}


### PR DESCRIPTION
Mail sidebar rows now use the sidebar palette, a raised card background for the active row, and muted count text. Nested-label behavior already shipped in #3558 and #3589, and the shared color tokens shipped in #3626; this PR applies only the remaining row styling.

- Applies matching hover colors to navigation and keyboard-shortcut controls, including the collapsed rail.
- Validation: Biome and diff checks passed; all 8 focused navigation-and-views Playwright tests passed with local test services. Inspected nested-label and Sent-view screenshots.
- CSS-only change; no additional runtime logic, database queries, or network calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the mail sidebar’s visual styling for improved consistency across navigation links, keyboard shortcuts, active rows, and message counts.
  - Applied sidebar-specific colors for accents, foreground text, muted text, and selected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->