### PR TITLE
rules: Reconcile learned patterns while preserving corrections

### DIFF
--- a/apps/web/__tests__/db/group-item-reconciliation.test.ts
+++ b/apps/web/__tests__/db/group-item-reconciliation.test.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Client } from "pg";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@/generated/prisma/client";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
+import { addGroupItem, saveGroupItem } from "@/utils/group/group-item";
+
+const state = vi.hoisted(() => ({ prisma: null as PrismaClient | null }));
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    get groupItem() {
+      return state.prisma!.groupItem;
+    },
+  },
+}));
+
+describe.skipIf(!process.env.RUN_DB_TESTS)("group item reconciliation", () => {
+  let client: Client;
+  let schema: string;
+
+  beforeEach(async () => {
+    client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+    schema = `group_items_${randomUUID().replaceAll("-", "")}`;
+    await client.query(
+      `CREATE SCHEMA "${schema}"; SET search_path TO "${schema}"`,
+    );
+    await client.query(`
+      CREATE TYPE "GroupItemType" AS ENUM ('FROM', 'SUBJECT');
+      CREATE TYPE "GroupItemSource" AS ENUM ('USER', 'AI', 'LABEL_ADDED', 'LABEL_REMOVED');
+      CREATE TABLE "GroupItem" (
+        "id" TEXT PRIMARY KEY, "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL, "groupId" TEXT,
+        "type" "GroupItemType" NOT NULL, "value" TEXT NOT NULL,
+        "exclude" BOOLEAN NOT NULL DEFAULT false, "reason" TEXT,
+        "threadId" TEXT, "messageId" TEXT, "source" "GroupItemSource",
+        UNIQUE ("groupId", "type", "value")
+      )
+    `);
+    state.prisma = new PrismaClient({
+      adapter: new PrismaPg(
+        { connectionString: process.env.DATABASE_URL },
+        { schema },
+      ),
+    });
+  });
+
+  afterEach(async () => {
+    await state.prisma?.$disconnect();
+    await client.query(`DROP SCHEMA "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  const pattern = {
+    groupId: "group",
+    type: GroupItemType.FROM,
+    value: "sender@example.com",
+  };
+
+  it("keeps user ownership through concurrent automatic saves and permits explicit edits", async () => {
+    await Promise.all([
+      addGroupItem({
+        ...pattern,
+        value: " Sender@Example.COM\n",
+        exclude: true,
+      }),
+      ...Array.from({ length: 8 }, () =>
+        saveGroupItem({
+          ...pattern,
+          exclude: false,
+          source: GroupItemSource.AI,
+        }),
+      ),
+    ]);
+    expect(await state.prisma!.groupItem.findMany()).toEqual([
+      expect.objectContaining({
+        ...pattern,
+        exclude: true,
+        source: GroupItemSource.USER,
+      }),
+    ]);
+    await addGroupItem({ ...pattern, exclude: false });
+    expect(await state.prisma!.groupItem.findFirst()).toMatchObject({
+      exclude: false,
+      source: GroupItemSource.USER,
+    });
+  });
+
+  it("retains exclusions and provenance for inferred saves", async () => {
+    await saveGroupItem({
+      ...pattern,
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+    });
+    await saveGroupItem({ ...pattern, source: GroupItemSource.AI });
+    expect(await state.prisma!.groupItem.findFirst()).toMatchObject({
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+    });
+    await saveGroupItem({
+      ...pattern,
+      exclude: false,
+      source: GroupItemSource.LABEL_ADDED,
+    });
+    expect(await state.prisma!.groupItem.findFirst()).toMatchObject({
+      exclude: false,
+      source: GroupItemSource.LABEL_REMOVED,
+    });
+  });
+
+  it("protects legacy ownership without inventing provenance", async () => {
+    await state.prisma!.groupItem.create({
+      data: { ...pattern, exclude: true },
+    });
+    await saveGroupItem({
+      ...pattern,
+      exclude: false,
+      source: GroupItemSource.AI,
+    });
+    expect(await state.prisma!.groupItem.findFirst()).toMatchObject({
+      exclude: true,
+      source: null,
+    });
+  });
+
+  it("normalizes and deduplicates legacy rows while preserving authored evidence", async () => {
+    await client.query(`
+      INSERT INTO "GroupItem" ("id", "updatedAt", "groupId", "type", "value", "exclude", "source")
+      VALUES
+        ('legacy', '2025-01-01', 'group', 'FROM', E' Sender@Example.COM\\n', true, NULL),
+        ('automatic', '2026-07-01', 'group', 'FROM', 'sender@example.com', false, 'AI'),
+        ('blank', '2025-01-01', 'group', 'SUBJECT', E' \\t\\n', false, NULL),
+        ('subject', '2025-01-01', 'group', 'SUBJECT', ' Invoice ', false, NULL),
+        ('ambiguous', '2025-01-01', 'group', 'FROM', 'older@example.com', false, NULL),
+        ('recent', '2026-07-01', 'group', 'FROM', 'recent@example.com', false, NULL)
+    `);
+    const migration = await readFile(
+      new URL(
+        "../../prisma/migrations/20260728170000_normalize_group_item_values/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    await client.query(migration);
+    const rows = await state.prisma!.groupItem.findMany({
+      orderBy: { id: "asc" },
+    });
+    expect(rows).toEqual([
+      expect.objectContaining({ id: "ambiguous", source: null }),
+      expect.objectContaining({
+        id: "legacy",
+        value: "sender@example.com",
+        exclude: true,
+        source: GroupItemSource.USER,
+      }),
+      expect.objectContaining({ id: "recent", source: null }),
+      expect.objectContaining({
+        id: "subject",
+        value: "invoice",
+        source: GroupItemSource.USER,
+      }),
+    ]);
+  });
+});

--- a/apps/web/__tests__/db/group-item-reconciliation.test.ts
+++ b/apps/web/__tests__/db/group-item-reconciliation.test.ts
@@ -125,6 +125,30 @@ describe.skipIf(!process.env.RUN_DB_TESTS)("group item reconciliation", () => {
     });
   });
 
+  it("keeps exclusions when normalized duplicates have equal authority and recency", async () => {
+    await client.query(`
+      INSERT INTO "GroupItem" ("id", "updatedAt", "groupId", "type", "value", "exclude", "source")
+      VALUES
+        ('a-exclude', '2026-07-01', 'group', 'FROM', 'SENDER@example.com', true, 'USER'),
+        ('z-include', '2026-07-01', 'group', 'FROM', 'sender@example.com', false, 'USER')
+    `);
+    const migration = await readFile(
+      new URL(
+        "../../prisma/migrations/20260728170000_normalize_group_item_values/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    await client.query(migration);
+    expect(await state.prisma!.groupItem.findMany()).toEqual([
+      expect.objectContaining({
+        id: "a-exclude",
+        exclude: true,
+        value: "sender@example.com",
+      }),
+    ]);
+  });
+
   it("normalizes and deduplicates legacy rows while preserving authored evidence", async () => {
     await client.query(`
       INSERT INTO "GroupItem" ("id", "updatedAt", "groupId", "type", "value", "exclude", "source")

--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -10,7 +10,7 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
   page,
   context,
 }, testInfo) => {
-  const { conversations } = await openMail(page);
+  const { conversations, emailAccountId } = await openMail(page);
   await expect(
     conversationWithSubject(page, conversations, "Archive Action Message"),
   ).toBeVisible();
@@ -77,6 +77,41 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
       )
       .toBe(true);
 
+    // The initial list can render from the network before IndexedDB is durable.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          (accountId) =>
+            new Promise<boolean>((resolve) => {
+              const request = indexedDB.open("inbox-zero-email-cache");
+              request.onerror = () => resolve(false);
+              request.onupgradeneeded = () => request.transaction?.abort();
+              request.onsuccess = () => {
+                const database = request.result;
+                if (!database.objectStoreNames.contains("mailboxSyncStates")) {
+                  database.close();
+                  resolve(false);
+                  return;
+                }
+                const transaction = database.transaction("mailboxSyncStates");
+                const state = transaction
+                  .objectStore("mailboxSyncStates")
+                  .get(accountId);
+                transaction.oncomplete = () => {
+                  database.close();
+                  resolve(Boolean(state.result?.completedAt));
+                };
+                transaction.onerror = () => {
+                  database.close();
+                  resolve(false);
+                };
+              };
+            }),
+          emailAccountId,
+        ),
+      )
+      .toBe(true);
+
     await context.setOffline(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(conversations).toBeVisible();
@@ -90,25 +125,6 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     );
 
     await context.setOffline(false);
-    // Confirm a live authenticated request before navigating the controlled page.
-    // The mail document and account list can both succeed from the offline cache.
-    await expect
-      .poll(() =>
-        page.evaluate(async () => {
-          try {
-            const response = await fetch("/api/auth/get-session", {
-              cache: "no-store",
-              signal: AbortSignal.timeout(3000),
-            });
-            if (!response.ok) return false;
-            const session = await response.json();
-            return Boolean(session?.session?.id);
-          } catch {
-            return false;
-          }
-        }),
-      )
-      .toBe(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(
       conversationWithSubject(page, conversations, "Archive Action Message"),

--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -90,6 +90,25 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     );
 
     await context.setOffline(false);
+    // Confirm a live authenticated request before navigating the controlled page.
+    // The mail document and account list can both succeed from the offline cache.
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          try {
+            const response = await fetch("/api/auth/get-session", {
+              cache: "no-store",
+              signal: AbortSignal.timeout(3000),
+            });
+            if (!response.ok) return false;
+            const session = await response.json();
+            return Boolean(session?.session?.id);
+          } catch {
+            return false;
+          }
+        }),
+      )
+      .toBe(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(
       conversationWithSubject(page, conversations, "Archive Action Message"),

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
@@ -1,0 +1,36 @@
+-- Legacy exclusions and subject patterns came from explicit user updates.
+-- Sender inclusions with unknown ownership remain null and are protected by
+-- the writer and matcher; update time does not establish provenance.
+UPDATE "GroupItem"
+SET "source" = 'USER'
+WHERE "source" IS NULL
+  AND (
+    "exclude"
+    OR "type" = 'SUBJECT'
+  );
+
+DELETE FROM "GroupItem"
+WHERE btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF') = '';
+
+WITH ranked_items AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "groupId", "type", lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
+      ORDER BY
+        coalesce("source" = 'USER', true) DESC,
+        "updatedAt" DESC,
+        "createdAt" DESC,
+        "id" DESC
+    ) AS rank
+  FROM "GroupItem"
+  WHERE "groupId" IS NOT NULL
+)
+DELETE FROM "GroupItem"
+USING ranked_items
+WHERE "GroupItem"."id" = ranked_items."id"
+  AND ranked_items.rank > 1;
+
+UPDATE "GroupItem"
+SET "value" = lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
+WHERE "value" <> lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'));

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
@@ -20,6 +20,7 @@ WITH ranked_items AS (
       ORDER BY
         coalesce("source" = 'USER', true) DESC,
         "updatedAt" DESC,
+        "exclude" DESC,
         "createdAt" DESC,
         "id" DESC
     ) AS rank

