### PR TITLE
fix: display draft-only email threads

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/reader-visuals.spec.ts
@@ -322,3 +322,39 @@ test("opens the sender profile beside the reader", async ({
   await expect(panel).toHaveCount(0);
   await expect(subject).toBeVisible();
 });
+
+for (const parentId of [undefined, "<missing-parent@example.com>"]) {
+  test(`renders a draft-only thread with ${parentId ? "a missing parent" : "no parent"}`, async ({
+    page,
+  }, testInfo) => {
+    await page.route(
+      "**/api/threads/thr_playwright_reader_visual?**",
+      async (route) => {
+        const response = await route.fetch();
+        const body = await response.json();
+        const draft = body.thread.messages[0];
+        draft.labelIds = ["DRAFT"];
+        draft.headers.references = parentId;
+        draft.headers["in-reply-to"] = parentId;
+        draft.textHtml = "<p>This unsent draft should remain visible.</p>";
+        body.thread.messages = [draft];
+        await route.fulfill({ response, json: body });
+      },
+    );
+    const { conversations } = await openMail(page);
+    await conversationWithSubject(
+      page,
+      conversations,
+      "Re: Reader Visual Message",
+    ).click();
+    const message = page.locator("[data-thread-message-id]");
+    await expect(message).toHaveCount(1);
+    await expect(message.getByText("Draft", { exact: true })).toBeVisible();
+    await expect(
+      message
+        .frameLocator('iframe[title="Email content preview"]')
+        .getByText("This unsent draft should remain visible."),
+    ).toBeVisible();
+    await capturePlaywrightCheckpoint(page, testInfo, "mail-reader-draft-only");
+  });
+}

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -412,9 +412,10 @@ function MessageHeader({
         </span>
       )}
 
-      {hasDraft && !expanded && (
-        <span className="shrink-0 text-primary text-xs">Draft</span>
-      )}
+      {hasDraft &&
+        (!expanded || message.labelIds?.includes(GmailLabel.DRAFT)) && (
+          <span className="shrink-0 text-primary text-xs">Draft</span>
+        )}
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
         {(showReplyButton || menu) && (

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -53,30 +53,10 @@ export function EmailThread({
   const { emailAccountId } = useAccount();
   const threadId = messages[0]?.threadId ?? "";
   const { drafts: localDrafts } = useReplyDrafts(emailAccountId, threadId);
-  // Place draft messages as replies to their parent message
-  const organizedMessages = useMemo(() => {
-    const drafts = new Map<string, ThreadMessage>();
-    const regularMessages: ThreadMessage[] = [];
-
-    messages?.forEach((message) => {
-      if (message.labelIds?.includes("DRAFT")) {
-        // Get the parent message ID from the references or in-reply-to header
-        const parentId =
-          message.headers.references?.split(" ").pop() ||
-          message.headers["in-reply-to"];
-        if (parentId) {
-          drafts.set(parentId, message);
-        }
-      } else {
-        regularMessages.push(message);
-      }
-    });
-
-    return regularMessages.map((message) => ({
-      message,
-      draftMessage: drafts.get(message.headers["message-id"] || ""),
-    }));
-  }, [messages]);
+  const organizedMessages = useMemo(
+    () => organizeMessages(messages),
+    [messages],
+  );
 
   const lastMessageId = organizedMessages.at(-1)?.message.id;
 
@@ -255,7 +235,11 @@ export function EmailThread({
               defaultComposeMode={defaultComposeMode}
               draftMessage={draftMessage}
               expanded={expanded(message.id, Boolean(defaultComposeMode))}
-              hasDraft={Boolean(draftMessage) || hasLocalDraft(message.id)}
+              hasDraft={
+                message.labelIds?.includes(GmailLabel.DRAFT) ||
+                Boolean(draftMessage) ||
+                hasLocalDraft(message.id)
+              }
               key={`${message.id}:${recoveredReply?.messageId === message.id ? recoveredReply.version : 0}`}
               message={message}
               menu={renderMessageMenu?.(message)}
@@ -282,7 +266,9 @@ export function EmailThread({
                     }
               }
               refetch={refetch}
-              showReplyButton={showReplyButton}
+              showReplyButton={
+                showReplyButton && !message.labelIds?.includes(GmailLabel.DRAFT)
+              }
             />
           );
         })}
@@ -340,4 +326,36 @@ function getDefaultComposeMode({
   if (autoOpenMode) return autoOpenMode;
   if (draftMessage) return "reply" as const;
   return localDraftMode;
+}
+
+function organizeMessages(messages: ThreadMessage[]) {
+  const drafts = new Map<string, ThreadMessage>();
+  const regularMessages: ThreadMessage[] = [];
+  const parentMessageIds = new Set(
+    messages
+      .filter((message) => !message.labelIds?.includes(GmailLabel.DRAFT))
+      .map((message) => message.headers["message-id"])
+      .filter(Boolean),
+  );
+
+  messages?.forEach((message) => {
+    if (message.labelIds?.includes(GmailLabel.DRAFT)) {
+      // Get the parent message ID from the references or in-reply-to header
+      const parentId =
+        message.headers.references?.split(" ").pop() ||
+        message.headers["in-reply-to"];
+      if (parentId && parentMessageIds.has(parentId)) {
+        drafts.set(parentId, message);
+      } else {
+        regularMessages.push(message);
+      }
+    } else {
+      regularMessages.push(message);
+    }
+  });
+
+  return regularMessages.map((message) => ({
+    message,
+    draftMessage: drafts.get(message.headers["message-id"] || ""),
+  }));
 }


### PR DESCRIPTION
Draft-only email threads now display their content and a Draft label when no parent message is available, while draft replies remain grouped with their parent.

- Extract message grouping into a helper and hide reply controls on standalone drafts.
- Add browser regression coverage for drafts with absent or missing parents.
- Formatting, build, unit tests, and browser CI pass; inspected both draft-only regression screenshots.
- Runtime remains linear in thread size, with no additional database or network calls.
