### PR TITLE
rules: Make draft replies optional during bulk processing

### DIFF
--- a/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/automation/bulk-processing.spec.ts
@@ -36,6 +36,15 @@ for (const tier of ["PLUS_MONTHLY", "PROFESSIONAL_MONTHLY"] as const) {
     await expect(
       dialog.getByText("Run your rules on emails already in your inbox."),
     ).toBeVisible();
+    const generateDraftReplies = dialog.getByRole("switch", {
+      name: "Generate draft replies",
+    });
+    await expect(generateDraftReplies).not.toBeChecked();
+    await generateDraftReplies.click();
+    await expect(generateDraftReplies).toBeChecked();
+    await generateDraftReplies.click();
+    await expect(generateDraftReplies).not.toBeChecked();
+
     const includeRead = dialog.getByRole("switch").first();
 
     if (tier === "PLUS_MONTHLY") {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
@@ -53,7 +53,7 @@ describe("onRun", () => {
     } as Response);
     const activeAction = createDeferred();
     vi.mocked(runAiRules).mockImplementation(
-      (_emailAccountId, _threads, _rerun, signal) =>
+      (_emailAccountId, _threads, _rerun, { signal } = {}) =>
         new Promise((_resolve, reject) => {
           signal?.addEventListener("abort", () => {
             activeAction.promise.then(() => {
@@ -158,7 +158,7 @@ describe("onRun", () => {
       "account-id",
       [expect.objectContaining({ id: "unprocessed-thread" })],
       false,
-      expect.any(AbortSignal),
+      { signal: expect.any(AbortSignal), skipDraftReplies: true },
     );
   });
 
@@ -183,7 +183,7 @@ describe("onRun", () => {
         expect.objectContaining({ id: "unprocessed-thread" }),
       ],
       true,
-      expect.any(AbortSignal),
+      { signal: expect.any(AbortSignal), skipDraftReplies: true },
     );
   });
 
@@ -209,7 +209,7 @@ describe("onRun", () => {
       "account-id",
       [expect.objectContaining({ id: "processed-thread" })],
       true,
-      expect.any(AbortSignal),
+      { signal: expect.any(AbortSignal), skipDraftReplies: true },
     );
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -75,6 +75,7 @@ export function BulkRunRules() {
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [includeRead, setIncludeRead] = useState(false);
   const [rerun, setRerun] = useState(false);
+  const [generateDraftReplies, setGenerateDraftReplies] = useState(false);
 
   const abortRef = useRef<() => void>(undefined);
 
@@ -120,6 +121,7 @@ export function BulkRunRules() {
           startDate,
           endDate,
           includeRead,
+          generateDraftReplies,
           rerun: isRerunEnabled,
           maxEmails: isTrial ? TRIAL_BULK_PROCESS_EMAIL_LIMIT : undefined,
         },
@@ -236,6 +238,16 @@ export function BulkRunRules() {
                 />
                 {!hasRerunAccess && <ProfessionalPlanBadge />}
               </div>
+
+              <Toggle
+                name="generate-draft-replies"
+                ariaLabel="Generate draft replies"
+                label="Generate draft replies"
+                enabled={generateDraftReplies}
+                onChange={setGenerateDraftReplies}
+                disabled={isBusy}
+                explainText="Run draft reply actions from your rules for these emails, including drafts sent to connected messaging channels. Off by default."
+              />
 
               {isTrial && (
                 <div className="flex flex-col gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.test.ts
@@ -14,6 +14,43 @@ beforeEach(() => {
 });
 
 describe("bulk processing", () => {
+  it.each([
+    undefined,
+    false,
+    true,
+  ])("preserves the draft choice across pages and reruns (%s)", async (generateDraftReplies) => {
+    const thread = {
+      id: "thread-id",
+      messages: [{ id: "message-id" }],
+      plan: {},
+    };
+    vi.mocked(fetchWithAccount)
+      .mockResolvedValueOnce(
+        Response.json({ threads: [thread], nextPageToken: "next-page" }),
+      )
+      .mockResolvedValueOnce(Response.json({ threads: [thread] }));
+    const complete = vi.fn();
+    await onRun(
+      "account-id",
+      { startDate: new Date(2025, 3, 1), rerun: true, generateDraftReplies },
+      vi.fn(),
+      complete,
+    );
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledWith("success", 2));
+    expect(runAiRules).toHaveBeenCalledTimes(2);
+    for (const call of vi.mocked(runAiRules).mock.calls) {
+      expect(call).toEqual([
+        "account-id",
+        [thread],
+        true,
+        {
+          signal: expect.any(AbortSignal),
+          skipDraftReplies: !generateDraftReplies,
+        },
+      ]);
+    }
+  });
+
   it("includes the entire selected end date, including a same-day range", async () => {
     const date = new Date(2025, 3, 10);
     const complete = vi.fn();
@@ -71,11 +108,9 @@ describe("bulk processing", () => {
       expect(query.get("before")).toBeNull();
     }
     expect(queries.at(1)?.get("nextPageToken")).toBe("next-page");
-    expect(runAiRules).toHaveBeenCalledWith(
-      "account-id",
-      [thread],
-      false,
-      expect.any(AbortSignal),
-    );
+    expect(runAiRules).toHaveBeenCalledWith("account-id", [thread], false, {
+      signal: expect.any(AbortSignal),
+      skipDraftReplies: true,
+    });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
@@ -17,12 +17,14 @@ export async function onRun(
     startDate,
     endDate,
     includeRead,
+    generateDraftReplies = false,
     rerun,
     maxEmails,
   }: {
     startDate: Date;
     endDate?: Date;
     includeRead?: boolean;
+    generateDraftReplies?: boolean;
     rerun?: boolean;
     maxEmails?: number;
   },
@@ -113,12 +115,10 @@ export async function onRun(
       if (completeIfCancelled()) return;
 
       onThreadsQueued(threadsToQueue);
-      await runAiRules(
-        emailAccountId,
-        threadsToQueue,
-        !!rerun,
-        abortController.signal,
-      );
+      await runAiRules(emailAccountId, threadsToQueue, !!rerun, {
+        signal: abortController.signal,
+        skipDraftReplies: !generateDraftReplies,
+      });
       totalProcessed += threadsToQueue.length;
 
       if (maxEmails !== undefined && totalProcessed >= maxEmails) break;

--- a/apps/web/utils/actions/ai-rule.test.ts
+++ b/apps/web/utils/actions/ai-rule.test.ts
@@ -130,6 +130,23 @@ describe("runRulesAction", () => {
     expect(settled).toBe(true);
   });
 
+  it.each([
+    undefined,
+    false,
+    true,
+  ])("passes the draft preference through validation (%s)", async (skipDraftReplies) => {
+    const result = await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: false,
+      skipDraftReplies,
+    });
+    expect(result?.serverError).toBeUndefined();
+    expect(runRulesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ skipDraftReplies }),
+    );
+  });
+
   it("does not flush logger for non-test runs", async () => {
     const result = await runRulesAction("account-1", {
       messageId: "message-1",

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -29,7 +29,7 @@ export const runRulesAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId, userId, provider, logger: ctxLogger },
-      parsedInput: { messageId, threadId, rerun, isTest },
+      parsedInput: { messageId, threadId, rerun, isTest, skipDraftReplies },
     }): Promise<RunRulesResult[]> => {
       const logger = ctxLogger.with({ messageId, threadId });
 
@@ -180,6 +180,7 @@ export const runRulesAction = actionClient
         emailAccount,
         logger,
         modelType: "chat",
+        skipDraftReplies,
       }).catch((error) => {
         logger.error("runRules failed", { error });
         return flushAndRethrowRunRulesActionError({

--- a/apps/web/utils/actions/ai-rule.validation.ts
+++ b/apps/web/utils/actions/ai-rule.validation.ts
@@ -10,5 +10,6 @@ export const runRulesBody = z.object({
   threadId: z.string(),
   rerun: z.boolean().nullish(),
   isTest: z.boolean(),
+  skipDraftReplies: z.boolean().optional(),
 });
 export type RunRulesBody = z.infer<typeof runRulesBody>;

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -526,12 +526,59 @@ describe("runRules draft attribution persistence", () => {
     expect(getActionItemsWithAiArgs).not.toHaveBeenCalled();
     expect(result).toEqual([
       expect.objectContaining({
-        rule: null,
+        rule: expect.objectContaining({ id: "draft-only-rule" }),
         status: ExecutedRuleStatus.SKIPPED,
       }),
     ]);
     expect(prisma.executedRule.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+    });
+  });
+
+  it("records a skipped draft-only rule alongside another applied rule", async () => {
+    const draftRule = createRule("draft-only-rule", null, [
+      getAction({ id: "draft-action", type: ActionType.DRAFT_EMAIL }),
+    ]);
+    const labelRule = createRule("label-rule", null, [
+      getAction({
+        id: "label-action",
+        type: ActionType.LABEL,
+        label: "Review",
+      }),
+    ]);
+    mockMatchingRules([
+      { rule: draftRule, matchReasons: [] },
+      { rule: labelRule, matchReasons: [] },
+    ]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockResolvedValue(labelRule.actions);
+    const createSpy = mockExecutedRuleCreate({ rule: labelRule });
+    vi.mocked(executeAct).mockResolvedValueOnce(ExecutedRuleStatus.APPLIED);
+
+    const results = await runRulesWithDefaults({
+      rules: [draftRule, labelRule],
+      skipDraftReplies: true,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        rule: expect.objectContaining({ id: draftRule.id }),
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+      expect.objectContaining({
+        rule: expect.objectContaining({ id: labelRule.id }),
+        status: ExecutedRuleStatus.APPLIED,
+      }),
+    ]);
+    expect(getActionItemsWithAiArgs).toHaveBeenCalledTimes(1);
+    expect(getActionItemsWithAiArgs).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedRule: labelRule }),
+    );
+    expect(createSpy).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        rule: { connect: { id: draftRule.id } },
         status: ExecutedRuleStatus.SKIPPED,
       }),
     });

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -457,6 +457,86 @@ describe("runRules draft attribution persistence", () => {
     ]);
   });
 
+  it.each([
+    ActionType.DRAFT_EMAIL,
+    ActionType.DRAFT_MESSAGING_CHANNEL,
+  ])("skips %s before generating action args when requested", async (draftType) => {
+    const bulkRule = createRule("bulk-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "label-action-1",
+        type: ActionType.LABEL,
+        label: "To Reply",
+      }),
+      getAction({
+        id: "draft-action-1",
+        type: draftType,
+      }),
+    ]);
+
+    mockMatchingRules([{ rule: bulkRule, matchReasons: [] }]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockImplementation(
+      async ({ selectedRule }) => {
+        expect(
+          selectedRule.actions.some((action) =>
+            isDraftReplyActionType(action.type),
+          ),
+        ).toBe(false);
+
+        return selectedRule.actions.map((action) => ({
+          ...action,
+          type: action.type as ActionType,
+        }));
+      },
+    );
+
+    const createSpy = mockExecutedRuleCreate({ rule: bulkRule });
+
+    await runRulesWithDefaults({
+      rules: [bulkRule],
+      skipDraftReplies: true,
+    });
+
+    const createdActions = getCreatedActionItems(createSpy);
+    expect(createdActions).toEqual([
+      expect.objectContaining({
+        type: ActionType.LABEL,
+        label: "To Reply",
+      }),
+    ]);
+  });
+
+  it("records draft-only historical matches as skipped after draft replies are removed", async () => {
+    const draftOnlyRule = createRule("draft-only-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+    ]);
+
+    mockMatchingRules([{ rule: draftOnlyRule, matchReasons: [] }]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    prisma.executedRule.create.mockResolvedValue({} as any);
+
+    const result = await runRulesWithDefaults({
+      rules: [draftOnlyRule],
+      skipDraftReplies: true,
+    });
+
+    expect(getActionItemsWithAiArgs).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      expect.objectContaining({
+        rule: null,
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+    ]);
+    expect(prisma.executedRule.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+    });
+  });
+
   it("persists a null draft pipeline version when draft attribution is missing", async () => {
     const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
       getAction({

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -265,6 +265,7 @@ export async function runRules({
       batchTimestamp,
       logger,
       skipArchive,
+      skipDraftReplies,
     );
 
     executedRules.push({
@@ -379,6 +380,7 @@ async function executeMatchedRule(
   batchTimestamp: Date,
   logger: Logger,
   skipArchive?: boolean,
+  skipDraftReplies?: boolean,
 ) {
   const blockedActionTypes = getBlockedLowTrustStaticFromActionTypes(
     rule.from,
@@ -415,10 +417,15 @@ async function executeMatchedRule(
     logger,
   });
 
-  if (actionItems.length === 0 && blockedActionTypes.length) {
-    const reasonToUse = reason
-      ? `${reason}. ${LOW_TRUST_STATIC_FROM_OUTBOUND_MESSAGE}`
+  const skippedDraftOnlyRule = skipDraftReplies && rule.actions.length === 0;
+  if (
+    actionItems.length === 0 &&
+    (blockedActionTypes.length || skippedDraftOnlyRule)
+  ) {
+    const skipReason = skippedDraftOnlyRule
+      ? "Draft replies were disabled for this bulk run"
       : LOW_TRUST_STATIC_FROM_OUTBOUND_MESSAGE;
+    const reasonToUse = reason ? `${reason}. ${skipReason}` : skipReason;
     let executedRule = null;
 
     if (!isTest) {
@@ -994,15 +1001,13 @@ function collectMessagingChannelsFromOtherRules<
 function removeDraftReplyActionsFromMatches<
   T extends { rule: RuleWithActions },
 >(matches: T[]): T[] {
-  return matches
-    .map((match) => ({
-      ...match,
-      rule: {
-        ...match.rule,
-        actions: match.rule.actions.filter(
-          (action) => !isDraftReplyActionType(action.type),
-        ),
-      },
-    }))
-    .filter((match) => match.rule.actions.length > 0);
+  return matches.map((match) => ({
+    ...match,
+    rule: {
+      ...match.rule,
+      actions: match.rule.actions.filter(
+        (action) => !isDraftReplyActionType(action.type),
+      ),
+    },
+  }));
 }

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -109,6 +109,7 @@ export async function runRules({
   modelType,
   logger,
   skipArchive,
+  skipDraftReplies,
 }: {
   provider: EmailProvider;
   message: ParsedMessage;
@@ -118,6 +119,7 @@ export async function runRules({
   modelType: ModelType;
   logger: Logger;
   skipArchive?: boolean;
+  skipDraftReplies?: boolean;
 }): Promise<RunRulesResult[]> {
   const batchTimestamp = new Date(); // Single timestamp for this batch execution
   const { regularRules, conversationRules } = prepareRulesWithMetaRule(rules);
@@ -191,7 +193,10 @@ export async function runRules({
     }
   }
 
-  const finalMatches = limitDraftEmailActions(matchesWithFlags, logger);
+  const executableMatches = skipDraftReplies
+    ? removeDraftReplyActionsFromMatches(matchesWithFlags)
+    : matchesWithFlags;
+  const finalMatches = limitDraftEmailActions(executableMatches, logger);
 
   logger.trace("Matching rule", () => ({
     module: MODULE,
@@ -984,4 +989,20 @@ function collectMessagingChannelsFromOtherRules<
   }
 
   return actions;
+}
+
+function removeDraftReplyActionsFromMatches<
+  T extends { rule: RuleWithActions },
+>(matches: T[]): T[] {
+  return matches
+    .map((match) => ({
+      ...match,
+      rule: {
+        ...match.rule,
+        actions: match.rule.actions.filter(
+          (action) => !isDraftReplyActionType(action.type),
+        ),
+      },
+    }))
+    .filter((match) => match.rule.actions.length > 0);
 }

--- a/apps/web/utils/queue/email-actions.test.ts
+++ b/apps/web/utils/queue/email-actions.test.ts
@@ -18,6 +18,24 @@ describe("runAiRules", () => {
     vi.clearAllMocks();
   });
 
+  it.each([
+    undefined,
+    false,
+    true,
+  ])("passes the draft preference to rule execution (%s)", async (skipDraftReplies) => {
+    vi.mocked(runRulesAction).mockResolvedValue({ data: [] });
+    await runAiRules("account-id", createThreads("thread-id"), false, {
+      skipDraftReplies,
+    });
+    expect(runRulesAction).toHaveBeenCalledWith("account-id", {
+      messageId: "thread-id-message",
+      threadId: "thread-id",
+      rerun: false,
+      isTest: false,
+      skipDraftReplies: skipDraftReplies ?? false,
+    });
+  });
+
   it("rejects when rule processing returns a server error", async () => {
     vi.mocked(runRulesAction).mockResolvedValue({
       serverError: "AI automation is unavailable.",
@@ -106,7 +124,7 @@ describe("runAiRules", () => {
       "account-id",
       createThreads("thread-1", "thread-2"),
       false,
-      abortController.signal,
+      { signal: abortController.signal },
     );
     let settled = false;
     const settlementPromise = runPromise.then(

--- a/apps/web/utils/queue/email-actions.ts
+++ b/apps/web/utils/queue/email-actions.ts
@@ -11,7 +11,13 @@ export const runAiRules = async (
     { id: string; messages: Array<{ id: string }> } | null | undefined
   >,
   rerun: boolean,
-  signal?: AbortSignal,
+  {
+    signal,
+    skipDraftReplies = false,
+  }: {
+    signal?: AbortSignal;
+    skipDraftReplies?: boolean;
+  } = {},
 ) => {
   const threads = threadsArray.filter(isDefined);
   const threadIds = threads.map((t) => t.id);
@@ -47,6 +53,7 @@ export const runAiRules = async (
                 threadId: thread.id,
                 rerun,
                 isTest: false,
+                skipDraftReplies,
               });
 
               if (result?.serverError) throw new Error(result.serverError);


### PR DESCRIPTION
Bulk processing can create unwanted reply drafts for old emails. Add a “Generate draft replies” switch, off by default, so users can explicitly include drafting when processing past emails.

- Preserve onboarding, live incoming-email, and individual email drafting behavior.
- Filter email and messaging-channel draft actions before content generation when the switch is off; retain other actions and record draft-only matches as skipped, including when other rules still execute.
- Carry the preference through pagination and reruns while preserving cancellation, error handling, and existing access checks. The switch follows configured draft actions; it does not add drafting to rules that lack it.
- Replace the approach in #2946 with user control instead of blanket suppression. No prompt or model-facing tool changes.

Validation: 75 focused unit tests passed across run-rules, both bulk-run suites, email-actions, and ai-rule; formatting and diff checks passed. The focused Playwright spec passed (authentication setup plus Plus and Professional toggle checks), and both final-state screenshots were inspected. Browser verification used a temporary local Postgres database and disabled the unrelated Todoist test transport after the suite runner hit a `tsx` startup issue.

Performance: no new database or network calls. Disabling drafts avoids their generation calls; enabling drafts retains existing execution behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to generate draft replies while bulk-processing emails with automation rules.
  * Draft-reply generation is disabled by default and can be toggled on or off in the bulk processing dialog.
  * Draft-only rule matches are recorded as skipped when draft generation is disabled.

* **Tests**
  * Added coverage for the new toggle, option handling across paginated runs, and draft-reply skipping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->