### PR TITLE
fix: Preserve actionable email preview errors

### DIFF
--- a/apps/web/app/api/threads/[id]/route.test.ts
+++ b/apps/web/app/api/threads/[id]/route.test.ts
@@ -65,13 +65,29 @@ describe("GET /api/threads/[id]", () => {
     });
   });
 
-  it("keeps unrelated provider failures generic", async () => {
-    mockGetThread.mockRejectedValue(new Error("Provider failed"));
+  it.each([
+    new Error("Provider failed"),
+    Object.assign(new Error("Permission denied"), {
+      errors: [{ reason: "insufficientPermissions" }],
+    }),
+  ])("passes provider failures to shared middleware: %s", async (error) => {
+    mockGetThread.mockRejectedValue(error);
+    await expect(getThread()).rejects.toBe(error);
+  });
 
+  it("preserves safe authorization failures for middleware", async () => {
+    mockGetThread.mockRejectedValue(
+      new SafeError(
+        "Microsoft authorization has expired. Please reconnect.",
+        401,
+      ),
+    );
     const response = await getThread();
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({ error: "Failed to fetch thread" });
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: "Microsoft authorization has expired. Please reconnect.",
+      isKnownError: true,
+    });
   });
 
   it.each([

--- a/apps/web/app/api/threads/[id]/route.ts
+++ b/apps/web/app/api/threads/[id]/route.ts
@@ -37,7 +37,6 @@ export const GET = withEmailProvider(
   "threads/detail",
   async (request, context) => {
     const { emailProvider } = request;
-    const { emailAccountId } = request.auth;
 
     const params = await context.params;
     const { id } = threadQuery.parse(params);
@@ -66,15 +65,7 @@ export const GET = withEmailProvider(
           429,
         );
       }
-      request.logger.error("Error fetching thread", {
-        error,
-        emailAccountId,
-        threadId: id,
-      });
-      return NextResponse.json(
-        { error: "Failed to fetch thread" },
-        { status: 500 },
-      );
+      throw error;
     }
   },
 );

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -18,7 +18,10 @@ import {
   NO_REFRESH_TOKEN_ERROR_CODE,
 } from "@/utils/config";
 import { prefixPath } from "@/utils/path";
-import { getSWRFetchErrorMessage } from "./swr-error";
+import {
+  getSWRFetchErrorMessage,
+  normalizeSWRFetchErrorData,
+} from "./swr-error";
 import { redirectToSafeUrl } from "@/utils/redirect";
 import {
   accountIdFromSnapshotKey,
@@ -48,7 +51,8 @@ const fetcher = async (
     // Try to parse JSON, but handle cases where response isn't JSON (e.g. HMR 404s)
     let errorData: Record<string, unknown> = {};
     try {
-      errorData = await res.json();
+      const payload: unknown = await res.json();
+      errorData = normalizeSWRFetchErrorData(payload);
     } catch {
       // Response wasn't JSON - common during dev HMR, unexpected in production
       if (process.env.NODE_ENV !== "development") {

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -18,6 +18,7 @@ import {
   NO_REFRESH_TOKEN_ERROR_CODE,
 } from "@/utils/config";
 import { prefixPath } from "@/utils/path";
+import { getSWRFetchErrorMessage } from "./swr-error";
 import { redirectToSafeUrl } from "@/utils/redirect";
 import {
   accountIdFromSnapshotKey,
@@ -86,9 +87,7 @@ const fetcher = async (
       }
     }
 
-    const errorMessage =
-      (errorData.message as string) ||
-      "An error occurred while fetching the data.";
+    const errorMessage = getSWRFetchErrorMessage(errorData);
     const error: Error & { info?: Record<string, unknown>; status?: number } =
       new Error(errorMessage);
 

--- a/apps/web/providers/swr-error.test.ts
+++ b/apps/web/providers/swr-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getSWRFetchErrorMessage } from "./swr-error";
+
+describe("getSWRFetchErrorMessage", () => {
+  it("preserves API explanations used by email previews", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        error:
+          "Gmail is temporarily limiting requests. Please try again shortly.",
+        isKnownError: true,
+      }),
+    ).toBe("Gmail is temporarily limiting requests. Please try again shortly.");
+  });
+  it("prefers an explicit message over error", () => {
+    expect(
+      getSWRFetchErrorMessage({ message: "Explanation", error: "Other" }),
+    ).toBe("Explanation");
+  });
+  it("formats validation issues without exposing object coercions", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        error: { issues: [{ message: "Invalid ID" }, null, { message: 42 }] },
+      }),
+    ).toBe("Invalid ID, Validation error, Validation error");
+  });
+  it.each([
+    null,
+    undefined,
+    {},
+    { error: {} },
+    { error: { issues: [] } },
+    { error: "" },
+  ])("safely handles malformed or empty payload %j", (payload) => {
+    expect(getSWRFetchErrorMessage(payload)).toBe(
+      "An error occurred while fetching the data.",
+    );
+  });
+  it("ignores non-string message fields", () => {
+    expect(
+      getSWRFetchErrorMessage({ message: {}, error: "Reconnect your account" }),
+    ).toBe("Reconnect your account");
+  });
+});

