### PR TITLE
chore(prisma): move User provisioning fields to the end

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -59,14 +59,6 @@ model Session {
 }
 
 model User {
-  ssoProviders           SsoProvider[]
-  scimAccessDisabled     Boolean                 @default(false)
-  scimIdentityTombstones ScimIdentityTombstone[]
-  scimSubject            ScimSubject?
-  scimUsers              ScimUser[]
-  scimProjectionGrants   ScimProjectionGrant[]
-  scimIdentityLinks      ScimIdentityLink[]
-
   id            String    @id @default(cuid())
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
@@ -127,6 +119,14 @@ model User {
   oauthRefreshTokenRecords OauthRefreshToken[]
   oauthAccessTokenRecords  OauthAccessToken[]
   oauthConsentRecords      OauthConsent[]
+
+  ssoProviders           SsoProvider[]
+  scimAccessDisabled     Boolean                 @default(false)
+  scimIdentityTombstones ScimIdentityTombstone[]
+  scimSubject            ScimSubject?
+  scimUsers              ScimUser[]
+  scimProjectionGrants   ScimProjectionGrant[]
+  scimIdentityLinks      ScimIdentityLink[]
 }
 
 enum ApiKeyScope {


### PR DESCRIPTION
Move the SSO and SCIM fields to the end of the Prisma User model so id and the core user fields remain first.

Only field ordering changes in one file. Verified that all schema lines are identical before and after; Prisma formatting and git diff checks pass. No database migration or runtime behavior change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal user-model fields without changing functionality, data relationships, or constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->