### PR TITLE
history: Group conversations with paginated message details

### DIFF
--- a/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
@@ -130,6 +130,53 @@ export async function seedAutomationHistory(emailAccountId: string) {
   });
 }
 
+export async function seedAutomationThreadHistory(
+  emailAccountId: string,
+  additionalThreads = 0,
+) {
+  await seedAutomationHistory(emailAccountId);
+  await withClient(async (client) => {
+    await client.query(
+      `INSERT INTO "ExecutedRule"
+         (id, "threadId", "messageId", status, automated, reason, "ruleId",
+          "emailAccountId", "createdAt", "updatedAt")
+       SELECT $1 || '-' || n, 'thr_playwright_1', 'history-message-' || n,
+              'APPLIED', true, 'Older conversation message', $2, $3,
+              CURRENT_TIMESTAMP - n * INTERVAL '1 minute', CURRENT_TIMESTAMP
+       FROM generate_series(1, 51) AS n`,
+      [HISTORY_EXECUTED_RULE_ID, HISTORY_RULE_ID, emailAccountId],
+    );
+    await client.query(
+      `INSERT INTO "ExecutedRule"
+         (id, "threadId", "messageId", status, automated, reason, "ruleId",
+          "emailAccountId", "createdAt", "updatedAt")
+       VALUES ($1, 'thr_playwright_1', 'msg_playwright_1', 'APPLIED', false,
+               'Second execution on the latest message', $2, $3,
+               CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [
+        `${HISTORY_EXECUTED_RULE_ID}-duplicate`,
+        HISTORY_RULE_ID,
+        emailAccountId,
+      ],
+    );
+    await client.query(
+      `INSERT INTO "ExecutedRule"
+         (id, "threadId", "messageId", status, automated, reason, "ruleId",
+          "emailAccountId", "createdAt", "updatedAt")
+       SELECT $1 || '-thread-' || n, 'history-thread-' || n, 'history-single-message-' || n,
+              'APPLIED', true, 'Another conversation', $2, $3,
+              CURRENT_TIMESTAMP - INTERVAL '1 day', CURRENT_TIMESTAMP
+       FROM generate_series(1, $4::int) AS n`,
+      [
+        HISTORY_EXECUTED_RULE_ID,
+        HISTORY_RULE_ID,
+        emailAccountId,
+        additionalThreads,
+      ],
+    );
+  });
+}
+
 export async function cleanupAutomationHistory() {
   await withClient(deleteAutomationHistory);
 }
@@ -345,9 +392,10 @@ export async function getKnowledgeState(emailAccountId: string) {
 }
 
 async function deleteAutomationHistory(client: Client) {
-  await client.query(`DELETE FROM "ExecutedRule" WHERE id = $1`, [
-    HISTORY_EXECUTED_RULE_ID,
-  ]);
+  await client.query(
+    `DELETE FROM "ExecutedRule" WHERE id = $1 OR "ruleId" = $2`,
+    [HISTORY_EXECUTED_RULE_ID, HISTORY_RULE_ID],
+  );
   await client.query(`DELETE FROM "Rule" WHERE id = $1`, [HISTORY_RULE_ID]);
 }
 

--- a/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/automation-tabs-test-helpers.ts
@@ -133,6 +133,7 @@ export async function seedAutomationHistory(emailAccountId: string) {
 export async function seedAutomationThreadHistory(
   emailAccountId: string,
   additionalThreads = 0,
+  olderMessageCount = 51,
 ) {
   await seedAutomationHistory(emailAccountId);
   await withClient(async (client) => {
@@ -143,8 +144,13 @@ export async function seedAutomationThreadHistory(
        SELECT $1 || '-' || n, 'thr_playwright_1', 'history-message-' || n,
               'APPLIED', true, 'Older conversation message', $2, $3,
               CURRENT_TIMESTAMP - n * INTERVAL '1 minute', CURRENT_TIMESTAMP
-       FROM generate_series(1, 51) AS n`,
-      [HISTORY_EXECUTED_RULE_ID, HISTORY_RULE_ID, emailAccountId],
+       FROM generate_series(1, $4::int) AS n`,
+      [
+        HISTORY_EXECUTED_RULE_ID,
+        HISTORY_RULE_ID,
+        emailAccountId,
+        olderMessageCount,
+      ],
     );
     await client.query(
       `INSERT INTO "ExecutedRule"

--- a/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
@@ -104,7 +104,7 @@ test("groups conversations and lazily pages older messages without duplicating t
   });
   expect(summary.results[0].executedRules).toHaveLength(2);
 
-  const detailsUrl = `${historyUrl}?ruleId=${HISTORY_RULE_ID}&threadId=thr_playwright_1`;
+  const detailsUrl = `${historyUrl}?ruleId=${HISTORY_RULE_ID}&threadId=thr_playwright_1&excludeMessageId=msg_playwright_1`;
   const firstPage = await (
     await page.request.get(detailsUrl, { headers })
   ).json();
@@ -113,14 +113,14 @@ test("groups conversations and lazily pages older messages without duplicating t
   ).json();
   expect(firstPage.totalPages).toBe(2);
   expect(firstPage.results).toHaveLength(50);
-  expect(secondPage.results).toHaveLength(2);
+  expect(secondPage.results).toHaveLength(1);
   expect(
     new Set(
       [...firstPage.results, ...secondPage.results].map(
         (result) => result.messageId,
       ),
     ).size,
-  ).toBe(52);
+  ).toBe(51);
   const unknownThread = await (
     await page.request.get(`${historyUrl}?threadId=unknown`, { headers })
   ).json();
@@ -160,7 +160,7 @@ test("groups conversations and lazily pages older messages without duplicating t
   await expect(page.getByText("Page 1 of 2", { exact: true })).toBeVisible();
   await expect(
     page.getByText("Email unavailable", { exact: true }),
-  ).toHaveCount(49);
+  ).toHaveCount(50);
   await expect(page.getByText("Applied manually", { exact: true })).toHaveCount(
     1,
   );
@@ -174,7 +174,7 @@ test("groups conversations and lazily pages older messages without duplicating t
   await expect(page.getByText("Page 2 of 2", { exact: true })).toBeVisible();
   await expect(
     page.getByText("Email unavailable", { exact: true }),
-  ).toHaveCount(2);
+  ).toHaveCount(1);
   await expect(
     page.getByRole("button", { name: "Next messages", exact: true }),
   ).toBeDisabled();
@@ -230,4 +230,18 @@ test("paginates whole conversations with stable ordering for tied dates", async 
     await page.request.get(`${url}&page=invalid`, { headers })
   ).json();
   expect(invalid.results).toEqual(first.results);
+  await seedAutomationThreadHistory(emailAccountId, 0, 50);
+  const olderMessages = await (
+    await page.request.get(
+      `${url}&threadId=thr_playwright_1&excludeMessageId=msg_playwright_1`,
+      { headers },
+    )
+  ).json();
+  expect(olderMessages.totalPages).toBe(1);
+  expect(olderMessages.results).toHaveLength(50);
+  expect(
+    olderMessages.results.map(
+      (result: { messageId: string }) => result.messageId,
+    ),
+  ).not.toContain("msg_playwright_1");
 });