--- a/apps/web/providers/swr-error.test.ts
+++ b/apps/web/providers/swr-error.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { getSWRFetchErrorMessage } from "./swr-error";
+import {
+  getSWRFetchErrorMessage,
+  normalizeSWRFetchErrorData,
+} from "./swr-error";
+
+describe("normalizeSWRFetchErrorData", () => {
+  it.each([
+    null,
+    [],
+    "error",
+    42,
+    false,
+  ])("normalizes malformed JSON response %j before metadata access", async (payload) => {
+    const response = Response.json(payload, { status: 500 });
+    const data = normalizeSWRFetchErrorData(await response.json());
+    expect(data.errorCode).toBeUndefined();
+    expect(data.isKnownError).toBeUndefined();
+    expect(getSWRFetchErrorMessage(data)).toBe(
+      "An error occurred while fetching the data.",
+    );
+  });
+  it("preserves authorization metadata and messages", () => {
+    const payload = {
+      error: "Reconnect",
+      errorCode: "NO_REFRESH_TOKEN",
+      isKnownError: true,
+    };
+    expect(normalizeSWRFetchErrorData(payload)).toEqual(payload);
+  });
+});
 
 describe("getSWRFetchErrorMessage", () => {
   it("preserves API explanations used by email previews", () => {
@@ -30,6 +59,8 @@ describe("getSWRFetchErrorMessage", () => {
     { error: {} },
     { error: { issues: [] } },
     { error: "" },
+    { error: "  " },
+    { message: " \t" },
   ])("safely handles malformed or empty payload %j", (payload) => {
     expect(getSWRFetchErrorMessage(payload)).toBe(
       "An error occurred while fetching the data.",
@@ -39,5 +70,13 @@ describe("getSWRFetchErrorMessage", () => {
     expect(
       getSWRFetchErrorMessage({ message: {}, error: "Reconnect your account" }),
     ).toBe("Reconnect your account");
+  });
+  it("falls through blank messages to a useful error", () => {
+    expect(getSWRFetchErrorMessage({ message: "  ", error: "Reconnect" })).toBe(
+      "Reconnect",
+    );
+    expect(
+      getSWRFetchErrorMessage({ error: { issues: [{ message: "  " }] } }),
+    ).toBe("Validation error");
   });
 });

--- a/apps/web/providers/swr-error.ts
+++ b/apps/web/providers/swr-error.ts
@@ -1,0 +1,35 @@
+export function getSWRFetchErrorMessage(errorData: unknown): string {
+  if (errorData && typeof errorData === "object") {
+    if (
+      "message" in errorData &&
+      typeof errorData.message === "string" &&
+      errorData.message
+    ) {
+      return errorData.message;
+    }
+    if ("error" in errorData) {
+      const error = errorData.error;
+      if (typeof error === "string" && error) return error;
+      if (
+        error &&
+        typeof error === "object" &&
+        "issues" in error &&
+        Array.isArray(error.issues)
+      ) {
+        const message = error.issues
+          .map((issue: unknown) =>
+            issue &&
+            typeof issue === "object" &&
+            "message" in issue &&
+            typeof issue.message === "string" &&
+            issue.message
+              ? issue.message
+              : "Validation error",
+          )
+          .join(", ");
+        if (message) return message;
+      }
+    }
+  }
+  return "An error occurred while fetching the data.";
+}

--- a/apps/web/providers/swr-error.ts
+++ b/apps/web/providers/swr-error.ts
@@ -1,15 +1,23 @@
+export function normalizeSWRFetchErrorData(
+  payload: unknown,
+): Record<string, unknown> {
+  return payload && typeof payload === "object" && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : {};
+}
+
 export function getSWRFetchErrorMessage(errorData: unknown): string {
   if (errorData && typeof errorData === "object") {
     if (
       "message" in errorData &&
       typeof errorData.message === "string" &&
-      errorData.message
+      errorData.message.trim()
     ) {
       return errorData.message;
     }
     if ("error" in errorData) {
       const error = errorData.error;
-      if (typeof error === "string" && error) return error;
+      if (typeof error === "string" && error.trim()) return error;
       if (
         error &&
         typeof error === "object" &&
@@ -22,7 +30,7 @@ export function getSWRFetchErrorMessage(errorData: unknown): string {
             typeof issue === "object" &&
             "message" in issue &&
             typeof issue.message === "string" &&
-            issue.message
+            issue.message.trim()
               ? issue.message
               : "Validation error",
           )


### PR DESCRIPTION
Email previews in assistant chat display SWR's error.message, but the fetcher ignored API explanations under `error`. Thread retrieval also converted recognized provider failures into a generic 500 before shared middleware could handle them.

- Parse string API errors and structured validation issues safely, retaining the generic fallback for malformed payloads.
- Forward thread failures to shared middleware while preserving the current provider-specific rate-limit response, draft selection, reply parsing, and cache behavior. Unknown failures remain generic through middleware.
- Add regression coverage for error parsing and provider/auth failure propagation; retain existing throttling and successful thread retrieval tests.

Replaces #1858, ported onto current main at a82e1a07b.

Validation: Biome passed for all five changed files; git diff --check passed. Dependency installation and the focused test command were interrupted by a network-approval cancellation in the editing environment, so test results are not verified. Draft pending CI and validation. Intended focused command: `pnpm test providers/swr-error.test.ts 'app/api/threads/[id]/route.test.ts' utils/middleware.test.ts`.

Performance: no additional database or provider requests; parsing runs only on failed fetches. Shared middleware now handles logging and classification for non-throttling thread failures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider errors now retain their appropriate status and messages instead of being replaced with a generic server error.
  * Expired Microsoft authorization is reported with a clear reconnect message.
  * Data-fetching errors now display more helpful messages, including API explanations and validation details.
  * Invalid or unrecognized error responses continue to use a consistent fallback message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->