### PR TITLE
fix(mail): Restore shortcuts from focused email bodies

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator } from "@playwright/test";
+import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import type { MailSettingsResponse } from "@/app/api/mail/settings/route";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
 import { test } from "../playwright-test";
@@ -64,6 +65,14 @@ test("deletes an open conversation and returns to the list", async ({
 test("advances the split reader after archiving an open conversation", async ({
   page,
 }, testInfo) => {
+  await page.route("**/api/threads/thr_playwright_3?**", async (route) => {
+    const response = await route.fetch();
+    const body: ThreadResponse = await response.json();
+    for (const message of body.thread.messages) {
+      message.textHtml = "<p>Message body for keyboard shortcut coverage.</p>";
+    }
+    await route.fulfill({ response, json: body });
+  });
   const settingsResponsePromise = page.waitForResponse(
     (response) =>
       response.request().method() === "GET" &&

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -117,6 +117,11 @@ test("advances the split reader after archiving an open conversation", async ({
       page.getByPlaceholder("When should it return? Try Friday at 3pm"),
     ).toBeVisible();
     await page.keyboard.press("Escape");
+    await expect(
+      page.getByPlaceholder("Type a command or search..."),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toBeHidden();
     await emailBody.click();
     await page.keyboard.press("e");
     archived = true;

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -107,12 +107,13 @@ test("advances the split reader after archiving an open conversation", async ({
   let archived = false;
   let restoreSucceeded: boolean | undefined;
   try {
-    const emailBody = page
-      .frameLocator('iframe[title="Email content preview"]')
-      .last()
-      .locator("body");
+    const emailFrame = page
+      .locator('iframe[title="Email content preview"]')
+      .last();
+    await expect(emailFrame).toHaveAttribute("data-email-ready", "true");
+    const emailBody = emailFrame.contentFrame().locator("body");
     await emailBody.click();
-    await page.keyboard.press("h");
+    await emailBody.press("h");
     await expect(
       page.getByPlaceholder("When should it return? Try Friday at 3pm"),
     ).toBeVisible();
@@ -123,7 +124,7 @@ test("advances the split reader after archiving an open conversation", async ({
     await page.keyboard.press("Escape");
     await expect(page.getByRole("dialog")).toBeHidden();
     await emailBody.click();
-    await page.keyboard.press("e");
+    await emailBody.press("e");
     archived = true;
     await expect(
       page

--- a/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/triage-actions.spec.ts
@@ -98,7 +98,18 @@ test("advances the split reader after archiving an open conversation", async ({
   let archived = false;
   let restoreSucceeded: boolean | undefined;
   try {
-    await page.getByRole("button", { name: /^Archive/ }).click();
+    const emailBody = page
+      .frameLocator('iframe[title="Email content preview"]')
+      .last()
+      .locator("body");
+    await emailBody.click();
+    await page.keyboard.press("h");
+    await expect(
+      page.getByPlaceholder("When should it return? Try Friday at 3pm"),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await emailBody.click();
+    await page.keyboard.press("e");
     archived = true;
     await expect(
       page

--- a/apps/web/components/email-list/BufferedEmailIframe.tsx
+++ b/apps/web/components/email-list/BufferedEmailIframe.tsx
@@ -133,7 +133,7 @@ function useEmailIframe(
         (key === "f" && Boolean(forward)) ||
         (isNavigationKey && Boolean(navigate));
       if (
-        !handlesKey ||
+        event.defaultPrevented ||
         event.altKey ||
         event.ctrlKey ||
         event.metaKey ||
@@ -150,13 +150,36 @@ function useEmailIframe(
       )
         return;
       if (event.key === "Enter" && target?.closest?.("a, button")) return;
+      if (!handlesKey) {
+        forwardShortcut(event);
+        return;
+      }
       event.preventDefault();
       if (event.key === "Enter") reply?.();
       else if (key === "f") forward?.();
       else navigate?.(event.key === "ArrowUp" ? -1 : 1);
     };
+    // Keyboard events do not bubble out of an iframe. Dispatch from its element
+    // so the app's existing shortcut scopes and overlay guards still apply.
+    const forwardShortcut = (event: KeyboardEvent) => {
+      const forwarded = new KeyboardEvent(event.type, {
+        key: event.key,
+        code: event.code,
+        location: event.location,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+        isComposing: event.isComposing,
+        repeat: event.repeat,
+        bubbles: true,
+        cancelable: true,
+      });
+      if (!iframe.dispatchEvent(forwarded)) event.preventDefault();
+    };
     const stopObservingDocument = () => {
       observedDocument?.removeEventListener("keydown", navigateMessage);
+      observedDocument?.removeEventListener("keyup", forwardShortcut);
       observedDocument?.removeEventListener("pointerdown", selectMessage);
       observedDocument?.removeEventListener("focusin", selectMessage);
     };
@@ -192,6 +215,7 @@ function useEmailIframe(
       stopObservingDocument();
       observedDocument = iframeDocument;
       observedDocument.addEventListener("keydown", navigateMessage);
+      observedDocument.addEventListener("keyup", forwardShortcut);
       observedDocument.addEventListener("pointerdown", selectMessage);
       observedDocument.addEventListener("focusin", selectMessage);
       observedRoot = root;

--- a/apps/web/components/email-list/EmailContents.test.tsx
+++ b/apps/web/components/email-list/EmailContents.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@/env", () => ({
 }));
 
 import { HtmlEmail, PlainEmail } from "./EmailContents";
+import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
+import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 
 (globalThis as { React?: typeof React }).React = React;
 
@@ -272,6 +274,66 @@ describe("HtmlEmail", () => {
         640,
       ),
     );
+  });
+
+  it("runs archive and snooze shortcuts from a focused email body", () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    const archive = vi.fn();
+    const snooze = vi.fn();
+    function MailShortcuts() {
+      useShortcuts({ archive, snooze });
+      return (
+        <HtmlEmail html="<p>Message body</p>" messageId="message-shortcuts" />
+      );
+    }
+    const { getByTitle } = render(
+      <ShortcutsProvider scopes={["global", "mail"]}>
+        <MailShortcuts />
+      </ShortcutsProvider>,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+    iframe.focus();
+    for (const [key, code] of [
+      ["e", "KeyE"],
+      ["h", "KeyH"],
+    ]) {
+      fireEvent.keyDown(iframe.contentDocument!.body, { key, code });
+      fireEvent.keyUp(iframe.contentDocument!.body, { key, code });
+    }
+    expect(archive).toHaveBeenCalledOnce();
+    expect(snooze).toHaveBeenCalledOnce();
+  });
+
+  it("bubbles unhandled email keys to the app without stealing typing", () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    const { getByTitle } = render(
+      <HtmlEmail html="<p>Message body</p>" messageId="message-shortcuts" />,
+    );
+    const iframe = getByTitle("Email content preview") as HTMLIFrameElement;
+    addEmailDocumentMarker(iframe, iframe.contentDocument);
+    iframe.dispatchEvent(new Event("load"));
+    const onKey = vi.fn((event: KeyboardEvent) => event.preventDefault());
+    document.addEventListener("keydown", onKey);
+    try {
+      for (const key of ["e", "h"]) {
+        expect(fireEvent.keyDown(iframe.contentDocument!.body, { key })).toBe(
+          false,
+        );
+      }
+      expect(onKey).toHaveBeenCalledTimes(2);
+      const input = iframe.contentDocument!.createElement("input");
+      iframe.contentDocument!.body.append(input);
+      fireEvent.keyDown(input, { key: "e" });
+      fireEvent.keyDown(iframe.contentDocument!.body, {
+        key: "e",
+        isComposing: true,
+      });
+      expect(onKey).toHaveBeenCalledTimes(2);
+    } finally {
+      document.removeEventListener("keydown", onKey);
+    }
   });
 
   it("forwards with F while focus is inside the email document", () => {

--- a/apps/web/emulate.playwright.config.yaml
+++ b/apps/web/emulate.playwright.config.yaml
@@ -44,6 +44,7 @@ google:
       to: __PLAYWRIGHT_TEST_EMAIL__
       subject: Second Unread Command Message
       body_text: Another unread message for bulk-action checks.
+      body_html: "<p>Another unread message for bulk-action checks.</p>"
       label_ids:
         - INBOX
         - UNREAD

--- a/apps/web/emulate.playwright.config.yaml
+++ b/apps/web/emulate.playwright.config.yaml
@@ -44,7 +44,6 @@ google:
       to: __PLAYWRIGHT_TEST_EMAIL__
       subject: Second Unread Command Message
       body_text: Another unread message for bulk-action checks.
-      body_html: "<p>Another unread message for bulk-action checks.</p>"
       label_ids:
         - INBOX
         - UNREAD


### PR DESCRIPTION
Clicking inside an email body could stop mail shortcuts from reaching the app in split and list views. Forward unhandled keyboard events from the email iframe while preserving typing, text selection, and message navigation.

- Add focused regression coverage and a browser scenario for archive and snooze shortcuts from an HTML email body.
- Validation: 32 focused tests and formatting checks pass; the CI mail-triage browser suite passes, and its archive screenshot was inspected.