--- a/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/history-tab.spec.ts
@@ -8,6 +8,7 @@ import {
   HISTORY_RULE_NAME,
   markAutomationOnboardingViewed,
   seedAutomationHistory,
+  seedAutomationThreadHistory,
 } from "./automation-tabs-test-helpers";
 
 test.afterEach(async () => {
@@ -79,4 +80,154 @@ test("shows persisted execution history and preserves rule filters", async ({
       exact: true,
     }),
   ).toBeVisible();
+});
+
+test("groups conversations and lazily pages older messages without duplicating the latest", async ({
+  page,
+}, testInfo) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await seedAutomationThreadHistory(emailAccountId);
+  await markAutomationOnboardingViewed(page);
+  const headers = { "X-Email-Account-ID": emailAccountId };
+  const historyUrl = "/api/user/executed-rules/history";
+  const summaryResponse = await page.request.get(
+    `${historyUrl}?ruleId=${HISTORY_RULE_ID}`,
+    { headers },
+  );
+  expect(summaryResponse.ok()).toBe(true);
+  const summary = await summaryResponse.json();
+  expect(summary.totalPages).toBe(1);
+  expect(summary.results).toHaveLength(1);
+  expect(summary.results[0]).toMatchObject({
+    messageId: "msg_playwright_1",
+    messageCount: 52,
+  });
+  expect(summary.results[0].executedRules).toHaveLength(2);
+
+  const detailsUrl = `${historyUrl}?ruleId=${HISTORY_RULE_ID}&threadId=thr_playwright_1`;
+  const firstPage = await (
+    await page.request.get(detailsUrl, { headers })
+  ).json();
+  const secondPage = await (
+    await page.request.get(`${detailsUrl}&page=2`, { headers })
+  ).json();
+  expect(firstPage.totalPages).toBe(2);
+  expect(firstPage.results).toHaveLength(50);
+  expect(secondPage.results).toHaveLength(2);
+  expect(
+    new Set(
+      [...firstPage.results, ...secondPage.results].map(
+        (result) => result.messageId,
+      ),
+    ).size,
+  ).toBe(52);
+  const unknownThread = await (
+    await page.request.get(`${historyUrl}?threadId=unknown`, { headers })
+  ).json();
+  expect(unknownThread.results).toEqual([]);
+  const skipped = await (
+    await page.request.get(
+      `${historyUrl}?threadId=thr_playwright_1&ruleId=skipped`,
+      { headers },
+    )
+  ).json();
+  expect(skipped.results).toEqual([]);
+
+  // Synthetic historical messages need not still exist in the mailbox.
+  await page.route("**/api/messages/batch?*", async (route) => {
+    const ids =
+      new URL(route.request().url()).searchParams.get("ids")?.split(",") ?? [];
+    if (ids.every((id) => id.startsWith("history-message-"))) {
+      await route.fulfill({ json: { messages: [] } });
+    } else {
+      await route.continue();
+    }
+  });
+  const detailRequests: string[] = [];
+  page.on("request", (request) => {
+    if (
+      request.url().includes(historyUrl) &&
+      new URL(request.url()).searchParams.has("threadId")
+    )
+      detailRequests.push(request.url());
+  });
+  await page.goto(
+    `/${emailAccountId}/automation?tab=history&ruleId=${HISTORY_RULE_ID}`,
+  );
+  await expect(page.getByText("52 messages handled")).toBeVisible();
+  expect(detailRequests).toHaveLength(0);
+  await page.getByRole("button", { name: "Expand conversation" }).click();
+  await expect(page.getByText("Page 1 of 2", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Email unavailable", { exact: true }),
+  ).toHaveCount(49);
+  await expect(page.getByText("Applied manually", { exact: true })).toHaveCount(
+    1,
+  );
+  await page.screenshot({
+    path: testInfo.outputPath("history-expanded.png"),
+    fullPage: true,
+  });
+  await page
+    .getByRole("button", { name: "Next messages", exact: true })
+    .click();
+  await expect(page.getByText("Page 2 of 2", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Email unavailable", { exact: true }),
+  ).toHaveCount(2);
+  await expect(
+    page.getByRole("button", { name: "Next messages", exact: true }),
+  ).toBeDisabled();
+  await page.getByRole("button", { name: "Collapse conversation" }).click();
+  await expect(
+    page.getByText("Email unavailable", { exact: true }),
+  ).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("history-collapsed.png"),
+    fullPage: true,
+  });
+});
+
+test("paginates whole conversations with stable ordering for tied dates", async ({
+  page,
+}) => {
+  const emailAccountId = await getEmailAccountId(page);
+  await seedAutomationThreadHistory(emailAccountId, 50);
+  const headers = { "X-Email-Account-ID": emailAccountId };
+  const url = `/api/user/executed-rules/history?ruleId=${HISTORY_RULE_ID}`;
+  const first = await (
+    await page.request.get(`${url}&page=1`, { headers })
+  ).json();
+  const second = await (
+    await page.request.get(`${url}&page=2`, { headers })
+  ).json();
+  expect(first.totalPages).toBe(2);
+  expect(first.results).toHaveLength(50);
+  expect(second.results).toHaveLength(1);
+  expect(first.results[0]).toMatchObject({
+    threadId: "thr_playwright_1",
+    messageCount: 52,
+  });
+  expect(
+    new Set(
+      [...first.results, ...second.results].map((result) => result.threadId),
+    ).size,
+  ).toBe(51);
+  const repeated = await (
+    await page.request.get(`${url}&page=1`, { headers })
+  ).json();
+  expect(
+    repeated.results.map((result: { threadId: string }) => result.threadId),
+  ).toEqual(
+    first.results.map((result: { threadId: string }) => result.threadId),
+  );
+  const empty = await (
+    await page.request.get(`${url}&page=3`, { headers })
+  ).json();
+  expect(empty.results).toEqual([]);
+  expect(empty.totalPages).toBe(2);
+  const invalid = await (
+    await page.request.get(`${url}&page=invalid`, { headers })
+  ).json();
+  expect(invalid.results).toEqual(first.results);
 });

