### PR TITLE
fix: normalize migration whitespace across PostgreSQL versions

### DIFF
--- a/apps/web/__tests__/db/README.md
+++ b/apps/web/__tests__/db/README.md
@@ -31,6 +31,10 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/inboxzero_test?schem
 Point `DATABASE_URL` at a throwaway database. These tests delete rows in
 `beforeEach`, so never aim them at a database you care about.
 
+The group item normalization migration regression should also run on PostgreSQL 15.
+Its string escape behavior differs from newer versions, which can hide invalid
+whitespace normalization.
+
 ## Conventions
 
 - Seed the rows the test needs in `beforeEach` and delete them again, rather

--- a/apps/web/__tests__/db/normalize-group-item-values-migration.test.ts
+++ b/apps/web/__tests__/db/normalize-group-item-values-migration.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { Client } from "pg";
+import { describe, expect, test } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../../prisma/migrations/20260728170000_normalize_group_item_values/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe.skipIf(!process.env.RUN_DB_TESTS)(
+  "group item normalization migration",
+  () => {
+    test("preserves letters, trims whitespace, and deduplicates before normalization", async () => {
+      const client = new Client({ connectionString: process.env.DATABASE_URL });
+      await client.connect();
+      try {
+        await client.query(`BEGIN;
+        CREATE SCHEMA normalize_group_item_migration_test;
+        SET LOCAL search_path = normalize_group_item_migration_test;
+        CREATE TYPE "GroupItemSource" AS ENUM ('AI', 'USER');
+        CREATE TYPE "GroupItemType" AS ENUM ('FROM', 'SUBJECT');
+        CREATE TABLE "GroupItem" (
+          "id" text PRIMARY KEY,
+          "groupId" text,
+          "type" "GroupItemType" NOT NULL DEFAULT 'FROM',
+          "value" text NOT NULL,
+          "source" "GroupItemSource",
+          "exclude" boolean NOT NULL DEFAULT false,
+          "createdAt" timestamp NOT NULL DEFAULT now(),
+          "updatedAt" timestamp NOT NULL DEFAULT now(),
+          UNIQUE ("groupId", "type", "value")
+        );
+        INSERT INTO "GroupItem" ("id", "groupId", "value", "source") VALUES
+          ('uppercase', 'sender', 'Vendor@example.com', 'USER'),
+          ('lowercase', 'sender', 'vendor@example.com', 'AI'),
+          ('letter', 'letter', 'v', NULL);
+      `);
+        await client.query(
+          `INSERT INTO "GroupItem" ("id", "groupId", "value", "type", "exclude") VALUES
+          ('whitespace', 'whitespace', $1, 'FROM', false),
+          ('subject', 'subject', $2, 'SUBJECT', false),
+          ('exclusion', 'exclusion', ' BLOCK@example.com ', 'FROM', true)`,
+          [" \t\n\r\f\v\u00a0\u2003\ufeff", "\v Invoice \v"],
+        );
+        await client.query(migration);
+        const readItems = () =>
+          client.query(
+            `SELECT "id", "value", "source", "exclude" FROM "GroupItem" ORDER BY "id"`,
+          );
+        const result = await readItems();
+        expect(result.rows).toEqual([
+          {
+            id: "exclusion",
+            value: "block@example.com",
+            source: "USER",
+            exclude: true,
+          },
+          { id: "letter", value: "v", source: null, exclude: false },
+          { id: "subject", value: "invoice", source: "USER", exclude: false },
+          {
+            id: "uppercase",
+            value: "vendor@example.com",
+            source: "USER",
+            exclude: false,
+          },
+        ]);
+        await client.query(migration);
+        expect((await readItems()).rows).toEqual(result.rows);
+      } finally {
+        await client.query("ROLLBACK");
+        await client.end();
+      }
+    });
+  },
+);

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/README.md
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/README.md
@@ -1,0 +1,42 @@
+# Recover group item normalization
+
+The original SQL used `\v`, which PostgreSQL 15 interprets as the literal letter
+`v`. The corrected SQL uses the portable octal escape `\013` for vertical tab.
+
+Changing this file does not rerun a completed migration or clear a recorded
+failure. Use this procedure for an affected database, including databases where
+the original migration completed successfully.
+
+Run from `apps/web` with `DIRECT_URL` set to a writable, direct connection to the
+affected database. Ensure Prisma's configured migration URL points to the same
+database; preview URL variables take precedence over `DIRECT_URL`.
+
+1. Check migration history with `pnpm exec prisma migrate status`.
+2. Apply the corrected SQL atomically. The lock prevents concurrent pattern
+   writes between deduplication and normalization; a lock timeout leaves the
+   database unchanged and allows a later retry.
+
+   ```sh
+   {
+     printf '%s\n' "SET LOCAL lock_timeout = '5s';" 'LOCK TABLE "GroupItem" IN SHARE ROW EXCLUSIVE MODE;'
+     cat prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+   } | psql "$DIRECT_URL" -X --single-transaction -v ON_ERROR_STOP=1
+   ```
+
+3. **Only if the SQL succeeds and Prisma recorded this migration as failed**, mark
+   it applied:
+
+   ```sh
+   pnpm exec prisma migrate resolve --applied 20260728170000_normalize_group_item_values
+   ```
+
+   Skip this step if the migration was already successfully applied.
+4. Run `pnpm exec prisma migrate status` again, then deploy normally to apply any
+   pending migrations.
+
+The corrected SQL is safe to rerun: it trims whitespace, removes empty values,
+and deduplicates normalized patterns using the migration's ownership and recency
+priorities. It cannot reconstruct letters stripped or records deleted by an
+already-successful run of the original SQL. Recover those from a backup if needed;
+do not guess original values. Do not delete migration history or mark a failed
+migration applied before its SQL completes successfully.

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/README.md
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/README.md
@@ -17,10 +17,14 @@ database; preview URL variables take precedence over `DIRECT_URL`.
    database unchanged and allows a later retry.
 
    ```sh
-   {
-     printf '%s\n' "SET LOCAL lock_timeout = '5s';" 'LOCK TABLE "GroupItem" IN SHARE ROW EXCLUSIVE MODE;'
-     cat prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
-   } | psql "$DIRECT_URL" -X --single-transaction -v ON_ERROR_STOP=1
+   (
+     set -eu
+     recovery_sql=$(mktemp)
+     trap 'rm -f "$recovery_sql"' EXIT
+     printf '%s\n' "SET LOCAL lock_timeout = '5s';" 'LOCK TABLE "GroupItem" IN SHARE ROW EXCLUSIVE MODE;' > "$recovery_sql"
+     cat prisma/migrations/20260728170000_normalize_group_item_values/migration.sql >> "$recovery_sql"
+     psql "$DIRECT_URL" -X --single-transaction -v ON_ERROR_STOP=1 -f "$recovery_sql"
+   )
    ```
 
 3. **Only if the SQL succeeds and Prisma recorded this migration as failed**, mark

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
@@ -9,14 +9,15 @@ WHERE "source" IS NULL
     OR "type" = 'SUBJECT'
   );
 