--- a/apps/web/utils/actions/group.validation.ts
+++ b/apps/web/utils/actions/group.validation.ts
@@ -9,7 +9,7 @@ export type CreateGroupBody = z.infer<typeof createGroupBody>;
 export const addGroupItemBody = z.object({
   groupId: z.string(),
   type: z.enum([GroupItemType.FROM, GroupItemType.SUBJECT]),
-  value: z.string(),
+  value: z.string().trim().min(1, "Pattern is required"),
   exclude: z.boolean().optional(),
 });
 export type AddGroupItemBody = z.infer<typeof addGroupItemBody>;

--- a/apps/web/utils/group/find-matching-group.test.ts
+++ b/apps/web/utils/group/find-matching-group.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findMatchingGroupItem } from "./find-matching-group";
-import { GroupItemType } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 
 describe("findMatchingGroupItem", () => {
   it("should match FROM rules", () => {
@@ -117,6 +117,123 @@ describe("findMatchingGroupItem", () => {
         expected: groupItems[0],
       },
     ]);
+  });
+
+  it("protects legacy inclusions with unknown ownership from automatic exclusions", () => {
+    const legacy = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: null,
+    };
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        legacy,
+        {
+          type: GroupItemType.FROM,
+          value: "@example.com",
+          exclude: true,
+          source: GroupItemSource.LABEL_REMOVED,
+          updatedAt: new Date(),
+        },
+      ]),
+    ).toBe(legacy);
+  });
+
+  it("prefers explicit user evidence over an automatic exclusion", () => {
+    const automaticExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+    const userInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.USER,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        automaticExclusion,
+        userInclusion,
+      ]),
+    ).toBe(userInclusion);
+  });
+
+  it("uses the newest automatic evidence when inclusion and exclusion overlap", () => {
+    const olderExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const newerInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        olderExclusion,
+        newerInclusion,
+      ]),
+    ).toBe(newerInclusion);
+  });
+
+  it("uses a newer automatic exclusion over an older automatic inclusion", () => {
+    const olderInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const newerExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        olderInclusion,
+        newerExclusion,
+      ]),
+    ).toBeNull();
+  });
+
+  it("keeps an explicit user exclusion ahead of newer automatic evidence", () => {
+    const userExclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: true,
+      source: GroupItemSource.USER,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const automaticInclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        automaticInclusion,
+        userExclusion,
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/utils/group/find-matching-group.ts
+++ b/apps/web/utils/group/find-matching-group.ts
@@ -1,7 +1,7 @@
 import prisma from "@/utils/prisma";
 import { generalizeSubject } from "@/utils/string";
 import type { ParsedMessage } from "@/utils/types";
-import { GroupItemType } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 import type { GroupItem } from "@/generated/prisma/client";
 
 export type GroupsWithRules = Awaited<ReturnType<typeof getGroupsWithRules>>;
@@ -26,20 +26,17 @@ export function findMatchingGroup(
   message: ParsedMessage,
   group: GroupsWithRules[number],
 ) {
-  // First check for exclude patterns
-  const excludeMatch = findExclusionMatch(message.headers, group.items);
-  if (excludeMatch) {
-    // If any exclusion pattern matches, this rule is completely excluded
+  const matchingItem = findBestMatchingItem(message.headers, group.items);
+
+  if (matchingItem?.exclude) {
     return {
       group,
       matchingItem: null,
       excluded: true,
-      excludedItem: excludeMatch,
+      excludedItem: matchingItem,
     };
   }
 
-  // If no exclusion patterns matched, check for inclusion patterns
-  const matchingItem = findInclusionMatch(message.headers, group.items);
   if (matchingItem)
     return { group, matchingItem, excluded: false, excludedItem: null };
 
@@ -82,28 +79,40 @@ function matchesPattern<T extends Pick<GroupItem, "type" | "value">>(
   return false;
 }
 
-function findExclusionMatch<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
->(headers: { from: string; subject: string }, groupItems: T[]) {
-  return groupItems.find(
-    (item) => item.exclude && matchesPattern(item, headers),
-  );
-}
-
-function findInclusionMatch<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
->(headers: { from: string; subject: string }, groupItems: T[]) {
-  return groupItems.find(
-    (item) => !item.exclude && matchesPattern(item, headers),
-  );
-}
-
 // Keep this for backward compatibility
 export function findMatchingGroupItem<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
+  T extends Pick<GroupItem, "type" | "value" | "exclude"> &
+    Partial<Pick<GroupItem, "source" | "updatedAt">>,
 >(headers: { from: string; subject: string }, groupItems: T[]) {
-  const hasExclusion = findExclusionMatch(headers, groupItems);
-  if (hasExclusion) return null;
+  const matchingItem = findBestMatchingItem(headers, groupItems);
+  return matchingItem?.exclude ? null : matchingItem;
+}
 
-  return findInclusionMatch(headers, groupItems);
+function findBestMatchingItem<
+  T extends Pick<GroupItem, "type" | "value" | "exclude"> &
+    Partial<Pick<GroupItem, "source" | "updatedAt">>,
+>(headers: { from: string; subject: string }, groupItems: T[]) {
+  const matches = groupItems.filter((item) => matchesPattern(item, headers));
+  if (!matches.length) return;
+
+  const userMatches = matches.filter(
+    // Unknown legacy provenance may represent an explicit user instruction.
+    (item) => item.source == null || item.source === GroupItemSource.USER,
+  );
+  const candidates = userMatches.length ? userMatches : matches;
+
+  return candidates.reduce((best, item) => {
+    const bestUpdatedAt = best.updatedAt?.getTime();
+    const itemUpdatedAt = item.updatedAt?.getTime();
+
+    if (itemUpdatedAt !== undefined && bestUpdatedAt !== undefined) {
+      if (itemUpdatedAt > bestUpdatedAt) return item;
+      if (itemUpdatedAt < bestUpdatedAt) return best;
+    }
+
+    if (itemUpdatedAt !== undefined && bestUpdatedAt === undefined) return item;
+    if (itemUpdatedAt === undefined && bestUpdatedAt !== undefined) return best;
+
+    return item.exclude && !best.exclude ? item : best;
+  });
 }

--- a/apps/web/utils/group/group-item.ts
+++ b/apps/web/utils/group/group-item.ts
@@ -31,7 +31,7 @@ export async function saveGroupItem({
   reason?: string | null;
   threadId?: string | null;
   messageId?: string | null;
-  source?: GroupItemSource | null;
+  source: GroupItemSource;
 }) {
   const normalizedValue = normalizeGroupItemValue(value);
   if (!normalizedValue) throw new Error("Learned pattern cannot be empty");

--- a/apps/web/utils/group/group-item.ts
+++ b/apps/web/utils/group/group-item.ts
@@ -1,7 +1,6 @@
 import prisma from "@/utils/prisma";
 import { isDuplicateError } from "@/utils/prisma-helpers";
-import type { GroupItemType } from "@/generated/prisma/enums";
-import { captureException } from "@/utils/error";
+import { GroupItemSource, type GroupItemType } from "@/generated/prisma/enums";
 
 export async function addGroupItem(data: {
   groupId: string;
@@ -9,15 +8,77 @@ export async function addGroupItem(data: {
   value: string;
   exclude?: boolean;
 }) {
+  return saveGroupItem({
+    ...data,
+    source: GroupItemSource.USER,
+  });
+}
+
+export async function saveGroupItem({
+  groupId,
+  type,
+  value,
+  exclude,
+  reason,
+  threadId,
+  messageId,
+  source,
+}: {
+  groupId: string;
+  type: GroupItemType;
+  value: string;
+  exclude?: boolean;
+  reason?: string | null;
+  threadId?: string | null;
+  messageId?: string | null;
+  source?: GroupItemSource | null;
+}) {
+  const normalizedValue = normalizeGroupItemValue(value);
+  if (!normalizedValue) throw new Error("Learned pattern cannot be empty");
+
+  const updateData = {
+    exclude,
+    reason,
+    threadId,
+    messageId,
+    // Inferred inclusions retain their original provenance for spam cleanup.
+    source:
+      source === GroupItemSource.USER || exclude === true ? source : undefined,
+  };
+  const updateWhere = {
+    groupId,
+    type,
+    value: normalizedValue,
+    ...(source !== GroupItemSource.USER && {
+      source: { not: GroupItemSource.USER },
+    }),
+  };
+
+  const updated = await prisma.groupItem.updateMany({
+    where: updateWhere,
+    data: updateData,
+  });
+  if (updated.count > 0) return;
+
   try {
-    return await prisma.groupItem.create({ data });
+    return await prisma.groupItem.create({
+      data: {
+        groupId,
+        type,
+        value: normalizedValue,
+        ...updateData,
+        exclude: exclude ?? false,
+        source,
+      },
+    });
   } catch (error) {
-    if (isDuplicateError(error)) {
-      captureException(error, { extra: { items: data } });
-    } else {
-      throw error;
-    }
+    if (!isDuplicateError(error)) throw error;
   }
+
+  await prisma.groupItem.updateMany({
+    where: updateWhere,
+    data: updateData,
+  });
 }
 
 export async function deleteGroupItem({
@@ -30,4 +91,8 @@ export async function deleteGroupItem({
   await prisma.groupItem.delete({
     where: { id, group: { emailAccountId } },
   });
+}
+
+function normalizeGroupItemValue(value: string) {
+  return value.trim().toLowerCase();
 }

--- a/apps/web/utils/offline/mail-cache.test.ts
+++ b/apps/web/utils/offline/mail-cache.test.ts
@@ -74,6 +74,37 @@ describe("offline mail cache", () => {
     expect(await (await response).text()).toBe("Saved mailbox");
   });
 
+  it("serves the saved mailbox while a background cache write is stalled", async () => {
+    const cache = makeCache();
+    network.mockResolvedValueOnce(html());
+    await cache.handle(documentRequest(), waitUntil);
+    await Promise.all(pending);
+
+    let finishWrite!: () => void;
+    const writing = new Promise<void>((resolve) => {
+      finishWrite = resolve;
+    });
+    vi.spyOn(storage, "put").mockReturnValueOnce(writing);
+    network.mockResolvedValueOnce(html("Refreshed mailbox"));
+    await cache.handle(documentRequest(), waitUntil);
+
+    vi.useFakeTimers();
+    network.mockImplementation(() => new Promise(() => {}));
+    let body: string | undefined;
+    const response = cache
+      .handle(documentRequest(), waitUntil)
+      .then(async (result) => {
+        body = await result.text();
+      });
+    await vi.advanceTimersByTimeAsync(3000);
+    try {
+      expect(body).toBe("Saved mailbox");
+    } finally {
+      finishWrite();
+      await response;
+    }
+  });
+
   it("uses saved mail when response headers arrive but the page body stalls", async () => {
     const cache = makeCache();
     network.mockResolvedValueOnce(html());

--- a/apps/web/utils/offline/mail-cache.ts
+++ b/apps/web/utils/offline/mail-cache.ts
@@ -56,7 +56,7 @@ export function createOfflineMailCache({
     const cached = async () => {
       if (startedAtGeneration !== generation) return;
       try {
-        await writes;
+        // An in-flight refresh must not block reading the previous saved copy.
         const response = await (await caches.open(cacheName)).match(key);
         return startedAtGeneration === generation ? response : undefined;
       } catch {

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -14,6 +14,35 @@ vi.mock("@/utils/prisma-helpers", () => ({
 describe("saveLearnedPattern", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockResolvedValue({} as any);
+    vi.mocked(isDuplicateError).mockReturnValue(false);
+  });
+
+  it("preserves exclusion and provenance when an inferred save omits exclude", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "sender@example.com",
+      ruleId: "rule-id",
+      source: GroupItemSource.AI,
+      logger: createTestLogger(),
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          exclude: undefined,
+          source: undefined,
+        }),
+      }),
+    );
   });
 
   it("should return early if rule not found", async () => {
@@ -26,7 +55,8 @@ describe("saveLearnedPattern", () => {
       logger: createTestLogger(),
     });
 
-    expect(prisma.groupItem.upsert).not.toHaveBeenCalled();
+    expect(prisma.groupItem.updateMany).not.toHaveBeenCalled();
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
   });
 
   it("should use existing groupId when rule has one", async () => {
@@ -36,8 +66,6 @@ describe("saveLearnedPattern", () => {
       name: "Test Rule",
       groupId: existingGroupId,
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -46,27 +74,135 @@ describe("saveLearnedPattern", () => {
     });
 
     expect(prisma.group.create).not.toHaveBeenCalled();
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith({
-      where: {
-        groupId_type_value: {
-          groupId: existingGroupId,
-          type: GroupItemType.FROM,
-          value: "test@example.com",
-        },
-      },
-      // Omitted fields must not reset stored state: overwriting exclude would
-      // silently re-block a sender the user had corrected.
-      update: expect.objectContaining({
-        exclude: undefined,
-        source: undefined,
-      }),
-      create: expect.objectContaining({
+    expect(prisma.groupItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
         groupId: existingGroupId,
         type: GroupItemType.FROM,
         value: "test@example.com",
         exclude: false,
       }),
     });
+  });
+
+  it("normalizes learned sender values before saving", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "\t Sender@Example.COM\n",
+      ruleId: "rule-id",
+      logger: createTestLogger(),
+    });
+
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          value: "sender@example.com",
+        }),
+      }),
+    );
+  });
+
+  it("guards automatic updates from user-authored rows", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "  Sender@Example.COM  ",
+      ruleId: "rule-id",
+      exclude: false,
+      logger: createTestLogger(),
+      source: GroupItemSource.LABEL_ADDED,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+        source: { not: GroupItemSource.USER },
+      },
+      data: expect.objectContaining({
+        source: undefined,
+      }),
+    });
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
+  });
+
+  it("allows a user-authored update to replace automatic evidence", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "Sender@Example.COM",
+      ruleId: "rule-id",
+      exclude: true,
+      logger: createTestLogger(),
+      source: GroupItemSource.USER,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+      },
+      data: expect.objectContaining({
+        exclude: true,
+        source: GroupItemSource.USER,
+      }),
+    });
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves a user pattern created during an automatic save", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockRejectedValue(
+      new Error("Duplicate key"),
+    );
+    vi.mocked(isDuplicateError).mockReturnValue(true);
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "Sender@Example.COM",
+      ruleId: "rule-id",
+      exclude: false,
+      logger: createTestLogger(),
+      source: GroupItemSource.LABEL_ADDED,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+        source: { not: GroupItemSource.USER },
+      },
+      data: expect.objectContaining({
+        exclude: false,
+        source: undefined,
+      }),
+    });
+    expect(prisma.groupItem.create).toHaveBeenCalledTimes(1);
   });
 
   it("should create a new group when rule has no groupId", async () => {
@@ -79,8 +215,6 @@ describe("saveLearnedPattern", () => {
     vi.mocked(prisma.group.create).mockResolvedValue({
       id: newGroupId,
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -95,15 +229,13 @@ describe("saveLearnedPattern", () => {
         rule: { connect: { id: "rule-id" } },
       },
     });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          groupId_type_value: {
-            groupId: newGroupId,
-            type: GroupItemType.FROM,
-            value: "test@example.com",
-          },
-        },
+        data: expect.objectContaining({
+          groupId: newGroupId,
+          type: GroupItemType.FROM,
+          value: "test@example.com",
+        }),
       }),
     );
   });