--- a/apps/web/__tests__/playwright/emulated/mail/mail-queue.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-queue.spec.ts
@@ -27,6 +27,7 @@ test("inspects an account's local queue and refreshes its progress", async ({
     });
     const transaction = database.transaction("mailMutations", "readwrite");
     const store = transaction.objectStore("mailMutations");
+    const now = Date.now();
     for (let index = 0; index < 201; index++) {
       store.put({
         id: `queue-diagnostics-${index}`,
@@ -38,9 +39,9 @@ test("inspects an account's local queue and refreshes its progress", async ({
         payload: {},
         status: "pending",
         attempts: 0,
-        createdAt: Date.now() - index,
-        updatedAt: Date.now(),
-        nextAttemptAt: Date.now(),
+        createdAt: now - index,
+        updatedAt: now,
+        nextAttemptAt: now,
       });
     }
     await new Promise<void>((resolve, reject) => {

--- a/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/manual-label.spec.ts
@@ -194,6 +194,7 @@ test("L labels the open conversation after it leaves the unread list", async ({
   await page.keyboard.press("Escape");
   await expect(picker).toBeHidden();
   await expect(heading).toBeVisible();
+  await expect(page.locator("body")).toBeFocused();
   await page.keyboard.press("l");
   await picker.getByRole("combobox").fill("Project Alpha");
   await expect(

--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -90,6 +90,22 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     );
 
     await context.setOffline(false);
+    // Confirm the browser can reach the server before testing a connected reload.
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          try {
+            const response = await fetch("/api/auth/ok", {
+              cache: "no-store",
+              signal: AbortSignal.timeout(3000),
+            });
+            return response.ok;
+          } catch {
+            return false;
+          }
+        }),
+      )
+      .toBe(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(
       conversationWithSubject(page, conversations, "Archive Action Message"),

--- a/apps/web/__tests__/playwright/emulated/playwright-test.ts
+++ b/apps/web/__tests__/playwright/emulated/playwright-test.ts
@@ -93,7 +93,11 @@ export const test = base.extend<BrowserEvidenceFixtures>({
         const pageTitle = page.isClosed()
           ? null
           : await page.title().catch(() => null);
-        if (!page.isClosed() && testInfo.errors.length === 0) {
+        if (
+          !page.isClosed() &&
+          page.url() !== "about:blank" &&
+          testInfo.errors.length === 0
+        ) {
           try {
             await capturePlaywrightCheckpoint(page, testInfo, "final-state");
           } catch (error) {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -188,10 +188,9 @@ function ThreadHistory({
     page,
     ruleId,
     threadId,
+    excludeMessageId: latestMessageId,
   });
-  const results =
-    data?.results.filter((result) => result.messageId !== latestMessageId) ??
-    [];
+  const results = data?.results ?? [];
   const ids = results.map((result) => result.messageId);
   const {
     data: messagesData,

--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Fragment, useMemo } from "react";
+import { Fragment, useMemo, useState } from "react";
+import { ChevronRightIcon } from "lucide-react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
 import { format, isToday, isYesterday } from "date-fns";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -50,6 +51,8 @@ export function History() {
         <LoadingContent loading={isLoading} error={error}>
           {results.length ? (
             <HistoryTable
+              key={`${page}-${ruleId}`}
+              ruleId={ruleId}
               data={results}
               totalPages={totalPages}
               messagesById={messagesById}
@@ -73,17 +76,17 @@ export function History() {
 
 function HistoryTable({
   data,
+  ruleId,
   totalPages,
   messagesById,
   messagesLoading,
 }: {
   data: GetExecutedRulesResponse["results"];
+  ruleId: string;
   totalPages: number;
   messagesById: Record<string, ParsedMessage>;
   messagesLoading: boolean;
 }) {
-  const { userEmail } = useAccount();
-  const { setInput } = useChat();
   const groups = useMemo(() => groupByDate(data), [data]);
 
   return (
@@ -100,37 +103,15 @@ function HistoryTable({
                   {formatDateGroupLabel(group.date)}
                 </TableCell>
               </TableRow>
-              {group.items.map((er) => {
-                const message = messagesById[er.messageId];
-                const isMessageLoading = !message && messagesLoading;
-
-                return (
-                  <TableRow key={er.messageId}>
-                    <TableCell>
-                      <EmailCell
-                        message={message}
-                        messageId={er.messageId}
-                        threadId={er.threadId}
-                        userEmail={userEmail}
-                        isMessageLoading={isMessageLoading}
-                      />
-                      {!er.executedRules[0]?.automated && (
-                        <Badge color="yellow" className="mt-2">
-                          Applied manually
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <RuleCell
-                        executedRules={er.executedRules}
-                        message={message}
-                        setInput={setInput}
-                        isMessageLoading={isMessageLoading}
-                      />
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+              {group.items.map((er) => (
+                <HistoryThread
+                  key={er.threadId}
+                  result={er}
+                  ruleId={ruleId}
+                  message={messagesById[er.messageId]}
+                  messagesLoading={messagesLoading}
+                />
+              ))}
             </Fragment>
           ))}
         </TableBody>
@@ -138,6 +119,190 @@ function HistoryTable({
 
       <TablePagination totalPages={totalPages} />
     </div>
+  );
+}
+
+function HistoryThread({
+  result,
+  ruleId,
+  message,
+  messagesLoading,
+}: {
+  result: ExecutedRuleResult;
+  ruleId: string;
+  message?: ParsedMessage;
+  messagesLoading: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <>
+      <HistoryMessageRow
+        result={result}
+        message={message}
+        messagesLoading={messagesLoading}
+        leading={
+          result.messageCount > 1 ? (
+            <Button
+              variant="ghost"
+              size="iconSm"
+              aria-label={
+                expanded ? "Collapse conversation" : "Expand conversation"
+              }
+              aria-expanded={expanded}
+              onClick={() => setExpanded((value) => !value)}
+            >
+              <ChevronRightIcon
+                className={expanded ? "size-4 rotate-90" : "size-4"}
+              />
+            </Button>
+          ) : undefined
+        }
+        messageCount={result.messageCount}
+      />
+      {expanded && (
+        <TableRow className="bg-muted/30 hover:bg-muted/30">
+          <TableCell colSpan={2} className="pl-10">
+            <ThreadHistory
+              threadId={result.threadId}
+              latestMessageId={result.messageId}
+              ruleId={ruleId}
+            />
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+function ThreadHistory({
+  threadId,
+  latestMessageId,
+  ruleId,
+}: {
+  threadId: string;
+  latestMessageId: string;
+  ruleId: string;
+}) {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, error } = useExecutedRules({
+    page,
+    ruleId,
+    threadId,
+  });
+  const results =
+    data?.results.filter((result) => result.messageId !== latestMessageId) ??
+    [];
+  const ids = results.map((result) => result.messageId);
+  const {
+    data: messagesData,
+    isLoading: messagesLoading,
+    error: messagesError,
+  } = useMessagesBatch({ ids });
+  const messagesById = mapMessagesById(messagesData?.messages ?? []);
+
+  return (
+    <LoadingContent loading={isLoading} error={error || messagesError}>
+      {data && (
+        <>
+          <Table>
+            <TableBody>
+              {results.map((result) => (
+                <HistoryMessageRow
+                  key={result.messageId}
+                  result={result}
+                  message={messagesById[result.messageId]}
+                  messagesLoading={messagesLoading}
+                />
+              ))}
+            </TableBody>
+          </Table>
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-end gap-2 py-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1}
+                onClick={() => setPage((value) => value - 1)}
+              >
+                Previous messages
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {data.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= data.totalPages}
+                onClick={() => setPage((value) => value + 1)}
+              >
+                Next messages
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </LoadingContent>
+  );
+}
+
+function HistoryMessageRow({
+  result,
+  message,
+  messagesLoading,
+  leading,
+  messageCount,
+}: {
+  result: ExecutedRuleResult;
+  message?: ParsedMessage;
+  messagesLoading: boolean;
+  leading?: React.ReactNode;
+  messageCount?: number;
+}) {
+  const { userEmail } = useAccount();
+  const { setInput } = useChat();
+  const isMessageLoading = !message && messagesLoading;
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex items-start gap-2">
+          {leading}
+          <div className="min-w-0 flex-1">
+            <EmailCell
+              message={message}
+              messageId={result.messageId}
+              threadId={result.threadId}
+              userEmail={userEmail}
+              isMessageLoading={isMessageLoading}
+            />
+            {messageCount === undefined &&
+              result.executedRules[0]?.createdAt && (
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {format(
+                    new Date(result.executedRules[0].createdAt),
+                    "MMM d, yyyy, p",
+                  )}
+                </div>
+              )}
+            <div className="mt-2 flex flex-wrap gap-2">
+              {messageCount && messageCount > 1 ? (
+                <Badge color="blue">{messageCount} messages handled</Badge>
+              ) : null}
+              {!result.executedRules[0]?.automated && (
+                <Badge color="yellow">Applied manually</Badge>
+              )}
+            </div>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <RuleCell
+          executedRules={result.executedRules}
+          message={message}
+          setInput={setInput}
+          isMessageLoading={isMessageLoading}
+        />
+      </TableCell>
+    </TableRow>
   );
 }
 

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -24,6 +24,9 @@ export const GET = withEmailAccount(
         ? requestedPage
         : 1;
     const threadId = url.searchParams.get("threadId") || undefined;
+    const excludeMessageId = threadId
+      ? url.searchParams.get("excludeMessageId") || undefined
+      : undefined;
     const ruleId = url.searchParams.get("ruleId") || "all";
 
     const result = await getExecutedRules({
@@ -31,6 +34,7 @@ export const GET = withEmailAccount(
       ruleId,
       emailAccountId,
       threadId,
+      excludeMessageId,
     });
 
     return NextResponse.json(result);
@@ -42,11 +46,13 @@ async function getExecutedRules({
   ruleId,
   emailAccountId,
   threadId,
+  excludeMessageId,
 }: {
   page: number;
   ruleId?: string;
   emailAccountId: string;
   threadId?: string;
+  excludeMessageId?: string;
 }) {
   const conditions = [Prisma.sql`"emailAccountId" = ${emailAccountId}`];
   if (ruleId === "skipped") {
@@ -62,6 +68,9 @@ async function getExecutedRules({
     }
   }
   if (threadId) conditions.push(Prisma.sql`"threadId" = ${threadId}`);
+  if (excludeMessageId) {
+    conditions.push(Prisma.sql`"messageId" != ${excludeMessageId}`);
+  }
   const where = Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
   const groupColumn = threadId
     ? Prisma.sql`"messageId"`

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -4,7 +4,7 @@ import { serializedMatchMetadataSchema } from "@/utils/ai/assistant/chat-context
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 import { ExecutedRuleStatus } from "@/generated/prisma/enums";
-import type { Prisma } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 
 const LIMIT = 50;
 
@@ -18,13 +18,19 @@ export const GET = withEmailAccount(
     const emailAccountId = request.auth.emailAccountId;
 
     const url = new URL(request.url);
-    const page = Number.parseInt(url.searchParams.get("page") || "1");
+    const requestedPage = Number(url.searchParams.get("page") || "1");
+    const page =
+      Number.isSafeInteger(requestedPage) && requestedPage > 0
+        ? requestedPage
+        : 1;
+    const threadId = url.searchParams.get("threadId") || undefined;
     const ruleId = url.searchParams.get("ruleId") || "all";
 
     const result = await getExecutedRules({
       page,
       ruleId,
       emailAccountId,
+      threadId,
     });
 
     return NextResponse.json(result);
@@ -35,74 +41,124 @@ async function getExecutedRules({
   page,
   ruleId,
   emailAccountId,
+  threadId,
 }: {
   page: number;
   ruleId?: string;
   emailAccountId: string;
+  threadId?: string;
 }) {
-  const where: Prisma.ExecutedRuleWhereInput = {
-    emailAccountId,
-    status:
-      ruleId === "skipped"
-        ? ExecutedRuleStatus.SKIPPED
-        : ExecutedRuleStatus.APPLIED,
-    rule: ruleId === "skipped" ? undefined : { isNot: null },
-    ruleId: ruleId === "all" || ruleId === "skipped" ? undefined : ruleId,
-  };
+  const conditions = [Prisma.sql`"emailAccountId" = ${emailAccountId}`];
+  if (ruleId === "skipped") {
+    conditions.push(
+      Prisma.sql`status = ${ExecutedRuleStatus.SKIPPED}::"ExecutedRuleStatus"`,
+    );
+  } else {
+    conditions.push(
+      Prisma.sql`status = ${ExecutedRuleStatus.APPLIED}::"ExecutedRuleStatus" AND "ruleId" IS NOT NULL`,
+    );
+    if (ruleId && ruleId !== "all") {
+      conditions.push(Prisma.sql`"ruleId" = ${ruleId}`);
+    }
+  }
+  if (threadId) conditions.push(Prisma.sql`"threadId" = ${threadId}`);
+  const where = Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
+  const groupColumn = threadId
+    ? Prisma.sql`"messageId"`
+    : Prisma.sql`"threadId"`;
 
-  const [executedRules, total] = await Promise.all([
-    prisma.executedRule.findMany({
-      where,
-      take: LIMIT,
-      skip: (page - 1) * LIMIT,
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        messageId: true,
-        threadId: true,
-        actionItems: true,
-        status: true,
-        reason: true,
-        matchMetadata: true,
-        automated: true,
-        createdAt: true,
-        rule: {
-          select: {
-            id: true,
-            name: true,
-            systemType: true,
-            instructions: true,
-            groupId: true,
-            from: true,
-            to: true,
-            subject: true,
-            body: true,
-            conditionalOperator: true,
-            group: { select: { name: true } },
-          },
-        },
-      },
-    }),
-    prisma.executedRule.count({ where }),
+  const [messages, totals] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        threadId: string;
+        messageId: string;
+        ids: string[];
+        messageCount: number;
+      }>
+    >(Prisma.sql`
+      WITH messages AS (
+        SELECT "threadId", "messageId", MAX("createdAt") AS "createdAt"
+        FROM "ExecutedRule" ${where}
+        GROUP BY "threadId", "messageId"
+      ), ranked AS (
+        SELECT *,
+          ROW_NUMBER() OVER (PARTITION BY "threadId" ORDER BY "createdAt" DESC, "messageId") AS position,
+          (COUNT(*) OVER (PARTITION BY "threadId"))::int AS "messageCount"
+        FROM messages
+      ), page AS (
+        SELECT * FROM ranked
+        ${threadId ? Prisma.empty : Prisma.sql`WHERE position = 1`}
+        ORDER BY "createdAt" DESC, "threadId", "messageId"
+        LIMIT ${LIMIT} OFFSET ${(page - 1) * LIMIT}
+      )
+      SELECT page."threadId", page."messageId", page."messageCount",
+        ARRAY(
+          SELECT id FROM "ExecutedRule" ${where}
+            AND "threadId" = page."threadId" AND "messageId" = page."messageId"
+        ) AS ids
+      FROM page
+      ORDER BY page."createdAt" DESC, page."threadId", page."messageId"
+    `),
+    prisma.$queryRaw<Array<{ total: bigint }>>(Prisma.sql`
+      SELECT COUNT(DISTINCT ${groupColumn}) AS total FROM "ExecutedRule" ${where}
+    `),
   ]);
 
-  const executedRulesByMessageId = groupBy(executedRules, (er) => er.messageId);
+  const executedRules = messages.length
+    ? await prisma.executedRule.findMany({
+        where: {
+          emailAccountId,
+          id: { in: messages.flatMap((message) => message.ids) },
+        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
+        select: {
+          id: true,
+          messageId: true,
+          threadId: true,
+          actionItems: true,
+          status: true,
+          reason: true,
+          matchMetadata: true,
+          automated: true,
+          createdAt: true,
+          rule: {
+            select: {
+              id: true,
+              name: true,
+              systemType: true,
+              instructions: true,
+              groupId: true,
+              from: true,
+              to: true,
+              subject: true,
+              body: true,
+              conditionalOperator: true,
+              group: { select: { name: true } },
+            },
+          },
+        },
+      })
+    : [];
 
-  const results = Object.entries(executedRulesByMessageId)
-    .filter(([, groupedExecutedRules]) => groupedExecutedRules.length > 0)
-    .map(([messageId, groupedExecutedRules]) => ({
+  const executedRulesByMessageId = groupBy(executedRules, (er) => er.messageId);
+  const results = messages
+    .map(({ messageId, threadId, messageCount }) => ({
       messageId,
-      threadId: groupedExecutedRules[0].threadId,
-      executedRules: groupedExecutedRules.map((executedRule) => ({
-        ...executedRule,
-        matchMetadata:
-          serializedMatchMetadataSchema.safeParse(executedRule.matchMetadata)
-            .data ?? null,
-      })),
-    }));
+      threadId,
+      messageCount,
+      executedRules: (executedRulesByMessageId[messageId] ?? []).map(
+        (executedRule) => ({
+          ...executedRule,
+          matchMetadata:
+            serializedMatchMetadataSchema.safeParse(executedRule.matchMetadata)
+              .data ?? null,
+        }),
+      ),
+    }))
+    .filter((message) => message.executedRules.length > 0);
 
   return {
     results,
-    totalPages: Math.ceil(total / LIMIT),
+    totalPages: Math.ceil(Number(totals[0]?.total ?? 0) / LIMIT),
   };
 }

--- a/apps/web/hooks/useExecutedRules.tsx
+++ b/apps/web/hooks/useExecutedRules.tsx
@@ -4,11 +4,15 @@ import type { GetExecutedRulesResponse } from "@/app/api/user/executed-rules/his
 export function useExecutedRules({
   page,
   ruleId,
+  threadId,
 }: {
   page: number;
   ruleId: string;
+  threadId?: string;
 }) {
+  const params = new URLSearchParams({ page: String(page), ruleId });
+  if (threadId) params.set("threadId", threadId);
   return useSWR<GetExecutedRulesResponse>(
-    `/api/user/executed-rules/history?page=${page}&ruleId=${ruleId}`,
+    `/api/user/executed-rules/history?${params}`,
   );
 }

--- a/apps/web/hooks/useExecutedRules.tsx
+++ b/apps/web/hooks/useExecutedRules.tsx
@@ -5,13 +5,16 @@ export function useExecutedRules({
   page,
   ruleId,
   threadId,
+  excludeMessageId,
 }: {
   page: number;
   ruleId: string;
   threadId?: string;
+  excludeMessageId?: string;
 }) {
   const params = new URLSearchParams({ page: String(page), ruleId });
   if (threadId) params.set("threadId", threadId);
+  if (excludeMessageId) params.set("excludeMessageId", excludeMessageId);
   return useSWR<GetExecutedRulesResponse>(
     `/api/user/executed-rules/history?${params}`,
   );

--- a/apps/web/lib/shortcuts/useShortcuts.test.tsx
+++ b/apps/web/lib/shortcuts/useShortcuts.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Suspense, startTransition } from "react";
 import type { ShortcutHandlers, ShortcutScope } from "./registry";
 import { ShortcutsProvider } from "./ShortcutsProvider";
 import { useShortcuts } from "./useShortcuts";
@@ -12,6 +19,30 @@ const GLOBAL_SCOPES: ShortcutScope[] = ["global"];
 afterEach(cleanup);
 
 describe("useShortcuts", () => {
+  it("keeps shortcuts on the visible state while a transition is suspended", async () => {
+    const visibleHandler = vi.fn();
+    const pendingHandler = vi.fn();
+    const pending = new Promise<void>(() => {});
+    const view = (handler: () => void, suspend: boolean) => (
+      <ShortcutsProvider scopes={MAIL_SCOPES}>
+        <Suspense fallback={<div>Loading next conversation</div>}>
+          <SuspendingShortcuts
+            handler={handler}
+            pending={suspend ? pending : undefined}
+          />
+        </Suspense>
+      </ShortcutsProvider>
+    );
+    const { rerender } = render(view(visibleHandler, false));
+    await act(async () => {
+      startTransition(() => rerender(view(pendingHandler, true)));
+    });
+    expect(screen.getByText("Visible conversation")).toBeTruthy();
+    press({ key: "s", code: "KeyS" });
+    expect(visibleHandler).toHaveBeenCalledOnce();
+    expect(pendingHandler).not.toHaveBeenCalled();
+  });
+
   it("runs the handler for a mail shortcut while the mail scope is active", () => {
     const archive = vi.fn();
     const snooze = vi.fn();
@@ -357,4 +388,16 @@ function press(init: KeyboardEventInit, target: Element = document.body) {
   });
   fireEvent(target, event);
   return event;
+}
+
+function SuspendingShortcuts({
+  handler,
+  pending,
+}: {
+  handler: () => void;
+  pending?: Promise<void>;
+}) {
+  useShortcuts({ star: handler });
+  if (pending) throw pending;
+  return <div>Visible conversation</div>;
 }

--- a/apps/web/lib/shortcuts/useShortcuts.ts
+++ b/apps/web/lib/shortcuts/useShortcuts.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { type HotkeyCallback, useHotkeys } from "react-hotkeys-hook";
 import {
   createSequencePrefixTracker,
@@ -59,7 +66,10 @@ export function useShortcuts(
   { isDesktopApp = false }: { isDesktopApp?: boolean } = {},
 ): void {
   const handlersRef = useRef(handlers);
-  handlersRef.current = handlers;
+  useLayoutEffect(() => {
+    // Suspended renders must not replace the visible screen's handlers.
+    handlersRef.current = handlers;
+  }, [handlers]);
 
   const [sequence] = useState(createSequencePrefixTracker);
 

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -90,6 +90,48 @@ describe("offline mail cache", () => {
     expect(await (await response).text()).toBe("Saved mailbox");
   });
 
+  it("returns saved mail while a background cache write is stalled", async () => {
+    vi.useFakeTimers();
+    const cache = makeCache();
+    await storage.put(mailUrl, html("Saved mailbox"));
+    const pendingWrite = Promise.withResolvers<void>();
+    vi.spyOn(storage, "put").mockReturnValueOnce(pendingWrite.promise);
+    network.mockResolvedValueOnce(html("Refreshed mailbox"));
+    await cache.handle(documentRequest(), waitUntil);
+    network.mockImplementation(() => new Promise(() => {}));
+    let fallback: Response | undefined;
+    const loading = cache
+      .handle(documentRequest(), waitUntil)
+      .then((response) => {
+        fallback = response;
+      });
+    try {
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(fallback).toBeDefined();
+      expect(await fallback?.text()).toBe("Saved mailbox");
+    } finally {
+      pendingWrite.resolve();
+      await loading;
+    }
+  });
+
+  it("does not return saved mail if logout starts during the cache lookup", async () => {
+    const cache = makeCache();
+    const lookupStarted = Promise.withResolvers<void>();
+    const lookup = Promise.withResolvers<Response | undefined>();
+    vi.spyOn(storage, "match").mockImplementationOnce(() => {
+      lookupStarted.resolve();
+      return lookup.promise;
+    });
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    const loading = cache.handle(documentRequest(), waitUntil);
+    await lookupStarted.promise;
+    await cache.clear();
+    lookup.resolve(html("Previous session mailbox"));
+    await expect(loading).rejects.toThrow("Network unavailable");
+    await Promise.all(pending);
+  });
+
   it("bounds a stalled request even when there is no saved mailbox", async () => {
     vi.useFakeTimers();
     network.mockImplementation(

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -56,7 +56,7 @@ export function createOfflineMailCache({
     const cached = async () => {
       if (startedAtGeneration !== generation) return;
       try {
-        await writes;
+        // A stalled refresh must not block reading the previously saved page.
         const response = await (await caches.open(cacheName)).match(key);
         return startedAtGeneration === generation ? response : undefined;
       } catch {


### PR DESCRIPTION
History currently splits a conversation across message rows and paginates individual rule executions. Show one expandable conversation row, preserving the current date headings and per-message results and Fix controls.

- Paginate 50 conversations at a time; fetch older handled messages only when expanded, in pages of 50, without repeating the headline message.
- Count groups in Postgres, use deterministic ordering, and fetch execution details only for the selected messages. Account, rule, and skipped-result filters apply to both summaries and expanded history.
- Add browser/API regression coverage for filters, repeated executions, lazy expansion, missing emails, long conversations, and stable conversation pagination.

Replaces #2401 for History grouping. Test-tab expansion remains deferred as a separate change.

Validation: focused emulated History browser suite passed (three regression tests plus authentication setup) against a disposable Postgres database; expanded/collapsed screenshots inspected; Biome and git diff checks passed. No standalone build run locally.

Performance: three database queries for a nonempty page (group selection, scalar count, execution details), plus at most 50 message metadata lookups. Expanding a conversation loads another bounded page. Grouping/counting still scan matching database history. A local Postgres 17 synthetic run with 100,000 executions across approximately 10,000 conversations took 123 ms for page selection and 35 ms for the scalar count; this is not a production benchmark.

E2E follow-ups: automatic final-state screenshots now skip untouched `about:blank` pages used by API-only tests. CI artifacts confirm that real History screenshots remain and the blank checkpoint is absent. Queue fixtures use a fixed timestamp, label shortcuts wait for focus restoration, and the offline reconnect test confirms connectivity before reloading.

Keyboard shortcuts now retain the committed screen’s handlers while a newer render is suspended, preventing a visible conversation from losing its action target. A failing-before/passing-after Suspense regression covers this behavior. All 38 focused shortcut and cache tests pass; the original star shortcut/menu browser spec passes locally using the CI production build with the equivalent handler change applied. Logout-during-cache-lookup coverage is retained alongside the cache fix now on main. Final CI passed on `3f94e4d6d`: all unit and browser test groups passed, with 28 successful checks and one neutral review check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assistant history is now grouped by conversation thread, with expandable rows showing message counts and timestamps.
  - Expanded threads support paginated loading of older history and filtering by rule.

- **Bug Fixes**
  - Improved history pagination for consistent results, missing messages, and tied timestamps.
  - Offline mail pages can now load previously cached content without waiting for stalled updates.
  - Prevented cached mail from a previous session from appearing after logout.
  - Preserved keyboard shortcuts for the visible conversation during loading transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