+-- PostgreSQL 15 treats \v as a literal letter; use octal for vertical tab.
 DELETE FROM "GroupItem"
-WHERE btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF') = '';
+WHERE btrim("value", E' \t\n\r\f\013' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF') = '';
 
 WITH ranked_items AS (
   SELECT
     "id",
     row_number() OVER (
-      PARTITION BY "groupId", "type", lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
+      PARTITION BY "groupId", "type", lower(btrim("value", E' \t\n\r\f\013' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
       ORDER BY
         coalesce("source" = 'USER', true) DESC,
         "updatedAt" DESC,
@@ -33,5 +34,5 @@ WHERE "GroupItem"."id" = ranked_items."id"
   AND ranked_items.rank > 1;
 
 UPDATE "GroupItem"
-SET "value" = lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
-WHERE "value" <> lower(btrim("value", E' \t\n\r\f\v' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'));
+SET "value" = lower(btrim("value", E' \t\n\r\f\013' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'))
+WHERE "value" <> lower(btrim("value", E' \t\n\r\f\013' || U&'\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'));


### PR DESCRIPTION
The normalization migration used a whitespace escape that PostgreSQL 15 interprets as a literal letter, potentially altering pattern values and causing unique-key collisions. Use an octal vertical-tab escape consistently in cleanup, deduplication, and normalization.

- Document recovery for failed and already-applied migrations, including the limits of recovering previously altered values.
- Add a database regression covering case variants, whitespace, user ownership, and repeat execution.
- Verified the original failure and corrected SQL on PostgreSQL 15; the focused Vitest regression, Biome, and diff checks pass.

No additional application runtime work or database calls. Databases with a recorded failure require the corrected SQL to complete before resolving the migration as applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected group-item value normalization on PostgreSQL 15 so vertical-tab whitespace is trimmed correctly.
  * Preserved trimming, lowercasing, deduplication, letters, and metadata during migration.

* **Tests**
  * Added PostgreSQL integration coverage for normalization, data preservation, and repeated migration runs.
  * Documented PostgreSQL 15 coverage for regression testing.

* **Documentation**
  * Added migration recovery guidance for safely preparing and rerunning recovery SQL after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->