### PR TITLE
ci: group browser specs by feature to reduce runner demand

### DIFF
--- a/apps/web/utils/playwright/emulated-suite-targets.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.mjs
@@ -1,6 +1,99 @@
 import { readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
+// Keep related behavior together without reallocating specs when their timings change.
+const featureGroups = [
+  {
+    name: "onboarding",
+    specs: [
+      "onboarding/control-onboarding.spec.ts",
+      "attachments/attachment-onboarding.spec.ts",
+    ],
+  },
+  {
+    name: "connected-apps",
+    specs: [
+      "calendars/calendar-core-flows.spec.ts",
+      "channels/channel-routing.spec.ts",
+      "integrations/integration-configuration.spec.ts",
+      "meetings/meeting-bot-core-flow.spec.ts",
+    ],
+  },
+  {
+    name: "automation-rules",
+    specs: [
+      "automation/manual-rule-management.spec.ts",
+      "automation/settings-controls.spec.ts",
+      "automation/settings-drafting-knowledge.spec.ts",
+      "automation/integration-action.spec.ts",
+    ],
+  },
+  {
+    name: "automation-processing",
+    specs: [
+      "automation/bulk-processing.spec.ts",
+      "automation/history-tab.spec.ts",
+      "automation/test-tab.spec.ts",
+    ],
+  },
+  {
+    name: "mail-compose",
+    specs: [
+      "mail/compose-and-reply.spec.ts",
+      "mail/contact-autocomplete.spec.ts",
+      "mail/scheduled-replies.spec.ts",
+      "mail/calendar-invitation.spec.ts",
+    ],
+  },
+  {
+    name: "mail-offline",
+    specs: [
+      "mail/local-cache.spec.ts",
+      "mail/offline-loading.spec.ts",
+      "mail/offline-outbox.spec.ts",
+      "mail/mail-queue.spec.ts",
+    ],
+  },
+  {
+    name: "mail-navigation",
+    specs: [
+      "mail/command-palette.spec.ts",
+      "mail/navigation-and-views.spec.ts",
+      "mail/split-tabs.spec.ts",
+      "mail/search.spec.ts",
+    ],
+  },
+  {
+    name: "mail-reader",
+    specs: [
+      "mail/reader-transition.spec.ts",
+      "mail/reader-visuals.spec.ts",
+      "mail/thread-navigation.spec.ts",
+      "mail/thread-states.spec.ts",
+      "mail/plain-text-links.spec.ts",
+    ],
+  },
+  {
+    name: "mail-triage",
+    specs: [
+      "mail/archive-reconciliation.spec.ts",
+      "mail/manual-label.spec.ts",
+      "mail/message-overflow.spec.ts",
+      "mail/starring.spec.ts",
+      "mail/triage-actions.spec.ts",
+    ],
+  },
+  {
+    name: "mail-preferences",
+    specs: [
+      "mail/account-selection.spec.ts",
+      "mail/cached-settings.spec.ts",
+      "mail/layout.spec.ts",
+      "mail/theme.spec.ts",
+    ],
+  },
+];
+
 export function expandPlaywrightTargets(paths, appRoot) {
   const files = new Set();
   for (const targetPath of paths) {
@@ -13,17 +106,19 @@ export function expandPlaywrightTargets(paths, appRoot) {
 }
 
 export function batchPlaywrightTargets(targets) {
-  const batchCount = Math.min(targets.length, 20);
-  const batches = Array.from({ length: batchCount }, (_, index) => ({
-    name:
-      targets.length <= batchCount ? targets[index].name : `batch-${index + 1}`,
-    paths: [],
-  }));
-  // Spread neighboring specs across runners so one large area cannot monopolize a job.
-  for (const [index, target] of targets.entries()) {
-    batches[index % batchCount].paths.push(target.path);
+  const batches = new Map();
+  for (const target of targets) {
+    const specPath = target.path.replace(
+      /^__tests__\/playwright\/emulated\//,
+      "",
+    );
+    const group = featureGroups.find(({ specs }) => specs.includes(specPath));
+    // New specs remain covered before an explicit feature group is assigned.
+    const name = group?.name ?? specPath.split("/")[0];
+    if (!batches.has(name)) batches.set(name, { name, paths: [] });
+    batches.get(name).paths.push(target.path);
   }
-  return batches.map((batch) => ({
+  return [...batches.values()].map((batch) => ({
     ...batch,
     timeoutMinutes: 4 + batch.paths.length * 8,
   }));

--- a/apps/web/utils/playwright/emulated-suite-targets.test.mjs
+++ b/apps/web/utils/playwright/emulated-suite-targets.test.mjs
@@ -68,41 +68,41 @@ test("target names round-trip spec paths that contain underscores", () => {
   }
 });
 
-test("batches a full selection without losing or repeating specs", () => {
-  const targets = Array.from({ length: 43 }, (_, index) => ({
-    name: `spec-${index}`,
-    path: `__tests__/playwright/emulated/mail/spec-${index}.spec.ts`,
+test("feature groups preserve every selected spec, including unassigned and nested specs", () => {
+  const paths = [
+    "mail/compose-and-reply.spec.ts",
+    "mail/contact-autocomplete.spec.ts",
+    "mail/offline-outbox.spec.ts",
+    "mail/new-behavior.spec.ts",
+    "mail/nested/new-behavior.spec.ts",
+    "settings/appearance.spec.ts",
+  ];
+  const targets = paths.map((spec) => ({
+    name: getPlaywrightTargetName(spec),
+    path: `__tests__/playwright/emulated/${spec}`,
   }));
   const batches = batchPlaywrightTargets(targets);
-
-  expect(batches).toHaveLength(20);
-  expect(new Set(batches.map(({ name }) => name)).size).toBe(20);
   expect(batches.flatMap(({ paths }) => paths).sort()).toEqual(
-    targets.map(({ path: specPath }) => specPath).sort(),
+    targets.map(({ path }) => path).sort(),
   );
-  expect(
-    batches.every(({ paths }) => paths.length >= 2 && paths.length <= 3),
-  ).toBe(true);
-  expect(
-    batches.map(
-      ({ timeoutMinutes, paths }) => (timeoutMinutes - 4) / paths.length,
-    ),
-  ).toEqual(new Array(20).fill(8));
+  expect(batches.find(({ name }) => name === "mail-compose")?.paths).toEqual(
+    targets.slice(0, 2).map(({ path }) => path),
+  );
+  expect(batches.find(({ name }) => name === "mail")?.paths).toEqual(
+    targets.slice(3, 5).map(({ path }) => path),
+  );
+  expect(new Set(batches.map(({ name }) => name)).size).toBe(batches.length);
 });
 
-test("keeps focused selections parallel and creates no empty jobs", () => {
+test("focused selections keep their feature names without adding unselected specs", () => {
   expect(batchPlaywrightTargets([])).toEqual([]);
-  const targets = [
-    { name: "mail_slayout.spec.ts", path: "mail/layout.spec.ts" },
-    { name: "settings_sdialog.spec.ts", path: "settings/dialog.spec.ts" },
-  ];
-  expect(batchPlaywrightTargets(targets)).toEqual(
-    targets.map(({ name, path: specPath }) => ({
-      name,
-      paths: [specPath],
-      timeoutMinutes: 12,
-    })),
-  );
+  const target = {
+    name: "mail_scontact-autocomplete.spec.ts",
+    path: "__tests__/playwright/emulated/mail/contact-autocomplete.spec.ts",
+  };
+  expect(batchPlaywrightTargets([target])).toEqual([
+    { name: "mail-compose", paths: [target.path], timeoutMinutes: 12 },
+  ]);
 });
 
 test.each([


### PR DESCRIPTION
Full browser runs currently request 20 runners, repeating installation and service setup on each. Group related specs into 13 feature jobs to reduce runner demand and setup work while preserving all 49 specs and their per-spec app, emulator, and authentication isolation.

Groups cover onboarding, connected apps, chat, cleanup, settings, automation rules/processing, and mail composition/offline/navigation/reader/triage/preferences. New specs fall back to their area so they cannot silently disappear from CI. Focused selections keep stable group names and run only selected specs.

Validation: 38 focused target-selection and runner tests passed; the full selection contains all 49 specs exactly once in 13 jobs. Based on the prior run's spec timings, the longest group has 175s of test execution. All 49 specs and PR checks passed in [CI](https://github.com/elie222/inbox-zero/actions/runs/34605229998).

Compared with the previous 20-job run:
- Aggregate browser worker time: 56m 48s → 43m 49s (23% lower).
- Aggregate setup/upload/cleanup overhead: 34m 25s → 21m 58s (36% lower).
- Aggregate test step time: 22m 23s → 21m 51s.
- Longest worker: 3m 54s → 4m 29s (35s longer).

Required-check completion was 13m 09s, including up to 6m 06s waiting for browser workers. This run proves lower runner consumption, not lower queue delay under changing repository load; competing workflows still use the old layout. No tests moved to nightly.
