### PR TITLE
mail: Refresh Outlook tokens early and preserve reader actions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/mail-queue.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-queue.spec.ts
@@ -27,6 +27,7 @@ test("inspects an account's local queue and refreshes its progress", async ({
     });
     const transaction = database.transaction("mailMutations", "readwrite");
     const store = transaction.objectStore("mailMutations");
+    const now = Date.now();
     for (let index = 0; index < 201; index++) {
       store.put({
         id: `queue-diagnostics-${index}`,
@@ -38,9 +39,9 @@ test("inspects an account's local queue and refreshes its progress", async ({
         payload: {},
         status: "pending",
         attempts: 0,
-        createdAt: Date.now() - index,
-        updatedAt: Date.now(),
-        nextAttemptAt: Date.now(),
+        createdAt: now - index,
+        updatedAt: now,
+        nextAttemptAt: now,
       });
     }
     await new Promise<void>((resolve, reject) => {

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -126,6 +126,103 @@ describe("useThread", () => {
     );
   });
 
+  it("keeps the open thread available while invalidation refreshes its details", async () => {
+    const refreshed = Promise.withResolvers<unknown>();
+    const initial = {
+      thread: { id: "refresh-thread", messages: [{ id: "visible" }] },
+    };
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockImplementationOnce(() => refreshed.promise);
+    const { result } = renderHook(() => useThread({ id: "refresh-thread" }), {
+      wrapper: createWrapper(fetcher),
+    });
+    await waitFor(() => expect(result.current.data).toEqual(initial));
+    let refresh: Promise<unknown>;
+    act(() => {
+      refresh = result.current.mutate(undefined, { revalidate: true });
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(result.current.isValidating).toBe(true);
+    expect(result.current.data).toEqual(initial);
+    expect(result.current.isLoading).toBe(false);
+    await act(async () => {
+      refreshed.resolve({
+        thread: { id: "refresh-thread", messages: [{ id: "updated" }] },
+      });
+      await refresh;
+    });
+    expect(result.current.data?.thread.messages[0]?.id).toBe("updated");
+  });
+
+  it.each([
+    "account",
+    "thread",
+    "variant",
+  ])("does not retain details when the %s changes", async (changed) => {
+    const threadId = `isolated-${changed}`;
+    const initial = {
+      thread: { id: threadId, messages: [{ id: "previous" }] },
+    };
+    const pending = Promise.withResolvers<unknown>();
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockImplementation(() => pending.promise);
+    const { result, rerender } = renderHook(
+      ({ emailAccountId, id, includeDrafts }) =>
+        useThread({ emailAccountId, id }, { includeDrafts }),
+      {
+        wrapper: createWrapper(fetcher),
+        initialProps: {
+          emailAccountId: "account-1",
+          id: threadId,
+          includeDrafts: false,
+        },
+      },
+    );
+    await waitFor(() => expect(result.current.data).toEqual(initial));
+    const next = {
+      emailAccountId: changed === "account" ? "account-2" : "account-1",
+      id: changed === "thread" ? `${threadId}-next` : threadId,
+      includeDrafts: changed === "variant",
+    };
+    rerender(next);
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+    await act(async () => {
+      pending.resolve({ thread: { id: next.id, messages: [{ id: "next" }] } });
+    });
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages[0]?.id).toBe("next"),
+    );
+  });
+
+  it("surfaces refresh errors after retained details finish revalidating", async () => {
+    const initial = {
+      thread: { id: "failed-refresh", messages: [{ id: "previous" }] },
+    };
+    const error = new Error("Refresh failed");
+    cache.read.mockResolvedValue(undefined);
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockRejectedValue(error);
+    const { result } = renderHook(() => useThread({ id: "failed-refresh" }), {
+      wrapper: createWrapper(fetcher),
+    });
+    await waitFor(() => expect(result.current.data).toEqual(initial));
+    await act(async () => {
+      await result.current.mutate(undefined, { revalidate: true });
+    });
+    await waitFor(() => expect(result.current.error).toBe(error));
+    expect(result.current.data).toBeUndefined();
+  });
+
   it("falls back to the network when no cached detail exists", async () => {
     const network = Promise.withResolvers<unknown>();
     cache.read.mockResolvedValue(undefined);

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -81,16 +81,23 @@ describe("useThread", () => {
   });
 
   it.each([
-    { kind: "archive" as const, emailAccountId: "account-1" },
-    { kind: "set_starred_state" as const, emailAccountId: "account-2" },
-  ])("keeps reader messages intact for $kind from $emailAccountId", async ({
-    kind,
+    { payload: { kind: "archive" as const }, emailAccountId: "account-1" },
+    {
+      payload: { kind: "set_starred_state" as const, starred: true },
+      emailAccountId: "account-2",
+    },
+    {
+      payload: { kind: "set_read_state" as const, read: true },
+      emailAccountId: "account-1",
+    },
+  ])("keeps reader messages intact for $payload.kind from $emailAccountId", async ({
+    payload,
     emailAccountId,
   }) => {
     const data = {
       thread: {
         id: "thread-1",
-        messages: [{ id: "message-1", labelIds: ["INBOX"] }],
+        messages: [{ id: "message-1", labelIds: ["INBOX", "UNREAD"] }],
       },
     };
     cache.read.mockResolvedValue(undefined);
@@ -101,7 +108,7 @@ describe("useThread", () => {
           emailAccountId,
           threadId: "thread-1",
           messageIds: ["message-1"],
-          ...(kind === "archive" ? { kind } : { kind, starred: true }),
+          ...payload,
           createdAt: 1,
         }),
       ],

--- a/apps/web/hooks/useThread.test.tsx
+++ b/apps/web/hooks/useThread.test.tsx
@@ -4,11 +4,18 @@ import type { ReactNode } from "react";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig, unstable_serialize } from "swr";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+import type { MailMutation } from "@/utils/email-cache/mail-mutations";
+import { useRetainedMailMutationOverlay } from "./useMailMutationOverlay";
 import { useThread } from "./useThread";
 
 const cache = vi.hoisted(() => ({
   read: vi.fn(),
   write: vi.fn(),
+}));
+
+vi.mock("./useMailMutationOverlay", () => ({
+  useRetainedMailMutationOverlay: vi.fn(),
 }));
 
 vi.mock("@/providers/EmailAccountProvider", () => ({
@@ -25,7 +32,87 @@ describe("useThread", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useRetainedMailMutationOverlay).mockReturnValue({
+      mutations: [],
+      isReady: true,
+      isReadable: true,
+      retainMutations: vi.fn(),
+    });
     cache.write.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    true,
+    false,
+  ])("preserves pending starred=%s over an older detail response", async (starred) => {
+    const originalLabels = starred ? ["INBOX"] : ["INBOX", "STARRED"];
+    const data = {
+      thread: {
+        id: "thread-1",
+        messages: [{ id: "message-1", labelIds: originalLabels }],
+      },
+    };
+    cache.read.mockResolvedValue(undefined);
+    vi.mocked(useRetainedMailMutationOverlay).mockReturnValue({
+      mutations: [
+        mockDeep<MailMutation>({
+          id: "star-1",
+          emailAccountId: "account-1",
+          threadId: "thread-1",
+          messageIds: ["message-1"],
+          kind: "set_starred_state",
+          starred,
+          createdAt: 1,
+        }),
+      ],
+      isReady: true,
+      isReadable: true,
+      retainMutations: vi.fn(),
+    });
+    const { result } = renderHook(() => useThread({ id: "thread-1" }), {
+      wrapper: createWrapper(vi.fn().mockResolvedValue(data)),
+    });
+    await waitFor(() =>
+      expect(result.current.data?.thread.messages[0]?.labelIds).toEqual(
+        starred ? ["INBOX", "STARRED"] : ["INBOX"],
+      ),
+    );
+    expect(data.thread.messages[0]?.labelIds).toEqual(originalLabels);
+  });
+
+  it.each([
+    { kind: "archive" as const, emailAccountId: "account-1" },
+    { kind: "set_starred_state" as const, emailAccountId: "account-2" },
+  ])("keeps reader messages intact for $kind from $emailAccountId", async ({
+    kind,
+    emailAccountId,
+  }) => {
+    const data = {
+      thread: {
+        id: "thread-1",
+        messages: [{ id: "message-1", labelIds: ["INBOX"] }],
+      },
+    };
+    cache.read.mockResolvedValue(undefined);
+    vi.mocked(useRetainedMailMutationOverlay).mockReturnValue({
+      mutations: [
+        mockDeep<MailMutation>({
+          id: "mutation-1",
+          emailAccountId,
+          threadId: "thread-1",
+          messageIds: ["message-1"],
+          ...(kind === "archive" ? { kind } : { kind, starred: true }),
+          createdAt: 1,
+        }),
+      ],
+      isReady: true,
+      isReadable: true,
+      retainMutations: vi.fn(),
+    });
+    const { result } = renderHook(() => useThread({ id: "thread-1" }), {
+      wrapper: createWrapper(vi.fn().mockResolvedValue(data)),
+    });
+    await waitFor(() => expect(result.current.data).toEqual(data));
   });
 
   it("returns an idle response when no thread is selected", async () => {

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,6 +1,8 @@
 import { useLayoutEffect, useMemo, useRef } from "react";
 import useSWR, { unstable_serialize, useSWRConfig } from "swr";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
+import { useRetainedMailMutationOverlay } from "@/hooks/useMailMutationOverlay";
+import { createMailMutationOverlay } from "@/utils/email-cache/mail-mutation-overlay";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import {
   readCachedThreadDetail,
@@ -108,9 +110,31 @@ export function useThread(
       ? lastResponse.current?.data
       : undefined);
 
+  const { mutations } = useRetainedMailMutationOverlay({
+    emailAccountId,
+    enabled: Boolean(request),
+    onReconcile: swr.mutate,
+  });
+  const overlaidData = useMemo(() => {
+    if (!data) return data;
+    const stateMutations = mutations.filter(
+      (mutation) =>
+        mutation.threadId === id &&
+        (mutation.kind === "set_read_state" ||
+          mutation.kind === "set_starred_state"),
+    );
+    if (!stateMutations.length) return data;
+    // The reader can outlive its list row while queued changes reach the server.
+    const messages = createMailMutationOverlay(stateMutations).applyToMessages(
+      emailAccountId,
+      data.thread.messages,
+    );
+    return { ...data, thread: { ...data.thread, messages } };
+  }, [data, emailAccountId, id, mutations]);
+
   return {
     ...swr,
-    data,
+    data: overlaidData,
     error: data ? undefined : swr.error,
     isLoading: !data && swr.isLoading,
     isValidating: swr.isValidating,

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -117,15 +117,14 @@ export function useThread(
   });
   const overlaidData = useMemo(() => {
     if (!data) return data;
-    const stateMutations = mutations.filter(
+    // Preserve fetched unread flags for the reader's initial message expansion.
+    const starMutations = mutations.filter(
       (mutation) =>
-        mutation.threadId === id &&
-        (mutation.kind === "set_read_state" ||
-          mutation.kind === "set_starred_state"),
+        mutation.threadId === id && mutation.kind === "set_starred_state",
     );
-    if (!stateMutations.length) return data;
+    if (!starMutations.length) return data;
     // The reader can outlive its list row while queued changes reach the server.
-    const messages = createMailMutationOverlay(stateMutations).applyToMessages(
+    const messages = createMailMutationOverlay(starMutations).applyToMessages(
       emailAccountId,
       data.thread.messages,
     );

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import useSWR, { unstable_serialize, useSWRConfig } from "swr";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -92,13 +92,27 @@ export function useThread(
       revalidateOnReconnect: false,
     },
   );
-  const data = swr.data?.thread.id === id ? swr.data : undefined;
+  const currentData = swr.data?.thread.id === id ? swr.data : undefined;
+  const lastResponse = useRef<{ key: string; data: ThreadResponse } | null>(
+    null,
+  );
+  useLayoutEffect(() => {
+    if (request && currentData) {
+      lastResponse.current = { key: request.cacheIdentity, data: currentData };
+    }
+  }, [currentData, request]);
+  // Cache invalidation must not disable actions for a reader that is still visible.
+  const data =
+    currentData ??
+    (swr.isValidating && lastResponse.current?.key === request?.cacheIdentity
+      ? lastResponse.current?.data
+      : undefined);
 
   return {
     ...swr,
     data,
     error: data ? undefined : swr.error,
-    isLoading: swr.isLoading,
+    isLoading: !data && swr.isLoading,
     isValidating: swr.isValidating,
     mutate: swr.mutate,
   };

--- a/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
+++ b/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
@@ -1,5 +1,7 @@
 import { Client } from "@microsoft/microsoft-graph-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+import type { CalendarConnection } from "@/generated/prisma/client";
 import { createTestLogger } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
@@ -38,19 +40,17 @@ describe("getCalendarClientWithRefresh token buffer", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(now);
-    vi.mocked(Client.initWithMiddleware).mockReturnValue({} as any);
-    vi.mocked(requestMicrosoftToken).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      Response.json({
         access_token: "new-access-token",
         refresh_token: "new-refresh-token",
         expires_in: 3600,
       }),
-    } as any);
+    );
     prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 });
-    prisma.calendarConnection.findFirst.mockResolvedValue({
-      id: "calendar-connection-id",
-    } as any);
+    prisma.calendarConnection.findFirst.mockResolvedValue(
+      mockDeep<CalendarConnection>({ id: "calendar-connection-id" }),
+    );
   });
 
   afterEach(() => {

--- a/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
+++ b/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
@@ -1,0 +1,106 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { getCalendarClientWithRefresh } from "./calendar-client";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    initWithMiddleware: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  getMicrosoftGraphClientOptions: vi.fn(() => ({
+    baseUrl: "http://localhost:4003/",
+  })),
+  getMicrosoftOauthAuthorizeUrl: vi.fn(
+    () => "http://localhost:4003/oauth2/v2.0/authorize",
+  ),
+  requestMicrosoftToken: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    MICROSOFT_CLIENT_ID: "client-id",
+    MICROSOFT_CLIENT_SECRET: "client-secret",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+describe("getCalendarClientWithRefresh token buffer", () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.mocked(Client.initWithMiddleware).mockReturnValue({} as any);
+    vi.mocked(requestMicrosoftToken).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 3600,
+      }),
+    } as any);
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 });
+    prisma.calendarConnection.findFirst.mockResolvedValue({
+      id: "calendar-connection-id",
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    9 * 60 * 1000,
+    10 * 60 * 1000,
+  ])("refreshes a cached token with %i milliseconds remaining", async (remainingMs) => {
+    await getCalendarClientWithRefresh({
+      accessToken: "cached-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: now.getTime() + remainingMs,
+      emailAccountId: "email-account-id",
+      logger: createTestLogger(),
+    });
+
+    expect(requestMicrosoftToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+        grant_type: "refresh_token",
+      }),
+    );
+    const options = vi.mocked(Client.initWithMiddleware).mock.calls[0][0];
+    expect(await options.authProvider.getAccessToken()).toBe(
+      "new-access-token",
+    );
+    expect(Client.initWithMiddleware).toHaveBeenCalledWith({
+      authProvider: expect.any(Object),
+      baseUrl: "http://localhost:4003/",
+    });
+  });
+
+  it("reuses a cached token beyond the ten-minute buffer", async () => {
+    await getCalendarClientWithRefresh({
+      accessToken: "cached-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: now.getTime() + 10 * 60 * 1000 + 1,
+      emailAccountId: "email-account-id",
+      logger: createTestLogger(),
+    });
+
+    expect(requestMicrosoftToken).not.toHaveBeenCalled();
+    expect(prisma.calendarConnection.updateMany).not.toHaveBeenCalled();
+    const options = vi.mocked(Client.initWithMiddleware).mock.calls[0][0];
+    expect(await options.authProvider.getAccessToken()).toBe(
+      "cached-access-token",
+    );
+  });
+});

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -14,6 +14,8 @@ import {
   type AuthenticationProvider,
 } from "@microsoft/microsoft-graph-client";
 
+const TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000;
+
 class CalendarAuthProvider implements AuthenticationProvider {
   private readonly accessToken: string;
 
@@ -58,7 +60,11 @@ export const getCalendarClientWithRefresh = async ({
   if (!refreshToken) throw new SafeError("No refresh token");
 
   // Check if token is still valid
-  if (expiresAt && expiresAt > Date.now() && accessToken) {
+  if (
+    expiresAt &&
+    expiresAt > Date.now() + TOKEN_REFRESH_BUFFER_MS &&
+    accessToken
+  ) {
     const authProvider = new CalendarAuthProvider(accessToken);
     return Client.initWithMiddleware({
       authProvider,


### PR DESCRIPTION
Outlook calendar clients reuse tokens until their exact expiry, which can interrupt multi-request calendar operations. Refresh tokens with ten minutes or less remaining before creating the Graph client, matching the Outlook mail client. Supersedes #2533 with coverage compatible with the shared token persistence helper.

Also fixes a reader refresh gap exposed by the mail-triage browser suite: invalidating cached thread details temporarily disabled actions for the still-visible reader. Keep the last committed response available only while refreshing the same account, thread, and response variant; surface refresh errors when revalidation ends.

Pending star changes now also apply to thread details until reconciliation finishes. When automatic marking as read removes a starred conversation from the unread list, the reader and its shortcuts keep the queued star state instead of reverting to an older detail response.

The mail-queue browser fixture now captures one timestamp for its seed rows, ensuring deterministic newest-first ordering on slow runners.

Validation:
- 37 focused unit tests pass, covering token expiry boundaries, reader invalidation, mutation overlays, account/thread/variant isolation, and refresh errors. Token-save concurrency tests also passed earlier.
- Reader-invalidation and pending-star regressions fail before their fixes and pass afterward.
- The unchanged starring and manual-label Playwright specs pass (including authentication setup); screenshots inspected. The thread-navigation spec also passes, preserving unread-message expansion.
- The mail-queue spec reproduces its ordering failure against main with CPU throttling and passes with the deterministic seed; screenshot inspected.
- Biome and git diff checks pass.

Performance: moves existing OAuth refresh and token-save work earlier. Reader retention keeps one response reference per mounted hook. Thread details reuse the existing queued-mutation subscription and refresh after mutations settle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread details now remain visible while data refreshes, reducing flicker and preventing temporary empty states.
  * Pending starred-state changes are reflected immediately in thread messages.
  * Calendar connections now refresh access tokens when they are within 10 minutes of expiration, helping prevent interruptions during calendar access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->