### PR TITLE
mail: Add star toggle to the thread actions menu

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
@@ -53,4 +53,12 @@ test("toggles a star with S and the command palette while preserving unread", as
   await capturePlaywrightCheckpoint(page, testInfo, "starred-reader-subject");
   await page.keyboard.press("s");
   await expect(readerStarStatus).toHaveCount(0);
+
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  const actionsMenu = page.getByRole("menu");
+  await actionsMenu.getByRole("menuitem", { name: /^Star/ }).click();
+  await expect(readerStarStatus).toBeVisible();
+  await page.getByRole("button", { name: /^More actions/ }).click();
+  await actionsMenu.getByRole("menuitem", { name: /^Unstar/ }).click();
+  await expect(readerStarStatus).toHaveCount(0);
 });

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1630,6 +1630,8 @@ export function MailShell() {
                     message={openMessages.at(-1) ?? null}
                     setChatInput={setChatInput}
                     isUnread={isOpenThreadUnread}
+                    isStarred={allStarred}
+                    onToggleStar={starTargets}
                     onMarkSpam={markSpamTargets}
                     onDelete={trashTargets}
                     onLabel={canLabel ? openLabelPicker : undefined}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -12,6 +12,8 @@ import {
   MoreHorizontalIcon,
   ShieldAlertIcon,
   SparklesIcon,
+  StarIcon,
+  StarOffIcon,
   Trash2Icon,
   TagIcon,
 } from "lucide-react";
@@ -58,6 +60,8 @@ export type ThreadActionsMenuProps = {
   /** `setInput` from `useChat()`: the fix flow seeds the assistant with it. */
   setChatInput: (input: string) => void;
   isUnread: boolean;
+  isStarred: boolean;
+  onToggleStar: () => void;
   onMarkSpam: () => void;
   onDelete: () => void;
   onMarkRead: () => void;
@@ -79,6 +83,8 @@ export function ThreadActionsMenu({
   message,
   setChatInput,
   isUnread,
+  isStarred,
+  onToggleStar,
   onMarkSpam,
   onDelete,
   onMarkRead,
@@ -175,6 +181,18 @@ export function ThreadActionsMenu({
               </DropdownMenuShortcut>
             </DropdownMenuItem>
           )}
+
+          <DropdownMenuItem onSelect={onToggleStar}>
+            {isStarred ? (
+              <StarOffIcon className="mr-2 size-4" />
+            ) : (
+              <StarIcon className="mr-2 size-4" />
+            )}
+            {isStarred ? "Unstar" : "Star"}
+            <DropdownMenuShortcut>
+              {getShortcutHint("star")}
+            </DropdownMenuShortcut>
+          </DropdownMenuItem>
 
           {isUnread ? (
             <DropdownMenuItem onSelect={onMarkRead}>


### PR DESCRIPTION
Starring a conversation was only reachable from the `S` shortcut and the command palette. This surfaces it in the reader's overflow menu too.

- New menu item between Move and the read/unread toggles, flipping between Star and Unstar with the thread's starred state and showing the existing shortcut hint
- Wired to the shell's existing star targets, so the menu, the shortcut, and the palette share one source of truth and act on the same threads
- Extends the starring browser test to star and unstar through the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

