### PR TITLE
ci: skip duplicate type checking in browser build

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -159,6 +159,7 @@ jobs:
         env:
           NODE_ENV: production
           NODE_OPTIONS: --max_old_space_size=16384
+          SKIP_TYPE_CHECK: "true"
 
       - name: Package browser app
         if: steps.targets.outputs.batches != '[]'


### PR DESCRIPTION
The browser production build repeats TypeScript checking already performed by the separate Build Check workflow. Enable the existing `SKIP_TYPE_CHECK` option only for the browser build; all browser tests remain enabled and the separate type check remains unchanged.

Measured against the previous full browser run:
- Browser build: 2m 33s → 1m 16s.
- Complete shared build job: 3m 22s → 2m 05s.
- Logs confirm type checking is skipped. The previous type-check phase took 57s; compilation also fell from 80s to 58s, so the entire 77s improvement cannot be attributed to this change.

Validation: actionlint and git diff --check passed. All 20 browser batches and all PR checks passed in [CI](https://github.com/elie222/inbox-zero/actions/runs/34603665299). Required-check completion took 10m 38s, including 1m 42s before the build job started and 2m 50s between the final browser worker finishing and the four-second Web E2E gate starting. Queue delay remains a separate constraint.
