### PR TITLE
mail: Add undo send for compose and replies

### DIFF
--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -10,6 +10,7 @@ import {
   conversationWithSubject,
   openMail,
   readLatestMailMutation,
+  waitForComposeOutboxSend,
 } from "./mail-test-helpers";
 
 test("keeps keyboard focus in the composer and follows the message field order", async ({
@@ -342,7 +343,7 @@ test("keeps editing state stable across formatting, links, paste, and files", as
 test("does not add a line break for the send shortcut", async ({
   page,
 }, testInfo) => {
-  const { conversations } = await openMail(page);
+  const { conversations, emailAccountId } = await openMail(page);
   const subject = `Shortcut Message ${testInfo.retry}`;
   await page.getByRole("button", { name: /^Compose/ }).click();
 
@@ -367,12 +368,13 @@ test("does not add a line break for the send shortcut", async ({
   await expect(dialog).toBeHidden();
   await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
   await page.getByRole("link", { name: /^Sent/ }).click();
+  await waitForComposeOutboxSend(page, emailAccountId);
   const sentConversation = conversationWithSubject(
     page,
     conversations,
     subject,
   );
-  await expect(sentConversation).toBeVisible({ timeout: 20_000 });
+  await expect(sentConversation).toBeVisible({ timeout: 60_000 });
   await sentConversation.click();
   const sentBody = page
     .frameLocator('iframe[title="Email content preview"]')
@@ -420,7 +422,7 @@ test("attaches files and discards a compose draft with shortcuts", async ({
 test("composes, sends, and reads a new message from Sent", async ({
   page,
 }, testInfo) => {
-  const { conversations } = await openMail(page);
+  const { conversations, emailAccountId } = await openMail(page);
   const subject = `Playwright Composed Message ${testInfo.retry}`;
 
   await page.getByRole("button", { name: /^Compose/ }).click();
@@ -445,12 +447,13 @@ test("composes, sends, and reads a new message from Sent", async ({
   await expect(page.getByText("Email sent!", { exact: true })).toBeVisible();
 
   await page.getByRole("link", { name: /^Sent/ }).click();
+  await waitForComposeOutboxSend(page, emailAccountId);
   const sentConversation = conversationWithSubject(
     page,
     conversations,
     subject,
   );
-  await expect(sentConversation).toBeVisible({ timeout: 20_000 });
+  await expect(sentConversation).toBeVisible({ timeout: 60_000 });
   await sentConversation.click();
   await expect(page.getByRole("heading", { name: subject })).toBeVisible();
   await expect(page.getByText("recipient@example.com").first()).toBeVisible();
@@ -462,7 +465,9 @@ test("composes, sends, and reads a new message from Sent", async ({
   await capturePlaywrightCheckpoint(page, testInfo, "composed-message-in-sent");
 });
 
-test("undoes a composed message before it is delivered", async ({ page }) => {
+test("undoes a composed message before it is delivered", async ({
+  page,
+}, testInfo) => {
   const { conversations, emailAccountId } = await openMail(page);
   const subject = `Playwright Undo Send ${Date.now()}`;
 
@@ -509,6 +514,7 @@ test("undoes a composed message before it is delivered", async ({ page }) => {
       }),
     )
     .toBeUndefined();
+  await capturePlaywrightCheckpoint(page, testInfo, "compose-undo-restored");
 
   await page.getByRole("link", { name: /^Sent/ }).click();
   await expect(

--- a/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/compose-and-reply.spec.ts
@@ -6,7 +6,11 @@ import {
   createSecondEmailAccount,
   deleteSecondEmailAccount,
 } from "./account-test-helpers";
-import { conversationWithSubject, openMail } from "./mail-test-helpers";
+import {
+  conversationWithSubject,
+  openMail,
+  readLatestMailMutation,
+} from "./mail-test-helpers";
 
 test("keeps keyboard focus in the composer and follows the message field order", async ({
   page,
@@ -368,6 +372,7 @@ test("does not add a line break for the send shortcut", async ({
     conversations,
     subject,
   );
+  await expect(sentConversation).toBeVisible({ timeout: 20_000 });
   await sentConversation.click();
   const sentBody = page
     .frameLocator('iframe[title="Email content preview"]')
@@ -445,7 +450,7 @@ test("composes, sends, and reads a new message from Sent", async ({
     conversations,
     subject,
   );
-  await expect(sentConversation).toBeVisible();
+  await expect(sentConversation).toBeVisible({ timeout: 20_000 });
   await sentConversation.click();
   await expect(page.getByRole("heading", { name: subject })).toBeVisible();
   await expect(page.getByText("recipient@example.com").first()).toBeVisible();
@@ -455,6 +460,60 @@ test("composes, sends, and reads a new message from Sent", async ({
   await expect(sentMessage.getByText("A composed message body.")).toBeVisible();
   await expect(sentMessage.getByText("Sent with Inbox Zero")).toBeVisible();
   await capturePlaywrightCheckpoint(page, testInfo, "composed-message-in-sent");
+});
+
+test("undoes a composed message before it is delivered", async ({ page }) => {
+  const { conversations, emailAccountId } = await openMail(page);
+  const subject = `Playwright Undo Send ${Date.now()}`;
+
+  await page.getByRole("button", { name: /^Compose/ }).click();
+  const dialog = page.getByRole("dialog", { name: "New Message" });
+  await dialog
+    .getByRole("combobox", { name: "To" })
+    .fill("recipient@example.com");
+  await dialog.getByPlaceholder("Subject").fill(subject);
+  await dialog
+    .locator("[contenteditable='true']")
+    .pressSequentially("This should not be delivered.");
+  await dialog.getByRole("button", { exact: true, name: "Send" }).click();
+
+  await expect(dialog).toBeHidden();
+  const notifications = page.getByRole("region", {
+    name: "Notifications alt+T",
+  });
+  await expect(
+    notifications.getByText("Email sent!", { exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "reply",
+        threadId: "compose:new-message",
+      }),
+    )
+    .toMatchObject({ status: "pending" });
+  await notifications.getByRole("button", { name: /^Undo/ }).click();
+
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByPlaceholder("Subject")).toHaveValue(subject);
+  await expect(
+    dialog.getByRole("textbox", { name: "Email message" }),
+  ).toContainText("This should not be delivered.");
+  await expect
+    .poll(() =>
+      readLatestMailMutation(page, {
+        emailAccountId,
+        kind: "reply",
+        threadId: "compose:new-message",
+      }),
+    )
+    .toBeUndefined();
+
+  await page.getByRole("link", { name: /^Sent/ }).click();
+  await expect(
+    conversationWithSubject(page, conversations, subject),
+  ).toHaveCount(0);
 });
 
 test("selects the sender when composing from all accounts", async ({
@@ -674,7 +733,7 @@ test("opens and sends a reply from the reader with Enter", async ({
       page
         .getByRole("region", { name: "Reply delivery status" })
         .getByText("Reply sent", { exact: true }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20_000 });
     await expect(sentByMe).toHaveCount(initialSentByMeCount + 1);
     await capturePlaywrightCheckpoint(
       page,
@@ -714,10 +773,12 @@ test("opens a sent forward in its provider thread", async ({
     .getByRole("button", { name: "Send", exact: true })
     .click();
 
-  await expect(page).not.toHaveURL(/thread-id=thr_playwright_reply/);
+  await expect(page).not.toHaveURL(/thread-id=thr_playwright_reply/, {
+    timeout: 20_000,
+  });
   await expect(
     page.getByRole("heading", { name: "Fwd: Reply Workflow Message" }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 20_000 });
   await expect(
     page
       .frameLocator('iframe[title="Email content preview"]')

--- a/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
+++ b/apps/web/__tests__/playwright/emulated/mail/mail-test-helpers.ts
@@ -28,6 +28,23 @@ export function conversationWithSubject(
     .filter({ has: page.getByText(subject, { exact: true }) });
 }
 
+export async function waitForComposeOutboxSend(
+  page: Page,
+  emailAccountId: string,
+) {
+  await expect
+    .poll(
+      () =>
+        readLatestMailMutation(page, {
+          emailAccountId,
+          kind: "reply",
+          threadId: "compose:new-message",
+        }),
+      { timeout: 20_000 },
+    )
+    .toMatchObject({ status: "succeeded" });
+}
+
 export async function readLatestMailMutation(
   page: Page,
   expected: {

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -70,7 +70,7 @@ import { ShortcutsProvider } from "@/lib/shortcuts/ShortcutsProvider";
 import { useShortcuts } from "@/lib/shortcuts/useShortcuts";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
-import { sendEmailAction, updateDraftAction } from "@/utils/actions/mail";
+import { updateDraftAction } from "@/utils/actions/mail";
 import { scheduleEmailAction } from "@/utils/actions/scheduled-email";
 import {
   extractEmailAddress,
@@ -79,6 +79,7 @@ import {
   splitRecipientList,
 } from "@/utils/email";
 import type { StoredReplyDraft } from "@/utils/email-cache/database";
+import { getMailMutation } from "@/utils/email-cache/mail-mutations";
 import type {
   ReplyDraftContent,
   ReplyDraftIdentity,
@@ -109,7 +110,8 @@ import {
   getReminderAfterSendTimeChange,
   parseDeliveryTimes,
 } from "./delivery-times";
-import { queueReaderEmail } from "./queued-reply";
+import { queueReaderEmail, waitForReaderEmailSettlement } from "./queued-reply";
+import { beginUndoSend, getUndoSendHoldUntil } from "./undo-send";
 
 export type ReplyingToEmail = {
   threadId?: string;
@@ -138,6 +140,7 @@ type ComposeEmailFormProps = {
   onSuccess?: (messageId: string, threadId: string) => void;
   onMarkDone?: () => void;
   onClose?: () => void;
+  onRestore?: () => void;
   onDiscard?: (draftId?: string) => boolean | Promise<boolean>;
 };
 
@@ -241,6 +244,7 @@ function ComposeEmailFormContent({
   onSuccess,
   onMarkDone,
   onClose,
+  onRestore,
   onDiscard,
   localDraftIdentity,
 }: ComposeEmailFormProps & {
@@ -792,104 +796,117 @@ function ComposeEmailFormContent({
           refetch?.();
           return;
         }
-        const readerThreadId = replyingToEmail?.threadId?.trim();
-        const readerMessageId = isInlineReply
-          ? draftKeyMessageId
-          : replyingToEmail?.messageId;
-        if (readerThreadId) {
-          let outcome: Awaited<ReturnType<typeof queueReaderEmail>>;
-          try {
-            outcome = await queueReaderEmail({
-              email: enrichedData,
-              mutationId: isInlineReply ? requestId : undefined,
-              emailAccountId: selectedEmailAccountId,
-              messageIds: readerMessageId ? [readerMessageId] : [],
-              online: navigator.onLine,
-              threadId: readerThreadId,
-              onQueued: isInlineReply
-                ? async () => {
-                    deliveryAccepted = true;
-                    try {
-                      await clearLocalDraft();
-                    } catch {
-                      toastError({
-                        description:
-                          "Reply queued, but its local draft copy could not be cleared.",
-                      });
-                    }
-                    await mutate([
-                      "thread-deliveries",
-                      selectedEmailAccountId,
-                      readerThreadId,
-                    ]);
-                    onClose?.();
-                  }
-                : undefined,
-            });
-          } catch (error) {
-            console.error(error);
-            const description =
-              error instanceof Error
-                ? error.message
-                : "Could not confirm this reply was queued. Check the thread delivery status before retrying.";
-            setSubmissionError(description);
-            toastError({ description });
-            return;
-          }
-          if (outcome.status === "sent") {
-            deliveryAccepted = true;
-            if (!isInlineReply) toastSuccess({ description: "Email sent!" });
-            if (markDoneAfterSend) onMarkDone?.();
-            onSuccess?.(outcome.messageId, outcome.threadId);
-            refetch?.();
-          } else if (outcome.status === "queued") {
-            deliveryAccepted = true;
-            if (!isInlineReply)
-              toastSuccess({
-                description: getQueuedEmailDescription(outcome.reason),
-              });
-            if (markDoneAfterSend) onMarkDone?.();
-            onClose?.();
-          } else if (outcome.status === "uncertain") {
-            deliveryAccepted = true;
-            if (outcome.ownsNotification) {
-              toastError({
-                description:
-                  "This reply may have sent. Check Sent before retrying.",
-              });
-            }
-            onClose?.();
-          } else if (outcome.ownsNotification) {
-            toastError({ description: outcome.error });
-          }
+        const readerThreadId =
+          replyingToEmail?.threadId?.trim() ||
+          localDraftIdentity?.threadId ||
+          requestId;
+        const readerMessageId =
+          (isInlineReply ? draftKeyMessageId : replyingToEmail?.messageId) ??
+          localDraftIdentity?.messageId ??
+          requestId;
+        const holdUntil = getUndoSendHoldUntil(navigator.onLine);
+        let outcome: Awaited<ReturnType<typeof queueReaderEmail>>;
+        try {
+          outcome = await queueReaderEmail({
+            email: enrichedData,
+            mutationId: requestId,
+            emailAccountId: selectedEmailAccountId,
+            holdUntil,
+            messageIds: [readerMessageId],
+            online: navigator.onLine,
+            threadId: readerThreadId,
+            onQueued: async () => {
+              deliveryAccepted = true;
+              try {
+                await clearLocalDraft();
+              } catch {
+                toastError({
+                  description: isInlineReply
+                    ? "Reply queued, but its local draft copy could not be cleared."
+                    : "Email queued, but its local draft copy could not be cleared.",
+                });
+              }
+              if (replyingToEmail?.threadId?.trim()) {
+                await mutate([
+                  "thread-deliveries",
+                  selectedEmailAccountId,
+                  readerThreadId,
+                ]);
+              }
+              onClose?.();
+            },
+          });
+        } catch (error) {
+          console.error(error);
+          const description =
+            error instanceof Error
+              ? error.message
+              : "Could not confirm this reply was queued. Check the thread delivery status before retrying.";
+          setSubmissionError(description);
+          toastError({ description });
           return;
         }
-
-        const result = await sendEmailAction(
-          selectedEmailAccountId,
-          enrichedData,
-        );
-        if (result?.data) {
-          deliveryAccepted = true;
-          if (localDraftIdentity) {
-            try {
-              await clearLocalDraft();
-            } catch {
-              toastError({
-                description:
-                  "Email sent, but its local draft copy could not be cleared.",
-              });
-            }
-          }
-          toastSuccess({ description: "Email sent!" });
-          if (markDoneAfterSend) onMarkDone?.();
-          onSuccess?.(result.data.messageId ?? "", result.data.threadId ?? "");
-        } else {
-          toastError({
-            description: getActionErrorMessage(result ?? {}, {
-              prefix: "There was an error sending the email",
-            }),
+        if (outcome.status === "held") {
+          const draftIdentity = localDraftIdentity ?? {
+            emailAccountId: selectedEmailAccountId,
+            threadId: outcome.threadId,
+            messageId: readerMessageId,
+          };
+          beginUndoSend({
+            mutationId: outcome.mutationId,
+            emailAccountId: selectedEmailAccountId,
+            identity: draftIdentity,
+            restoreComposer: () => onRestore?.(),
           });
+          waitForReaderEmailSettlement({
+            mutationId: outcome.mutationId,
+            threadId: outcome.threadId,
+          })
+            .then(async (settled) => {
+              if (!(await getMailMutation(outcome.mutationId))) return;
+              if (settled.status === "sent") {
+                if (markDoneAfterSend) onMarkDone?.();
+                onSuccess?.(settled.messageId, settled.threadId);
+                refetch?.();
+                return;
+              }
+              if (settled.status === "failed" && settled.ownsNotification) {
+                toastError({ description: settled.error });
+              } else if (
+                settled.status === "uncertain" &&
+                settled.ownsNotification
+              ) {
+                toastError({
+                  description:
+                    "This reply may have sent. Check Sent before retrying.",
+                });
+              }
+            })
+            .catch(() => {});
+          return;
+        }
+        if (outcome.status === "sent") {
+          if (!isInlineReply) toastSuccess({ description: "Email sent!" });
+          if (markDoneAfterSend) onMarkDone?.();
+          onSuccess?.(outcome.messageId, outcome.threadId);
+          refetch?.();
+        } else if (outcome.status === "queued") {
+          if (!isInlineReply)
+            toastSuccess({
+              description: getQueuedEmailDescription(outcome.reason),
+            });
+          if (markDoneAfterSend) onMarkDone?.();
+          onClose?.();
+        } else if (outcome.status === "uncertain") {
+          if (outcome.ownsNotification) {
+            toastError({
+              description:
+                "This reply may have sent. Check Sent before retrying.",
+            });
+          }
+          onClose?.();
+        } else if (outcome.ownsNotification) {
+          toastError({ description: outcome.error });
         }
       } catch (error) {
         console.error(error);
@@ -919,6 +936,7 @@ function ComposeEmailFormContent({
       flushDraft,
       mutate,
       onClose,
+      onRestore,
       onMarkDone,
       onSuccess,
       preservedBlocks,

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -863,6 +863,7 @@ function ComposeEmailFormContent({
           beginUndoSend({
             mutationId: outcome.mutationId,
             emailAccountId: selectedEmailAccountId,
+            holdUntil: outcome.holdUntil,
             identity: draftIdentity,
             restoreComposer: () => onRestore?.(),
           });

--- a/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/compose/ComposeEmailForm.tsx
@@ -110,8 +110,16 @@ import {
   getReminderAfterSendTimeChange,
   parseDeliveryTimes,
 } from "./delivery-times";
-import { queueReaderEmail, waitForReaderEmailSettlement } from "./queued-reply";
-import { beginUndoSend, getUndoSendHoldUntil } from "./undo-send";
+import {
+  queueReaderEmail,
+  READER_EMAIL_SETTLEMENT_TIMEOUT_MS,
+  waitForReaderEmailSettlement,
+} from "./queued-reply";
+import {
+  beginUndoSend,
+  getUndoSendHoldUntil,
+  UNDO_SEND_DELAY_MS,
+} from "./undo-send";
 
 export type ReplyingToEmail = {
   threadId?: string;
@@ -860,6 +868,8 @@ function ComposeEmailFormContent({
           });
           waitForReaderEmailSettlement({
             mutationId: outcome.mutationId,
+            settlementTimeoutMs:
+              UNDO_SEND_DELAY_MS + READER_EMAIL_SETTLEMENT_TIMEOUT_MS,
             threadId: outcome.threadId,
           })
             .then(async (settled) => {

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
@@ -247,6 +247,7 @@ describe("queueReaderEmail", () => {
         threadId: "thread",
       }),
     ).resolves.toEqual({
+      holdUntil,
       mutationId: "mutation-id",
       status: "held",
       threadId: "thread",

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.test.ts
@@ -232,6 +232,37 @@ describe("queueReaderEmail", () => {
     });
   });
 
+  it("holds an online send so undo can cancel it before delivery", async () => {
+    const holdUntil = Date.now() + 5000;
+    const onQueued = vi.fn();
+
+    await expect(
+      queueReaderEmail({
+        email: createEmail(),
+        emailAccountId: "account",
+        holdUntil,
+        messageIds: ["message"],
+        onQueued,
+        online: true,
+        threadId: "thread",
+      }),
+    ).resolves.toEqual({
+      mutationId: "mutation-id",
+      status: "held",
+      threadId: "thread",
+    });
+    expect(outbox.enqueue).toHaveBeenCalledWith({
+      email: createEmail(),
+      emailAccountId: "account",
+      kind: "reply",
+      messageIds: ["message"],
+      nextAttemptAt: holdUntil,
+      threadId: "thread",
+    });
+    expect(onQueued).toHaveBeenCalledOnce();
+    expect(outbox.get).not.toHaveBeenCalled();
+  });
+
   it("explains when the queued email is waiting for account reconnection", async () => {
     outbox.get.mockResolvedValue(createMutation("blocked_auth"));
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
@@ -15,6 +15,7 @@ export type ReaderEmailOutcome =
       reason: "offline" | "pending" | "blocked_auth";
       threadId: string;
     }
+  | { status: "held"; mutationId: string; threadId: string }
   | { status: "uncertain"; ownsNotification: boolean; threadId: string }
   | { status: "failed"; error: string; ownsNotification: boolean };
 
@@ -25,6 +26,7 @@ export async function queueReaderEmail({
   online,
   onQueued,
   mutationId,
+  holdUntil,
   settlementTimeoutMs = DEFAULT_SETTLEMENT_TIMEOUT_MS,
   threadId,
 }: {
@@ -34,6 +36,7 @@ export async function queueReaderEmail({
   online: boolean;
   onQueued?: () => Promise<void>;
   mutationId?: string;
+  holdUntil?: number;
   settlementTimeoutMs?: number;
   threadId: string;
 }): Promise<ReaderEmailOutcome> {
@@ -42,6 +45,7 @@ export async function queueReaderEmail({
     try {
       mutation = await enqueueMailMutation({
         ...(mutationId ? { id: mutationId } : {}),
+        ...(holdUntil !== undefined ? { nextAttemptAt: holdUntil } : {}),
         email,
         emailAccountId,
         kind: "reply",
@@ -64,6 +68,9 @@ export async function queueReaderEmail({
     );
   }
   await onQueued?.();
+  if (mutation.nextAttemptAt > Date.now()) {
+    return { status: "held", mutationId: mutation.id, threadId };
+  }
   if (!online) return { status: "queued", reason: "offline", threadId };
 
   return waitForSettlement({
@@ -154,6 +161,17 @@ async function waitForSettlement({
       settlementTimeoutMs,
     );
     inspect();
+  });
+}
+
+export function waitForReaderEmailSettlement(options: {
+  mutationId: string;
+  settlementTimeoutMs?: number;
+  threadId: string;
+}) {
+  return waitForSettlement({
+    settlementTimeoutMs: DEFAULT_SETTLEMENT_TIMEOUT_MS,
+    ...options,
   });
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
@@ -6,7 +6,7 @@ import {
   subscribeToMailMutations,
 } from "@/utils/email-cache/mail-mutations";
 
-const DEFAULT_SETTLEMENT_TIMEOUT_MS = 15_000;
+export const READER_EMAIL_SETTLEMENT_TIMEOUT_MS = 15_000;
 
 export type ReaderEmailOutcome =
   | { status: "sent"; messageId: string; threadId: string }
@@ -27,7 +27,7 @@ export async function queueReaderEmail({
   onQueued,
   mutationId,
   holdUntil,
-  settlementTimeoutMs = DEFAULT_SETTLEMENT_TIMEOUT_MS,
+  settlementTimeoutMs = READER_EMAIL_SETTLEMENT_TIMEOUT_MS,
   threadId,
 }: {
   email: SendEmailBody;
@@ -170,7 +170,7 @@ export function waitForReaderEmailSettlement(options: {
   threadId: string;
 }) {
   return waitForSettlement({
-    settlementTimeoutMs: DEFAULT_SETTLEMENT_TIMEOUT_MS,
+    settlementTimeoutMs: READER_EMAIL_SETTLEMENT_TIMEOUT_MS,
     ...options,
   });
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/queued-reply.ts
@@ -15,7 +15,12 @@ export type ReaderEmailOutcome =
       reason: "offline" | "pending" | "blocked_auth";
       threadId: string;
     }
-  | { status: "held"; mutationId: string; threadId: string }
+  | {
+      status: "held";
+      holdUntil: number;
+      mutationId: string;
+      threadId: string;
+    }
   | { status: "uncertain"; ownsNotification: boolean; threadId: string }
   | { status: "failed"; error: string; ownsNotification: boolean };
 
@@ -69,7 +74,12 @@ export async function queueReaderEmail({
   }
   await onQueued?.();
   if (mutation.nextAttemptAt > Date.now()) {
-    return { status: "held", mutationId: mutation.id, threadId };
+    return {
+      status: "held",
+      holdUntil: mutation.nextAttemptAt,
+      mutationId: mutation.id,
+      threadId,
+    };
   }
   if (!online) return { status: "queued", reason: "offline", threadId };
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginUndoSend,
+  getUndoSendHoldUntil,
+  undoPendingSend,
+  UNDO_SEND_DELAY_MS,
+} from "./undo-send";
+
+const restore = vi.hoisted(() => vi.fn());
+const notifications = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  toastError: vi.fn(),
+  toastUndo: vi.fn(),
+}));
+
+vi.mock("@/utils/email-cache/reply-drafts", () => ({
+  restoreReplyFromOutbox: restore,
+}));
+vi.mock("@/components/Toast", () => ({
+  toastError: notifications.toastError,
+  toastUndo: notifications.toastUndo,
+}));
+vi.mock("sonner", () => ({
+  toast: { dismiss: notifications.dismiss },
+}));
+vi.mock("@/lib/shortcuts/registry", () => ({
+  getShortcutHint: () => "z",
+}));
+
+describe("undo send", () => {
+  beforeEach(async () => {
+    restore.mockResolvedValue(undefined);
+    await undoPendingSend();
+    vi.clearAllMocks();
+    restore.mockResolvedValue(undefined);
+  });
+
+  it("holds online sends and skips the delay when offline", () => {
+    expect(getUndoSendHoldUntil(false, 1000)).toBeUndefined();
+    expect(getUndoSendHoldUntil(true, 1000)).toBe(1000 + UNDO_SEND_DELAY_MS);
+  });
+
+  it("restores the composer when undo cancels a held send", async () => {
+    const restoreComposer = vi.fn();
+    beginUndoSend({
+      mutationId: "mutation",
+      emailAccountId: "account",
+      identity: {
+        emailAccountId: "account",
+        threadId: "thread",
+        messageId: "message",
+      },
+      restoreComposer,
+    });
+
+    expect(notifications.toastUndo).toHaveBeenCalledWith({
+      duration: UNDO_SEND_DELAY_MS,
+      message: "Email sent!",
+      onUndo: expect.any(Function),
+      shortcut: "z",
+    });
+    await expect(undoPendingSend()).resolves.toBe(true);
+    expect(restore).toHaveBeenCalledWith("mutation", "account", {
+      emailAccountId: "account",
+      threadId: "thread",
+      messageId: "message",
+    });
+    expect(restoreComposer).toHaveBeenCalledOnce();
+    expect(notifications.dismiss).toHaveBeenCalledWith("undo");
+    await expect(undoPendingSend()).resolves.toBe(false);
+  });
+
+  it("does not restore when the send has already started", async () => {
+    const restoreComposer = vi.fn();
+    restore.mockRejectedValue(new Error("Sending has already started"));
+    beginUndoSend({
+      mutationId: "mutation",
+      emailAccountId: "account",
+      identity: {
+        emailAccountId: "account",
+        threadId: "thread",
+        messageId: "message",
+      },
+      restoreComposer,
+    });
+
+    await expect(undoPendingSend()).resolves.toBe(false);
+    expect(restoreComposer).not.toHaveBeenCalled();
+    expect(notifications.toastError).toHaveBeenCalledWith({
+      description: "Couldn't undo send",
+    });
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./undo-send";
 
 const restore = vi.hoisted(() => vi.fn());
+const cancel = vi.hoisted(() => vi.fn());
 const notifications = vi.hoisted(() => ({
   dismiss: vi.fn(),
   toastError: vi.fn(),
@@ -15,6 +16,9 @@ const notifications = vi.hoisted(() => ({
 
 vi.mock("@/utils/email-cache/reply-drafts", () => ({
   restoreReplyFromOutbox: restore,
+}));
+vi.mock("@/utils/email-cache/mail-mutations", () => ({
+  cancelPendingMailMutation: cancel,
 }));
 vi.mock("@/components/Toast", () => ({
   toastError: notifications.toastError,
@@ -30,9 +34,11 @@ vi.mock("@/lib/shortcuts/registry", () => ({
 describe("undo send", () => {
   beforeEach(async () => {
     restore.mockResolvedValue(undefined);
+    cancel.mockResolvedValue(false);
     await undoPendingSend();
     vi.clearAllMocks();
     restore.mockResolvedValue(undefined);
+    cancel.mockResolvedValue(false);
   });
 
   it("holds online sends and skips the delay when offline", () => {
@@ -42,9 +48,11 @@ describe("undo send", () => {
 
   it("restores the composer when undo cancels a held send", async () => {
     const restoreComposer = vi.fn();
+    const holdUntil = Date.now() + UNDO_SEND_DELAY_MS;
     beginUndoSend({
       mutationId: "mutation",
       emailAccountId: "account",
+      holdUntil,
       identity: {
         emailAccountId: "account",
         threadId: "thread",
@@ -54,11 +62,15 @@ describe("undo send", () => {
     });
 
     expect(notifications.toastUndo).toHaveBeenCalledWith({
-      duration: UNDO_SEND_DELAY_MS,
+      duration: expect.any(Number),
+      id: "undo-send",
       message: "Email sent!",
       onUndo: expect.any(Function),
       shortcut: "z",
     });
+    expect(
+      notifications.toastUndo.mock.calls[0]?.[0].duration,
+    ).toBeLessThanOrEqual(UNDO_SEND_DELAY_MS);
     await expect(undoPendingSend()).resolves.toBe(true);
     expect(restore).toHaveBeenCalledWith("mutation", "account", {
       emailAccountId: "account",
@@ -66,7 +78,7 @@ describe("undo send", () => {
       messageId: "message",
     });
     expect(restoreComposer).toHaveBeenCalledOnce();
-    expect(notifications.dismiss).toHaveBeenCalledWith("undo");
+    expect(notifications.dismiss).toHaveBeenCalledWith("undo-send");
     await expect(undoPendingSend()).resolves.toBe(false);
   });
 
@@ -76,6 +88,7 @@ describe("undo send", () => {
     beginUndoSend({
       mutationId: "mutation",
       emailAccountId: "account",
+      holdUntil: Date.now() + UNDO_SEND_DELAY_MS,
       identity: {
         emailAccountId: "account",
         threadId: "thread",
@@ -85,9 +98,34 @@ describe("undo send", () => {
     });
 
     await expect(undoPendingSend()).resolves.toBe(false);
+    expect(cancel).toHaveBeenCalledWith("mutation");
     expect(restoreComposer).not.toHaveBeenCalled();
     expect(notifications.toastError).toHaveBeenCalledWith({
       description: "Couldn't undo send",
     });
+  });
+
+  it("cancels a held send when a newer draft blocks restore", async () => {
+    const restoreComposer = vi.fn();
+    restore.mockRejectedValue(
+      new Error("Finish or discard the current draft first."),
+    );
+    cancel.mockResolvedValue(true);
+    beginUndoSend({
+      mutationId: "mutation",
+      emailAccountId: "account",
+      holdUntil: Date.now() + UNDO_SEND_DELAY_MS,
+      identity: {
+        emailAccountId: "account",
+        threadId: "thread",
+        messageId: "message",
+      },
+      restoreComposer,
+    });
+
+    await expect(undoPendingSend()).resolves.toBe(true);
+    expect(cancel).toHaveBeenCalledWith("mutation");
+    expect(restoreComposer).not.toHaveBeenCalled();
+    expect(notifications.toastError).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
@@ -44,9 +44,7 @@ export function beginUndoSend({
     message: "Email sent!",
     shortcut: getShortcutHint("undo"),
     duration: UNDO_SEND_DELAY_MS,
-    onUndo: () => {
-      undoPendingSend().catch(() => {});
-    },
+    onUndo: () => undoPendingSend(),
   });
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
@@ -1,0 +1,71 @@
+import { toast } from "sonner";
+import { toastError, toastUndo } from "@/components/Toast";
+import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { restoreReplyFromOutbox } from "@/utils/email-cache/reply-drafts";
+import type { ReplyDraftIdentity } from "@/utils/email-cache/reply-drafts";
+
+export const UNDO_SEND_DELAY_MS = 5000;
+
+type PendingUndoSend = {
+  mutationId: string;
+  emailAccountId: string;
+  identity: ReplyDraftIdentity;
+  restoreComposer: () => void;
+  undone: boolean;
+};
+
+let pending: PendingUndoSend | null = null;
+
+export function getUndoSendHoldUntil(online: boolean, now = Date.now()) {
+  return online ? now + UNDO_SEND_DELAY_MS : undefined;
+}
+
+export function beginUndoSend({
+  mutationId,
+  emailAccountId,
+  identity,
+  restoreComposer,
+}: {
+  mutationId: string;
+  emailAccountId: string;
+  identity: ReplyDraftIdentity;
+  restoreComposer: () => void;
+}) {
+  pending = {
+    mutationId,
+    emailAccountId,
+    identity,
+    restoreComposer,
+    undone: false,
+  };
+  toastUndo({
+    message: "Email sent!",
+    shortcut: getShortcutHint("undo"),
+    duration: UNDO_SEND_DELAY_MS,
+    onUndo: () => {
+      undoPendingSend().catch(() => {});
+    },
+  });
+}
+
+export async function undoPendingSend() {
+  const current = pending;
+  if (!current || current.undone) return false;
+  current.undone = true;
+  try {
+    await restoreReplyFromOutbox(
+      current.mutationId,
+      current.emailAccountId,
+      current.identity,
+    );
+  } catch {
+    current.undone = false;
+    if (pending === current) pending = null;
+    toastError({ description: "Couldn't undo send" });
+    return false;
+  }
+  if (pending === current) pending = null;
+  toast.dismiss("undo");
+  current.restoreComposer();
+  return true;
+}

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
@@ -1,12 +1,14 @@
 import { toast } from "sonner";
 import { toastError, toastUndo } from "@/components/Toast";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
+import { cancelPendingMailMutation } from "@/utils/email-cache/mail-mutations";
 import {
   restoreReplyFromOutbox,
   type ReplyDraftIdentity,
 } from "@/utils/email-cache/reply-drafts";
 
 export const UNDO_SEND_DELAY_MS = 5000;
+const UNDO_SEND_TOAST_ID = "undo-send";
 
 type PendingUndoSend = {
   mutationId: string;
@@ -27,11 +29,13 @@ export function beginUndoSend({
   emailAccountId,
   identity,
   restoreComposer,
+  holdUntil,
 }: {
   mutationId: string;
   emailAccountId: string;
   identity: ReplyDraftIdentity;
   restoreComposer: () => void;
+  holdUntil: number;
 }) {
   pending = {
     mutationId,
@@ -41,9 +45,10 @@ export function beginUndoSend({
     undone: false,
   };
   toastUndo({
+    id: UNDO_SEND_TOAST_ID,
     message: "Email sent!",
     shortcut: getShortcutHint("undo"),
-    duration: UNDO_SEND_DELAY_MS,
+    duration: Math.max(0, holdUntil - Date.now()),
     onUndo: () => undoPendingSend(),
   });
 }
@@ -59,13 +64,18 @@ export async function undoPendingSend() {
       current.identity,
     );
   } catch {
-    current.undone = false;
+    if (!(await cancelPendingMailMutation(current.mutationId))) {
+      current.undone = false;
+      if (pending === current) pending = null;
+      toastError({ description: "Couldn't undo send" });
+      return false;
+    }
     if (pending === current) pending = null;
-    toastError({ description: "Couldn't undo send" });
-    return false;
+    toast.dismiss(UNDO_SEND_TOAST_ID);
+    return true;
   }
   if (pending === current) pending = null;
-  toast.dismiss("undo");
+  toast.dismiss(UNDO_SEND_TOAST_ID);
   current.restoreComposer();
   return true;
 }

--- a/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
+++ b/apps/web/app/(app)/[emailAccountId]/compose/undo-send.ts
@@ -1,8 +1,10 @@
 import { toast } from "sonner";
 import { toastError, toastUndo } from "@/components/Toast";
 import { getShortcutHint } from "@/lib/shortcuts/registry";
-import { restoreReplyFromOutbox } from "@/utils/email-cache/reply-drafts";
-import type { ReplyDraftIdentity } from "@/utils/email-cache/reply-drafts";
+import {
+  restoreReplyFromOutbox,
+  type ReplyDraftIdentity,
+} from "@/utils/email-cache/reply-drafts";
 
 export const UNDO_SEND_DELAY_MS = 5000;
 

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -93,7 +93,7 @@ import {
 } from "@/utils/email/provider-types";
 import { useEmail } from "@/providers/EmailProvider";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
-import { undoPendingSend } from "@/app/(app)/[emailAccountId]/compose/undo-send";
+import { undoLatestToast } from "@/components/Toast";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useLabelCounts } from "@/hooks/useLabelCounts";
 import { useSplitLabels } from "@/hooks/useLabels";
@@ -1114,7 +1114,7 @@ export function MailShell() {
           ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
           : undefined,
       undo: async () => {
-        if (await undoPendingSend()) return;
+        if (await undoLatestToast()) return;
         await undo();
       },
       toggleLayout: isAllAccounts ? undefined : toggleLayout,

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailShell.tsx
@@ -93,6 +93,7 @@ import {
 } from "@/utils/email/provider-types";
 import { useEmail } from "@/providers/EmailProvider";
 import { useComposeModal } from "@/providers/ComposeModalProvider";
+import { undoPendingSend } from "@/app/(app)/[emailAccountId]/compose/undo-send";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useLabelCounts } from "@/hooks/useLabelCounts";
 import { useSplitLabels } from "@/hooks/useLabels";
@@ -1112,7 +1113,10 @@ export function MailShell() {
         isReaderTarget && openExternalUrl
           ? () => window.open(openExternalUrl, "_blank", "noopener,noreferrer")
           : undefined,
-      undo: () => undo(),
+      undo: async () => {
+        if (await undoPendingSend()) return;
+        await undo();
+      },
       toggleLayout: isAllAccounts ? undefined : toggleLayout,
       togglePreview,
       help: () => setIsHelpOpen(true),

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -36,15 +36,26 @@ export function toastInfo(options: {
   });
 }
 
+type ToastUndoHandler = () => void | Promise<void>;
+
+let latestToastUndo: ToastUndoHandler | null = null;
+
 export function toastUndo(options: {
   message: string;
   shortcut?: string;
   duration?: number;
-  onUndo: () => void;
+  onUndo: ToastUndoHandler;
 }) {
+  const onUndo = options.onUndo;
+  latestToastUndo = onUndo;
+  const release = () => {
+    if (latestToastUndo === onUndo) latestToastUndo = null;
+  };
   return toast.success(options.message, {
     id: "undo",
     duration: options.duration,
+    onAutoClose: release,
+    onDismiss: release,
     action: {
       label: (
         <>
@@ -54,9 +65,18 @@ export function toastUndo(options: {
           )}
         </>
       ),
-      onClick: options.onUndo,
+      onClick: onUndo,
     },
   });
+}
+
+export async function undoLatestToast() {
+  const onUndo = latestToastUndo;
+  if (!onUndo) return false;
+  latestToastUndo = null;
+  toast.dismiss("undo");
+  await onUndo();
+  return true;
 }
 
 export function Toaster() {

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -39,10 +39,12 @@ export function toastInfo(options: {
 export function toastUndo(options: {
   message: string;
   shortcut?: string;
+  duration?: number;
   onUndo: () => void;
 }) {
   return toast.success(options.message, {
     id: "undo",
+    duration: options.duration,
     action: {
       label: (
         <>

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -38,21 +38,23 @@ export function toastInfo(options: {
 
 type ToastUndoHandler = () => void | Promise<void>;
 
-let latestToastUndo: ToastUndoHandler | null = null;
+let latestToastUndo: { id: string; onUndo: ToastUndoHandler } | null = null;
 
 export function toastUndo(options: {
+  id?: string;
   message: string;
   shortcut?: string;
   duration?: number;
   onUndo: ToastUndoHandler;
 }) {
+  const id = options.id ?? "undo";
   const onUndo = options.onUndo;
-  latestToastUndo = onUndo;
+  latestToastUndo = { id, onUndo };
   const release = () => {
-    if (latestToastUndo === onUndo) latestToastUndo = null;
+    if (latestToastUndo?.onUndo === onUndo) latestToastUndo = null;
   };
   return toast.success(options.message, {
-    id: "undo",
+    id,
     duration: options.duration,
     onAutoClose: release,
     onDismiss: release,
@@ -71,11 +73,11 @@ export function toastUndo(options: {
 }
 
 export async function undoLatestToast() {
-  const onUndo = latestToastUndo;
-  if (!onUndo) return false;
+  const current = latestToastUndo;
+  if (!current) return false;
   latestToastUndo = null;
-  toast.dismiss("undo");
-  await onUndo();
+  toast.dismiss(current.id);
+  await current.onUndo();
   return true;
 }
 

--- a/apps/web/components/Toast.undo.test.ts
+++ b/apps/web/components/Toast.undo.test.ts
@@ -31,6 +31,14 @@ describe("toast undo", () => {
     await expect(undoLatestToast()).resolves.toBe(false);
   });
 
+  it("dismisses the matching toast id", async () => {
+    const onUndo = vi.fn();
+    toastUndo({ id: "undo-send", message: "Email sent!", onUndo });
+    await expect(undoLatestToast()).resolves.toBe(true);
+    expect(sonner.dismiss).toHaveBeenCalledWith("undo-send");
+    expect(onUndo).toHaveBeenCalledOnce();
+  });
+
   it("stops handling keyboard undo after the toast expires", async () => {
     const onUndo = vi.fn();
     toastUndo({ duration: 5000, message: "Email sent!", onUndo });

--- a/apps/web/components/Toast.undo.test.ts
+++ b/apps/web/components/Toast.undo.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toastUndo, undoLatestToast } from "./Toast";
+
+const sonner = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: sonner,
+}));
+
+describe("toast undo", () => {
+  beforeEach(async () => {
+    await undoLatestToast();
+    vi.clearAllMocks();
+  });
+
+  it("runs the latest undo toast from the keyboard", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    toastUndo({ message: "Email sent!", onUndo: first });
+    toastUndo({ message: "Archived", onUndo: second });
+
+    await expect(undoLatestToast()).resolves.toBe(true);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(sonner.dismiss).toHaveBeenCalledWith("undo");
+    await expect(undoLatestToast()).resolves.toBe(false);
+  });
+
+  it("stops handling keyboard undo after the toast expires", async () => {
+    const onUndo = vi.fn();
+    toastUndo({ duration: 5000, message: "Email sent!", onUndo });
+    const toastOptions = sonner.success.mock.calls[0]?.[1] as {
+      onAutoClose?: () => void;
+    };
+    toastOptions.onAutoClose?.();
+
+    await expect(undoLatestToast()).resolves.toBe(false);
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -104,6 +104,7 @@ export function EmailMessage({
   const onCloseCompose = useCallback(() => {
     setComposeOverride("closed");
   }, []);
+  const undoSendSessionRef = useRef<ComposeSession | null>(null);
 
   const onStartDiscard = useCallback((): ComposeSession | undefined => {
     if (!composeMode) return;
@@ -120,6 +121,19 @@ export function EmailMessage({
     composeSessionRef.current += 1;
     setComposeOverride(composeSession.mode);
   }, []);
+  const onCloseComposeAfterSend = useCallback(() => {
+    if (composeMode) {
+      undoSendSessionRef.current = {
+        id: composeSessionRef.current,
+        mode: composeMode,
+      };
+    }
+    onCloseCompose();
+  }, [composeMode, onCloseCompose]);
+  const onRestoreComposeAfterSend = useCallback(() => {
+    const session = undoSendSessionRef.current;
+    if (session) onRestoreCompose(session);
+  }, [onRestoreCompose]);
 
   const toggleDetails = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -225,7 +239,8 @@ export function EmailMessage({
               defaultComposeMode={defaultComposeMode}
               draftMessage={draftMessage}
               message={message}
-              onCloseCompose={onCloseCompose}
+              onCloseCompose={onCloseComposeAfterSend}
+              onRestore={onRestoreComposeAfterSend}
               onRestoreCompose={onRestoreCompose}
               onSendSuccess={onSendSuccess}
               onMarkDone={onMarkDone}
@@ -466,6 +481,7 @@ function ReplyPanel({
   onSendSuccess,
   onMarkDone,
   onCloseCompose,
+  onRestore,
   onRestoreCompose,
   onStartDiscard,
   defaultComposeMode,
@@ -477,6 +493,7 @@ function ReplyPanel({
   onSendSuccess: (messageId: string, threadId: string) => void;
   onMarkDone?: () => void;
   onCloseCompose: () => void;
+  onRestore?: () => void;
   onRestoreCompose: (composeSession: ComposeSession) => void;
   onStartDiscard: () => ComposeSession | undefined;
   defaultComposeMode?: ReplyDraftMode;
@@ -567,6 +584,7 @@ function ReplyPanel({
         draftMode={composeMode}
         draftSessionId={getReplyDraftSessionId(message.id, composeMode)}
         onClose={onCloseCompose}
+        onRestore={onRestore}
         onDiscard={onDiscard}
         onMarkDone={onMarkDone}
         onSuccess={(messageId: string, threadId: string) => {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -104,6 +104,7 @@ export function EmailMessage({
   const onCloseCompose = useCallback(() => {
     setComposeOverride("closed");
   }, []);
+  const [composerKey, setComposerKey] = useState(0);
   const undoSendSessionRef = useRef<ComposeSession | null>(null);
 
   const onStartDiscard = useCallback((): ComposeSession | undefined => {
@@ -132,8 +133,11 @@ export function EmailMessage({
   }, [composeMode, onCloseCompose]);
   const onRestoreComposeAfterSend = useCallback(() => {
     const session = undoSendSessionRef.current;
-    if (session) onRestoreCompose(session);
-  }, [onRestoreCompose]);
+    if (!session) return;
+    composeSessionRef.current += 1;
+    setComposerKey((key) => key + 1);
+    setComposeOverride(session.mode);
+  }, []);
 
   const toggleDetails = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -236,6 +240,7 @@ export function EmailMessage({
 
           {composeMode && (
             <ReplyPanel
+              key={composerKey}
               defaultComposeMode={defaultComposeMode}
               draftMessage={draftMessage}
               message={message}

--- a/apps/web/components/email-list/ThreadDeliveryStatus.tsx
+++ b/apps/web/components/email-list/ThreadDeliveryStatus.tsx
@@ -224,7 +224,11 @@ export function ThreadDeliveryStatus({
               </a>
             )}
             {canEditReply &&
-              !(online && row.status === "pending") &&
+              !(
+                online &&
+                row.status === "pending" &&
+                row.nextAttemptAt <= Date.now()
+              ) &&
               ["pending", "retry_wait", "blocked_auth", "failed"].includes(
                 row.status,
               ) && (

--- a/apps/web/providers/ComposeModalProvider.tsx
+++ b/apps/web/providers/ComposeModalProvider.tsx
@@ -30,6 +30,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [isExpanded, setIsExpanded] = useState(false);
+  const [composerKey, setComposerKey] = useState(0);
   const isAllAccountsMailView =
     pathname.endsWith("/mail") && searchParams.get("accountScope") === "all";
   const { data: accountsData } = useAccounts(isAllAccountsMailView);
@@ -127,6 +128,7 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
               )}
             >
               <ComposeEmailFormLazy
+                key={composerKey}
                 draftSessionId="compose:new-message"
                 fromAccounts={accountsData?.emailAccounts}
                 layout="window"
@@ -134,6 +136,10 @@ export function ComposeModalProvider(props: { children: React.ReactNode }) {
                 onDiscard={() => {
                   closeCompose();
                   return true;
+                }}
+                onRestore={() => {
+                  setComposerKey((key) => key + 1);
+                  openCompose();
                 }}
                 onSuccess={closeCompose}
               />

--- a/apps/web/utils/email-cache/mail-mutations.test.ts
+++ b/apps/web/utils/email-cache/mail-mutations.test.ts
@@ -1120,6 +1120,28 @@ describe("mail mutation outbox", () => {
     await expect(getMailMutation("blocked")).resolves.toBeUndefined();
   });
 
+  it("does not claim a send until its undo hold elapses", async () => {
+    await enqueueMailMutation(
+      {
+        id: "reply",
+        emailAccountId: "account",
+        threadId: "thread",
+        messageIds: ["message"],
+        kind: "reply",
+        email: { to: "to@example.com", subject: "Hi", messageHtml: "Hi" },
+        nextAttemptAt: 50,
+      },
+      10,
+    );
+
+    await expect(
+      claimNextMailMutation({ ownerId: "worker", leaseMs: 100, now: 40 }),
+    ).resolves.toBeUndefined();
+    await expect(getNextMailMutationWakeAt()).resolves.toBe(50);
+    await expect(cancelPendingMailMutation("reply")).resolves.toBe(true);
+    await expect(getMailMutation("reply")).resolves.toBeUndefined();
+  });
+
   it("reports the earliest retry wake time", async () => {
     for (const [id, now] of [
       ["later", 200],

--- a/apps/web/utils/email-cache/mail-mutations.ts
+++ b/apps/web/utils/email-cache/mail-mutations.ts
@@ -29,6 +29,7 @@ export type EnqueueMailMutationInput = MailMutationPayload & {
   emailAccountId: string;
   threadId: string;
   messageIds: string[];
+  nextAttemptAt?: number;
 };
 
 export type MailMutationSyncGroup = {
@@ -798,7 +799,7 @@ async function enqueueInStore(
         messageIds: [...new Set(input.messageIds)],
         payload: getStoredPayload(input),
         status: "pending",
-        nextAttemptAt: now,
+        nextAttemptAt: input.nextAttemptAt ?? now,
         updatedAt: now,
         lastError: undefined,
       };
@@ -819,7 +820,7 @@ async function enqueueInStore(
     status: "pending",
     attempts: 0,
     syncAttempts: 0,
-    nextAttemptAt: now,
+    nextAttemptAt: input.nextAttemptAt ?? now,
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/web/utils/email-cache/reply-drafts.test.ts
+++ b/apps/web/utils/email-cache/reply-drafts.test.ts
@@ -262,6 +262,37 @@ describe("local reply drafts", () => {
       )?.content,
     ).toMatchObject({ composeMode: "forward" });
   });
+  it("restores a new compose draft into the provided identity", async () => {
+    const composeIdentity = {
+      emailAccountId: "account",
+      threadId: "compose:new-message",
+      messageId: "compose:new-message",
+    };
+    const queued = await enqueueMailMutation({
+      ...composeIdentity,
+      messageIds: [composeIdentity.messageId],
+      kind: "reply",
+      email: {
+        to: "person@example.com",
+        subject: "Hello",
+        messageHtml: "<p>New message</p>",
+      },
+    });
+
+    const restored = await restoreReplyFromOutbox(
+      queued.id,
+      composeIdentity.emailAccountId,
+      composeIdentity,
+    );
+
+    expect(restored).toEqual({
+      messageId: composeIdentity.messageId,
+      mode: "forward",
+    });
+    expect(
+      (await getReplyDraft(composeIdentity))?.content?.draft.editableHtml,
+    ).toContain("New message");
+  });
   it("does not restore a reply already claimed for sending", async () => {
     const queued = await enqueueMailMutation({
       ...identity,

--- a/apps/web/utils/email-cache/reply-drafts.ts
+++ b/apps/web/utils/email-cache/reply-drafts.ts
@@ -289,6 +289,7 @@ function notifyReplyDraftChange(scope: ReplyDraftScope) {
 export async function restoreReplyFromOutbox(
   id: string,
   emailAccountId: string,
+  identityOverride?: ReplyDraftIdentity,
 ) {
   const epoch = captureEmailCacheEpoch(emailAccountId);
   const database = await getEmailCacheDatabase();
@@ -319,9 +320,9 @@ export async function restoreReplyFromOutbox(
     })),
   };
   const originalMessageId = row.messageIds[0];
-  if (!originalMessageId)
+  if (!identityOverride && !originalMessageId)
     throw new Error("The reply's original message is unavailable.");
-  const identity = {
+  const identity = identityOverride ?? {
     emailAccountId: row.emailAccountId,
     threadId: row.threadId,
     messageId: getReplyDraftSessionId(originalMessageId, composeMode),
@@ -366,5 +367,9 @@ export async function restoreReplyFromOutbox(
   for (const listener of listeners) listener(identity);
   channel?.postMessage(identity);
   notifyMailMutationChange();
-  return { messageId: originalMessageId, mode: composeMode };
+  return {
+    messageId:
+      identityOverride?.messageId ?? originalMessageId ?? identity.messageId,
+    mode: composeMode,
+  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hold outgoing mail in the local outbox for five seconds after Send so it can still be cancelled.

- Queue compose and replies through the durable outbox with a short `nextAttemptAt` hold while online
- Show an Email sent toast with Undo (`z`) and restore the draft if send is cancelled before delivery
- Keep send undo on its own toast so archiving during the hold does not hide it; keyboard `z` still follows the latest toast
- Remount the reply composer after restore, and cancel a held send if a newer draft blocks restore
- Leave scheduled send-later mail and offline queuing on their current paths

Validation: unit tests for outbox, queued-reply, undo-send, toast-undo, and reply-drafts. Playwright: compose undo-before-delivery and send-to-Sent.

![Composer restored after undo send](https://cursor.com/artifacts/c/art-ba2721a5-80e2-497b-bf9a-ca37d0734862)
![Composed message in Sent after the undo hold](https://cursor.com/artifacts/c/art-d1db4802-c2f2-40ba-9959-ee937eda6935)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e6d0012-162d-45f8-81d0-323ac6978c52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e6d0012-162d-45f8-81d0-323ac6978c52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a five-second Undo option after sending emails.
  - Undo restores the message to the composer and prevents delivery when used in time.
  - Pending messages awaiting delivery can be edited before sending.
  - Keyboard Undo now prioritizes the latest send notification.
  - Improved visibility for messages waiting to retry.

- **Bug Fixes**
  - Improved delivery tracking, send-status updates, and composer restoration reliability.
  - Resolved issues affecting message visibility and navigation after sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->