### PR TITLE
chore: drop temporary next ncu/maturity exclude after 16.3.4

### DIFF
--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -76,8 +76,5 @@ module.exports = {
     // Stay pinned until a dedicated formatting migration.
     "ultracite",
     "@biomejs/biome",
-
-    "next",
-    "@next/*",
   ],
 };

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,10 +10,6 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@inboxzero/*"
   - "@inbox-zero/emulate"
-  # Next.js security patch requested explicitly; remove after the 24h maturity
-  # window together with the matching `next` / `@next/*` entries in `.ncurc.cjs`.
-  - "next"
-  - "@next/*"
 
 overrides:
   "@hono/node-server": "1.19.14"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Post-#3491 cleanup: the temporary Next.js ncu reject and pnpm maturity-window exclude were left in place after the 16.3.4 security bump landed on `main`.

## Changes
- Remove `"next"` and `"@next/*"` from `.ncurc.cjs` `reject` so `ncu -u` can consider Next again.
- Remove the matching temporary `minimumReleaseAgeExclude` entries (and comment) from `pnpm-workspace.yaml`, keeping `@inboxzero/*` and `@inbox-zero/emulate`.
- Leave `apps/web/package.json` Next `16.3.4` and `overrides.next: "16.3.4"` unchanged.

## Why
Those two temporary entries contradicted each other: Next stayed permanently out of `ncu -u` while also permanently bypassing the 24h supply-chain cooldown. The maturity window for 16.3.4 is over, so both temporary pin/exclude sides come off together.

## Validation
- Diff is only `.ncurc.cjs` and `pnpm-workspace.yaml` (7 deletions).
- Confirmed no `next` / `@next/*` remain in ncu reject or maturity exclude.
- Confirmed `overrides.next` and package Next version remain `16.3.4`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5383d73-a9d1-4fb2-a8c4-e73e249f7109?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5383d73-a9d1-4fb2-a8c4-e73e249f7109&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

