### PR TITLE
mail: Prevent blank frames when navigating between threads

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -90,5 +90,9 @@
     "app/(app)/[emailAccountId]/mail/ListToolbar.tsx",
     "app/(app)/[emailAccountId]/mail/use-thread-actions.ts",
     "app/(app)/[emailAccountId]/mail/use-thread-selection.ts"
+  ],
+  "reader-transition.spec.ts": [
+    "app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx",
+    "components/email-list/BufferedEmailIframe.tsx"
   ]
 }

--- a/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/local-cache.spec.ts
@@ -173,6 +173,11 @@ test("renders a cached thread body when the reader request is offline", async ({
     emailAccountId,
   );
   await leaveThreadReader(page, emailAccountId);
+  // Keep sync offline too: a successful read-status delta correctly invalidates
+  // the seeded detail and would turn this into a partial-connectivity test.
+  await page.route("**/api/mobile/mailbox-sync", (route) =>
+    route.abort("connectionfailed"),
+  );
   await page.route(threadDetailRoute(threadId), (route) =>
     route.abort("connectionfailed"),
   );

--- a/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
@@ -6,7 +6,7 @@ import { openMail } from "./mail-test-helpers";
 test("never paints an empty reader when moving between loaded HTML threads", async ({
   page,
 }, testInfo) => {
-  await page.route("**/api/threads/*?**", async (route) => {
+  await page.route(/\/api\/threads\/thr_playwright_[^/?]+\?/, async (route) => {
     const response = await route.fetch();
     const body = await response.json();
     if (body.thread?.messages) {
@@ -52,10 +52,13 @@ test("never paints an empty reader when moving between loaded HTML threads", asy
     requestAnimationFrame(sample);
   });
   const initialUrl = page.url();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await expect(page.getByRole("menu")).toBeVisible();
   for (const key of ["j", "k", "j", "k"]) {
     await page.keyboard.press(key);
     if (key === "j") await expect(page).not.toHaveURL(initialUrl);
     else await expect(page).toHaveURL(initialUrl);
+    await expect(page.getByRole("menu")).toHaveCount(0);
     const threadId = new URL(page.url()).searchParams.get("thread-id");
     await expect(
       page
@@ -94,5 +97,43 @@ test("never paints an empty reader when moving between loaded HTML threads", asy
     testInfo,
     "reader-navigation-without-blank-frames",
   );
+  // Simulate a readiness signal that never arrives, even after the body loads.
+  await page.evaluate(() => {
+    const blockReadiness = () => {
+      for (const frame of document.querySelectorAll(
+        "iframe[data-email-ready]",
+      )) {
+        if (frame.getAttribute("data-email-ready") !== "false") {
+          frame.setAttribute("data-email-ready", "false");
+        }
+      }
+    };
+    const observer = new MutationObserver(blockReadiness);
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["data-email-ready"],
+    });
+    blockReadiness();
+    Object.assign(window, { readerReadinessObserver: observer });
+  });
+  await page.keyboard.press("j");
+  await expect(page).not.toHaveURL(initialUrl);
+  const nextThreadId = new URL(page.url()).searchParams.get("thread-id");
+  await expect(
+    page
+      .frameLocator('iframe[title="Email content preview"]:visible')
+      .last()
+      .getByText(`Navigation body for ${nextThreadId}`),
+  ).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await expect(page.getByRole("menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await page.evaluate(() => {
+    (
+      window as unknown as { readerReadinessObserver: MutationObserver }
+    ).readerReadinessObserver.disconnect();
+  });
   await page.unrouteAll({ behavior: "ignoreErrors" });
 });

--- a/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
@@ -97,6 +97,29 @@ test("never paints an empty reader when moving between loaded HTML threads", asy
     testInfo,
     "reader-navigation-without-blank-frames",
   );
+  await page.evaluate(() => {
+    window.history.pushState(null, "", window.location.href);
+  });
+  await page.keyboard.press("j");
+  await expect(page).not.toHaveURL(initialUrl);
+  const historyDestination = page.url();
+  await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await expect(page.getByRole("menu")).toBeVisible();
+  await page.goBack();
+  await expect(page).toHaveURL(initialUrl);
+  await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+  await expect(page.getByRole("menu")).toHaveCount(0);
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await expect(page.getByRole("menu")).toBeVisible();
+  await page.goForward();
+  await expect(page).toHaveURL(historyDestination);
+  await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+  await expect(page.getByRole("menu")).toHaveCount(0);
+  await page.goBack();
+  await expect(page).toHaveURL(initialUrl);
+  await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+
   // Simulate a readiness signal that never arrives, even after the body loads.
   await page.evaluate(() => {
     const blockReadiness = () => {

--- a/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-transition.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { openMail } from "./mail-test-helpers";
+
+test("never paints an empty reader when moving between loaded HTML threads", async ({
+  page,
+}, testInfo) => {
+  await page.route("**/api/threads/*?**", async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    if (body.thread?.messages) {
+      for (const message of body.thread.messages) {
+        message.textHtml = `<p>Navigation body for ${body.thread.id}</p>`;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await route.fulfill({ response, json: body });
+  });
+  const { conversations } = await openMail(page);
+  await expect(conversations.getByRole("option").nth(1)).toBeVisible();
+  await conversations.getByRole("option").first().click();
+  const frames = page.locator('iframe[title="Email content preview"]:visible');
+  await expect
+    .poll(() => frames.last().evaluate((frame) => frame.clientHeight), {
+      timeout: 60_000,
+    })
+    .toBeGreaterThan(1);
+
+  await page.evaluate(() => {
+    const samples: boolean[] = [];
+    Object.assign(window, { readerPaintSamples: samples });
+    const sample = () => {
+      const readers = Array.from(
+        document.querySelectorAll('[data-testid="thread-reader"]'),
+      );
+      const visibleBody = readers.some((reader) =>
+        Array.from(reader.querySelectorAll("iframe")).some(
+          (frame) =>
+            frame.checkVisibility({ visibilityProperty: true }) &&
+            frame.getBoundingClientRect().height > 1 &&
+            Boolean(frame.contentDocument?.body?.textContent?.trim()),
+        ),
+      );
+      samples.push(visibleBody);
+      if (
+        !(window as unknown as { stopReaderPaintSamples?: boolean })
+          .stopReaderPaintSamples
+      )
+        requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  });
+  const initialUrl = page.url();
+  for (const key of ["j", "k", "j", "k"]) {
+    await page.keyboard.press(key);
+    if (key === "j") await expect(page).not.toHaveURL(initialUrl);
+    else await expect(page).toHaveURL(initialUrl);
+    const threadId = new URL(page.url()).searchParams.get("thread-id");
+    await expect(
+      page
+        .frameLocator('iframe[title="Email content preview"]:visible')
+        .last()
+        .getByText(`Navigation body for ${threadId}`),
+    ).toBeVisible();
+  }
+  await page.keyboard.press("j");
+  await page.keyboard.press("k");
+  await expect(page).toHaveURL(initialUrl);
+  await expect(
+    page
+      .frameLocator('iframe[title="Email content preview"]:visible')
+      .last()
+      .getByText(
+        `Navigation body for ${new URL(initialUrl).searchParams.get("thread-id")}`,
+      ),
+  ).toBeVisible();
+  const samples = await page.evaluate(() => {
+    Object.assign(window, { stopReaderPaintSamples: true });
+    return (window as unknown as { readerPaintSamples: boolean[] })
+      .readerPaintSamples;
+  });
+  await testInfo.attach("reader-navigation-frames", {
+    body: JSON.stringify({
+      frames: samples.length,
+      blankFrames: samples.filter((visible) => !visible).length,
+    }),
+    contentType: "application/json",
+  });
+  expect(samples.length).toBeGreaterThan(4);
+  expect(samples.filter((visible) => !visible)).toHaveLength(0);
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "reader-navigation-without-blank-frames",
+  );
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+});

--- a/apps/web/__tests__/playwright/emulated/setup/auth.setup.ts
+++ b/apps/web/__tests__/playwright/emulated/setup/auth.setup.ts
@@ -10,7 +10,9 @@ const APP_BASE_URL =
 test("google emulator signs in and creates an app account", async ({
   page,
 }) => {
-  await page.goto("/login?next=%2Fwelcome-redirect%3Fforce%3Dtrue");
+  await page.goto("/login?next=%2Fwelcome-redirect%3Fforce%3Dtrue", {
+    waitUntil: "domcontentloaded",
+  });
   await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
 
   const signInPayload = await page.evaluate(async () => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  cloneElement,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import type { ThreadReaderProps } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
+
+type Reader = {
+  key: string;
+  content: ReactElement<ThreadReaderProps>;
+};
+
+export function BufferedThreadReader({
+  children,
+  threadKey,
+  dataReady,
+  onReady,
+}: {
+  children: ReactElement<ThreadReaderProps>;
+  threadKey: string;
+  dataReady: boolean;
+  onReady: (threadKey: string) => void;
+}) {
+  const [visible, setVisible] = useState<Reader | null>(null);
+  const pendingRef = useRef<HTMLDivElement>(null);
+  const replacing = visible !== null && visible.key !== threadKey;
+  useLayoutEffect(() => {
+    if (!dataReady) return;
+    let frame: number;
+    const reveal = () => {
+      const iframes = pendingRef.current?.querySelectorAll("iframe");
+      // React committing the message does not mean its srcDoc has been parsed
+      // and measured. Keep the complete previous reader until both are ready.
+      if (
+        iframes &&
+        Array.from(iframes).some(
+          (iframe) => iframe.dataset.emailReady !== "true",
+        )
+      ) {
+        frame = requestAnimationFrame(reveal);
+        return;
+      }
+      setVisible({ key: threadKey, content: children });
+      onReady(threadKey);
+    };
+    reveal();
+    return () => cancelAnimationFrame(frame);
+  }, [children, onReady, dataReady, threadKey]);
+
+  const current = {
+    key: threadKey,
+    content:
+      !dataReady && visible?.key === threadKey ? visible.content : children,
+  };
+  const readers = replacing ? [visible, current] : [current];
+
+  return (
+    <div className="relative flex min-h-0 min-w-0 flex-1" aria-busy={replacing}>
+      {readers.map((reader) => {
+        const pending = replacing && reader.key === threadKey;
+        return (
+          <div
+            key={reader.key}
+            ref={reader.key === threadKey ? pendingRef : undefined}
+            className="flex min-h-0 min-w-0 flex-1"
+            style={
+              pending
+                ? { position: "absolute", inset: 0, visibility: "hidden" }
+                : undefined
+            }
+            inert={replacing}
+            aria-hidden={pending || undefined}
+          >
+            {cloneElement(reader.content, {
+              enableMessageNavigation:
+                !replacing && reader.content.props.enableMessageNavigation,
+              detailSelectionSettled:
+                !replacing && reader.content.props.detailSelectionSettled,
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx
@@ -27,15 +27,37 @@ export function BufferedThreadReader({
 }) {
   const [visible, setVisible] = useState<Reader | null>(null);
   const pendingRef = useRef<HTMLDivElement>(null);
-  const replacing = visible !== null && visible.key !== threadKey;
+  const readinessDeadline = useRef<{ key: string; expiresAt: number } | null>(
+    null,
+  );
+  const replacing =
+    visible !== null &&
+    visible.key !== threadKey &&
+    visible.content.props.threadId !== null;
   useLayoutEffect(() => {
+    if (!replacing) onReady(threadKey);
     if (!dataReady) return;
+    if (readinessDeadline.current?.key !== threadKey) {
+      readinessDeadline.current = {
+        key: threadKey,
+        expiresAt: performance.now() + 2000,
+      };
+    }
+    const { expiresAt } = readinessDeadline.current;
+    const remaining = expiresAt - performance.now();
     let frame: number;
+    const commit = () => {
+      setVisible({ key: threadKey, content: children });
+      onReady(threadKey);
+    };
+    // A malformed or empty email must not leave navigation locked indefinitely.
+    const timeout = setTimeout(commit, Math.max(0, remaining));
     const reveal = () => {
       const iframes = pendingRef.current?.querySelectorAll("iframe");
       // React committing the message does not mean its srcDoc has been parsed
       // and measured. Keep the complete previous reader until both are ready.
       if (
+        performance.now() < expiresAt &&
         iframes &&
         Array.from(iframes).some(
           (iframe) => iframe.dataset.emailReady !== "true",
@@ -44,12 +66,15 @@ export function BufferedThreadReader({
         frame = requestAnimationFrame(reveal);
         return;
       }
-      setVisible({ key: threadKey, content: children });
-      onReady(threadKey);
+      clearTimeout(timeout);
+      commit();
     };
     reveal();
-    return () => cancelAnimationFrame(frame);
-  }, [children, onReady, dataReady, threadKey]);
+    return () => {
+      cancelAnimationFrame(frame);
+      clearTimeout(timeout);
+    };
+  }, [children, onReady, dataReady, threadKey, replacing]);
 
   const current = {
     key: threadKey,
@@ -76,6 +101,7 @@ export function BufferedThreadReader({
             aria-hidden={pending || undefined}
           >
             {cloneElement(reader.content, {
+              menu: replacing ? undefined : reader.content.props.menu,
               enableMessageNavigation:
                 !replacing && reader.content.props.enableMessageNavigation,
               detailSelectionSettled:

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -429,6 +429,9 @@ export function MailShell() {
   const deferredReaderSelection = useDeferredValue(openThreadSelection);
   const readerThreadKey = getThreadSelectionKey(deferredReaderSelection);
   const openReaderThreadKey = getThreadSelectionKey(openThreadSelection);
+  useLayoutEffect(() => {
+    if (openReaderThreadKey) setIsMenuOpen(false);
+  }, [openReaderThreadKey]);
   const readerSelectionSettled = readerThreadKey === openReaderThreadKey;
   const [visibleReaderThreadKey, setVisibleReaderThreadKey] =
     useState<string>();

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -211,12 +211,14 @@ export function MailShell() {
 
   const isAllAccounts = accountScope === "all";
   const setOpenThread = useCallback(
-    (selection: ThreadSelection | null) =>
-      setOpenThreadQuery({
+    (selection: ThreadSelection | null) => {
+      setIsMenuOpen(false);
+      return setOpenThreadQuery({
         "thread-id": selection?.threadId ?? null,
         "thread-account-id":
           isAllAccounts && selection ? selection.emailAccountId : null,
-      }),
+      });
+    },
     [isAllAccounts, setOpenThreadQuery],
   );
   const combinedAccounts = useMemo(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -46,6 +46,7 @@ import type { MailSplitFilterDraft } from "@/utils/mail/split-filters";
 import { extractEmailAddress } from "@/utils/email";
 import { LabelPickerDialog } from "@/app/(app)/[emailAccountId]/mail/LabelPickerDialog";
 import { ThreadList } from "@/app/(app)/[emailAccountId]/mail/ThreadList";
+import { BufferedThreadReader } from "@/app/(app)/[emailAccountId]/mail/BufferedThreadReader";
 import { ThreadReader } from "@/app/(app)/[emailAccountId]/mail/ThreadReader";
 import {
   getActiveThreadIndex,
@@ -427,6 +428,8 @@ export function MailShell() {
   const readerThreadKey = getThreadSelectionKey(deferredReaderSelection);
   const openReaderThreadKey = getThreadSelectionKey(openThreadSelection);
   const readerSelectionSettled = readerThreadKey === openReaderThreadKey;
+  const [visibleReaderThreadKey, setVisibleReaderThreadKey] =
+    useState<string>();
   const threadPrefetchCoordinator = useThreadPrefetchCoordinator();
   const adjacentPrefetchScopeKey = `adjacent:${readerThreadKey ?? "none"}`;
   const threadSelections = useMemo(
@@ -486,6 +489,13 @@ export function MailShell() {
     readerSelectionSettled,
   ]);
   const actionTargets = useMemo(() => {
+    // Navigation can outpace the visible reader; do not act on an unseen email.
+    if (
+      openReaderThreadKey &&
+      openReaderThreadKey !== visibleReaderThreadKey &&
+      !selection.hasSelection
+    )
+      return [];
     const listTargets = threads.map((thread) => ({
       key: getListThreadKey(thread),
       messages: thread.messages,
@@ -509,6 +519,9 @@ export function MailShell() {
   }, [
     emailAccountId,
     focusedThread,
+    openReaderThreadKey,
+    visibleReaderThreadKey,
+    selection.hasSelection,
     openMessages,
     openThread,
     openThreadKey,
@@ -1506,64 +1519,74 @@ export function MailShell() {
 
         {showReader && (!openThreadSelection || readerEmailAccount) ? (
           <EmailAccountScopeProvider emailAccount={readerEmailAccount}>
-            <ThreadReader
-              enableMessageNavigation={!sidePanelThreadId}
-              key={openReaderThreadKey ?? "empty"}
-              thread={openThread ?? null}
-              threadId={openThreadId}
-              detailSelectionSettled={readerSelectionSettled}
-              loading={
-                Boolean(openThreadSelection) &&
-                (!readerSelectionSettled || isOpenThreadLoading)
+            <BufferedThreadReader
+              key={readerEmailAccount?.id ?? "empty"}
+              threadKey={openReaderThreadKey ?? "empty"}
+              dataReady={
+                !openThreadSelection ||
+                (readerSelectionSettled &&
+                  Boolean(openThreadData || openThreadError))
               }
-              error={readerSelectionSettled ? openThreadError : undefined}
-              messages={openMessages}
-              userLabels={readerUserLabels}
-              layout={layout}
-              labelHref={labelHref}
-              onRemoveLabel={onRemoveLabel}
-              onBackToInbox={closeReader}
-              onArchive={archiveTargets}
-              refetch={refetchOpenThread}
-              onSendSuccess={(_messageId, sentThreadId) => {
-                if (
-                  !openThreadSelection ||
-                  !sentThreadId.trim() ||
-                  sentThreadId === openThreadSelection.threadId
-                )
-                  return;
-                setReplyToMessageId(undefined);
-                setOpenThread({
-                  emailAccountId: openThreadSelection.emailAccountId,
-                  threadId: sentThreadId,
-                });
-              }}
-              autoOpenReplyForMessageId={replyToMessageId}
-              autoOpenForwardForMessageId={forwardToMessageId}
-              menu={
-                <ThreadActionsMenu
-                  plans={openThread?.plans ?? []}
-                  message={openMessages.at(-1) ?? null}
-                  setChatInput={setChatInput}
-                  isUnread={isOpenThreadUnread}
-                  onMarkSpam={markSpamTargets}
-                  onDelete={trashTargets}
-                  onLabel={canLabel ? openLabelPicker : undefined}
-                  onMove={canLabel ? openMovePicker : undefined}
-                  onMarkRead={() => {
-                    if (!openThreadKey) return;
-                    setReadState([openThreadKey], true);
-                  }}
-                  onMarkUnread={markUnreadTargets}
-                  showFixWithChat={
-                    !isAllAccounts ||
-                    openThreadSelection?.emailAccountId === emailAccountId
-                  }
-                  open={isMenuOpen}
-                  onOpenChange={setIsMenuOpen}
-                />
-              }
-            />
+              onReady={setVisibleReaderThreadKey}
+            >
+              <ThreadReader
+                enableMessageNavigation={!sidePanelThreadId}
+                thread={openThread ?? null}
+                threadId={openThreadId}
+                detailSelectionSettled={readerSelectionSettled}
+                loading={
+                  Boolean(openThreadSelection) &&
+                  (!readerSelectionSettled || isOpenThreadLoading)
+                }
+                error={readerSelectionSettled ? openThreadError : undefined}
+                messages={openMessages}
+                userLabels={readerUserLabels}
+                layout={layout}
+                labelHref={labelHref}
+                onRemoveLabel={onRemoveLabel}
+                onBackToInbox={closeReader}
+                onArchive={archiveTargets}
+                refetch={refetchOpenThread}
+                onSendSuccess={(_messageId, sentThreadId) => {
+                  if (
+                    !openThreadSelection ||
+                    !sentThreadId.trim() ||
+                    sentThreadId === openThreadSelection.threadId
+                  )
+                    return;
+                  setReplyToMessageId(undefined);
+                  setOpenThread({
+                    emailAccountId: openThreadSelection.emailAccountId,
+                    threadId: sentThreadId,
+                  });
+                }}
+                autoOpenReplyForMessageId={replyToMessageId}
+                autoOpenForwardForMessageId={forwardToMessageId}
+                menu={
+                  <ThreadActionsMenu
+                    plans={openThread?.plans ?? []}
+                    message={openMessages.at(-1) ?? null}
+                    setChatInput={setChatInput}
+                    isUnread={isOpenThreadUnread}
+                    onMarkSpam={markSpamTargets}
+                    onDelete={trashTargets}
+                    onLabel={canLabel ? openLabelPicker : undefined}
+                    onMove={canLabel ? openMovePicker : undefined}
+                    onMarkRead={() => {
+                      if (!openThreadKey) return;
+                      setReadState([openThreadKey], true);
+                    }}
+                    onMarkUnread={markUnreadTargets}
+                    showFixWithChat={
+                      !isAllAccounts ||
+                      openThreadSelection?.emailAccountId === emailAccountId
+                    }
+                    open={isMenuOpen}
+                    onOpenChange={setIsMenuOpen}
+                  />
+                }
+              />
+            </BufferedThreadReader>
           </EmailAccountScopeProvider>
         ) : null}
 

--- a/apps/web/components/email-list/BufferedEmailIframe.tsx
+++ b/apps/web/components/email-list/BufferedEmailIframe.tsx
@@ -81,6 +81,7 @@ function EmailIframe({
       ref={iframeRef}
       srcDoc={document.srcDoc}
       className="min-h-0 w-full"
+      data-email-ready={height > 0}
       height={1}
       // Measure the replacement without collapsing or unloading the visible email.
       style={{


### PR DESCRIPTION
Moving between conversations could remove the current body before the next thread response and HTML iframe were ready, briefly showing an empty reader. Keep the complete current reader mounted while preparing its replacement, then reveal the next reader after its data and iframe layout are ready.

- Buffer at most two readers and reset the buffer across accounts. Close action menus during navigation and keep actions available on first opening a thread.
- Bound the iframe-readiness wait so an empty or malformed email cannot lock navigation.
- Add animation-frame coverage for repeated J/K navigation and rapid reversals, asserting destination content and zero blank frames. Also cover menu closure and a stalled readiness signal.
- Make the offline-reader test block mailbox sync as well as detail requests, preventing live read-status updates from invalidating its seeded offline fixture.
- Validation: all 7 local-cache checks pass on the first attempt; focused browser navigation, starring, archive/delete, split-reader, and keyboard-selection checks; screenshots inspected. The 21 focused iframe/cache unit tests, Biome, and diff checks pass.
- Performance: no added database or API calls. Navigation briefly retains the old reader and checks iframe readiness until the replacement can be shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mail thread navigation by keeping the current thread visible while the next thread loads.
  - Ensured the next thread appears even when embedded email content does not report readiness.
  - Automatically closes the More actions menu when navigating between threads.
  - Prevented actions from being applied to a thread that is not yet visible.
  - Improved reliability when viewing cached mail while offline.
- **Tests**
  - Expanded coverage for thread transitions, menu behavior, offline caching, and sign-in loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->