### PR TITLE
auth: Handle verified Google email renames

### DIFF
--- a/apps/web/__tests__/db/email-rename.test.ts
+++ b/apps/web/__tests__/db/email-rename.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/prisma";
+import { renameGoogleEmail } from "@/utils/auth/rename-email";
+
+vi.mock("@/utils/redis/account-validation", () => ({
+  invalidateAccountValidation: vi.fn(),
+}));
+
+const userId = "email-rename-test-user";
+const otherUserId = "email-rename-test-other-user";
+const accountId = "email-rename-test-account";
+const mailboxId = "email-rename-test-mailbox";
+const input = {
+  account: {
+    id: accountId,
+    userId,
+    providerId: "google",
+    accountId: "email-rename-subject",
+  },
+  mailbox: { id: mailboxId, email: "rename-old@example.com" },
+  userEmail: "rename-old@example.com",
+  profile: {
+    email: "rename-new@example.com",
+    sub: "email-rename-subject",
+    emailVerified: true,
+    hostedDomain: "example.com",
+  },
+};
+
+describe.skipIf(!process.env.RUN_DB_TESTS)(
+  "email rename (real database)",
+  () => {
+    beforeEach(async () => {
+      await prisma.user.deleteMany({
+        where: { id: { in: [userId, otherUserId] } },
+      });
+      await prisma.user.create({
+        data: { id: userId, email: input.userEmail },
+      });
+      await prisma.account.create({
+        data: {
+          id: accountId,
+          userId,
+          provider: "google",
+          providerAccountId: input.account.accountId,
+        },
+      });
+      await prisma.emailAccount.create({
+        data: {
+          id: mailboxId,
+          email: input.mailbox.email,
+          userId,
+          accountId,
+          about: "Keep these mailbox settings",
+        },
+      });
+    });
+    afterAll(async () => {
+      await prisma.user.deleteMany({
+        where: { id: { in: [userId, otherUserId] } },
+      });
+    });
+
+    it("keeps the same user and mailbox with their settings", async () => {
+      await renameGoogleEmail(input);
+      expect(
+        await prisma.emailAccount.findUnique({ where: { id: mailboxId } }),
+      ).toMatchObject({
+        userId,
+        accountId,
+        email: input.profile.email,
+        about: "Keep these mailbox settings",
+      });
+      expect(
+        await prisma.user.findUnique({ where: { id: userId } }),
+      ).toMatchObject({ email: input.profile.email, emailVerified: true });
+    });
+
+    it("does not merge a colliding mailbox or partially rename the user", async () => {
+      await prisma.user.create({
+        data: { id: otherUserId, email: "rename-other@example.com" },
+      });
+      const otherAccount = await prisma.account.create({
+        data: {
+          userId: otherUserId,
+          provider: "google",
+          providerAccountId: "other-rename-subject",
+        },
+      });
+      await prisma.emailAccount.create({
+        data: {
+          email: input.profile.email,
+          userId: otherUserId,
+          accountId: otherAccount.id,
+        },
+      });
+      await expect(renameGoogleEmail(input)).rejects.toMatchObject({
+        body: { code: "email_already_linked" },
+      });
+      expect(
+        await prisma.user.findUnique({ where: { id: userId } }),
+      ).toMatchObject({ email: input.userEmail });
+      expect(
+        await prisma.emailAccount.findUnique({ where: { id: mailboxId } }),
+      ).toMatchObject({ email: input.mailbox.email, userId });
+    });
+
+    it("rolls back when the new primary email belongs to another user", async () => {
+      await prisma.user.create({
+        data: { id: otherUserId, email: input.profile.email },
+      });
+      await expect(renameGoogleEmail(input)).rejects.toMatchObject({
+        body: { code: "email_already_linked" },
+      });
+      expect(
+        await prisma.emailAccount.findUnique({ where: { id: mailboxId } }),
+      ).toMatchObject({ email: input.mailbox.email });
+      expect(
+        await prisma.user.findUnique({ where: { id: otherUserId } }),
+      ).toMatchObject({ email: input.profile.email });
+    });
+
+    it("rolls back the mailbox rename if the primary user email changed concurrently", async () => {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { email: "rename-changed@example.com" },
+      });
+      await expect(renameGoogleEmail(input)).rejects.toMatchObject({
+        body: { code: "email_already_linked" },
+      });
+      expect(
+        await prisma.emailAccount.findUnique({ where: { id: mailboxId } }),
+      ).toMatchObject({ email: input.mailbox.email });
+      expect(
+        await prisma.user.findUnique({ where: { id: userId } }),
+      ).toMatchObject({ email: "rename-changed@example.com" });
+    });
+
+    it("rejects a stale ownership snapshot without taking the mailbox back", async () => {
+      await prisma.user.create({
+        data: { id: otherUserId, email: "rename-other@example.com" },
+      });
+      await prisma.account.update({
+        where: { id: accountId },
+        data: { userId: otherUserId },
+      });
+      await prisma.emailAccount.update({
+        where: { id: mailboxId },
+        data: { userId: otherUserId },
+      });
+      await expect(renameGoogleEmail(input)).rejects.toMatchObject({
+        body: { code: "email_already_linked" },
+      });
+      expect(
+        await prisma.emailAccount.findUnique({ where: { id: mailboxId } }),
+      ).toMatchObject({ userId: otherUserId, email: input.mailbox.email });
+      expect(
+        await prisma.user.findUnique({ where: { id: userId } }),
+      ).toMatchObject({ email: input.userEmail });
+    });
+  },
+);

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import type { Account } from "better-auth";
+import { setSessionCookie } from "better-auth/cookies";
 import { cookies } from "next/headers";
 import { createReferral } from "@/utils/referral/referral-code";
 import { captureException } from "@/utils/error";
 import { saveTokens } from "@/utils/auth/save-tokens";
 import { createOutlookClient } from "@/utils/outlook/client";
