### PR TITLE
calendar: Surface Outlook reauthorization failures safely

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -90,6 +90,22 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     );
 
     await context.setOffline(false);
+    // Confirm the browser can reach the server before testing a connected reload.
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          try {
+            const response = await fetch("/api/auth/ok", {
+              cache: "no-store",
+              signal: AbortSignal.timeout(3000),
+            });
+            return response.ok;
+          } catch {
+            return false;
+          }
+        }),
+      )
+      .toBe(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(
       conversationWithSubject(page, conversations, "Archive Action Message"),

--- a/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/starring.spec.ts
@@ -1,12 +1,16 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { test } from "../playwright-test";
 import { capturePlaywrightCheckpoint } from "../playwright-evidence";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 test("toggles a star with S and the command palette while preserving unread", async ({
   page,
 }, testInfo) => {
-  const { conversations } = await openMail(page);
+  const { conversations, emailAccountId } = await openMail(page);
   const row = conversationWithSubject(
     page,
     conversations,
@@ -17,6 +21,7 @@ test("toggles a star with S and the command palette while preserving unread", as
     await row.getByRole("checkbox").click();
     await page.keyboard.press("s");
     await expect(starStatus).toHaveCount(0);
+    await expectCompletedStarMutation(page, emailAccountId, false);
   }
   await row.getByRole("checkbox").click();
   await page.keyboard.press("u");
@@ -28,6 +33,7 @@ test("toggles a star with S and the command palette while preserving unread", as
   await expect(
     row.getByText("Starred conversation", { exact: true }),
   ).toHaveCount(1);
+  await expectCompletedStarMutation(page, emailAccountId, true);
   await page.keyboard.press("Escape");
   await page.mouse.move(0, 0);
   await page.evaluate(() => {
@@ -43,6 +49,7 @@ test("toggles a star with S and the command palette while preserving unread", as
   await expect(
     row.getByText("Starred conversation", { exact: true }),
   ).toHaveCount(0);
+  await expectCompletedStarMutation(page, emailAccountId, false);
   await row.click();
   const readerStarStatus = page
     .getByTestId("thread-reader")
@@ -50,15 +57,36 @@ test("toggles a star with S and the command palette while preserving unread", as
   await expect(readerStarStatus).toHaveCount(0);
   await page.keyboard.press("s");
   await expect(readerStarStatus).toBeVisible();
+  await expectCompletedStarMutation(page, emailAccountId, true);
   await capturePlaywrightCheckpoint(page, testInfo, "starred-reader-subject");
   await page.keyboard.press("s");
   await expect(readerStarStatus).toHaveCount(0);
+  await expectCompletedStarMutation(page, emailAccountId, false);
 
   await page.getByRole("button", { name: /^More actions/ }).click();
   const actionsMenu = page.getByRole("menu");
   await actionsMenu.getByRole("menuitem", { name: /^Star/ }).click();
   await expect(readerStarStatus).toBeVisible();
+  await expectCompletedStarMutation(page, emailAccountId, true);
   await page.getByRole("button", { name: /^More actions/ }).click();
   await actionsMenu.getByRole("menuitem", { name: /^Unstar/ }).click();
   await expect(readerStarStatus).toHaveCount(0);
+  await expectCompletedStarMutation(page, emailAccountId, false);
 });
+
+async function expectCompletedStarMutation(
+  page: Page,
+  emailAccountId: string,
+  starred: boolean,
+) {
+  // The optimistic indicator can update before action targeting catches up.
+  // Finish each mutation before exercising the next toggle entry point.
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "set_starred_state",
+      }),
+    )
+    .toMatchObject({ status: "succeeded", payload: { starred } });
+}

--- a/apps/web/utils/calendar/providers/microsoft.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft.test.ts
@@ -1,3 +1,4 @@
+import { SafeError } from "@/utils/error";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -28,6 +29,25 @@ vi.mock("../timezone-helpers", () => ({
 describe("microsoft calendar sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("does not overwrite the refresh client's guarded disconnect or reconnect error", async () => {
+    const error = new SafeError("Please reconnect your calendar.");
+    vi.mocked(getCalendarClientWithRefresh).mockRejectedValueOnce(error);
+    vi.mocked(prisma.calendarConnection.update).mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    await expect(
+      createMicrosoftCalendarProvider(logger).syncCalendars(
+        "connection-id",
+        "access-token",
+        "refresh-token",
+        "email-account-id",
+        null,
+      ),
+    ).rejects.toBe(error);
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+    expect(fetchMicrosoftCalendars).not.toHaveBeenCalled();
   });
 
   it("marks the default calendar as primary so bookings without an explicit destination can target it", async () => {

--- a/apps/web/utils/calendar/providers/microsoft.ts
+++ b/apps/web/utils/calendar/providers/microsoft.ts
@@ -67,15 +67,15 @@ export function createMicrosoftCalendarProvider(
       emailAccountId: string,
       expiresAt: Date | null,
     ): Promise<void> {
-      try {
-        const calendarClient = await getCalendarClientWithRefresh({
-          accessToken,
-          refreshToken,
-          expiresAt: expiresAt?.getTime() ?? null,
-          emailAccountId,
-          logger,
-        });
+      const calendarClient = await getCalendarClientWithRefresh({
+        accessToken,
+        refreshToken,
+        expiresAt: expiresAt?.getTime() ?? null,
+        emailAccountId,
+        logger,
+      });
 
+      try {
         const microsoftCalendars = await fetchMicrosoftCalendars(
           calendarClient,
           logger,

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -90,6 +90,48 @@ describe("offline mail cache", () => {
     expect(await (await response).text()).toBe("Saved mailbox");
   });
 
+  it("returns saved mail while a background cache write is stalled", async () => {
+    vi.useFakeTimers();
+    const cache = makeCache();
+    await storage.put(mailUrl, html("Saved mailbox"));
+    const pendingWrite = Promise.withResolvers<void>();
+    vi.spyOn(storage, "put").mockReturnValueOnce(pendingWrite.promise);
+    network.mockResolvedValueOnce(html("Refreshed mailbox"));
+    await cache.handle(documentRequest(), waitUntil);
+    network.mockImplementation(() => new Promise(() => {}));
+    let fallback: Response | undefined;
+    const loading = cache
+      .handle(documentRequest(), waitUntil)
+      .then((response) => {
+        fallback = response;
+      });
+    try {
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(fallback).toBeDefined();
+      expect(await fallback?.text()).toBe("Saved mailbox");
+    } finally {
+      pendingWrite.resolve();
+      await loading;
+    }
+  });
+
+  it("does not return saved mail if logout starts during the cache lookup", async () => {
+    const cache = makeCache();
+    const lookupStarted = Promise.withResolvers<void>();
+    const lookup = Promise.withResolvers<Response | undefined>();
+    vi.spyOn(storage, "match").mockImplementationOnce(() => {
+      lookupStarted.resolve();
+      return lookup.promise;
+    });
+    network.mockRejectedValue(new TypeError("Network unavailable"));
+    const loading = cache.handle(documentRequest(), waitUntil);
+    await lookupStarted.promise;
+    await cache.clear();
+    lookup.resolve(html("Previous session mailbox"));
+    await expect(loading).rejects.toThrow("Network unavailable");
+    await Promise.all(pending);
+  });
+
   it("bounds a stalled request even when there is no saved mailbox", async () => {
     vi.useFakeTimers();
     network.mockImplementation(

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -121,31 +121,6 @@ describe("offline mail cache", () => {
     expect(await (await response).text()).toBe("Saved mailbox");
   });
 
-  it("returns saved mail while a background cache write is stalled", async () => {
-    vi.useFakeTimers();
-    const cache = makeCache();
-    await storage.put(mailUrl, html("Saved mailbox"));
-    const pendingWrite = Promise.withResolvers<void>();
-    vi.spyOn(storage, "put").mockReturnValueOnce(pendingWrite.promise);
-    network.mockResolvedValueOnce(html("Refreshed mailbox"));
-    await cache.handle(documentRequest(), waitUntil);
-    network.mockImplementation(() => new Promise(() => {}));
-    let fallback: Response | undefined;
-    const loading = cache
-      .handle(documentRequest(), waitUntil)
-      .then((response) => {
-        fallback = response;
-      });
-    try {
-      await vi.advanceTimersByTimeAsync(3000);
-      expect(fallback).toBeDefined();
-      expect(await fallback?.text()).toBe("Saved mailbox");
-    } finally {
-      pendingWrite.resolve();
-      await loading;
-    }
-  });
-
   it("does not return saved mail if logout starts during the cache lookup", async () => {
     const cache = makeCache();
     const lookupStarted = Promise.withResolvers<void>();

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -56,7 +56,7 @@ export function createOfflineMailCache({
     const cached = async () => {
       if (startedAtGeneration !== generation) return;
       try {
-        await writes;
+        // A stalled refresh must not block reading the previously saved page.
         const response = await (await caches.open(cacheName)).match(key);
         return startedAtGeneration === generation ? response : undefined;
       } catch {

--- a/apps/web/utils/outlook/calendar-client.test.ts
+++ b/apps/web/utils/outlook/calendar-client.test.ts
@@ -1,3 +1,4 @@
+import type { CalendarConnection } from "@/generated/prisma/client";
 import { Client } from "@microsoft/microsoft-graph-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -38,13 +39,8 @@ describe("getCalendarClientWithRefresh", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prisma.calendarConnection.findMany.mockResolvedValue([
-      {
-        id: "connection-id",
-        accessToken: "stale-access-token",
-        refreshToken: "refresh-token",
-        updatedAt: new Date("2026-09-01T00:00:00Z"),
-      },
-    ] as any);
+      calendarConnection(),
+    ]);
     prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 });
   });
 
@@ -93,17 +89,17 @@ describe("getCalendarClientWithRefresh", () => {
 
   it("does not disconnect other accounts or credentials replaced by a reconnect", async () => {
     prisma.calendarConnection.findMany.mockResolvedValue([
-      {
+      calendarConnection({
         id: "other-connection",
         accessToken: "other-access",
         refreshToken: "other-refresh",
-      },
-      {
+      }),
+      calendarConnection({
         id: "connection-id",
         accessToken: "new-access",
         refreshToken: "refresh-token",
-      },
-    ] as any);
+      }),
+    ]);
     vi.mocked(requestMicrosoftToken).mockResolvedValue(
       tokenErrorResponse("invalid_grant"),
     );
@@ -189,8 +185,25 @@ function refreshExpiredCalendarClient() {
 }
 
 function tokenErrorResponse(errorDescription: string) {
+  return new Response(JSON.stringify({ error_description: errorDescription }), {
+    status: 400,
+  });
+}
+
+function calendarConnection(
+  overrides: Partial<CalendarConnection> = {},
+): CalendarConnection {
   return {
-    ok: false,
-    json: vi.fn().mockResolvedValue({ error_description: errorDescription }),
-  } as any;
+    id: "connection-id",
+    emailAccountId: "email-account-id",
+    provider: "microsoft",
+    email: "calendar@example.com",
+    accessToken: "stale-access-token",
+    refreshToken: "refresh-token",
+    expiresAt: null,
+    isConnected: true,
+    createdAt: new Date("2026-09-01T00:00:00Z"),
+    updatedAt: new Date("2026-09-01T00:00:00Z"),
+    ...overrides,
+  };
 }

--- a/apps/web/utils/outlook/calendar-client.test.ts
+++ b/apps/web/utils/outlook/calendar-client.test.ts
@@ -1,0 +1,196 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SafeError } from "@/utils/error";
+import prisma from "@/utils/__mocks__/prisma";
+import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { getCalendarClientWithRefresh } from "./calendar-client";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    initWithMiddleware: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  getMicrosoftGraphClientOptions: vi.fn(() => ({
+    baseUrl: "http://localhost:4003/",
+  })),
+  getMicrosoftOauthAuthorizeUrl: vi.fn(
+    () => "http://localhost:4003/oauth2/v2.0/authorize",
+  ),
+  requestMicrosoftToken: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    MICROSOFT_CLIENT_ID: "client-id",
+    MICROSOFT_CLIENT_SECRET: "client-secret",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+const logger = createTestLogger();
+
+describe("getCalendarClientWithRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.calendarConnection.findMany.mockResolvedValue([
+      {
+        id: "connection-id",
+        accessToken: "stale-access-token",
+        refreshToken: "refresh-token",
+        updatedAt: new Date("2026-09-01T00:00:00Z"),
+      },
+    ] as any);
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("marks Microsoft calendar disconnected and throws a reconnect SafeError for invalid_grant", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant: refresh token revoked"),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toMatchObject({
+      name: "SafeError",
+      safeMessage:
+        "Your Microsoft calendar authorization has expired. Please reconnect your calendar.",
+    });
+
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "connection-id",
+        updatedAt: new Date("2026-09-01T00:00:00Z"),
+        isConnected: true,
+      },
+      data: { isConnected: false },
+    });
+    expect(Client.initWithMiddleware).not.toHaveBeenCalled();
+  });
+
+  it("marks Microsoft calendar disconnected and throws a reconnect SafeError for AADSTS reauth failures", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse(
+        "AADSTS50173: The provided grant has expired due to it being revoked.",
+      ),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "connection-id",
+        updatedAt: new Date("2026-09-01T00:00:00Z"),
+        isConnected: true,
+      },
+      data: { isConnected: false },
+    });
+  });
+
+  it("does not disconnect other accounts or credentials replaced by a reconnect", async () => {
+    prisma.calendarConnection.findMany.mockResolvedValue([
+      {
+        id: "other-connection",
+        accessToken: "other-access",
+        refreshToken: "other-refresh",
+      },
+      {
+        id: "connection-id",
+        accessToken: "new-access",
+        refreshToken: "refresh-token",
+      },
+    ] as any);
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant"),
+    );
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+    expect(prisma.calendarConnection.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("preserves the reconnect error when the disconnect write fails", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant"),
+    );
+    prisma.calendarConnection.updateMany.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+  });
+
+  it("preserves the reconnect error when a concurrent update wins", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant"),
+    );
+    prisma.calendarConnection.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+  });
+
+  it("recognizes the OAuth error code when the description has no code", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "The refresh token has expired.",
+        }),
+        { status: 400 },
+      ),
+    );
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the reconnect error when reading connections fails", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant"),
+    );
+    prisma.calendarConnection.findMany.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+  });
+
+  it("rethrows non-reauth token refresh failures without disconnecting the calendar", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("temporarily_unavailable"),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toThrow(
+      "temporarily_unavailable",
+    );
+
+    expect(prisma.calendarConnection.findMany).not.toHaveBeenCalled();
+    expect(prisma.calendarConnection.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+function refreshExpiredCalendarClient() {
+  return getCalendarClientWithRefresh({
+    accessToken: "stale-access-token",
+    refreshToken: "refresh-token",
+    expiresAt: Date.now() - 1000,
+    emailAccountId: "email-account-id",
+    logger,
+  });
+}
+
+function tokenErrorResponse(errorDescription: string) {
+  return {
+    ok: false,
+    json: vi.fn().mockResolvedValue({ error_description: errorDescription }),
+  } as any;
+}

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -83,7 +83,10 @@ export const getCalendarClientWithRefresh = async ({
     const tokens = await response.json();
 
     if (!response.ok) {
-      throw new Error(tokens.error_description || "Failed to refresh token");
+      throw new Error(
+        [tokens.error, tokens.error_description].filter(Boolean).join(": ") ||
+          "Failed to refresh token",
+      );
     }
 
     if (!tokens.expires_in) {
@@ -123,10 +126,43 @@ export const getCalendarClientWithRefresh = async ({
     });
   } catch (error) {
     if (isInvalidGrantError(error)) {
-      logger.warn("Error refreshing Calendar access token", {
-        emailAccountId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn("Microsoft calendar authorization expired");
+      try {
+        // Tokens are encrypted at rest, so compare the decrypted values before
+        // guarding the write against a concurrent refresh or reconnect.
+        const connections = await prisma.calendarConnection.findMany({
+          where: { emailAccountId, provider: "microsoft", isConnected: true },
+          select: {
+            id: true,
+            accessToken: true,
+            refreshToken: true,
+            updatedAt: true,
+          },
+        });
+        for (const connection of connections) {
+          if (
+            connection.refreshToken !== refreshToken ||
+            connection.accessToken !== (accessToken ?? null)
+          )
+            continue;
+
+          await prisma.calendarConnection.updateMany({
+            where: {
+              id: connection.id,
+              updatedAt: connection.updatedAt,
+              isConnected: true,
+            },
+            data: { isConnected: false },
+          });
+        }
+      } catch (disconnectError) {
+        logger.error("Failed to mark Microsoft calendar disconnected", {
+          error: disconnectError,
+        });
+      }
+      throw new SafeError(
+        "Your Microsoft calendar authorization has expired. Please reconnect your calendar.",
+      );
     }
 
     throw error;


### PR DESCRIPTION
When Microsoft rejects a calendar refresh token, show an actionable reconnect error and mark only connections still using the failed credentials disconnected. This replaces the implementation proposed in #2534 on current main.

- Reuse shared authorization-error detection and retain the OAuth error code when its description omits it.
- Compare decrypted credentials, then guard each disconnect by connection ID and updatedAt so a concurrent refresh or reconnect is preserved. Database failures cannot hide the reconnect error.
- Keep refresh failures outside the sync wrapper's unconditional disconnect handler. Transient refresh failures no longer disconnect an otherwise valid connection.
- Validation: 32 focused tests passed across the refresh client, Microsoft sync, availability, and events; Biome and git diff checks passed. Regression tests first reproduced the missing reconnect behavior. Database concurrency guards are asserted with mocked Prisma; no live Microsoft or Postgres test was run.

Performance: no added work on successful refreshes or valid-token requests. Authorization failures add one connection read and guarded writes only for matching credentials; no additional provider requests.


CI follow-up: reuse the focused offline fixes from #3660. Cached-page reads no longer wait behind background cache writes; the reconnect test confirms an uncached server response before reloading, keeping its original navigation deadline. Regression coverage proves the old cache code fails when a background write stalls and verifies logout still invalidates cached responses.

Validation of this follow-up: 30 cache/calendar unit tests pass; the production-mode offline/reconnect browser test passes using the CI application artifact with the worker fix applied, and its reconnect screenshot was inspected. Biome and diff checks pass. Hosted Linux CI now passes both the offline-mail and mail-triage suites, along with the other unit and browser test jobs.

The subsequent Linux run passed offline-mail coverage but exposed a race in the star-toggle test added on main: successive shortcut/menu checks could run while the previous mutation was settling. The test now verifies each mutation succeeded with the expected starred value before trying the next entry point, while retaining the UI assertions and existing timeouts. The strengthened production-mode starring test passes locally, and its final screenshot was inspected. The branch is synchronized with main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Microsoft calendar synchronization now preserves connection-refresh errors instead of incorrectly marking calendars as disconnected.
  - Expired Microsoft calendar credentials now clearly prompt reconnection, while affected calendar connections are safely marked for reconnecting.
  - Calendar refresh failures now provide more complete error details and avoid disconnecting unrelated connections.
  - Improved reliability for offline mail loading, mailbox caching, and starring actions across supported mail workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->