### PR TITLE
fix(mail): clarify rule action display

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/message-actions.spec.ts
@@ -39,7 +39,11 @@ test("shows matched reasons only for the selected message", async ({
           id: "earlier-match",
           messageId: "earlier-message",
           rule: { id: "rule-1", name: "Example rule" },
-          actionItems: [],
+          actionItems: [
+            { id: "label-action", type: "LABEL", label: "Needs response" },
+            { id: "draft-action", type: "DRAFT_EMAIL" },
+            { id: "task-action", type: "INTEGRATION" },
+          ],
           status: "APPLIED",
           reason: "Reason for the earlier message.",
         },
@@ -47,9 +51,14 @@ test("shows matched reasons only for the selected message", async ({
           id: "later-match",
           messageId: "later-message",
           rule: { id: "rule-1", name: "Example rule" },
-          actionItems: [],
+          actionItems: [
+            { id: "label-action", type: "LABEL", label: "Needs response" },
+            { id: "draft-action", type: "DRAFT_EMAIL" },
+            { id: "task-action", type: "INTEGRATION" },
+          ],
           status: "APPLIED",
-          reason: "Reason for the later message.",
+          reason:
+            "Reason for the later message.\nAction failures: INTEGRATION:INTEGRATION_CALL_FAILED",
         },
       ];
     }
@@ -89,6 +98,26 @@ test("shows matched reasons only for the selected message", async ({
     await expect(
       page.getByText(otherReason, { exact: true }),
     ).not.toBeVisible();
+    await expect(
+      page.getByText("Label as 'Needs response'", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Draft Reply", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(
+        id === "earlier-message" ? "Actions applied" : "Rule actions",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    if (id === "later-message") {
+      await expect(
+        page.getByText("The integration action could not be completed.", {
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Actions applied", { exact: true }),
+      ).not.toBeVisible();
+    }
     await capturePlaywrightCheckpoint(page, testInfo, `matched-reason-${id}`);
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
@@ -18,12 +18,7 @@ import { useRuleDialog } from "@/app/(app)/[emailAccountId]/assistant/RuleDialog
 import { ThreadSkipHint } from "@/app/(app)/[emailAccountId]/assistant/ThreadSkipHint";
 import { LearnedPatternExclusionHint } from "@/app/(app)/[emailAccountId]/assistant/LearnedPatternExclusionHint";
 import type { RunRulesResult } from "@/utils/ai/choose-rule/run-rules";
-import {
-  getActionDisplay,
-  getActionIcon,
-  getVisibleActions,
-} from "@/utils/action-display";
-import { getActionColor } from "@/components/PlanBadge";
+import { RuleActions } from "@/components/RuleActions";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
 export function ResultsDisplay({
@@ -146,7 +141,7 @@ export function ResultDisplayContent({ result }: { result: RunRulesResult }) {
         {result.actionItems?.length ? (
           <>
             <div className="font-medium text-sm mb-1">Actions:</div>
-            <Actions
+            <RuleActions
               actions={
                 result.actionItems?.map((action) => ({
                   id: action.id,
@@ -211,69 +206,6 @@ export function ResultDisplayContent({ result }: { result: RunRulesResult }) {
       )}
 
       <RuleDialogComponent />
-    </div>
-  );
-}
-
-function Actions({
-  actions,
-  provider,
-  labels,
-}: {
-  actions: {
-    id: string;
-    type: ActionType;
-    label?: string | null;
-    labelId?: string | null;
-    folderName?: string | null;
-    content?: string | null;
-    to?: string | null;
-    subject?: string | null;
-    cc?: string | null;
-    bcc?: string | null;
-    url?: string | null;
-  }[];
-  provider: string;
-  labels: Array<{ id: string; name: string }>;
-}) {
-  return (
-    <div className="flex flex-col gap-2 flex-wrap">
-      {getVisibleActions(actions).map((action) => {
-        const Icon = getActionIcon(action.type);
-        const fields = [
-          { key: "to", value: action.to },
-          { key: "cc", value: action.cc },
-          { key: "bcc", value: action.bcc },
-          { key: "subject", value: action.subject },
-          { key: "content", value: action.content },
-          { key: "url", value: action.url },
-        ].filter((field) => field.value);
-
-        return (
-          <div key={action.id} className="flex flex-col gap-1">
-            <Badge
-              color={getActionColor(action.type)}
-              className="w-fit text-nowrap"
-            >
-              <Icon className="size-3 mr-1.5" />
-              {getActionDisplay(action, provider, labels)}
-            </Badge>
-            {fields.length > 0 && (
-              <div className="ml-1 space-y-0.5 text-sm text-muted-foreground">
-                {fields.map((field) => (
-                  <div
-                    key={field.key}
-                    className="whitespace-pre-wrap break-all"
-                  >
-                    <span className="font-medium capitalize">{field.key}:</span>{" "}
-                    {field.value}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MessageActionsMenu.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MessageActionsMenu.tsx
@@ -4,7 +4,8 @@ import type { ComponentProps } from "react";
 import { MoreHorizontalIcon, SparklesIcon } from "lucide-react";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { getRuleResultReasonDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
-import { MailLabelChip } from "@/app/(app)/[emailAccountId]/mail/MailLabelChip";
+import { RuleActions } from "@/components/RuleActions";
+import { useAccount } from "@/providers/EmailAccountProvider";
 import type { ThreadPlan } from "@/app/(app)/[emailAccountId]/mail/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,8 +17,7 @@ import {
   DropdownMenuPortal,
   DropdownMenuSubContent,
 } from "@/components/ui/dropdown-menu";
-import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
-import { ACTION_TYPE_LABELS, getVisibleActions } from "@/utils/action-display";
+import { ExecutedRuleStatus } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
 
 type FixWithChatResults = ComponentProps<typeof FixWithChat>["results"];
@@ -98,13 +98,7 @@ function RuleAttribution({
   setChatInput: (input: string) => void;
   showFixWithChat: boolean;
 }) {
-  const actions = getVisibleActions(plan.actionItems);
-  const labels = actions.filter(
-    (action) => action.type === ActionType.LABEL && action.label,
-  );
-  const otherActions = actions.filter(
-    (action) => action.type !== ActionType.LABEL,
-  );
+  const { provider } = useAccount();
   const reasonDisplay = getRuleResultReasonDisplay(plan.reason ?? "");
 
   return (
@@ -148,16 +142,20 @@ function RuleAttribution({
         </div>
       ) : null}
 
-      {labels.length > 0 || otherActions.length > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          {labels.map((action) => (
-            <MailLabelChip key={action.id} name={action.label ?? ""} />
-          ))}
-          {otherActions.map((action) => (
-            <span className="text-muted-foreground text-xs" key={action.id}>
-              {ACTION_TYPE_LABELS[action.type]}
-            </span>
-          ))}
+      {plan.actionItems.length > 0 ? (
+        <div className="mt-3 space-y-2">
+          <div className="font-medium text-xs">
+            {plan.status === ExecutedRuleStatus.APPLIED &&
+            reasonDisplay.actionFailureMessages.length === 0
+              ? "Actions applied"
+              : "Rule actions"}
+          </div>
+          <RuleActions
+            actions={plan.actionItems}
+            provider={provider}
+            labels={[]}
+            showDetails={false}
+          />
         </div>
       ) : null}
 

--- a/apps/web/components/RuleActions.tsx
+++ b/apps/web/components/RuleActions.tsx
@@ -1,0 +1,73 @@
+import { Badge } from "@/components/Badge";
+import { getActionColor } from "@/components/PlanBadge";
+import type { ActionType } from "@/generated/prisma/enums";
+import {
+  getActionDisplay,
+  getActionIcon,
+  getVisibleActions,
+} from "@/utils/action-display";
+
+export function RuleActions({
+  actions,
+  provider,
+  labels,
+  showDetails = true,
+}: {
+  actions: {
+    id: string;
+    type: ActionType;
+    label?: string | null;
+    labelId?: string | null;
+    folderName?: string | null;
+    content?: string | null;
+    to?: string | null;
+    subject?: string | null;
+    cc?: string | null;
+    bcc?: string | null;
+    url?: string | null;
+  }[];
+  provider: string;
+  labels: Array<{ id: string; name: string }>;
+  showDetails?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2 flex-wrap">
+      {getVisibleActions(actions).map((action) => {
+        const Icon = getActionIcon(action.type);
+        const fields = [
+          { key: "to", value: action.to },
+          { key: "cc", value: action.cc },
+          { key: "bcc", value: action.bcc },
+          { key: "subject", value: action.subject },
+          { key: "content", value: action.content },
+          { key: "url", value: action.url },
+        ].filter((field) => field.value);
+
+        return (
+          <div key={action.id} className="flex flex-col gap-1">
+            <Badge
+              color={getActionColor(action.type)}
+              className="w-fit max-w-full whitespace-normal break-words"
+            >
+              <Icon className="size-3 shrink-0 mr-1.5" />
+              {getActionDisplay(action, provider, labels)}
+            </Badge>
+            {showDetails && fields.length > 0 && (
+              <div className="ml-1 space-y-0.5 text-sm text-muted-foreground">
+                {fields.map((field) => (
+                  <div
+                    key={field.key}
+                    className="whitespace-pre-wrap break-all"
+                  >
+                    <span className="font-medium capitalize">{field.key}:</span>{" "}
+                    {field.value}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Reuses the automation action display in the message menu so labels and other actions have explicit names and icons. Successful executions show “Actions applied,” while executions with reported issues retain neutral wording and failure details.

- Adds browser coverage for action descriptions and failure messaging.
- Validation: focused Biome and diff checks pass; the focused browser test passes with screenshots inspected using an isolated local test database.
