### PR TITLE
fix: isolate mail panel errors and improve recovery

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/MailPanelErrorBoundary.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailPanelErrorBoundary.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MailPanelErrorBoundary } from "./MailPanelErrorBoundary";
+
+vi.mock("@/components/AppErrorBoundary", () => ({
+  AppErrorBoundary: ({ reset }: { reset: () => void }) => (
+    <button type="button" onClick={reset}>
+      Try again
+    </button>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe("MailPanelErrorBoundary", () => {
+  it("keeps sibling content usable and recovers on retry", () => {
+    let broken = true;
+    function Reader() {
+      if (broken) throw new Error("Reader failed");
+      return <div>Message content</div>;
+    }
+    render(
+      <>
+        <button type="button">Inbox</button>
+        <MailPanelErrorBoundary
+          resetKey="thread-1"
+          title="Unable to show conversation"
+        >
+          <Reader />
+        </MailPanelErrorBoundary>
+      </>,
+    );
+    expect(screen.getByRole("button", { name: "Inbox" })).toBeTruthy();
+    broken = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(screen.getByText("Message content")).toBeTruthy();
+  });
+
+  it("recovers when the selection changes without remounting healthy content", () => {
+    function Content({ broken }: { broken: boolean }) {
+      if (broken) throw new Error("Reader failed");
+      return <input aria-label="Reply" defaultValue="" />;
+    }
+    const { rerender } = render(
+      <MailPanelErrorBoundary
+        resetKey="thread-1"
+        title="Unable to show conversation"
+      >
+        <Content broken />
+      </MailPanelErrorBoundary>,
+    );
+    rerender(
+      <MailPanelErrorBoundary
+        resetKey="thread-2"
+        title="Unable to show conversation"
+      >
+        <Content broken={false} />
+      </MailPanelErrorBoundary>,
+    );
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Draft" } });
+    rerender(
+      <MailPanelErrorBoundary
+        resetKey="thread-3"
+        title="Unable to show conversation"
+      >
+        <Content broken={false} />
+      </MailPanelErrorBoundary>,
+    );
+    expect(screen.getByRole("textbox")).toBe(input);
+    expect(input.value).toBe("Draft");
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailPanelErrorBoundary.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailPanelErrorBoundary.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { AppErrorBoundary } from "@/components/AppErrorBoundary";
+
+type Props = {
+  children: ReactNode;
+  resetKey: string;
+  title: string;
+  onBack?: () => void;
+};
+
+export class MailPanelErrorBoundary extends Component<
+  Props,
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidUpdate(previousProps: Props) {
+    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+      this.reset();
+    }
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="min-h-0 min-w-0 flex-1 overflow-auto" role="alert">
+          <AppErrorBoundary
+            error={this.state.error}
+            reset={this.reset}
+            title={this.props.title}
+            description="Try again, or select another folder or conversation. If the problem continues, contact support with the reference below."
+            onBack={this.props.onBack}
+          />
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { MailPanelErrorBoundary } from "@/app/(app)/[emailAccountId]/mail/MailPanelErrorBoundary";
+
 import { GmailLabel } from "@/utils/gmail/label";
 import { isThreadStarred } from "@/app/(app)/[emailAccountId]/mail/star-state";
 import {
@@ -1549,109 +1551,126 @@ export function MailShell() {
                 their connections.
               </div>
             ) : null}
-            <LoadingContent
-              loading={isLoading && !threads.length}
-              error={error}
+            <MailPanelErrorBoundary
+              resetKey={JSON.stringify([
+                emailAccountId,
+                isAllAccounts,
+                query,
+                displayedActiveSplitId,
+                searchQuery,
+              ])}
+              title="Unable to show your mail list"
             >
-              <ThreadList
-                threads={threads}
-                layout={layout}
-                expandedPreview={expandedPreview}
-                userEmail={userEmail}
-                userLabels={isAllAccounts ? NO_LABELS : userLabels}
-                labelsByAccount={labelsByAccount}
-                focusedIndex={clampedIndex}
-                isSelected={selection.isSelected}
-                selectedCount={selection.selectedCount}
-                onOpenThread={openAt}
-                onToggleSelect={selection.toggle}
-                onSelectRangeTo={selection.selectRangeTo}
-                showLoadMore={hasMore}
-                isLoadingMore={isLoadingMore}
-                onLoadMore={loadMore}
-                listKey={
-                  isAllAccounts
-                    ? `all-accounts:${searchQuery ?? displayedActiveSplitId}`
-                    : JSON.stringify(query)
-                }
-              />
-            </LoadingContent>
+              <LoadingContent
+                loading={isLoading && !threads.length}
+                error={error}
+              >
+                <ThreadList
+                  threads={threads}
+                  layout={layout}
+                  expandedPreview={expandedPreview}
+                  userEmail={userEmail}
+                  userLabels={isAllAccounts ? NO_LABELS : userLabels}
+                  labelsByAccount={labelsByAccount}
+                  focusedIndex={clampedIndex}
+                  isSelected={selection.isSelected}
+                  selectedCount={selection.selectedCount}
+                  onOpenThread={openAt}
+                  onToggleSelect={selection.toggle}
+                  onSelectRangeTo={selection.selectRangeTo}
+                  showLoadMore={hasMore}
+                  isLoadingMore={isLoadingMore}
+                  onLoadMore={loadMore}
+                  listKey={
+                    isAllAccounts
+                      ? `all-accounts:${searchQuery ?? displayedActiveSplitId}`
+                      : JSON.stringify(query)
+                  }
+                />
+              </LoadingContent>
+            </MailPanelErrorBoundary>
           </section>
         )}
 
         {showReader && (!openThreadSelection || readerEmailAccount) ? (
-          <EmailAccountScopeProvider emailAccount={readerEmailAccount}>
-            <BufferedThreadReader
-              key={readerEmailAccount?.id ?? "empty"}
-              threadKey={openReaderThreadKey ?? "empty"}
-              dataReady={
-                !openThreadSelection ||
-                (readerSelectionSettled &&
-                  Boolean(openThreadData || openThreadError))
-              }
-              onReady={setVisibleReaderThreadKey}
-            >
-              <ThreadReader
-                enableMessageNavigation={!sidePanelThreadId}
-                thread={openThread ?? null}
-                threadId={openThreadId}
-                detailSelectionSettled={readerSelectionSettled}
-                loading={
-                  Boolean(openThreadSelection) &&
-                  (!readerSelectionSettled || isOpenThreadLoading)
+          <MailPanelErrorBoundary
+            resetKey={openReaderThreadKey ?? "empty"}
+            title="Unable to show this conversation"
+            onBack={closeReader}
+          >
+            <EmailAccountScopeProvider emailAccount={readerEmailAccount}>
+              <BufferedThreadReader
+                key={readerEmailAccount?.id ?? "empty"}
+                threadKey={openReaderThreadKey ?? "empty"}
+                dataReady={
+                  !openThreadSelection ||
+                  (readerSelectionSettled &&
+                    Boolean(openThreadData || openThreadError))
                 }
-                error={readerSelectionSettled ? openThreadError : undefined}
-                messages={openMessages}
-                userLabels={readerUserLabels}
-                layout={layout}
-                labelHref={labelHref}
-                onRemoveLabel={onRemoveLabel}
-                onBackToInbox={closeReader}
-                onArchive={archiveTargets}
-                refetch={refetchOpenThread}
-                onSendSuccess={(_messageId, sentThreadId) => {
-                  if (
-                    !openThreadSelection ||
-                    !sentThreadId.trim() ||
-                    sentThreadId === openThreadSelection.threadId
-                  )
-                    return;
-                  setReplyToMessageId(undefined);
-                  setOpenThread({
-                    emailAccountId: openThreadSelection.emailAccountId,
-                    threadId: sentThreadId,
-                  });
-                }}
-                autoOpenReplyForMessageId={replyToMessageId}
-                autoOpenForwardForMessageId={forwardToMessageId}
-                menu={
-                  <ThreadActionsMenu
-                    plans={openThread?.plans ?? []}
-                    message={openMessages.at(-1) ?? null}
-                    setChatInput={setChatInput}
-                    isUnread={isOpenThreadUnread}
-                    isStarred={allStarred}
-                    onToggleStar={starTargets}
-                    onMarkSpam={markSpamTargets}
-                    onDelete={trashTargets}
-                    onLabel={canLabel ? openLabelPicker : undefined}
-                    onMove={canLabel ? openMovePicker : undefined}
-                    onMarkRead={() => {
-                      if (!openThreadKey) return;
-                      setReadState([openThreadKey], true);
-                    }}
-                    onMarkUnread={markUnreadTargets}
-                    showFixWithChat={
-                      !isAllAccounts ||
-                      openThreadSelection?.emailAccountId === emailAccountId
-                    }
-                    open={isMenuOpen}
-                    onOpenChange={setIsMenuOpen}
-                  />
-                }
-              />
-            </BufferedThreadReader>
-          </EmailAccountScopeProvider>
+                onReady={setVisibleReaderThreadKey}
+              >
+                <ThreadReader
+                  enableMessageNavigation={!sidePanelThreadId}
+                  thread={openThread ?? null}
+                  threadId={openThreadId}
+                  detailSelectionSettled={readerSelectionSettled}
+                  loading={
+                    Boolean(openThreadSelection) &&
+                    (!readerSelectionSettled || isOpenThreadLoading)
+                  }
+                  error={readerSelectionSettled ? openThreadError : undefined}
+                  messages={openMessages}
+                  userLabels={readerUserLabels}
+                  layout={layout}
+                  labelHref={labelHref}
+                  onRemoveLabel={onRemoveLabel}
+                  onBackToInbox={closeReader}
+                  onArchive={archiveTargets}
+                  refetch={refetchOpenThread}
+                  onSendSuccess={(_messageId, sentThreadId) => {
+                    if (
+                      !openThreadSelection ||
+                      !sentThreadId.trim() ||
+                      sentThreadId === openThreadSelection.threadId
+                    )
+                      return;
+                    setReplyToMessageId(undefined);
+                    setOpenThread({
+                      emailAccountId: openThreadSelection.emailAccountId,
+                      threadId: sentThreadId,
+                    });
+                  }}
+                  autoOpenReplyForMessageId={replyToMessageId}
+                  autoOpenForwardForMessageId={forwardToMessageId}
+                  menu={
+                    <ThreadActionsMenu
+                      plans={openThread?.plans ?? []}
+                      message={openMessages.at(-1) ?? null}
+                      setChatInput={setChatInput}
+                      isUnread={isOpenThreadUnread}
+                      isStarred={allStarred}
+                      onToggleStar={starTargets}
+                      onMarkSpam={markSpamTargets}
+                      onDelete={trashTargets}
+                      onLabel={canLabel ? openLabelPicker : undefined}
+                      onMove={canLabel ? openMovePicker : undefined}
+                      onMarkRead={() => {
+                        if (!openThreadKey) return;
+                        setReadState([openThreadKey], true);
+                      }}
+                      onMarkUnread={markUnreadTargets}
+                      showFixWithChat={
+                        !isAllAccounts ||
+                        openThreadSelection?.emailAccountId === emailAccountId
+                      }
+                      open={isMenuOpen}
+                      onOpenChange={setIsMenuOpen}
+                    />
+                  }
+                />
+              </BufferedThreadReader>
+            </EmailAccountScopeProvider>
+          </MailPanelErrorBoundary>
         ) : null}
 
         {showReader && openThreadSelection && !readerEmailAccount ? (

--- a/apps/web/components/AppErrorBoundary.test.tsx
+++ b/apps/web/components/AppErrorBoundary.test.tsx
@@ -28,9 +28,9 @@ describe("AppErrorBoundary", () => {
 
     expect(screen.getByText("event-reference")).toBeTruthy();
     expect(screen.queryByText(error.message)).toBeNull();
-    const href = screen
-      .getByRole("link", { name: "support@example.com" })
-      .getAttribute("href")!;
+    const { href } = screen.getByRole<HTMLAnchorElement>("link", {
+      name: "support@example.com",
+    });
     const body = new URL(href).searchParams.get("body");
     expect(body).toContain("event-reference");
     expect(body).not.toContain(error.message);
@@ -42,5 +42,27 @@ describe("AppErrorBoundary", () => {
     expect(reset).toHaveBeenCalledOnce();
     fireEvent.click(screen.getByRole("button", { name: "Back to inbox" }));
     expect(onBack).toHaveBeenCalledOnce();
+  });
+  it("hides the previous reference while capturing a replacement error", () => {
+    vi.mocked(Sentry.captureException).mockReturnValueOnce("previous-event");
+    const reset = vi.fn();
+    const { rerender } = render(
+      <AppErrorBoundary error={new Error("First failure")} reset={reset} />,
+    );
+    expect(screen.getByText("previous-event")).toBeTruthy();
+    vi.mocked(Sentry.captureException).mockImplementationOnce(() => {
+      expect(screen.queryByText("previous-event")).toBeNull();
+      const { href } = screen.getByRole<HTMLAnchorElement>("link", {
+        name: "support@example.com",
+      });
+      expect(new URL(href).searchParams.get("body")).not.toContain(
+        "previous-event",
+      );
+      return "replacement-event";
+    });
+    rerender(
+      <AppErrorBoundary error={new Error("Second failure")} reset={reset} />,
+    );
+    expect(screen.getByText("replacement-event")).toBeTruthy();
   });
 });

--- a/apps/web/components/AppErrorBoundary.test.tsx
+++ b/apps/web/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import * as Sentry from "@sentry/nextjs";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppErrorBoundary } from "./AppErrorBoundary";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/account/mail",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ emailAccountId: "account" }),
+}));
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_SUPPORT_EMAIL: "support@example.com" },
+}));
+
+afterEach(cleanup);
+
+describe("AppErrorBoundary", () => {
+  it("includes the captured event reference in the screen and support link without exposing error details", () => {
+    vi.mocked(Sentry.captureException).mockReturnValue("event-reference");
+    const error = new Error("Private exception details");
+    const reset = vi.fn();
+    const onBack = vi.fn();
+    render(<AppErrorBoundary error={error} reset={reset} onBack={onBack} />);
+
+    expect(screen.getByText("event-reference")).toBeTruthy();
+    expect(screen.queryByText(error.message)).toBeNull();
+    const href = screen
+      .getByRole("link", { name: "support@example.com" })
+      .getAttribute("href")!;
+    const body = new URL(href).searchParams.get("body");
+    expect(body).toContain("event-reference");
+    expect(body).not.toContain(error.message);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.anything(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: "Back to inbox" }));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/components/AppErrorBoundary.tsx
+++ b/apps/web/components/AppErrorBoundary.tsx
@@ -30,7 +30,12 @@ export function AppErrorBoundary({
   description?: string;
   onBack?: () => void;
 }) {
-  const [supportReference, setSupportReference] = useState<string>();
+  const [capturedError, setCapturedError] = useState<{
+    error: Error;
+    eventId: string;
+  }>();
+  const supportReference =
+    capturedError?.error === error ? capturedError.eventId : undefined;
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const params = useParams<{
@@ -49,7 +54,7 @@ export function AppErrorBoundary({
     });
     // Correlate with the exception details without copying raw error text into Axiom.
     const sentryEventId = Sentry.captureException(error, { extra: context });
-    setSupportReference(sentryEventId);
+    setCapturedError({ error, eventId: sentryEventId });
     logger.error("App error boundary triggered", {
       ...context,
       sentryEventId,
@@ -76,7 +81,7 @@ export function AppErrorBoundary({
             Try again
           </Button>
           {onBack && (
-            <Button onClick={onBack} variant="outline">
+            <Button type="button" onClick={onBack} variant="outline">
               Back to inbox
             </Button>
           )}

--- a/apps/web/components/AppErrorBoundary.tsx
+++ b/apps/web/components/AppErrorBoundary.tsx
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 import { AlertCircle, Home, RotateCcw } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { env } from "@/env";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,10 +20,17 @@ import { createClientLogger } from "@/utils/logger-client";
 export function AppErrorBoundary({
   error,
   reset,
+  title = "Something went wrong",
+  description,
+  onBack,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
+  title?: string;
+  description?: string;
+  onBack?: () => void;
 }) {
+  const [supportReference, setSupportReference] = useState<string>();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const params = useParams<{
@@ -42,6 +49,7 @@ export function AppErrorBoundary({
     });
     // Correlate with the exception details without copying raw error text into Axiom.
     const sentryEventId = Sentry.captureException(error, { extra: context });
+    setSupportReference(sentryEventId);
     logger.error("App error boundary triggered", {
       ...context,
       sentryEventId,
@@ -56,16 +64,22 @@ export function AppErrorBoundary({
           <EmptyMedia variant="icon" className="bg-destructive/10">
             <AlertCircle className="text-destructive" />
           </EmptyMedia>
-          <EmptyTitle>Something went wrong</EmptyTitle>
+          <EmptyTitle>{title}</EmptyTitle>
           <EmptyDescription>
-            {error.message || "An unexpected error occurred."}
+            {description ||
+              "We couldn’t load this view. Try again. If the problem continues, contact support with the reference below."}
           </EmptyDescription>
         </EmptyHeader>
-        <div className="mt-6 flex flex-col gap-2 sm:flex-row">
+        <div className="mt-6 flex flex-col flex-wrap justify-center gap-2 sm:flex-row">
           <Button onClick={reset} variant="outline">
             <RotateCcw className="mr-2 size-4" />
             Try again
           </Button>
+          {onBack && (
+            <Button onClick={onBack} variant="outline">
+              Back to inbox
+            </Button>
+          )}
           <Button asChild>
             <Link href="/">
               <Home className="mr-2 size-4" />
@@ -73,11 +87,17 @@ export function AppErrorBoundary({
             </Link>
           </Button>
         </div>
+        {supportReference && (
+          <p className="break-all text-xs text-muted-foreground">
+            Support reference:{" "}
+            <span className="select-all font-mono">{supportReference}</span>
+          </p>
+        )}
         <p className="mt-6 text-sm text-muted-foreground">
           If this error persists, please contact support at{" "}
           <a
-            href={`mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}`}
-            className="underline"
+            href={`mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}?${new URLSearchParams({ subject: "App error report", body: `Support reference: ${supportReference || error.digest || "Unavailable"}\n\nWhat were you doing when the error occurred?\n` })}`}
+            className="break-all underline"
           >
             {env.NEXT_PUBLIC_SUPPORT_EMAIL}
           </a>

--- a/apps/web/components/AppErrorBoundary.tsx
+++ b/apps/web/components/AppErrorBoundary.tsx
@@ -96,7 +96,7 @@ export function AppErrorBoundary({
         <p className="mt-6 text-sm text-muted-foreground">
           If this error persists, please contact support at{" "}
           <a
-            href={`mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}?${new URLSearchParams({ subject: "App error report", body: `Support reference: ${supportReference || error.digest || "Unavailable"}\n\nWhat were you doing when the error occurred?\n` })}`}
+            href={`mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}?${new URLSearchParams({ subject: "App error report", body: `Support reference: ${supportReference || error.digest || "Unavailable"}` })}`}
             className="break-all underline"
           >
             {env.NEXT_PUBLIC_SUPPORT_EMAIL}


### PR DESCRIPTION
Isolate mail-list and conversation rendering failures so a panel error preserves the rest of the mailbox, with retry, return-to-inbox, and recovery when the selection changes.
Improve error messages and include a Sentry event reference in the fallback and support email link without exposing raw exception details.

- Validation: three focused regression tests, formatting checks, and secret scanning passed; browser validation was blocked during database-backed sign-in before reaching the mailbox.
- Performance: adds lightweight client boundaries and reset-key serialization, with no new database calls or normal-path network requests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated error handling for the mail list and conversation panels.
  - Users can retry failed panels or return to the inbox without affecting healthy content.
  - Panel errors reset automatically when switching accounts, searches, selections, or conversations.
  - Error messages provide clearer context and may include a support reference for troubleshooting.
  - Added optional navigation back to the inbox from conversation errors.

- **Tests**
  - Added coverage for panel recovery, state preservation, retry actions, navigation, and support references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->