### PR TITLE
ci: Run all browser specs in production mode

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -85,10 +85,10 @@ env:
   UPSTASH_REDIS_URL: http://localhost:8079
   UPSTASH_REDIS_TOKEN: playwright-token
   PLAYWRIGHT_PRODUCTION: "1"
-  # Public flags are frozen into the shared build. Contacts keeps its dev-only variant.
+  # Public flags are frozen into the shared build. Match the enabled production UI.
   NEXT_PUBLIC_EMAIL_SEND_ENABLED: "true"
   NEXT_PUBLIC_MEETING_RECORDER_ENABLED: "true"
-  NEXT_PUBLIC_CONTACTS_ENABLED: "false"
+  NEXT_PUBLIC_CONTACTS_ENABLED: "true"
   NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true"
   NEXT_PUBLIC_INTEGRATION_ACTION_ENABLED: "true"
   NEXT_PUBLIC_EXTERNAL_API_ENABLED: "true"

--- a/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/command-palette.spec.ts
@@ -421,7 +421,7 @@ test("the open reader exposes its actions in Command K and forwards with F", asy
   await page.keyboard.press("Escape");
   await expect(palette).toBeHidden();
   await page.keyboard.press("KeyF");
-  await expect(page.getByRole("textbox", { name: "To" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "To" })).toBeVisible();
 });
 
 async function ensureReadState(

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -757,7 +757,7 @@ test("keeps reply and forward drafts in separate composer sessions", async ({
   await expect(editor).toContainText("Reply-only draft text");
   await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
   await expect(
-    message.getByRole("button", { name: /Remove leslie@example\.com/i }),
+    message.getByRole("button", { name: /^Remove .*leslie@example\.com/i }),
   ).toBeVisible();
 
   await message.getByRole("button", { name: "Forward", exact: true }).click();

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -15,12 +15,12 @@ test("keeps keyboard focus in the composer and follows the message field order",
   await page.getByRole("button", { name: /^Compose/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
-  const toField = dialog.getByRole("textbox", { name: "To" });
+  const toField = dialog.getByRole("combobox", { name: "To" });
   await expect(toField).toBeFocused();
 
   for (const field of [
-    dialog.getByRole("textbox", { exact: true, name: "Cc" }),
-    dialog.getByRole("textbox", { exact: true, name: "Bcc" }),
+    dialog.getByRole("combobox", { exact: true, name: "Cc" }),
+    dialog.getByRole("combobox", { exact: true, name: "Bcc" }),
     dialog.getByPlaceholder("Subject"),
     dialog.getByRole("textbox", { name: "Email message" }),
     dialog.getByRole("button", { name: "Show signature" }),
@@ -129,7 +129,7 @@ test("restores a new message draft after closing the composer", async ({
   await page.getByRole("button", { name: /^Compose/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "New Message" });
-  const toField = dialog.getByRole("textbox", { name: "To" });
+  const toField = dialog.getByRole("combobox", { name: "To" });
   const subjectField = dialog.getByPlaceholder("Subject");
   const messageField = dialog.getByRole("textbox", { name: "Email message" });
   await toField.fill("recipient@example.com");
@@ -140,7 +140,9 @@ test("restores a new message draft after closing the composer", async ({
   await expect(dialog).toBeHidden();
   await page.getByRole("button", { name: /^Compose/ }).click();
 
-  await expect(toField).toHaveValue("recipient@example.com");
+  await expect(
+    dialog.getByRole("button", { name: "Remove recipient@example.com" }),
+  ).toBeVisible();
   await expect(subjectField).toHaveValue("Preserved compose draft");
   await expect(messageField).toContainText("Keep this message after closing.");
   await capturePlaywrightCheckpoint(
@@ -154,6 +156,9 @@ test("restores a new message draft after closing the composer", async ({
 
   await page.getByRole("button", { name: /^Compose/ }).click();
   await expect(toField).toHaveValue("");
+  await expect(
+    dialog.getByRole("button", { name: "Remove recipient@example.com" }),
+  ).toHaveCount(0);
   await expect(subjectField).toHaveValue("");
   await expect(messageField).not.toContainText(
     "Keep this message after closing.",
@@ -220,7 +225,7 @@ test("keeps editing state stable across formatting, links, paste, and files", as
     dialog.getByRole("button", { name: "Expand compose" }),
   ).toBeVisible();
   await dialog
-    .getByRole("textbox", { name: "To" })
+    .getByRole("combobox", { name: "To" })
     .fill("teammate@example.com");
   await dialog.getByPlaceholder("Subject").fill("Project update");
   await editor.pressSequentially("Alpha omega");
@@ -340,7 +345,7 @@ test("does not add a line break for the send shortcut", async ({
   const dialog = page.getByRole("dialog", { name: "New Message" });
   const editor = dialog.locator("[contenteditable='true']");
   await dialog
-    .getByRole("textbox", { name: "To" })
+    .getByRole("combobox", { name: "To" })
     .fill("recipient@example.com");
   await dialog.getByPlaceholder("Subject").fill(subject);
   await editor.pressSequentially("Draft body");
@@ -416,7 +421,7 @@ test("composes, sends, and reads a new message from Sent", async ({
   await page.getByRole("button", { name: /^Compose/ }).click();
   const dialog = page.getByRole("dialog", { name: "New Message" });
   await dialog
-    .getByRole("textbox", { name: "To" })
+    .getByRole("combobox", { name: "To" })
     .fill("recipient@example.com");
   await dialog.getByPlaceholder("Subject").fill(subject);
   const composeEditor = dialog.locator("[contenteditable='true']");
@@ -698,7 +703,7 @@ test("opens a sent forward in its provider thread", async ({
     .getByRole("button", { name: "Forward", exact: true })
     .click();
   await sourceMessage
-    .getByRole("textbox", { name: "To" })
+    .getByRole("combobox", { name: "To" })
     .fill("recipient@example.com");
   const editor = sourceMessage.getByRole("textbox", {
     name: "Email message",
@@ -742,19 +747,25 @@ test("keeps reply and forward drafts in separate composer sessions", async ({
 
   await message.getByRole("button", { name: "Forward", exact: true }).click();
   await expect(editor).not.toContainText("Reply-only draft text");
-  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue("");
+  await expect(message.getByRole("combobox", { name: "To" })).toHaveValue("");
+  await expect(message.getByRole("button", { name: /^Remove / })).toHaveCount(
+    0,
+  );
   await editor.fill("Forward-only draft text");
 
   await message.getByRole("button", { name: "Reply", exact: true }).click();
   await expect(editor).toContainText("Reply-only draft text");
   await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
-  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue(
-    /leslie@example\.com/i,
-  );
+  await expect(
+    message.getByRole("button", { name: /Remove leslie@example\.com/i }),
+  ).toBeVisible();
 
   await message.getByRole("button", { name: "Forward", exact: true }).click();
   await expect(editor).toContainText("Forward-only draft text");
-  await expect(message.getByRole("textbox", { name: "To" })).toHaveValue("");
+  await expect(message.getByRole("combobox", { name: "To" })).toHaveValue("");
+  await expect(message.getByRole("button", { name: /^Remove / })).toHaveCount(
+    0,
+  );
 });
 
 async function selectEditorText(editor: Locator, text: string) {

--- a/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/scheduled-replies.spec.ts
@@ -213,7 +213,7 @@ test("schedules a new message from the composer", async ({
     await page.getByRole("button", { name: /^Compose/ }).click();
     const dialog = page.getByRole("dialog", { name: "New Message" });
     await dialog
-      .getByRole("textbox", { name: "To" })
+      .getByRole("combobox", { name: "To" })
       .fill("recipient@example.com");
     await dialog.getByPlaceholder("Subject").fill(subject);
     await dialog

--- a/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-navigation.spec.ts
@@ -7,33 +7,41 @@ import { openMail } from "./mail-test-helpers";
 test("expands unread messages when opening a thread", async ({
   page,
 }, testInfo) => {
-  await page.route("**/api/threads/thr_playwright_reader?**", async (route) => {
-    const response = await route.fetch();
-    const body: ThreadResponse = await response.json();
-    const first = body.thread.messages[0];
-    expect(first).toBeDefined();
-    if (!first) throw new Error("Reader fixture has no messages");
-    body.thread.messages = [
-      {
-        ...first,
-        id: "msg_playwright_reader_read_history",
-        labelIds: ["INBOX"],
-        textPlain: "An earlier read message stays collapsed.",
-        snippet: "An earlier read message stays collapsed.",
-      },
-      {
-        ...first,
-        id: "msg_playwright_reader_unread_history",
-        labelIds: ["INBOX", "UNREAD"],
-        textPlain: "Another unread message opens with the conversation.",
-        snippet: "Another unread message opens with the conversation.",
-      },
-      ...body.thread.messages,
-    ];
-    await route.fulfill({ response, json: body });
-  });
-
   const { emailAccountId } = await openMail(page);
+  const response = await page.request.get(
+    "/api/threads/thr_playwright_reader?parseReplies=true",
+    { headers: { "x-email-account-id": emailAccountId } },
+  );
+  expect(response.ok()).toBe(true);
+  const body: ThreadResponse = await response.json();
+  // Opening the conversation marks provider messages read, including across retries.
+  const first = body.thread.messages[0];
+  expect(first).toBeDefined();
+  if (!first) throw new Error("Reader fixture has no messages");
+  body.thread.messages = [
+    {
+      ...first,
+      id: "msg_playwright_reader_read_history",
+      labelIds: ["INBOX"],
+      textPlain: "An earlier read message stays collapsed.",
+      snippet: "An earlier read message stays collapsed.",
+    },
+    {
+      ...first,
+      id: "msg_playwright_reader_unread_history",
+      labelIds: ["INBOX", "UNREAD"],
+      textPlain: "Another unread message opens with the conversation.",
+      snippet: "Another unread message opens with the conversation.",
+    },
+    ...body.thread.messages.map((message) => ({
+      ...message,
+      labelIds: ["INBOX", "UNREAD"],
+    })),
+  ];
+  await page.route("**/api/threads/thr_playwright_reader?**", (route) =>
+    route.fulfill({ json: body }),
+  );
+
   await page.goto(`/${emailAccountId}/mail?thread-id=thr_playwright_reader`, {
     waitUntil: "domcontentloaded",
   });

--- a/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/thread-states.spec.ts
@@ -65,7 +65,7 @@ test("captures thread reading and reply states", async ({ page }, testInfo) => {
   await capturePlaywrightCheckpoint(page, testInfo, "06-populated-reply");
   await page.getByRole("button", { name: /^Draft to Leslie/ }).click();
   await expect(
-    page.getByRole("textbox", { name: "Cc", exact: true }),
+    page.getByRole("combobox", { name: "Cc", exact: true }),
   ).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "07-reply-recipients");
   await page

--- a/apps/web/__tests__/playwright/run-emulated-suite.mjs
+++ b/apps/web/__tests__/playwright/run-emulated-suite.mjs
@@ -141,14 +141,6 @@ for (const target of targets) {
         ),
         PLAYWRIGHT_OUTPUT_DIR: path.join(testResultsDir, target.name),
         PLAYWRIGHT_RUN_ID: targetRunId,
-        // Contacts needs a different public flag; Todoist URL overrides are dev-only.
-        ...(target.path.endsWith("contact-autocomplete.spec.ts") ||
-        target.path.endsWith("automation/integration-action.spec.ts")
-          ? { PLAYWRIGHT_PRODUCTION: "0" }
-          : {}),
-        ...(target.path.endsWith("contact-autocomplete.spec.ts")
-          ? { NEXT_PUBLIC_CONTACTS_ENABLED: "true" }
-          : {}),
         ...(isIntegrationsTarget(target.path)
           ? { NEXT_PUBLIC_INTEGRATIONS_ENABLED: "true" }
           : {}),

--- a/apps/web/__tests__/playwright/todoist-transport.ts
+++ b/apps/web/__tests__/playwright/todoist-transport.ts
@@ -1,0 +1,29 @@
+import { Agent, setGlobalDispatcher } from "undici";
+import { MCP_INTEGRATIONS } from "../../utils/mcp/integrations";
+
+const emulator = new URL(process.env.PLAYWRIGHT_TODOIST_BASE_URL ?? "");
+if (
+  emulator.protocol !== "http:" ||
+  !["localhost", "127.0.0.1"].includes(emulator.hostname)
+) {
+  throw new Error("Playwright Todoist transport requires a local emulator");
+}
+const todoist = new URL(MCP_INTEGRATIONS.todoist.serverUrl!);
+
+// Redirect at the test process's transport boundary so the production app's
+// bearer-token URL guard and MCP request/response handling are still exercised.
+setGlobalDispatcher(
+  new Agent().compose((dispatch) => (options, handler) => {
+    if (String(options.origin) !== todoist.origin) {
+      return dispatch(options, handler);
+    }
+    const request = new URL(options.path, todoist.origin);
+    if (request.pathname !== todoist.pathname) {
+      throw new Error(`Unexpected Todoist request path: ${request.pathname}`);
+    }
+    return dispatch(
+      { ...options, origin: emulator.origin, path: `/mcp${request.search}` },
+      handler,
+    );
+  }),
+);

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -63,9 +63,7 @@ process.env.PLAYWRIGHT_AUTH_FILE = authStatePath;
 process.env.PLAYWRIGHT_RUN_ID = runId;
 process.env.PLAYWRIGHT_TEST_EMAIL = playwrightTestEmail;
 if (todoistBaseUrl) {
-  process.env.MCP_SERVER_URL_OVERRIDES = JSON.stringify({
-    todoist: `${todoistBaseUrl}/mcp`,
-  });
+  process.env.PLAYWRIGHT_TODOIST_BASE_URL = todoistBaseUrl;
 }
 
 export default defineConfig({
@@ -147,9 +145,11 @@ export default defineConfig({
     {
       name: "Next.js",
       stdout: "pipe",
-      command: production
-        ? `pnpm exec next start --port ${basePort}`
-        : `pnpm exec next dev --turbopack --port ${basePort}`,
+      command: `${
+        todoistEnabled
+          ? "pnpm exec node --import tsx --import ./__tests__/playwright/todoist-transport.ts node_modules/next/dist/bin/next"
+          : "pnpm exec next"
+      } ${production ? "start" : "dev --turbopack"} --port ${basePort}`,
       cwd: process.cwd(),
       url: `${baseURL}/api/auth/ok`,
       timeout: 240_000,
@@ -200,7 +200,7 @@ export default defineConfig({
         NEXT_PUBLIC_DUB_REFER_DOMAIN: "",
         NEXT_PUBLIC_IS_RESEND_CONFIGURED: "",
         NEXT_PUBLIC_CONTACTS_ENABLED:
-          process.env.NEXT_PUBLIC_CONTACTS_ENABLED ?? "false",
+          process.env.NEXT_PUBLIC_CONTACTS_ENABLED ?? "true",
         NEXT_PUBLIC_EMAIL_SEND_ENABLED: "true",
         NEXT_PUBLIC_MEETING_RECORDER_ENABLED: "true",
         PLAYWRIGHT_TEST_EMAIL: playwrightTestEmail,

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -156,6 +156,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       env: {
         ...process.env,
+        MCP_SERVER_URL_OVERRIDES: "",
         NODE_ENV: production ? "production" : "development",
         NODE_OPTIONS: nodeOptions,
         NEXT_PUBLIC_BASE_URL: baseURL,

--- a/apps/web/utils/playwright/todoist-transport.test.ts
+++ b/apps/web/utils/playwright/todoist-transport.test.ts
@@ -1,0 +1,93 @@
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { promisify } from "node:util";
+import { expect, test } from "vitest";
+import { MCP_INTEGRATIONS } from "../mcp/integrations";
+
+const execFileAsync = promisify(execFile);
+
+test("production fetch reaches the Todoist emulator with its MCP body and token intact", async () => {
+  const server = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        path: request.url,
+        method: request.method,
+        authorization: request.headers.authorization,
+        body,
+      }),
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("No test port");
+  const origin = `http://127.0.0.1:${address.port}`;
+  try {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--import",
+        "./__tests__/playwright/todoist-transport.ts",
+        "--input-type=module",
+        "--eval",
+        `const response = await fetch(${JSON.stringify(MCP_INTEGRATIONS.todoist.serverUrl)}, {
+          method: "POST",
+          headers: { authorization: "Bearer emulator-token", "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+          signal: AbortSignal.timeout(5000),
+        });
+        const other = await fetch(${JSON.stringify(`${origin}/unrelated`)});
+        console.log(JSON.stringify({ mcp: await response.json(), other: await other.json() }));`,
+      ],
+      {
+        env: {
+          ...process.env,
+          NODE_ENV: "production",
+          PLAYWRIGHT_TODOIST_BASE_URL: origin,
+        },
+        timeout: 10_000,
+      },
+    );
+    expect(JSON.parse(stdout)).toMatchObject({
+      mcp: {
+        path: "/mcp",
+        method: "POST",
+        authorization: "Bearer emulator-token",
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      },
+      other: { path: "/unrelated", method: "GET" },
+    });
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+test("refuses a non-local Todoist emulator destination", async () => {
+  await expect(
+    execFileAsync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--import",
+        "./__tests__/playwright/todoist-transport.ts",
+        "--eval",
+        "",
+      ],
+      {
+        env: {
+          ...process.env,
+          PLAYWRIGHT_TODOIST_BASE_URL: "https://example.com",
+        },
+        timeout: 10_000,
+      },
+    ),
+  ).rejects.toThrow("requires a local emulator");
+});


### PR DESCRIPTION
Remove the two dev-mode exceptions from browser CI so all 49 specs use one shared contacts-enabled production build.

- Exercise the contacts-enabled recipient UI throughout the mail tests, including persisted recipient chips and clearing recipients when discarding or switching drafts.
- Start the existing Todoist emulator and redirect its canonical MCP endpoint at the test process's HTTP transport boundary. Production MCP URL validation stays unchanged; the real MCP client, request bodies, tokens, and response handling still run.
- Keep local browser tests in dev mode by default, with contacts enabled consistently. Clear local MCP overrides from the test server so they cannot bypass its transport.
- Make the unread-expansion fixture independent of provider read state across retries, and prepare its response before routing to avoid response disposal during teardown.

Validation: two real HTTP transport tests (production forwarding and rejecting non-local emulator destinations), Biome, actionlint, and full PR CI at ebbc51a46. All 49 browser specs passed with no retries and no dev-server starts. Inspected contacts, Todoist, and unread-expansion screenshots. Review feedback was addressed; the existing composer behavior for pending recipient text and the supported package-level test working directory were verified and retained.

[Full production run](https://github.com/elie222/inbox-zero/actions/runs/34601238831): contacts 15s, Todoist integration 29s, compose/reply 71s, thread navigation 20s (including each spec's setup). One shared build serves all specs. The E2E gate took 14m25s elapsed, but the final worker started 7m28s after the build completed while other workflows were active; that elapsed time is not a clean execution-speed comparison.
