### PR TITLE
fix: scope Outlook draft queries to the drafts folder

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -675,6 +675,27 @@ describe("OutlookProvider.searchMessages", () => {
 
 describe("OutlookProvider.getThreadsWithQuery", () => {
   it.each([
+    { type: "draft" },
+    { labelId: "DRAFT" },
+  ])("scopes draft queries to the drafts folder with an uncached folder map: %j", async (query) => {
+    getFolderIdsMock.mockImplementation(async (_client, _logger, options) => ({
+      inbox: "inbox-folder-id",
+      ...(options?.includeDrafts ? { drafts: "drafts-folder-id" } : {}),
+    }));
+    const client = createMockOutlookClient([]);
+    const provider = new OutlookProvider(client);
+
+    await provider.getThreadsWithQuery({ query });
+
+    expect(client.getRequestLog()).toContainEqual(
+      expect.objectContaining({
+        apiPath: "/me/messages",
+        filter: "parentFolderId eq 'drafts-folder-id'",
+      }),
+    );
+  });
+
+  it.each([
     true,
     undefined,
   ])("puts date filters before folder and read filters for historical inbox queries (unread: %s)", async (isUnread) => {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1660,7 +1660,8 @@ export class OutlookProvider implements EmailProvider {
       ? requiredLabelIds
       : undefined;
     const resolvedFolderIds = await getFolderIds(this.client, this.logger, {
-      includeDrafts: false,
+      includeDrafts:
+        requiredLabelIds?.some((id) => id.toUpperCase() === "DRAFT") ?? false,
     });
     const cachedCategoryMap = this.client.getCategoryMapCache() || undefined;
     const needsCategoryMapForFiltering = shouldFetchOutlookCategoryMap({


### PR DESCRIPTION
Outlook draft queries could omit the folder filter when the folder cache did not contain the Drafts folder, returning messages from other folders. Resolve the Drafts folder whenever the requested thread labels require it.

- Add regression coverage for the Drafts view and explicit Draft label queries with an uncached folder map.
- Validation: all 59 Outlook provider tests pass; Biome checks pass.
- Performance: adds a cached folder lookup only for draft queries, with no database changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Draft thread searches now correctly retrieve messages from the drafts folder, including when folder details are not cached.
- **Tests**
  - Added coverage to verify draft-scoped queries apply the correct drafts-folder filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->