### PR TITLE
fix(mail): show matched reasons per message

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/coverage.json
+++ b/apps/web/__tests__/playwright/emulated/mail/coverage.json
@@ -94,5 +94,11 @@
   "reader-transition.spec.ts": [
     "app/(app)/[emailAccountId]/mail/BufferedThreadReader.tsx",
     "components/email-list/BufferedEmailIframe.tsx"
+  ],
+  "message-actions.spec.ts": [
+    "app/(app)/[emailAccountId]/mail/MessageActionsMenu.tsx",
+    "app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx",
+    "components/email-list/EmailMessage.tsx",
+    "utils/threads/load.ts"
   ]
 }

--- a/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "@playwright/test";
+import { capturePlaywrightCheckpoint } from "../playwright-evidence";
+import { test } from "../playwright-test";
+import { conversationWithSubject, openMail } from "./mail-test-helpers";
+
+test("shows matched reasons only for the selected message", async ({
+  page,
+}, testInfo) => {
+  await page.route(
+    "**/api/threads/thr_playwright_reader_visual?**",
+    async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      const message = body.thread.messages.at(-1);
+      body.thread.messages = [
+        {
+          ...message,
+          id: "earlier-message",
+          textHtml: "<p>Earlier message body.</p>",
+        },
+        {
+          ...message,
+          id: "later-message",
+          textHtml: "<p>Later message body.</p>",
+        },
+      ];
+      await route.fulfill({ response, json: body });
+    },
+  );
+  await page.route("**/api/threads?**", async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    const thread = body.threads?.find(
+      (thread: { id: string }) => thread.id === "thr_playwright_reader_visual",
+    );
+    if (thread) {
+      thread.plans = [
+        {
+          id: "earlier-match",
+          messageId: "earlier-message",
+          rule: { id: "rule-1", name: "Example rule" },
+          actionItems: [],
+          status: "APPLIED",
+          reason: "Reason for the earlier message.",
+        },
+        {
+          id: "later-match",
+          messageId: "later-message",
+          rule: { id: "rule-1", name: "Example rule" },
+          actionItems: [],
+          status: "APPLIED",
+          reason: "Reason for the later message.",
+        },
+      ];
+    }
+    await route.fulfill({ response, json: body });
+  });
+  const { conversations } = await openMail(page);
+  await conversationWithSubject(
+    page,
+    conversations,
+    "Re: Reader Visual Message",
+  ).click();
+  for (const [id, reason, otherReason] of [
+    [
+      "earlier-message",
+      "Reason for the earlier message.",
+      "Reason for the later message.",
+    ],
+    [
+      "later-message",
+      "Reason for the later message.",
+      "Reason for the earlier message.",
+    ],
+  ]) {
+    const message = page.locator(`[data-thread-message-id="${id}"]`);
+    await message.hover();
+    await expect(
+      message.getByRole("button", { name: "Reply", exact: true }),
+    ).toBeVisible();
+    await expect(
+      message.getByRole("button", { name: "Forward", exact: true }),
+    ).toBeVisible();
+    await message.getByRole("button", { name: "More message actions" }).click();
+    await page.getByRole("menuitem", { name: "Matched reason" }).click();
+    await expect(page.getByText(reason, { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(otherReason, { exact: true }),
+    ).not.toBeVisible();
+    await capturePlaywrightCheckpoint(page, testInfo, `matched-reason-${id}`);
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+  }
+});

