### PR TITLE
auth: Reuse linked mailboxes by provider account identity

### DIFF
--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -356,12 +356,14 @@ describe("handleLinkAccount", () => {
       }),
       getUserPhoto: vi.fn().mockResolvedValue(null),
     } as any);
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      id: "email_account_1",
-      userId: "existing_user",
-      accountId: "existing_account",
-      account: { provider: "microsoft" },
-    } as any);
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({
+        id: "email_account_1",
+        userId: "existing_user",
+        accountId: "existing_account",
+        account: { provider: "microsoft" },
+      } as any);
 
     await expect(
       handleLinkAccount({
@@ -377,6 +379,63 @@ describe("handleLinkAccount", () => {
         message: "email_already_linked",
       },
     });
+  });
+
+  it("reuses the linked mailbox when the provider profile email changes", async () => {
+    mockGoogleProfile();
+    const mailbox = {
+      id: "email_account_1",
+      userId: "user_1",
+      accountId: "account_1",
+      email: "original@example.com",
+      account: { provider: "google" },
+    };
+    prisma.emailAccount.findUnique.mockImplementation(async ({ where }) =>
+      where.accountId === mailbox.accountId ? (mailbox as any) : null,
+    );
+    prisma.user.findUnique.mockResolvedValue({
+      email: "original@example.com",
+      name: "Test User",
+      image: null,
+    } as any);
+    prisma.emailAccount.upsert.mockImplementation(({ where }) => {
+      if (where.accountId !== mailbox.accountId) {
+        throw new Error("Unique constraint failed on accountId");
+      }
+      return Promise.resolve(mailbox) as any;
+    });
+    prisma.$transaction.mockResolvedValue([mailbox, {}] as never);
+
+    await expect(
+      handleLinkAccount(getGoogleAccount()),
+    ).resolves.toBeUndefined();
+
+    const upsert = prisma.emailAccount.upsert.mock.calls[0]?.[0];
+    expect(upsert?.update).not.toHaveProperty("email");
+    expect(upsert?.update).not.toHaveProperty("mailSplits");
+    expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalled();
+    expect(mockAfter).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a provider account linked to another user despite a changed email", async () => {
+    mockGoogleProfile();
+    prisma.emailAccount.findUnique.mockImplementation(async ({ where }) =>
+      where.accountId === "account_1"
+        ? ({
+            id: "email_account_1",
+            userId: "other_user",
+            accountId: "account_1",
+            email: "original@example.com",
+            account: { provider: "google" },
+          } as any)
+        : null,
+    );
+
+    await expect(handleLinkAccount(getGoogleAccount())).rejects.toMatchObject({
+      body: { code: "email_already_linked" },
+    });
+    expect(prisma.emailAccount.upsert).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
   });
 
   it("schedules email watch registration after a Google account is linked", async () => {
@@ -437,11 +496,13 @@ describe("handleLinkAccount", () => {
       accountId: "microsoft_account_1",
       account: { provider: "microsoft" },
     };
-    prisma.emailAccount.findUnique.mockResolvedValue(
-      existingEmailAccount as Awaited<
-        ReturnType<typeof prisma.emailAccount.findUnique>
-      >,
-    );
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(
+        existingEmailAccount as Awaited<
+          ReturnType<typeof prisma.emailAccount.findUnique>
+        >,
+      );
     prisma.$transaction.mockResolvedValue([] as never);
     vi.mocked(ensureEmailAccountsWatched).mockResolvedValue([]);
 

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -646,9 +646,9 @@ export async function handleLinkAccount(account: Account) {
 
     const normalizedEmail = primaryEmail.trim().toLowerCase();
 
-    // Check if email already belongs to a different user
-    const existingEmailAccount = await prisma.emailAccount.findUnique({
-      where: { email: normalizedEmail },
+    // Profile emails can change while the provider account remains the same.
+    const linkedEmailAccount = await prisma.emailAccount.findUnique({
+      where: { accountId: account.id },
       select: {
         id: true,
         userId: true,
@@ -656,6 +656,17 @@ export async function handleLinkAccount(account: Account) {
         account: { select: { provider: true } },
       },
     });
+    const existingEmailAccount =
+      linkedEmailAccount ??
+      (await prisma.emailAccount.findUnique({
+        where: { email: normalizedEmail },
+        select: {
+          id: true,
+          userId: true,
+          accountId: true,
+          account: { select: { provider: true } },
+        },
+      }));
 
     if (
       existingEmailAccount &&
@@ -732,7 +743,9 @@ export async function handleLinkAccount(account: Account) {
 
     const [upsertedEmailAccount] = await prisma.$transaction([
       prisma.emailAccount.upsert({
-        where: { email: normalizedEmail },
+        where: linkedEmailAccount
+          ? { accountId: account.id }
+          : { email: normalizedEmail },
         update: data,
         create: {
           ...data,


### PR DESCRIPTION
When a provider profile reports a different email for an already linked account, sign-in can try to create another mailbox with the same unique account ID and fail. Reuse the mailbox linked to that provider account before falling back to an email lookup, preserving its stored address and settings and retaining ownership checks.

- Adds regression coverage for profile email changes and cross-user ownership rejection; existing cross-provider behavior remains covered.
- Validation: all 16 auth unit tests pass; Ultracite and git diff checks pass. Both new regression tests failed before the fix.
- Performance: existing links still use one indexed lookup; new links add one indexed lookup before email matching. No additional network calls or schema changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account linking when an email address changes with an existing provider account.
  - Existing linked mailboxes are now correctly reused based on the provider account, even if the associated email has changed.
  - Added safeguards to prevent linking a mailbox that belongs to another user.
  - Improved reliability for cross-provider account linking and mailbox watch registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->