@@ -114,8 +246,6 @@ describe("saveLearnedPattern", () => {
       name: "Test Rule",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "excluded@example.com",
@@ -126,22 +256,8 @@ describe("saveLearnedPattern", () => {
       source: GroupItemSource.USER,
     });
 
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith({
-      where: {
-        groupId_type_value: {
-          groupId: "group-id",
-          type: GroupItemType.FROM,
-          value: "excluded@example.com",
-        },
-      },
-      update: {
-        exclude: true,
-        reason: "User excluded",
-        threadId: undefined,
-        messageId: undefined,
-        source: GroupItemSource.USER,
-      },
-      create: {
+    expect(prisma.groupItem.create).toHaveBeenCalledWith({
+      data: {
         groupId: "group-id",
         type: GroupItemType.FROM,
         value: "excluded@example.com",
@@ -152,58 +268,6 @@ describe("saveLearnedPattern", () => {
         source: GroupItemSource.USER,
       },
     });
-  });
-
-  it("should record label removal as the source of an exclusion", async () => {
-    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
-      id: "rule-id",
-      name: "Test Rule",
-      groupId: "group-id",
-    } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
-    await saveLearnedPattern({
-      emailAccountId: "email-account-id",
-      from: "excluded@example.com",
-      ruleId: "rule-id",
-      exclude: true,
-      logger: createTestLogger(),
-      reason: "Label removed",
-      source: GroupItemSource.LABEL_REMOVED,
-    });
-
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        update: expect.objectContaining({
-          exclude: true,
-          source: GroupItemSource.LABEL_REMOVED,
-        }),
-      }),
-    );
-  });
-
-  it("should preserve the existing source for an inferred inclusion", async () => {
-    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
-      id: "rule-id",
-      name: "Test Rule",
-      groupId: "group-id",
-    } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
-    await saveLearnedPattern({
-      emailAccountId: "email-account-id",
-      from: "sender@example.com",
-      ruleId: "rule-id",
-      logger: createTestLogger(),
-      source: GroupItemSource.AI,
-    });
-
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        update: expect.objectContaining({ source: undefined }),
-        create: expect.objectContaining({ source: GroupItemSource.AI }),
-      }),
-    );
   });
 
   it("should handle duplicate group creation by finding existing group", async () => {
@@ -225,8 +289,6 @@ describe("saveLearnedPattern", () => {
       id: existingGroupId,
     } as any);
     vi.mocked(prisma.rule.update).mockResolvedValue({} as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -243,15 +305,13 @@ describe("saveLearnedPattern", () => {
       },
       select: { id: true },
     });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          groupId_type_value: {
-            groupId: existingGroupId,
-            type: GroupItemType.FROM,
-            value: "test@example.com",
-          },
-        },
+        data: expect.objectContaining({
+          groupId: existingGroupId,
+          type: GroupItemType.FROM,
+          value: "test@example.com",
+        }),
       }),
     );
   });