--- a/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
@@ -81,7 +81,9 @@ test("shows matched reasons only for the selected message", async ({
     await expect(
       message.getByRole("button", { name: "Forward", exact: true }),
     ).toBeVisible();
-    await message.getByRole("button", { name: "More message actions" }).click();
+    await message
+      .getByRole("button", { name: "More message actions", exact: true })
+      .click();
     await page.getByRole("menuitem", { name: "Matched reason" }).click();
     await expect(page.getByText(reason, { exact: true })).toBeVisible();
     await expect(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { MessageActionsMenu } from "@/app/(app)/[emailAccountId]/mail/MessageActionsMenu";
+
 import { GmailLabel } from "@/utils/gmail/label";
 import { isThreadStarred } from "@/app/(app)/[emailAccountId]/mail/star-state";
 import {
@@ -1624,11 +1626,20 @@ export function MailShell() {
                 }}
                 autoOpenReplyForMessageId={replyToMessageId}
                 autoOpenForwardForMessageId={forwardToMessageId}
+                renderMessageMenu={(message) => (
+                  <MessageActionsMenu
+                    message={message}
+                    plans={openThread?.plans ?? []}
+                    setChatInput={setChatInput}
+                    showFixWithChat={
+                      !isAllAccounts ||
+                      openThreadSelection?.emailAccountId === emailAccountId
+                    }
+                  />
+                )}
                 menu={
                   <ThreadActionsMenu
-                    plans={openThread?.plans ?? []}
                     message={openMessages.at(-1) ?? null}
-                    setChatInput={setChatInput}
                     isUnread={isOpenThreadUnread}
                     onMarkSpam={markSpamTargets}
                     onDelete={trashTargets}
@@ -1639,10 +1650,6 @@ export function MailShell() {
                       setReadState([openThreadKey], true);
                     }}
                     onMarkUnread={markUnreadTargets}
-                    showFixWithChat={
-                      !isAllAccounts ||
-                      openThreadSelection?.emailAccountId === emailAccountId
-                    }
                     open={isMenuOpen}
                     onOpenChange={setIsMenuOpen}
                   />

--- a/apps/web/app/(app)/[emailAccountId]/mail/MessageActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MessageActionsMenu.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { MoreHorizontalIcon, SparklesIcon } from "lucide-react";
+import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
+import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
+import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuPortal,
+  DropdownMenuSubContent,
+} from "@/components/ui/dropdown-menu";
+import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
+import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
+import type { ParsedMessage } from "@/utils/types";
+
+type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
+
+export function MessageActionsMenu({
+  message,
+  plans,
+  setChatInput,
+  showFixWithChat,
+}: {
+  message: ParsedMessage;
+  plans: ThreadPlan[];
+  setChatInput: (input: string) => void;
+  showFixWithChat: boolean;
+}) {
+  const messagePlans = plans.filter((plan) => plan.messageId === message.id);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="More message actions"
+          className="size-7 text-muted-foreground"
+          size="icon"
+          variant="ghost"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <MoreHorizontalIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
+        onEscapeKeyDown={(event) => event.stopPropagation()}
+      >
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <SparklesIcon className="mr-2 size-4" />
+            Matched reason
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent
+              className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto p-0"
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+            >
+              {messagePlans.length ? (
+                messagePlans.map((plan) => (
+                  <RuleAttribution
+                    key={plan.id}
+                    message={message}
+                    plan={plan}
+                    setChatInput={setChatInput}
+                    showFixWithChat={showFixWithChat}
+                  />
+                ))
+              ) : (
+                <p className="p-3 text-muted-foreground text-xs">
+                  No matched rules for this message.
+                </p>
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function RuleAttribution({
+  plan,
+  message,
+  setChatInput,
+  showFixWithChat,
+}: {
+  plan: ThreadPlan;
+  message: ParsedMessage | null;
+  setChatInput: (input: string) => void;
+  showFixWithChat: boolean;
+}) {
+  const actions = getVisibleActions(plan.actionItems);
+  const labels = actions.filter(
+    (action) => action.type === ActionType.LABEL && action.label,
+  );
+  const otherActions = actions.filter(
+    (action) => action.type !== ActionType.LABEL,
+  );
+  const reasonDisplay = getRuleResultReasonDisplay(plan.reason ?? "");
+
+  return (
+    <div className="min-w-0 border-border border-b px-3 py-3 last:border-b-0">
+      <div className="min-w-0 text-xs">
+        <span className="text-muted-foreground">
+          {plan.status === ExecutedRuleStatus.APPLIED
+            ? "Applied rule:"
+            : "Matched rule:"}{" "}
+        </span>
+        <span className="font-medium text-foreground break-words [overflow-wrap:anywhere]">
+          {plan.rule?.name ?? "a deleted rule"}
+        </span>
+      </div>
+
+      {reasonDisplay.reason ? (
+        <p className="mt-1.5 whitespace-pre-wrap text-foreground text-xs leading-relaxed break-words [overflow-wrap:anywhere]">
+          {reasonDisplay.reason}
+        </p>
+      ) : null}
+
+      {reasonDisplay.actionFailureMessages.length > 0 ? (
+        <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-destructive text-xs">
+          <div className="font-medium">
+            {reasonDisplay.actionFailureMessages.length === 1
+              ? "Action issue"
+              : "Action issues"}
+          </div>
+          <ul className="mt-0.5 list-disc space-y-0.5 pl-4">
+            {reasonDisplay.actionFailureMessages.map(
+              (failureMessage, failureIndex) => (
+                <li
+                  className="break-words [overflow-wrap:anywhere]"
+                  key={`${failureMessage}-${failureIndex}`}
+                >
+                  {failureMessage}
+                </li>
+              ),
+            )}
+          </ul>
+        </div>
+      ) : null}
+
+      {labels.length > 0 || otherActions.length > 0 ? (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          {labels.map((action) => (
+            <MailLabelChip key={action.id} name={action.label ?? ""} />
+          ))}
+          {otherActions.map((action) => (
+            <span className="text-muted-foreground text-xs" key={action.id}>
+              {ACTION_TYPE_LABELS[action.type]}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {message && showFixWithChat ? (
+        <div className="mt-2.5">
+          <FixWithChat
+            message={message}
+            results={toFixResults(plan)}
+            setInput={setChatInput}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * `ThreadPlan` has no `createdAt`: the list route uses it to pick each rule's
+ * latest execution per message and then drops it. `ResultsDisplay`, inside `FixWithChat`,
+ * still requires one — but only as the key it groups and orders batches by, and
+ * never renders it. Each menu entry passes a single result, so grouping has
+ * nothing to do and any constant serves; a sentinel is honest about the
+ * execution time being unknown here, where a real date would be invented.
+ */
+const FIX_RESULT_BATCH = new Date(0);
+
+function toFixResults(plan: ThreadPlan): FixWithChatResults {
+  return [
+    {
+      rule: plan.rule,
+      actionItems: plan.actionItems,
+      reason: plan.reason,
+      status: plan.status,
+      createdAt: FIX_RESULT_BATCH,
+    },
+  ];
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadActionsMenu.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ComponentProps } from "react";
 import {
   ArchiveIcon,
   ArchiveRestoreIcon,
@@ -11,14 +10,9 @@ import {
   MailOpenIcon,
   MoreHorizontalIcon,
   ShieldAlertIcon,
-  SparklesIcon,
   Trash2Icon,
   TagIcon,
 } from "lucide-react";
-import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
-import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
-import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
-import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
 import { useSenderCommands } from "@/app/(app)/[emailAccountId]/mail/use-sender-commands";
 import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions";
 import { Button } from "@/components/ui/button";
@@ -26,37 +20,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuPortal,
-  DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import type { ParsedMessage } from "@/utils/types";
 
-type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
-
 export type ThreadActionsMenuProps = {
-  /**
-   * Every rule that fired on the thread, newest first. Attribution is
-   * rule-scoped, not label-scoped: one entry per rule, each with its own reason,
-   * the actions it applied, and its own way to correct it.
-   */
-  plans: ThreadPlan[];
-  /**
-   * The thread's latest message: what the fix flow reasons about, and the
-   * sender the unsubscribe entry acts on.
-   */
   message: ParsedMessage | null;
-  /** `setInput` from `useChat()`: the fix flow seeds the assistant with it. */
-  setChatInput: (input: string) => void;
   isUnread: boolean;
   onMarkSpam: () => void;
   onDelete: () => void;
@@ -64,20 +37,15 @@ export type ThreadActionsMenuProps = {
   onMarkUnread: () => void;
   onLabel?: () => void;
   onMove?: () => void;
-  /** Chat remains scoped to the route account, so cross-account rows hide it. */
-  showFixWithChat?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 };
 
 /**
- * The reader's ⋯ menu: why the thread looks the way it does, and everything you
- * can do to it that isn't worth a button of its own.
+ * Thread-wide actions in the reader toolbar.
  */
 export function ThreadActionsMenu({
-  plans,
   message,
-  setChatInput,
   isUnread,
   onMarkSpam,
   onDelete,
@@ -85,7 +53,6 @@ export function ThreadActionsMenu({
   onMarkUnread,
   onLabel,
   onMove,
-  showFixWithChat = true,
   open,
   onOpenChange,
 }: ThreadActionsMenuProps) {
@@ -132,30 +99,6 @@ export function ThreadActionsMenu({
           className="w-80 max-w-[calc(100vw-1rem)]"
           onEscapeKeyDown={(event) => event.stopPropagation()}
         >
-          {plans.length > 0 ? (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <SparklesIcon className="mr-2 size-4" />
-                Matched reason
-              </DropdownMenuSubTrigger>
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto p-0">
-                  {plans.map((plan) => (
-                    <RuleAttribution
-                      key={plan.id}
-                      message={message}
-                      plan={plan}
-                      setChatInput={setChatInput}
-                      showFixWithChat={showFixWithChat}
-                    />
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          ) : null}
-
-          {plans.length > 0 ? <DropdownMenuSeparator /> : null}
-
           {onLabel && (
             <DropdownMenuItem onSelect={onLabel}>
               <TagIcon className="mr-2 size-4" />
@@ -256,113 +199,4 @@ export function ThreadActionsMenu({
       <PremiumModal />
     </>
   );
-}
-
-function RuleAttribution({
-  plan,
-  message,
-  setChatInput,
-  showFixWithChat,
-}: {
-  plan: ThreadPlan;
-  message: ParsedMessage | null;
-  setChatInput: (input: string) => void;
-  showFixWithChat: boolean;
-}) {
-  const actions = getVisibleActions(plan.actionItems);
-  const labels = actions.filter(
-    (action) => action.type === ActionType.LABEL && action.label,
-  );
-  const otherActions = actions.filter(
-    (action) => action.type !== ActionType.LABEL,
-  );
-  const reasonDisplay = getRuleResultReasonDisplay(plan.reason ?? "");
-
-  return (
-    <div className="min-w-0 border-border border-b px-3 py-3 last:border-b-0">
-      <div className="min-w-0 text-xs">
-        <span className="text-muted-foreground">
-          {plan.status === ExecutedRuleStatus.APPLIED
-            ? "Applied rule:"
-            : "Matched rule:"}{" "}
-        </span>
-        <span className="font-medium text-foreground break-words [overflow-wrap:anywhere]">
-          {plan.rule?.name ?? "a deleted rule"}
-        </span>
-      </div>
-
-      {reasonDisplay.reason ? (
-        <p className="mt-1.5 whitespace-pre-wrap text-foreground text-xs leading-relaxed break-words [overflow-wrap:anywhere]">
-          {reasonDisplay.reason}
-        </p>
-      ) : null}
-
-      {reasonDisplay.actionFailureMessages.length > 0 ? (
-        <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-destructive text-xs">
-          <div className="font-medium">
-            {reasonDisplay.actionFailureMessages.length === 1
-              ? "Action issue"
-              : "Action issues"}
-          </div>
-          <ul className="mt-0.5 list-disc space-y-0.5 pl-4">
-            {reasonDisplay.actionFailureMessages.map(
-              (failureMessage, failureIndex) => (
-                <li
-                  className="break-words [overflow-wrap:anywhere]"
-                  key={`${failureMessage}-${failureIndex}`}
-                >
-                  {failureMessage}
-                </li>
-              ),
-            )}
-          </ul>
-        </div>
-      ) : null}
-
-      {labels.length > 0 || otherActions.length > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          {labels.map((action) => (
-            <MailLabelChip key={action.id} name={action.label ?? ""} />
-          ))}
-          {otherActions.map((action) => (
-            <span className="text-muted-foreground text-xs" key={action.id}>
-              {ACTION_TYPE_LABELS[action.type]}
-            </span>
-          ))}
-        </div>
-      ) : null}
-
-      {message && showFixWithChat ? (
-        <div className="mt-2.5">
-          <FixWithChat
-            message={message}
-            results={toFixResults(plan)}
-            setInput={setChatInput}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-/**
- * `ThreadPlan` has no `createdAt`: the list route uses it to pick each rule's
- * latest execution and then drops it. `ResultsDisplay`, inside `FixWithChat`,
- * still requires one — but only as the key it groups and orders batches by, and
- * never renders it. Each menu entry passes a single result, so grouping has
- * nothing to do and any constant serves; a sentinel is honest about the
- * execution time being unknown here, where a real date would be invented.
- */
-const FIX_RESULT_BATCH = new Date(0);
-
-function toFixResults(plan: ThreadPlan): FixWithChatResults {
-  return [
-    {
-      rule: plan.rule,
-      actionItems: plan.actionItems,
-      reason: plan.reason,
-      status: plan.status,
-      createdAt: FIX_RESULT_BATCH,
-    },
-  ];
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/ThreadReader.tsx
@@ -68,6 +68,7 @@ export type ThreadReaderProps = {
   autoOpenForwardForMessageId?: string;
   /** The ⋯ dropdown, i.e. `ThreadActionsMenu`, composed by the shell. */
   menu?: ReactNode;
+  renderMessageMenu?: (message: ThreadMessage) => ReactNode;
 };
 
 export function ThreadReader({
@@ -89,6 +90,7 @@ export function ThreadReader({
   autoOpenReplyForMessageId,
   autoOpenForwardForMessageId,
   menu,
+  renderMessageMenu,
 }: ThreadReaderProps) {
   const [senderContext, setSenderContext] = useState<{
     messageId: string;
@@ -162,6 +164,7 @@ export function ThreadReader({
           {messages.length > 0 ? (
             <EmailThread
               renderToolbar={renderToolbar}
+              renderMessageMenu={renderMessageMenu}
               enableMessageNavigation={enableMessageNavigation}
               autoOpenReplyForMessageId={autoOpenReplyForMessageId}
               autoOpenForwardForMessageId={autoOpenForwardForMessageId}

--- a/apps/web/app/(app)/[emailAccountId]/mail/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/mail/types.ts
@@ -4,7 +4,7 @@ import type { ThreadListItem } from "@/utils/threads/load";
 export type ListThread = ThreadListItem | CombinedListThread;
 export type ListMessage = ListThread["messages"][number];
 
-/** One rule that fired on a thread, with the reason it matched. */
+/** One rule execution for a message in a thread, with its matched reason. */
 export type ThreadPlan = NonNullable<ListThread["plans"]>[number];
 
 /** Split view is the two-column list + reader; list view gives the list the full width. */

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -254,7 +254,7 @@ describe("GET /api/threads", () => {
       expect(body.threads[0].plan.id).toBe("executed-rule-2");
     });
 
-    it("keeps only the most recent execution of each rule", async () => {
+    it("keeps only the most recent execution of each rule per message", async () => {
       mockGetThreadsWithQuery.mockResolvedValue({
         threads: [{ id: "thread-1", snippet: "", messages: [getMessage()] }],
       });
@@ -266,7 +266,7 @@ describe("GET /api/threads", () => {
           reason: "Latest reason",
           createdAt: new Date("2024-01-03T00:00:00Z"),
         }),
-        getExecutedRule({ id: "executed-rule-oldest" }),
+        getExecutedRule({ id: "executed-rule-oldest", messageId: "message-2" }),
       ]);
 
       const response = await GET(

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -49,6 +49,7 @@ type ComposeSession = { id: number; mode: ReplyDraftMode };
 
 export function EmailMessage({
   message,
+  menu,
   refetch,
   showReplyButton,
   defaultComposeMode,
@@ -64,6 +65,7 @@ export function EmailMessage({
   onNavigateMessage,
 }: {
   message: ThreadMessage;
+  menu?: React.ReactNode;
   draftMessage?: ThreadMessage;
   refetch: () => void;
   showReplyButton: boolean;
@@ -180,6 +182,7 @@ export function EmailMessage({
       <MessageHeader
         expanded={expanded}
         message={message}
+        menu={menu}
         onForward={onForward}
         onOpenSenderContext={onOpenSenderContext}
         onReply={onReply}
@@ -244,6 +247,7 @@ export function EmailMessage({
  */
 function MessageHeader({
   message,
+  menu,
   expanded,
   showDetails,
   toggleDetails,
@@ -256,6 +260,7 @@ function MessageHeader({
   hasDraft,
 }: {
   message: ParsedMessage;
+  menu?: React.ReactNode;
   expanded: boolean;
   showDetails: boolean;
   toggleDetails: (e: React.MouseEvent) => void;
@@ -412,35 +417,35 @@ function MessageHeader({
       )}
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
-        {showReplyButton && (
-          <span
-            className={cn(
-              "shrink-0 items-center transition-opacity focus-within:opacity-100 group-hover/message:opacity-100",
-              expanded ? "flex sm:opacity-0" : "hidden sm:flex sm:opacity-0",
+        {(showReplyButton || menu) && (
+          <span className="flex shrink-0 items-center transition-opacity focus-within:opacity-100 group-hover/message:opacity-100 has-[[data-state=open]]:opacity-100 sm:opacity-0">
+            {showReplyButton && (
+              <>
+                <Tooltip content="Reply">
+                  <Button
+                    className="size-7 text-muted-foreground"
+                    onClick={compose(onReply)}
+                    size="icon"
+                    variant="ghost"
+                  >
+                    <ReplyIcon className="size-3.5" />
+                    <span className="sr-only">Reply</span>
+                  </Button>
+                </Tooltip>
+                <Tooltip content="Forward">
+                  <Button
+                    className="size-7 text-muted-foreground"
+                    onClick={compose(onForward)}
+                    size="icon"
+                    variant="ghost"
+                  >
+                    <ForwardIcon className="size-3.5" />
+                    <span className="sr-only">Forward</span>
+                  </Button>
+                </Tooltip>
+              </>
             )}
-          >
-            <Tooltip content="Reply">
-              <Button
-                className="size-7 text-muted-foreground"
-                onClick={compose(onReply)}
-                size="icon"
-                variant="ghost"
-              >
-                <ReplyIcon className="size-3.5" />
-                <span className="sr-only">Reply</span>
-              </Button>
-            </Tooltip>
-            <Tooltip content="Forward">
-              <Button
-                className="size-7 text-muted-foreground"
-                onClick={compose(onForward)}
-                size="icon"
-                variant="ghost"
-              >
-                <ForwardIcon className="size-3.5" />
-                <span className="sr-only">Forward</span>
-              </Button>
-            </Tooltip>
+            {menu}
           </span>
         )}
         <time

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -29,6 +29,7 @@ export function EmailThread({
   onOpenSenderContext,
   withHeader,
   renderToolbar,
+  renderMessageMenu,
   enableMessageNavigation = false,
 }: {
   messages: ThreadMessage[];
@@ -42,6 +43,7 @@ export function EmailThread({
   onOpenSenderContext?: (message: ThreadMessage) => void;
   withHeader?: boolean;
   enableMessageNavigation?: boolean;
+  renderMessageMenu?: (message: ThreadMessage) => ReactNode;
   renderToolbar?: (controls: {
     allExpanded: boolean;
     canExpand: boolean;
@@ -256,6 +258,7 @@ export function EmailThread({
               hasDraft={Boolean(draftMessage) || hasLocalDraft(message.id)}
               key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
+              menu={renderMessageMenu?.(message)}
               onOpenSenderContext={onOpenSenderContext}
               onMarkDone={onMarkDone}
               onSendSuccess={(messageId, sentThreadId) => {

--- a/apps/web/utils/threads/load.test.ts
+++ b/apps/web/utils/threads/load.test.ts
@@ -84,6 +84,54 @@ describe("loadThreads", () => {
     );
   });
 
+  it("keeps the latest execution of a rule separately for each message", async () => {
+    const emailProvider = {
+      getThreadsWithQuery: vi.fn().mockResolvedValue({
+        threads: [
+          {
+            id: "thread-1",
+            snippet: "Thread",
+            messages: [
+              {
+                id: "message-1",
+                threadId: "thread-1",
+                headers: { from: "sender@example.com" },
+              },
+            ],
+          },
+        ],
+        nextPageToken: null,
+      }),
+    };
+    prisma.executedRule.findMany.mockResolvedValue([
+      {
+        ...executedRule("latest", new Date("2026-08-14T12:00:00Z")),
+        messageId: "message-2",
+        rule: { id: "rule-1" },
+      },
+      {
+        ...executedRule("earlier-message", new Date("2026-08-14T11:00:00Z")),
+        messageId: "message-1",
+        rule: { id: "rule-1" },
+      },
+      {
+        ...executedRule("superseded", new Date("2026-08-14T10:00:00Z")),
+        messageId: "message-2",
+        rule: { id: "rule-1" },
+      },
+    ] as never);
+    const result = await loadThreads({
+      query: { type: "inbox" },
+      emailAccountId: "account-1",
+      emailProvider: emailProvider as never,
+      messageFormat: "metadata",
+    });
+    expect(result.threads[0]?.plans.map((plan) => plan.id)).toEqual([
+      "latest",
+      "earlier-message",
+    ]);
+  });
+
   it("keeps every provider message ID when ignored messages are hidden", async () => {
     const emailProvider = {
       getThreadsWithQuery: vi.fn().mockResolvedValue({

--- a/apps/web/utils/threads/load.ts
+++ b/apps/web/utils/threads/load.ts
@@ -51,7 +51,7 @@ export async function loadThreads({
       reason: true,
       createdAt: true,
     },
-    // The aggregation below keeps the first execution of each rule.
+    // The aggregation below keeps the first execution of each rule per message.
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
   });
 
@@ -125,12 +125,20 @@ export type ThreadListItem = ReturnType<
 >["threads"][number];
 
 function aggregateThreadPlans<
-  T extends { id: string; createdAt: Date; rule: { id: string } | null },
+  T extends {
+    id: string;
+    messageId: string;
+    createdAt: Date;
+    rule: { id: string } | null;
+  },
 >(executedRules: T[]): Omit<T, "createdAt">[] {
   const latestByRule = new Map<string, Omit<T, "createdAt">>();
 
   for (const executedRule of executedRules) {
-    const key = executedRule.rule?.id ?? executedRule.id;
+    const key = JSON.stringify([
+      executedRule.messageId,
+      executedRule.rule?.id ?? executedRule.id,
+    ]);
     if (latestByRule.has(key)) continue;
     const { createdAt: _createdAt, ...plan } = executedRule;
     latestByRule.set(key, plan);


### PR DESCRIPTION
Each email now has a more-actions menu beside Reply and Forward, with matched reasons and corrections scoped to that message. Thread loading retains the latest rule execution per message so earlier matches remain available.

- Removed matched reasons from the thread toolbar menu and preserved keyboard and touch access to message actions.
- Validation: 22 focused tests pass; formatting and secret checks pass. The message-specific browser test passes in CI, and both matched-reason screenshots were inspected.
- Performance: no additional database or network calls; thread payloads retain more rule executions, and each message filters its matching plans.
