### PR TITLE
mail: Support domain sender conditions

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/offline-loading.spec.ts
@@ -90,6 +90,22 @@ test("opens saved mail offline, reconnects, and clears it on sign-out", async ({
     );
 
     await context.setOffline(false);
+    // Confirm the browser's network has recovered before navigating away.
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          try {
+            const response = await fetch("/api/user/me", {
+              cache: "no-store",
+              signal: AbortSignal.timeout(5000),
+            });
+            return response.ok;
+          } catch {
+            return false;
+          }
+        }),
+      )
+      .toBe(true);
     await page.reload({ waitUntil: "domcontentloaded", timeout: 15_000 });
     await expect(
       conversationWithSubject(page, conversations, "Archive Action Message"),

--- a/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/split-tabs.spec.ts
@@ -132,6 +132,31 @@ test("moves focus with the active split when cycling by keyboard", async ({
   );
 });
 
+test("creates and edits a domain sender condition", async ({
+  page,
+}, testInfo) => {
+  await openMail(page);
+  await page.getByRole("button", { name: "New split" }).click();
+  await page.getByRole("button", { name: "Build your own" }).click();
+  await page.getByLabel("Condition field").first().selectOption("FROM");
+  await page.getByLabel("Sender", { exact: true }).fill("@example.com");
+  await page.getByLabel("Split name").fill("Example domain");
+  await capturePlaywrightCheckpoint(
+    page,
+    testInfo,
+    "mail-domain-split-builder",
+  );
+  await page.getByRole("button", { name: "Add split", exact: true }).click();
+  const tab = page.getByRole("button", { name: "Example domain", exact: true });
+  await expect(tab).toBeVisible();
+  await tab.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit filters and name" }).click();
+  await expect(page.getByLabel("Sender", { exact: true })).toHaveValue(
+    "@example.com",
+  );
+  await capturePlaywrightCheckpoint(page, testInfo, "mail-domain-split-edit");
+});
+
 test("builds a split from conditions and shows only matching mail", async ({
   page,
 }, testInfo) => {

--- a/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/NewSplitDialog.tsx
@@ -891,7 +891,7 @@ function ConditionRow({
         <Input
           value={condition.value ?? ""}
           onChange={(event) => onChangeValue(event.target.value)}
-          placeholder="name@company.com"
+          placeholder="name@company.com or @company.com"
           aria-label="Sender"
           className="h-8 min-w-0 flex-1 text-xs"
         />

--- a/apps/web/utils/email-cache/mailbox.test.ts
+++ b/apps/web/utils/email-cache/mailbox.test.ts
@@ -23,6 +23,68 @@ describe("synced mailbox cache", () => {
     await clearEmailCache();
   });
 
+  it("matches cached domains and defers unsupported unions to the server", async () => {
+    await applyMailboxSyncPage({
+      emailAccountId: "account-1",
+      after: new Date("2020-01-01"),
+      page: {
+        cursor: "complete",
+        reset: true,
+        hasMore: false,
+        deletedMessageIds: [],
+        upsertedMessages: [
+          getMessage({
+            id: "hit",
+            threadId: "hit",
+            from: "User <USER@example.com>",
+            labelIds: ["INBOX", "UNREAD"],
+          }),
+          getMessage({
+            id: "sub",
+            threadId: "sub",
+            from: "user@sub.example.com",
+            labelIds: ["INBOX"],
+          }),
+          getMessage({
+            id: "archived",
+            threadId: "archived",
+            from: "user@example.com",
+            labelIds: [],
+          }),
+          getMessage({
+            id: "mixed-inbox",
+            threadId: "mixed",
+            from: "user@sub.example.com",
+            labelIds: ["INBOX", "UNREAD"],
+          }),
+          getMessage({
+            id: "mixed-archive",
+            threadId: "mixed",
+            from: "user@example.com",
+            labelIds: [],
+          }),
+        ],
+      },
+    });
+    for (const query of [
+      { labelIds: ["INBOX"], fromEmail: "@example.com", isUnread: true },
+      {
+        labelIds: ["INBOX"],
+        anyOf: [
+          { fromEmail: "@example.com" },
+          { fromEmail: "other@elsewhere.com" },
+        ],
+      },
+    ]) {
+      const result = await readSyncedMailboxThreads({
+        emailAccountId: "account-1",
+        query,
+      });
+      if (query.anyOf) expect(result).toBeUndefined();
+      else expect(result?.threads.map(({ id }) => id)).toEqual(["hit"]);
+    }
+  });
+
   it("excludes named splits from cached Other results", async () => {
     await applyMailboxSyncPage({
       emailAccountId: "account-1",

--- a/apps/web/utils/email-cache/mailbox.ts
+++ b/apps/web/utils/email-cache/mailbox.ts
@@ -1,7 +1,7 @@
 import { createOtherSplitFilter } from "@/utils/mail/thread-matches-split";
 import type { ThreadResponse } from "@/app/api/threads/[id]/route";
 import { internalDateToDate, sortByInternalDate } from "@/utils/date";
-import { canonicalizeEmailAddress } from "@/utils/email";
+import { matchesSenderFilter } from "@/utils/mail/sender-filter";
 import type { MailboxSyncPage } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import type { CombinedListThread } from "@/utils/threads/load-combined";
@@ -546,6 +546,7 @@ function groupMessagesByThread(messages: ParsedMessage[]) {
 function isSupportedMailboxQuery(query: ThreadsQuery) {
   if (
     query.q ||
+    query.anyOf?.length ||
     query.nextPageToken ||
     query.inboxSection ||
     query.excludeLabelNames?.length
@@ -615,8 +616,12 @@ function threadMatchesQuery(messages: ParsedMessage[], query: ThreadsQuery) {
   return messages.some((message) => {
     if (
       query.fromEmail &&
-      canonicalizeEmailAddress(message.headers.from) !==
-        canonicalizeEmailAddress(query.fromEmail)
+      (!matchesSenderFilter(message.headers.from, query.fromEmail) ||
+        !requiredLabelIds.every((labelId) =>
+          message.labelIds?.includes(labelId),
+        ) ||
+        ((query.isUnread || query.type === "unread") &&
+          !message.labelIds?.includes("UNREAD")))
     ) {
       return false;
     }

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { gmail_v1 } from "@googleapis/gmail";
+import { auth, gmail_v1 } from "@googleapis/gmail";
 import type { EmailThread } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { GmailLabel } from "@/utils/gmail/label";
@@ -528,11 +528,9 @@ describe("GmailProvider.getThreadsWithQuery", () => {
           ],
         },
       ]);
-    const provider = new GmailProvider({
-      context: {
-        _options: { auth: { credentials: { access_token: "access-token" } } },
-      },
-    } as gmail_v1.Gmail);
+    const oauth = new auth.OAuth2();
+    oauth.setCredentials({ access_token: "access-token" });
+    const provider = new GmailProvider(new gmail_v1.Gmail({ auth: oauth }));
     const result = await provider.getThreadsWithQuery({
       query: { fromEmail: "@example.com", labelIds: ["INBOX"] },
       maxResults: 1,

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -481,6 +481,72 @@ describe("GmailProvider.getSentMessageIds", () => {
 });
 
 describe("GmailProvider.getThreadsWithQuery", () => {
+  it("filters domain candidates on the same inbox message and continues paging", async () => {
+    const list = vi
+      .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")
+      .mockResolvedValueOnce({
+        threads: [{ id: "miss" }],
+        nextPageToken: "next",
+      })
+      .mockResolvedValueOnce({
+        threads: [{ id: "hit" }],
+        nextPageToken: undefined,
+      });
+    vi.spyOn(gmailThreadModule, "getThreadsBatch")
+      .mockResolvedValueOnce([
+        {
+          id: "miss",
+          messages: [
+            {
+              id: "sub",
+              labelIds: ["INBOX"],
+              payload: {
+                headers: [{ name: "From", value: "user@sub.example.com" }],
+              },
+            },
+            {
+              id: "archived",
+              labelIds: [],
+              payload: {
+                headers: [{ name: "From", value: "user@example.com" }],
+              },
+            },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "hit",
+          messages: [
+            {
+              id: "hit",
+              labelIds: ["INBOX"],
+              payload: {
+                headers: [{ name: "From", value: "User <USER@example.com>" }],
+              },
+            },
+          ],
+        },
+      ]);
+    const provider = new GmailProvider({
+      context: {
+        _options: { auth: { credentials: { access_token: "access-token" } } },
+      },
+    } as any);
+    const result = await provider.getThreadsWithQuery({
+      query: { fromEmail: "@example.com", labelIds: ["INBOX"] },
+      maxResults: 1,
+    });
+    expect(result.threads.map(({ id }) => id)).toEqual(["hit"]);
+    expect(list).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        q: "from:@example.com",
+        labelIds: ["INBOX"],
+        pageToken: "next",
+      }),
+    );
+  });
+
   it("uses multiple label IDs in preference to the legacy single label", async () => {
     const getThreadsWithNextPageToken = vi
       .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -532,7 +532,7 @@ describe("GmailProvider.getThreadsWithQuery", () => {
       context: {
         _options: { auth: { credentials: { access_token: "access-token" } } },
       },
-    } as any);
+    } as gmail_v1.Gmail);
     const result = await provider.getThreadsWithQuery({
       query: { fromEmail: "@example.com", labelIds: ["INBOX"] },
       maxResults: 1,

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1,3 +1,4 @@
+import { matchesSenderFilter } from "@/utils/mail/sender-filter";
 import type { gmail_v1 } from "@googleapis/gmail";
 import chunk from "lodash/chunk";
 import { SafeError } from "@/utils/error";
@@ -1703,20 +1704,48 @@ export class GmailProvider implements EmailProvider {
         }
       }
 
-      const { threads: gmailThreads, nextPageToken } =
-        await getThreadsWithNextPageToken({
+      const threads: EmailThread[] = [];
+      const maxResults = options.maxResults || 50;
+      const domainFilter = fromEmail?.trim().startsWith("@") ? fromEmail : null;
+      let nextPageToken = options.pageToken;
+      for (let page = 0; page < (domainFilter ? 5 : 1); page++) {
+        const result = await getThreadsWithNextPageToken({
           gmail: this.client,
           q: getQuery(),
           labelIds: getLabelIds(type) || [],
-          maxResults: options.maxResults || 50,
-          pageToken: options.pageToken || undefined,
+          maxResults: maxResults - threads.length,
+          pageToken: nextPageToken,
           logger: this.logger,
         });
-
-      return {
-        threads: await this.hydrateThreads(gmailThreads, options.messageFormat),
-        nextPageToken: nextPageToken || undefined,
-      };
+        const hydrated = await this.hydrateThreads(
+          result.threads,
+          options.messageFormat,
+        );
+        threads.push(
+          ...hydrated.filter(
+            (thread) =>
+              !domainFilter ||
+              thread.messages.some((message) => {
+                if (!matchesSenderFilter(message.headers.from, domainFilter))
+                  return false;
+                const labels = message.labelIds ?? [];
+                if (getLabelIds(type)?.some((label) => !labels.includes(label)))
+                  return false;
+                if (isUnread && !labels.includes(GmailLabel.UNREAD))
+                  return false;
+                if (type === "archive" && labels.includes(GmailLabel.INBOX))
+                  return false;
+                const timestamp = Number(message.internalDate);
+                if (after && !(timestamp > after.getTime())) return false;
+                if (before && !(timestamp < before.getTime())) return false;
+                return true;
+              }),
+          ),
+        );
+        nextPageToken = result.nextPageToken || undefined;
+        if (!nextPageToken || threads.length >= maxResults) break;
+      }
+      return { threads, nextPageToken };
     });
   }
 

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -674,6 +674,69 @@ describe("OutlookProvider.searchMessages", () => {
 });
 
 describe("OutlookProvider.getThreadsWithQuery", () => {
+  it("pages domain filters without dropping inbox, unread, or date constraints", async () => {
+    const next =
+      "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=domain";
+    const miss = createMessage({
+      id: "miss",
+      conversationId: "miss",
+      parentFolderId: "inbox-folder-id",
+      isRead: false,
+    });
+    miss.from = { emailAddress: { address: "user@sub.example.com" } };
+    const client = createMockOutlookClient([], {
+      responsesByApiPath: {
+        "/me/messages": { value: [miss], "@odata.nextLink": next },
+        [next]: {
+          value: [
+            createMessage({
+              id: "hit",
+              conversationId: "hit",
+              parentFolderId: "inbox-folder-id",
+              isRead: false,
+            }),
+          ],
+        },
+      },
+    });
+    const result = await new OutlookProvider(client).getThreadsWithQuery({
+      query: {
+        type: "inbox",
+        fromEmail: "@example.com",
+        isUnread: true,
+        before: new Date("2026-02-01"),
+      },
+      maxResults: 1,
+    });
+    expect(result.threads.map((thread) => thread.id)).toEqual(["hit"]);
+    expect(client.getRequestLog()[0].filter).toContain("parentFolderId eq");
+    expect(client.getRequestLog()[0].filter).toContain("isRead eq false");
+    expect(client.getRequestLog()[0].filter).toContain("receivedDateTime lt");
+    expect(client.getRequestLog()[0].filter).not.toContain("from/emailAddress");
+    expect(client.getRequestLog()[1].apiPath).toBe(next);
+  });
+
+  it("returns a continuation after a bounded scan with no domain matches", async () => {
+    const next =
+      "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=domain";
+    const miss = createMessage({
+      id: "miss",
+      parentFolderId: "inbox-folder-id",
+    });
+    miss.from = { emailAddress: { address: "user@other.com" } };
+    const client = createMockOutlookClient([], {
+      responsesByApiPath: {
+        "/me/messages": { value: [miss], "@odata.nextLink": next },
+        [next]: { value: [miss], "@odata.nextLink": next },
+      },
+    });
+    const result = await new OutlookProvider(client).getThreadsWithQuery({
+      query: { type: "inbox", fromEmail: "@example.com" },
+    });
+    expect(result).toEqual({ threads: [], nextPageToken: next });
+    expect(client.getRequestLog()).toHaveLength(5);
+  });
+
   it.each([
     { type: "draft" },
     { labelId: "DRAFT" },

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -716,7 +716,10 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     expect(client.getRequestLog()[1].apiPath).toBe(next);
   });
 
-  it("returns a continuation after a bounded scan with no domain matches", async () => {
+  it.each([
+    undefined,
+    ["INBOX"],
+  ])("bounds domain scans with local label filters %s", async (labelIds) => {
     const next =
       "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=domain";
     const miss = createMessage({
@@ -731,7 +734,7 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
       },
     });
     const result = await new OutlookProvider(client).getThreadsWithQuery({
-      query: { type: "inbox", fromEmail: "@example.com" },
+      query: { type: "inbox", fromEmail: "@example.com", labelIds },
     });
     expect(result).toEqual({ threads: [], nextPageToken: next });
     expect(client.getRequestLog()).toHaveLength(5);

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1,3 +1,4 @@
+import { matchesSenderFilter } from "@/utils/mail/sender-filter";
 import { SafeError } from "@/utils/error";
 import type { Message } from "@microsoft/microsoft-graph-types";
 import type { OutlookClient } from "@/utils/outlook/client";
@@ -1636,6 +1637,38 @@ export class OutlookProvider implements EmailProvider {
     threads: EmailThread[];
     nextPageToken?: string;
   }> {
+    const senderFilter = options.query?.fromEmail?.trim();
+    if (senderFilter?.startsWith("@")) {
+      const threads: EmailThread[] = [];
+      let nextPageToken = options.pageToken;
+      const maxResults = options.maxResults || 50;
+      // Graph sender search caps results and cannot preserve OData filters.
+      // Scan normal filtered pages, retaining the cursor for sparse matches.
+      for (let page = 0; page < 5; page++) {
+        const result = await this.getThreadsWithQuery({
+          ...options,
+          query: { ...options.query, fromEmail: undefined },
+          maxResults: maxResults - threads.length,
+          pageToken: nextPageToken,
+        });
+        threads.push(
+          ...result.threads.filter((thread) =>
+            thread.messages.some(
+              (message) =>
+                matchesSenderFilter(message.headers.from, senderFilter) &&
+                (
+                  options.query?.labelIds ??
+                  (options.query?.labelId ? [options.query.labelId] : [])
+                ).every((label) => message.labelIds?.includes(label)),
+            ),
+          ),
+        );
+        nextPageToken = result.nextPageToken;
+        if (!nextPageToken || threads.length >= maxResults) break;
+      }
+      return { threads, nextPageToken };
+    }
+
     const {
       fromEmail,
       after,

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1638,36 +1638,7 @@ export class OutlookProvider implements EmailProvider {
     nextPageToken?: string;
   }> {
     const senderFilter = options.query?.fromEmail?.trim();
-    if (senderFilter?.startsWith("@")) {
-      const threads: EmailThread[] = [];
-      let nextPageToken = options.pageToken;
-      const maxResults = options.maxResults || 50;
-      // Graph sender search caps results and cannot preserve OData filters.
-      // Scan normal filtered pages, retaining the cursor for sparse matches.
-      for (let page = 0; page < 5; page++) {
-        const result = await this.getThreadsWithQuery({
-          ...options,
-          query: { ...options.query, fromEmail: undefined },
-          maxResults: maxResults - threads.length,
-          pageToken: nextPageToken,
-        });
-        threads.push(
-          ...result.threads.filter((thread) =>
-            thread.messages.some(
-              (message) =>
-                matchesSenderFilter(message.headers.from, senderFilter) &&
-                (
-                  options.query?.labelIds ??
-                  (options.query?.labelId ? [options.query.labelId] : [])
-                ).every((label) => message.labelIds?.includes(label)),
-            ),
-          ),
-        );
-        nextPageToken = result.nextPageToken;
-        if (!nextPageToken || threads.length >= maxResults) break;
-      }
-      return { threads, nextPageToken };
-    }
+    const domainFilter = senderFilter?.startsWith("@") ? senderFilter : null;
 
     const {
       fromEmail,
@@ -1773,7 +1744,7 @@ export class OutlookProvider implements EmailProvider {
         }
       }
 
-      if (fromEmail) {
+      if (fromEmail && !domainFilter) {
         const escapedEmail = escapeODataString(fromEmail);
         filters.push(`from/emailAddress/address eq '${escapedEmail}'`);
       }
@@ -1801,7 +1772,7 @@ export class OutlookProvider implements EmailProvider {
         request = request.filter(filter);
       }
 
-      if (!fromEmail) {
+      if (!fromEmail || domainFilter) {
         request = request.orderby("receivedDateTime DESC");
       }
 
@@ -1819,6 +1790,14 @@ export class OutlookProvider implements EmailProvider {
 
     do {
       const response = await fetchThreadPage(nextPageTokenToFetch);
+      if (domainFilter) {
+        response.value = response.value.filter((message: Message) =>
+          matchesSenderFilter(
+            message.from?.emailAddress?.address ?? "",
+            domainFilter,
+          ),
+        );
+      }
       const currentPageIndex = fetchedPages.length;
       fetchedPages.push({
         pageToken: nextPageTokenToFetch,
@@ -1837,7 +1816,14 @@ export class OutlookProvider implements EmailProvider {
       collectedMessages.push(...response.value);
       nextPageToken = response["@odata.nextLink"];
 
-      if (!requiresLocalLabelFiltering || !nextPageToken) break;
+      // Graph search caps results and cannot preserve OData filters. Scan
+      // normal query pages instead, bounding sparse domain scans per request.
+      if (
+        (!requiresLocalLabelFiltering && !domainFilter) ||
+        !nextPageToken ||
+        (domainFilter && fetchedPages.length >= 5)
+      )
+        break;
 
       const matchedThreads = buildOutlookThreadsFromMessages({
         messages: collectedMessages,

--- a/apps/web/utils/mail/sender-filter.test.ts
+++ b/apps/web/utils/mail/sender-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  senderFilterSchema,
+  matchesSenderFilter,
+} from "@/utils/mail/sender-filter";
+
+describe("sender filters", () => {
+  it.each([
+    "@example.com",
+    "@mail.example.com",
+    "User@example.com",
+  ])("accepts %s", (value) => {
+    expect(senderFilterSchema.safeParse(value).success).toBe(true);
+  });
+  it.each([
+    "example.com",
+    "@a..com",
+    "@-example.com",
+    "@example-.com",
+    "@example.com OR from:other",
+    "@example.com/path",
+  ])("rejects %s", (value) => {
+    expect(senderFilterSchema.safeParse(value).success).toBe(false);
+  });
+  it.each([
+    ["Person <USER@Example.com>", "@example.com", true],
+    ["user@sub.example.com", "@example.com", false],
+    ["user@notexample.com", "@example.com", false],
+    ["user@example.com.evil", "@example.com", false],
+    ["Example.com <user@other.com>", "@example.com", false],
+    ["Person <USER@Example.com>", "user@example.com", true],
+  ])("matches %s against %s", (sender, filter, expected) => {
+    expect(matchesSenderFilter(sender, filter)).toBe(expected);
+  });
+});

--- a/apps/web/utils/mail/sender-filter.ts
+++ b/apps/web/utils/mail/sender-filter.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { canonicalizeEmailAddress } from "@/utils/email";
+
+export const senderFilterSchema = z.string().refine((value) => {
+  if (!value.startsWith("@")) return z.email().safeParse(value).success;
+  const domain = value.slice(1);
+  const labels = domain.split(".");
+  return (
+    domain.length <= 253 &&
+    labels.length >= 2 &&
+    labels.every((label) =>
+      /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(label),
+    )
+  );
+}, "Enter a sender email address or @domain.com");
+
+export function matchesSenderFilter(sender: string, filter: string): boolean {
+  const address = canonicalizeEmailAddress(sender);
+  const normalizedFilter = filter.trim().toLowerCase();
+  return normalizedFilter.startsWith("@")
+    ? address.endsWith(normalizedFilter)
+    : address === canonicalizeEmailAddress(filter);
+}

--- a/apps/web/utils/mail/split-filters.ts
+++ b/apps/web/utils/mail/split-filters.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { senderFilterSchema } from "@/utils/mail/sender-filter";
 import { MailSplitFilterKind } from "@/generated/prisma/enums";
 import { OLDER_THAN_OPTIONS } from "@/utils/mail/split-query";
 
@@ -30,8 +31,8 @@ export const mailSplitFilterSchema = z
   .refine(
     (filter) =>
       filter.kind !== MailSplitFilterKind.FROM ||
-      z.email().safeParse(filter.value).success,
-    { message: "Enter a sender email address", path: ["value"] },
+      senderFilterSchema.safeParse(filter.value).success,
+    { message: "Enter a sender email address or @domain.com", path: ["value"] },
   )
   .refine(
     (filter) =>

--- a/apps/web/utils/mail/thread-matches-split.test.ts
+++ b/apps/web/utils/mail/thread-matches-split.test.ts
@@ -12,6 +12,16 @@ const important: MailSplit = {
 };
 
 describe("Other inbox membership", () => {
+  it("excludes domain splits but keeps subdomains in Other", () => {
+    const split: MailSplit = {
+      ...important,
+      filters: [{ kind: "FROM", value: "@example.com" }],
+    };
+    const conversation = thread(["INBOX"]);
+    expect(threadMatchesSplit(conversation, split, now)).toBe(true);
+    conversation.messages[0].headers.from = "sender@sub.example.com";
+    expect(threadMatchesSplit(conversation, split, now)).toBe(false);
+  });
   it("excludes a conversation when an earlier inbox message matches a split", () => {
     expect(
       threadMatchesSplit(

--- a/apps/web/utils/mail/thread-matches-split.ts
+++ b/apps/web/utils/mail/thread-matches-split.ts
@@ -1,5 +1,5 @@
 import { internalDateToDate } from "@/utils/date";
-import { isSameEmailAddress } from "@/utils/email";
+import { matchesSenderFilter } from "@/utils/mail/sender-filter";
 import type { ParsedMessage } from "@/utils/types";
 import { mailSplitToThreadsQuery } from "@/utils/mail/split-query";
 import type {
@@ -59,7 +59,7 @@ function matchesMessage(
   if (query.isUnread && !labels.includes("UNREAD")) return false;
   if (
     query.fromEmail &&
-    !isSameEmailAddress(message.headers.from, query.fromEmail)
+    !matchesSenderFilter(message.headers.from, query.fromEmail)
   )
     return false;
   if (query.before) {


### PR DESCRIPTION
Adds `@domain.com` to the existing From condition so a saved split can include every sender at an exact domain. This is the remaining feature from #3492, using the current condition builder and storage.

- Match domains consistently in Gmail, Outlook, cached inboxes, and Other exclusions; subdomains remain separate. Preserve inbox and combined conditions, and defer unsupported cached match-any queries to the server.
- Gmail narrows candidates with its existing sender search. Outlook scans normal filtered pages to avoid Graph search's 1,000-result cap and preserve OData constraints. Domain scans stop after five Graph pages per Outlook call and retain their continuation; sparse matches can require additional requests. No new database calls or migrations.
- Validation: 167 focused unit tests and formatting checks passed. All 8 emulated split browser checks passed, including creating and reopening a domain condition; builder and edit screenshots inspected.

- Retained main’s offline test fixes when resolving the merge conflict; its offline reload, reconnect, and sign-out checks pass on the combined branch. Independent review found no issues.