@@ -260,6 +320,9 @@ describe("saveLearnedPattern", () => {
 describe("saveLearnedPatterns", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockResolvedValue({} as any);
+    vi.mocked(isDuplicateError).mockReturnValue(false);
   });
 
   it("should return error if rule not found", async () => {
@@ -280,8 +343,6 @@ describe("saveLearnedPatterns", () => {
       id: "rule-id",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     const result = await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Test Rule",
@@ -293,57 +354,55 @@ describe("saveLearnedPatterns", () => {
     });
 
     expect(result).toEqual({ success: true });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledTimes(2);
+    expect(prisma.groupItem.create).toHaveBeenCalledTimes(2);
   });
 
-  // Matches saveLearnedPattern: omitting exclude must not reset a stored exclusion,
-  // which would silently re-block a sender the user had corrected.
-  it("should leave exclude untouched when a pattern omits it", async () => {
+  it("preserves an existing exclusion when a bulk pattern omits exclude", async () => {
     vi.mocked(prisma.rule.findUnique).mockResolvedValue({
       id: "rule-id",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
     await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Test Rule",
       patterns: [{ type: GroupItemType.FROM, value: "sender@example.com" }],
       logger: createTestLogger(),
     });
-
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        update: { exclude: undefined },
-        create: expect.objectContaining({ exclude: false }),
+        data: expect.objectContaining({ exclude: undefined }),
       }),
     );
   });
 
-  it("should still apply exclude when a pattern sets it", async () => {
+  it("normalizes explicit learned patterns and records them as user-authored", async () => {
     vi.mocked(prisma.rule.findUnique).mockResolvedValue({
       id: "rule-id",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
-    await saveLearnedPatterns({
+    const result = await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Test Rule",
       patterns: [
         {
           type: GroupItemType.FROM,
-          value: "sender@example.com",
+          value: "\r Sender@Example.COM\v",
           exclude: true,
         },
       ],
       logger: createTestLogger(),
     });
 
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(result).toEqual({ success: true });
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        update: { exclude: true },
-        create: expect.objectContaining({ exclude: true }),
+        data: expect.objectContaining({
+          groupId: "group-id",
+          type: GroupItemType.FROM,
+          value: "sender@example.com",
+          source: GroupItemSource.USER,
+        }),
       }),
     );
   });

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -49,6 +49,7 @@ describe("saveLearnedPattern", () => {
     vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
 
     await saveLearnedPattern({
+      source: GroupItemSource.AI,
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "nonexistent-rule",
@@ -67,6 +68,7 @@ describe("saveLearnedPattern", () => {
       groupId: existingGroupId,
     } as any);
     await saveLearnedPattern({
+      source: GroupItemSource.AI,
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",
@@ -91,6 +93,7 @@ describe("saveLearnedPattern", () => {
       groupId: "group-id",
     } as any);
     await saveLearnedPattern({
+      source: GroupItemSource.AI,
       emailAccountId: "email-account-id",
       from: "\t Sender@Example.COM\n",
       ruleId: "rule-id",
@@ -216,6 +219,7 @@ describe("saveLearnedPattern", () => {
       id: newGroupId,
     } as any);
     await saveLearnedPattern({
+      source: GroupItemSource.AI,
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",
@@ -290,6 +294,7 @@ describe("saveLearnedPattern", () => {
     } as any);
     vi.mocked(prisma.rule.update).mockResolvedValue({} as any);
     await saveLearnedPattern({
+      source: GroupItemSource.AI,
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",

--- a/apps/web/utils/rule/learned-patterns.ts
+++ b/apps/web/utils/rule/learned-patterns.ts
@@ -1,7 +1,8 @@
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
-import { type GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
+import { saveGroupItem } from "@/utils/group/group-item";
 
 /**
  * Saves a learned pattern for a rule
@@ -47,34 +48,15 @@ export async function saveLearnedPattern({
     logger,
   });
 
-  await prisma.groupItem.upsert({
-    where: {
-      groupId_type_value: {
-        groupId,
-        type: GroupItemType.FROM,
-        value: from,
-      },
-    },
-    // Undefined fields are left untouched by Prisma, so inferred inclusions do not
-    // overwrite how the pattern was first learned. Explicit exclusions claim the row
-    // so later cleanup cannot mistake a correction for spam learning.
-    update: {
-      exclude,
-      reason,
-      threadId,
-      messageId,
-      source: exclude === true ? source : undefined,
-    },
-    create: {
-      groupId,
-      type: GroupItemType.FROM,
-      value: from,
-      exclude: exclude ?? false,
-      reason,
-      threadId,
-      messageId,
-      source,
-    },
+  await saveGroupItem({
+    groupId,
+    type: GroupItemType.FROM,
+    value: from,
+    exclude,
+    reason,
+    threadId,
+    messageId,
+    source,
   });
 }
 
@@ -131,25 +113,12 @@ export async function saveLearnedPatterns({
   // Process all patterns in a single function
   for (const pattern of patterns) {
     try {
-      await prisma.groupItem.upsert({
-        where: {
-          groupId_type_value: {
-            groupId,
-            type: pattern.type,
-            value: pattern.value,
-          },
-        },
-        // Same rule as saveLearnedPattern: a pattern that says nothing about exclude
-        // must not reset one, which would re-block a sender the user had corrected.
-        update: {
-          exclude: pattern.exclude,
-        },
-        create: {
-          groupId,
-          type: pattern.type,
-          value: pattern.value,
-          exclude: pattern.exclude ?? false,
-        },
+      await saveGroupItem({
+        groupId,
+        type: pattern.type,
+        value: pattern.value,
+        exclude: pattern.exclude,
+        source: GroupItemSource.USER,
       });
     } catch (error) {
       const message = `${pattern.value} (${pattern.type}) ${

--- a/apps/web/utils/rule/learned-patterns.ts
+++ b/apps/web/utils/rule/learned-patterns.ts
@@ -28,7 +28,7 @@ export async function saveLearnedPattern({
   reason?: string | null;
   threadId?: string | null;
   messageId?: string | null;
-  source?: GroupItemSource | null;
+  source: GroupItemSource;
 }) {
   const rule = await prisma.rule.findUnique({
     where: { id: ruleId, emailAccountId },


### PR DESCRIPTION
Replaces #3074 with a refreshed implementation on current main.

Learned exclusions currently win over every overlapping inclusion, and manual pattern rows do not consistently record ownership. Normalize patterns and protect authored corrections while retaining the exclusion/provenance fixes merged in #3075, #3191, and #3192.

- Route manual and learned writes through an atomic conditional update/create path. Automatic writes cannot overwrite USER or unknown legacy ownership; explicit user edits can.
- Preserve existing exclusion values when omitted and preserve provenance on inferred inclusions. New patterns default to inclusion.
- Prefer authored or unknown legacy evidence over automatic evidence; within that priority, use the most recent update, with exclusions winning ties.
- Normalize values and deduplicate existing rows. Backfill known legacy exclusions/subjects, but do not infer sender ownership from update dates. Unknown sender provenance stays null and protected.
- Keep static-rule exclusion behavior unchanged. This replaces the original proposal to let static matches bypass automatic exclusions.

Validation: 169 tests passed across persistence, matching, label-removal cleanup, replied-sender handling, and real Postgres reconciliation suites. The database suite uses an isolated temporary schema and covers concurrent writes, legacy ownership, omitted exclusions, provenance, and migration deduplication including Unicode surrounding whitespace. The two omitted-exclusion regression tests were confirmed failing before the fix. An additional migration tie-break regression also passed (all five database tests pass). Biome and git diff checks passed. No local build was run.

Performance: existing patterns take one conditional update; new patterns take update + create, with one retry after a uniqueness race. Matching scans already-loaded patterns in memory. The one-time migration deletes duplicates and normalizes existing rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved group-item matching to prioritize explicit user choices and the most recent evidence.
  * Automatically learned patterns now preserve user-authored exclusions and ownership details.
  * Group patterns are normalized consistently by trimming whitespace and converting values to lowercase.

* **Bug Fixes**
  * Prevented blank or duplicate group patterns from being saved.
  * Added validation requiring group patterns to contain at least one character.
  * Preserved exclusions and matching behavior for older, previously saved group items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Offline CI fix: saved-mail reads no longer wait for background cache writes, so a stalled refresh cannot defeat the cached fallback. The browser test waits for completed IndexedDB synchronization before disconnecting. A new cache regression was confirmed red/green; all 19 cache tests and the focused production-mode Linux Chromium flow passed locally.