-import { getContactsClient } from "@/utils/gmail/client";
+import { fetchGoogleOpenIdProfile } from "@/utils/google/oauth";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import {
   betterAuthConfig,
@@ -45,6 +46,13 @@ vi.mock("better-auth", () => {
   };
 });
 vi.mock("@/utils/prisma");
+vi.mock("better-auth/cookies", async (importActual) => ({
+  ...(await importActual<typeof import("better-auth/cookies")>()),
+  setSessionCookie: vi.fn(),
+}));
+vi.mock("@/utils/redis/account-validation", () => ({
+  invalidateAccountValidation: vi.fn(),
+}));
 vi.mock("@/utils/error-messages", () => ({
   addUserErrorMessage: vi.fn().mockResolvedValue(undefined),
   clearAccountDisconnectedErrorIfResolved: vi.fn().mockResolvedValue(undefined),
@@ -63,8 +71,9 @@ vi.mock("@googleapis/gmail", () => ({
 vi.mock("@/utils/outlook/client", () => ({
   createOutlookClient: vi.fn(),
 }));
-vi.mock("@/utils/gmail/client", () => ({
-  getContactsClient: vi.fn(),
+vi.mock("@/utils/google/oauth", async (importActual) => ({
+  ...(await importActual<typeof import("@/utils/google/oauth")>()),
+  fetchGoogleOpenIdProfile: vi.fn(),
 }));
 vi.mock("@/utils/email/watch-manager", () => ({
   ensureEmailAccountsWatched: vi.fn(),
@@ -320,6 +329,75 @@ describe("handleLinkAccount", () => {
     vi.clearAllMocks();
   });
 
+  it.each([
+    "/callback/google",
+    "/callback/:id",
+    "/oauth2/callback/google",
+  ])("renames and refreshes the new session on %s", async (path) => {
+    mockGoogleProfile();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "mailbox",
+      email: "old@example.com",
+      userId: "user_1",
+      accountId: "account_1",
+      account: { provider: "google" },
+    } as any);
+    prisma.user.findUnique.mockImplementation(async ({ where }) =>
+      where.id
+        ? ({ email: "old@example.com", name: "Test User", image: null } as any)
+        : null,
+    );
+    prisma.$transaction.mockResolvedValue([{ id: "mailbox" }, {}] as never);
+    const context = { path, params: { id: "google" }, context: {} as any };
+    const options = (betterAuthConfig as any).options;
+    await options.databaseHooks.account.update.after(
+      getGoogleAccount(),
+      context,
+    );
+    context.context.newSession = {
+      user: { id: "user_1", email: "old@example.com", emailVerified: false },
+      session: {},
+    };
+    await options.hooks.after(context);
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { email: "user@example.com", emailVerified: true },
+      }),
+    );
+    expect(setSessionCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ path }),
+      expect.objectContaining({
+        user: expect.objectContaining({
+          email: "user@example.com",
+          emailVerified: true,
+        }),
+      }),
+    );
+  });
+
+  it("does not rename during token refresh", async () => {
+    mockGoogleProfile();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "mailbox",
+      email: "old@example.com",
+      userId: "user_1",
+      accountId: "account_1",
+      account: { provider: "google" },
+    } as any);
+    prisma.user.findUnique.mockResolvedValue({
+      email: "old@example.com",
+    } as any);
+    prisma.$transaction.mockResolvedValue([{ id: "mailbox" }, {}] as never);
+    await (betterAuthConfig as any).options.databaseHooks.account.update.after(
+      getGoogleAccount(),
+      { path: "/get-access-token", context: {} },
+    );
+    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: "Test User", image: null } }),
+    );
+  });
+
   it("skips auth-only providers without requiring an access token", async () => {
     await expect(
       handleLinkAccount({
@@ -398,9 +476,13 @@ describe("handleLinkAccount", () => {
       name: "Test User",
       image: null,
     } as any);
-    prisma.emailAccount.upsert.mockImplementation(({ where }) => {
-      if (where.accountId !== mailbox.accountId) {
-        throw new Error("Unique constraint failed on accountId");
+    prisma.emailAccount.update.mockImplementation(({ where }) => {
+      if (
+        where.id !== mailbox.id ||
+        where.userId !== mailbox.userId ||
+        where.accountId !== mailbox.accountId
+      ) {
+        throw new Error("Mailbox ownership changed");
       }
       return Promise.resolve(mailbox) as any;
     });
@@ -410,9 +492,11 @@ describe("handleLinkAccount", () => {
       handleLinkAccount(getGoogleAccount()),
     ).resolves.toBeUndefined();
 
-    const upsert = prisma.emailAccount.upsert.mock.calls[0]?.[0];
-    expect(upsert?.update).not.toHaveProperty("email");
-    expect(upsert?.update).not.toHaveProperty("mailSplits");
+    expect(prisma.emailAccount.upsert).not.toHaveBeenCalled();
+    const update = prisma.emailAccount.update.mock.calls[0]?.[0];
+    expect(update?.data).not.toHaveProperty("email");
+    expect(update?.data).not.toHaveProperty("userId");
+    expect(update?.data).not.toHaveProperty("mailSplits");
     expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalled();
     expect(mockAfter).toHaveBeenCalledOnce();
   });
@@ -520,24 +604,13 @@ describe("handleLinkAccount", () => {
 });
 
 function mockGoogleProfile() {
-  const people = {
-    get: vi.fn().mockResolvedValue({
-      data: {
-        emailAddresses: [
-          {
-            value: "user@example.com",
-            metadata: { primary: true },
-          },
-        ],
-        names: [{ displayName: "Test User", metadata: { primary: true } }],
-        photos: [],
-      },
-    }),
-  } as ReturnType<typeof getContactsClient>["people"];
-
-  vi.mocked(getContactsClient).mockReturnValue({
-    people,
-  } as ReturnType<typeof getContactsClient>);
+  vi.mocked(fetchGoogleOpenIdProfile).mockResolvedValue({
+    email: "user@example.com",
+    sub: "provider_account_1",
+    name: "Test User",
+    email_verified: true,
+    hd: "example.com",
+  });
 }
 
 function getGoogleAccount(): Account {

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -9,6 +9,8 @@ import { createContact as createResendContact } from "@inboxzero/transactional-e
 import type { Account } from "better-auth";
 import { APIError, betterAuth } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";
+import { setSessionCookie } from "better-auth/cookies";
+import { renameGoogleEmail } from "@/utils/auth/rename-email";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import { cookies, headers } from "next/headers";
@@ -25,7 +27,6 @@ import {
 } from "@/utils/email/provider-types";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import { captureException } from "@/utils/error";
-import { getContactsClient as getGoogleContactsClient } from "@/utils/gmail/client";
 import { SCOPES as GMAIL_SCOPES } from "@/utils/gmail/scopes";
 import {
   fetchGoogleOpenIdProfile,
@@ -66,6 +67,10 @@ import {
 } from "@/utils/auth/email-otp";
 
 const logger = createScopedLogger("auth");
+const renamedAuthUsers = new WeakMap<
+  object,
+  { userId: string; email: string }
+>();
 const EMAIL_ALREADY_LINKED_ERROR = "email_already_linked";
 const useGoogleOauthEmulator = isGoogleOauthEmulationEnabled();
 const useMicrosoftOauthEmulator = isMicrosoftEmulationEnabled();
@@ -348,8 +353,18 @@ export const betterAuthConfig = betterAuth({
         },
       },
       update: {
-        after: async (account: Account) => {
-          await handleLinkAccount(account);
+        after: async (account: Account, context) => {
+          const isGoogleCallback =
+            !!(
+              context?.path?.startsWith("/callback/") ||
+              context?.path?.startsWith("/oauth2/callback/")
+            ) && getAuthProviderFromContext(context) === "google";
+          const renamedUser = await handleLinkAccount(
+            account,
+            isGoogleCallback,
+          );
+          if (renamedUser && context?.context)
+            renamedAuthUsers.set(context.context, renamedUser);
         },
       },
     },
@@ -357,6 +372,13 @@ export const betterAuthConfig = betterAuth({
   hooks: {
     before: emailOtpBeforeHook,
     after: createAuthMiddleware(async (context) => {
+      const renamedUser = renamedAuthUsers.get(context.context);
+      const newSession = context.context.newSession;
+      if (renamedUser && newSession?.user.id === renamedUser.userId) {
+        newSession.user.email = renamedUser.email;
+        newSession.user.emailVerified = true;
+        await setSessionCookie(context, newSession);
+      }
       await emailOtpAfterHook(context);
       try {
         const authenticatedSession = context.context.newSession;
@@ -544,29 +566,14 @@ export async function handleReferralOnSignUp({
 // TODO: move into email provider instead of checking the provider type
 async function getProfileData(providerId: string, accessToken: string) {
   if (isGoogleProvider(providerId)) {
-    if (useGoogleOauthEmulator) {
-      const profile = await fetchGoogleOpenIdProfile(accessToken);
-
-      return {
-        email: profile.email?.toLowerCase(),
-        name: profile.name,
-        image: profile.picture ?? null,
-      };
-    }
-
-    const contactsClient = getGoogleContactsClient({ accessToken });
-    const profileResponse = await contactsClient.people.get({
-      resourceName: "people/me",
-      personFields: "emailAddresses,names,photos",
-    });
-
+    const profile = await fetchGoogleOpenIdProfile(accessToken);
     return {
-      email: profileResponse.data.emailAddresses
-        ?.find((e) => e.metadata?.primary)
-        ?.value?.toLowerCase(),
-      name: profileResponse.data.names?.find((n) => n.metadata?.primary)
-        ?.displayName,
-      image: profileResponse.data.photos?.find((p) => p.metadata?.primary)?.url,
+      email: profile.email.toLowerCase(),
+      name: profile.name,
+      image: profile.picture ?? null,
+      sub: profile.sub,
+      emailVerified: profile.email_verified,
+      hostedDomain: profile.hd,
     };
   }
 
@@ -604,7 +611,10 @@ function shouldLinkEmailAccount(providerId: string) {
   return isGoogleProvider(providerId) || isMicrosoftProvider(providerId);
 }
 
-export async function handleLinkAccount(account: Account) {
+export async function handleLinkAccount(
+  account: Account,
+  allowEmailRename = false,
+) {
   let primaryEmail: string | null | undefined;
   let primaryName: string | null | undefined;
   let primaryPhotoUrl: string | null | undefined;
@@ -651,6 +661,7 @@ export async function handleLinkAccount(account: Account) {
       where: { accountId: account.id },
       select: {
         id: true,
+        email: true,
         userId: true,
         accountId: true,
         account: { select: { provider: true } },
@@ -734,6 +745,16 @@ export async function handleLinkAccount(account: Account) {
       return;
     }
 
+    const renamedMailbox =
+      allowEmailRename && linkedEmailAccount && profileData
+        ? await renameGoogleEmail({
+            account,
+            mailbox: linkedEmailAccount,
+            userEmail: user.email,
+            profile: { ...profileData, email: normalizedEmail },
+          })
+        : undefined;
+
     const data = {
       userId: account.userId,
       accountId: account.id,
@@ -741,29 +762,50 @@ export async function handleLinkAccount(account: Account) {
       image: primaryPhotoUrl,
     };
 
-    const [upsertedEmailAccount] = await prisma.$transaction([
-      prisma.emailAccount.upsert({
-        where: linkedEmailAccount
-          ? { accountId: account.id }
-          : { email: normalizedEmail },
-        update: data,
-        create: {
-          ...data,
-          email: normalizedEmail,
-          mailSplits: {
-            create: INITIAL_MAIL_SPLITS.map((split, order) => ({
-              ...split,
-              order,
-            })),
-          },
-        },
-        select: { id: true },
-      }),
-      prisma.account.update({
-        where: { id: account.id },
-        data: { disconnectedAt: null },
-      }),
-    ]);
+    const upsertedEmailAccount =
+      renamedMailbox ??
+      (
+        await prisma.$transaction([
+          linkedEmailAccount
+            ? prisma.emailAccount.update({
+                where: {
+                  id: linkedEmailAccount.id,
+                  userId: account.userId,
+                  accountId: account.id,
+                  account: {
+                    userId: account.userId,
+                    provider: account.providerId,
+                    providerAccountId: account.accountId,
+                  },
+                },
+                data: { name: primaryName, image: primaryPhotoUrl },
+                select: { id: true },
+              })
+            : prisma.emailAccount.upsert({
+                where: { email: normalizedEmail },
+                update: data,
+                create: {
+                  ...data,
+                  email: normalizedEmail,
+                  mailSplits: {
+                    create: INITIAL_MAIL_SPLITS.map((split, order) => ({
+                      ...split,
+                      order,
+                    })),
+                  },
+                },
+                select: { id: true },
+              }),
+          prisma.account.update({
+            where: {
+              id: account.id,
+              userId: account.userId,
+              providerAccountId: account.accountId,
+            },
+            data: { disconnectedAt: null },
+          }),
+        ])
+      )[0];
 
     await clearAccountDisconnectedErrorIfResolved({
       userId: account.userId,
@@ -795,6 +837,7 @@ export async function handleLinkAccount(account: Account) {
       userId: account.userId,
       accountId: account.id,
     });
+    return renamedMailbox?.renamedUser;
   } catch (error) {
     logger.error("[linkAccount] Error during linking process:", {
       userId: account.userId,

--- a/apps/web/utils/auth/rename-email.test.ts
+++ b/apps/web/utils/auth/rename-email.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { renameGoogleEmail } from "@/utils/auth/rename-email";
+import prisma from "@/utils/__mocks__/prisma";
+import { invalidateAccountValidation } from "@/utils/redis/account-validation";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/redis/account-validation", () => ({
+  invalidateAccountValidation: vi.fn(),
+}));
+
+const input = {
+  account: {
+    id: "account",
+    userId: "user",
+    providerId: "google",
+    accountId: "subject",
+  },
+  mailbox: { id: "mailbox", email: "old@example.com" },
+  userEmail: "old@example.com",
+  profile: {
+    email: "new@example.com",
+    sub: "subject",
+    emailVerified: true,
+    hostedDomain: "example.com",
+  },
+};
+
+describe("renameGoogleEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.$transaction.mockResolvedValue([]);
+  });
+
+  it("does no database work when the address is unchanged", async () => {
+    await renameGoogleEmail({
+      ...input,
+      profile: { ...input.profile, email: input.mailbox.email },
+    });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      providerId: "microsoft",
+      sub: "subject",
+      emailVerified: true,
+      hostedDomain: "example.com",
+    },
+    {
+      providerId: "google",
+      sub: "other-subject",
+      emailVerified: true,
+      hostedDomain: "example.com",
+    },
+    {
+      providerId: "google",
+      sub: "subject",
+      emailVerified: false,
+      hostedDomain: "example.com",
+    },
+    {
+      providerId: "google",
+      sub: "subject",
+      emailVerified: undefined,
+      hostedDomain: "example.com",
+    },
+    {
+      providerId: "google",
+      sub: "subject",
+      emailVerified: true,
+      hostedDomain: undefined,
+    },
+  ])("does not rename without authoritative matching identity: %j", async ({
+    providerId,
+    ...profile
+  }) => {
+    await renameGoogleEmail({
+      ...input,
+      account: { ...input.account, providerId },
+      profile: { ...input.profile, ...profile },
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { email: "new@example.com", hostedDomain: "example.com" },
+    { email: "new@gmail.com", hostedDomain: undefined },
+  ])("updates the primary login and clears mailbox cache for $email", async (profile) => {
+    expect(
+      await renameGoogleEmail({
+        ...input,
+        profile: { ...input.profile, ...profile },
+      }),
+    ).toEqual({
+      id: "mailbox",
+      renamedUser: { userId: "user", email: profile.email },
+    });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user", email: "old@example.com" },
+      data: { email: profile.email, emailVerified: true },
+    });
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "mailbox",
+          email: "old@example.com",
+          userId: "user",
+          accountId: "account",
+          account: {
+            userId: "user",
+            provider: "google",
+            providerAccountId: "subject",
+          },
+        },
+      }),
+    );
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(invalidateAccountValidation).toHaveBeenCalledWith({
+      userId: "user",
+      emailAccountId: "mailbox",
+    });
+  });
+
+  it("does not change the primary login when renaming a secondary mailbox", async () => {
+    expect(
+      await renameGoogleEmail({ ...input, userEmail: "primary@example.com" }),
+    ).toEqual({ id: "mailbox", renamedUser: undefined });
+    expect(prisma.emailAccount.update).toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses an email claimed by a different user", async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: "other-user" } as any);
+    await expect(
+      renameGoogleEmail({ ...input, userEmail: "primary@example.com" }),
+    ).rejects.toMatchObject({
+      body: { code: "email_already_linked" },
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "P2002",
+    "P2025",
+  ])("fails safely on a database conflict (%s)", async (code) => {
+    prisma.$transaction.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("conflict", {
+        code,
+        clientVersion: "test",
+      }),
+    );
+    await expect(renameGoogleEmail(input)).rejects.toMatchObject({
+      body: { code: "email_already_linked" },
+    });
+    expect(invalidateAccountValidation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/auth/rename-email.ts
+++ b/apps/web/utils/auth/rename-email.ts
@@ -1,0 +1,108 @@
+import { APIError, type Account } from "better-auth";
+import prisma from "@/utils/prisma";
+import { isDuplicateError, isNotFoundError } from "@/utils/prisma-helpers";
+import { assertAllowedAuthSignupEmail } from "@/utils/auth-signup-policy";
+import { invalidateAccountValidation } from "@/utils/redis/account-validation";
+
+export async function renameGoogleEmail({
+  account,
+  mailbox,
+  userEmail,
+  profile,
+}: {
+  account: Pick<Account, "id" | "userId" | "providerId" | "accountId">;
+  mailbox: { id: string; email: string };
+  userEmail: string;
+  profile: {
+    email: string;
+    sub?: string;
+    emailVerified?: boolean;
+    hostedDomain?: string;
+    name?: string | null;
+    image?: string | null;
+  };
+}) {
+  const email = profile.email.trim().toLowerCase();
+  if (email === mailbox.email) return;
+
+  // Google is not authoritative for third-party email addresses, even when
+  // email_verified is true. Microsoft profile emails are not identity proofs.
+  if (
+    account.providerId !== "google" ||
+    profile.sub !== account.accountId ||
+    profile.emailVerified !== true ||
+    !(email.endsWith("@gmail.com") || profile.hostedDomain)
+  ) {
+    return;
+  }
+  assertAllowedAuthSignupEmail(email);
+
+  const isPrimary = userEmail === mailbox.email;
+  // Secondary-mailbox updates do not touch User.email, so its unique
+  // constraint cannot catch a conflicting login owned by another user.
+  if (!isPrimary) {
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (existingUser && existingUser.id !== account.userId) {
+      throw APIError.from("BAD_REQUEST", {
+        code: "email_already_linked",
+        message: "email_already_linked",
+      });
+    }
+  }
+
+  try {
+    await prisma.$transaction([
+      prisma.emailAccount.update({
+        where: {
+          id: mailbox.id,
+          email: mailbox.email,
+          userId: account.userId,
+          accountId: account.id,
+          account: {
+            userId: account.userId,
+            provider: "google",
+            providerAccountId: account.accountId,
+          },
+        },
+        data: { email, name: profile.name, image: profile.image },
+      }),
+      prisma.account.update({
+        where: {
+          id: account.id,
+          userId: account.userId,
+          provider: "google",
+          providerAccountId: account.accountId,
+        },
+        data: { disconnectedAt: null },
+      }),
+      ...(isPrimary
+        ? [
+            prisma.user.update({
+              where: { id: account.userId, email: userEmail },
+              data: { email, emailVerified: true },
+            }),
+          ]
+        : []),
+    ]);
+  } catch (error) {
+    if (isDuplicateError(error) || isNotFoundError(error)) {
+      throw APIError.from("BAD_REQUEST", {
+        code: "email_already_linked",
+        message: "email_already_linked",
+      });
+    }
+    throw error;
+  }
+
+  await invalidateAccountValidation({
+    userId: account.userId,
+    emailAccountId: mailbox.id,
+  });
+  return {
+    id: mailbox.id,
+    renamedUser: isPrimary ? { userId: account.userId, email } : undefined,
+  };
+}

--- a/apps/web/utils/google/oauth.test.ts
+++ b/apps/web/utils/google/oauth.test.ts
@@ -94,6 +94,8 @@ describe("google oauth helpers", () => {
       json: vi.fn().mockResolvedValue({
         sub: "google-user-1",
         email: "user@example.com",
+        email_verified: true,
+        hd: "example.com",
         picture: null,
       }),
     } as unknown as Response);
@@ -101,6 +103,8 @@ describe("google oauth helpers", () => {
     await expect(oauth.fetchGoogleOpenIdProfile("token")).resolves.toEqual({
       sub: "google-user-1",
       email: "user@example.com",
+      email_verified: true,
+      hd: "example.com",
       picture: null,
     });
     expect(global.fetch).toHaveBeenCalledWith(

--- a/apps/web/utils/google/oauth.ts
+++ b/apps/web/utils/google/oauth.ts
@@ -16,6 +16,7 @@ const googleOpenIdProfileSchema = z.object({
   email: z.string().min(1),
   email_verified: z.boolean().optional(),
   family_name: z.string().optional(),
+  hd: z.string().optional(),
   given_name: z.string().optional(),
   name: z.string().optional(),
   picture: z.string().nullish(),


### PR DESCRIPTION
A returning Google user can keep the same provider identity while their email changes. Update the linked mailbox address and, when it is the primary mailbox, the login address without replacing the user, subscription, or mailbox data.

- Use Google OpenID UserInfo in place of the existing People profile request. Automatic renames require a matching subject, a verified email, and a Gmail address or Google-hosted domain. Microsoft and non-authoritative third-party email claims do not trigger renames.
- Apply address changes and account metadata in one transaction with ownership/identity guards. Unique-address conflicts and stale snapshots fail safely instead of merging accounts. Preserve the login address when only a secondary mailbox changes.
- Invalidate the mailbox-address cache after a rename and update the newly issued callback session with the new primary email.
- Performance: no additional database/network work on ordinary app requests. Unchanged callback emails skip rename queries; profile retrieval remains one request. A primary rename adds one user-row update to the existing transaction, while a secondary rename adds one indexed ownership lookup. Cache invalidation/session refresh happen only after a rename. No latency benchmark is claimed.
- Validation: 36 focused unit tests, 5 real-PostgreSQL tests on a disposable local database, Ultracite, and git diff checks pass. Tests cover subject/verification requirements, callback-only execution, session refresh, no-op query avoidance, conflicting addresses, and rollback after stale ownership or primary-email changes.

This does not merge distinct provider identities or modify external billing contact details. Existing sessions may retain the old email until their normal cache refresh.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

