### PR TITLE
desktop: Open mailboxes in multiple windows

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -18,6 +18,12 @@ INBOX_ZERO_APP_URL=http://localhost:3000 pnpm --filter @inboxzero/desktop dev
 
 Sign-in uses the system browser and returns through `inboxzero://`. The web app's `DESKTOP_AUTH_ORIGIN` defaults to this scheme.
 
+## Multiple windows
+
+File → New Window (⌘N / Ctrl+N) opens another mailbox window. ⌘-click or Ctrl-click an account in the switcher to open that inbox in its own window. Each window keeps its own account and size; they are restored on the next launch.
+
+Clicking a new-mail notification focuses a window already showing that account, or opens one if needed.
+
 ## Mail badge and notifications
 
 The macOS Dock badge shows the combined unread inbox count across connected accounts, refreshed about once a minute and on focus. Linux uses the supported launcher badge; Windows does not currently display a numeric badge.

--- a/apps/desktop/src/application-menu.test.ts
+++ b/apps/desktop/src/application-menu.test.ts
@@ -25,7 +25,11 @@ describe("desktop application menu", () => {
 
   it("lets Windows users check for updates and view the installed version", () => {
     const checkForUpdates = vi.fn();
-    configureDesktopApplicationMenu(checkForUpdates, "win32");
+    configureDesktopApplicationMenu({
+      checkForUpdates,
+      createWindow: vi.fn(),
+      platform: "win32",
+    });
 
     const template = Menu.buildFromTemplate.mock.results[0].value;
     expect(Menu.setApplicationMenu).toHaveBeenCalledWith(template);
@@ -43,5 +47,22 @@ describe("desktop application menu", () => {
       applicationVersion: "0.2.0",
     });
     expect(app.showAboutPanel).toHaveBeenCalledOnce();
+  });
+
+  it("adds New Window to the File menu", () => {
+    const createWindow = vi.fn();
+    configureDesktopApplicationMenu({
+      checkForUpdates: vi.fn(),
+      createWindow,
+      platform: "darwin",
+    });
+
+    const template = Menu.buildFromTemplate.mock.results[0].value;
+    const file = template.find((item) => item.label === "File");
+    const submenu = file?.submenu as MenuItemConstructorOptions[];
+    const newWindow = submenu.find((item) => item.label === "New Window");
+    expect(newWindow?.accelerator).toBe("CommandOrControl+N");
+    newWindow?.click?.({} as never, {} as never, {} as never);
+    expect(createWindow).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/application-menu.ts
+++ b/apps/desktop/src/application-menu.ts
@@ -2,10 +2,15 @@ import { app, Menu, type MenuItemConstructorOptions } from "electron";
 
 const PRODUCT_NAME = "Inbox Zero";
 
-export function configureDesktopApplicationMenu(
-  checkForUpdates: () => void,
+export function configureDesktopApplicationMenu({
+  checkForUpdates,
+  createWindow,
   platform = process.platform,
-) {
+}: {
+  checkForUpdates: () => void;
+  createWindow: () => void;
+  platform?: NodeJS.Platform;
+}) {
   app.setAboutPanelOptions({
     applicationName: PRODUCT_NAME,
     applicationVersion: app.getVersion(),
@@ -36,7 +41,20 @@ export function configureDesktopApplicationMenu(
           } satisfies MenuItemConstructorOptions,
         ]
       : []),
-    { role: "fileMenu" },
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "New Window",
+          accelerator: "CommandOrControl+N",
+          click: createWindow,
+        },
+        { role: "close" },
+        ...(platform === "darwin"
+          ? []
+          : [{ type: "separator" as const }, { role: "quit" as const }]),
+      ],
+    },
     { role: "editMenu" },
     { role: "viewMenu" },
     { role: "windowMenu" },

--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -7,6 +7,7 @@ import {
   getDesktopLoginUrl,
   DESKTOP_WINDOW_DRAG_CSS,
   getDesktopPostAuthUrl,
+  getDesktopMailAccountId,
   getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
   getDesktopWindowDragCss,
@@ -203,6 +204,17 @@ describe("desktop shell helpers", () => {
     ).toBeNull();
     expect(getDesktopSessionRestoreUrl(origin, null)).toBeNull();
     expect(getDesktopSessionRestoreUrl(origin, 42)).toBeNull();
+  });
+
+  it("reads a mail account id only from same-origin mailbox URLs", () => {
+    const origin = "https://www.getinboxzero.com";
+    expect(
+      getDesktopMailAccountId(`${origin}/account-1/mail?type=inbox`, origin),
+    ).toBe("account-1");
+    expect(getDesktopMailAccountId(`${origin}/mail`, origin)).toBeNull();
+    expect(
+      getDesktopMailAccountId("https://evil.test/account-1/mail", origin),
+    ).toBeNull();
   });
 
   it("scopes window dragging to a titlebar strip instead of the whole page", () => {

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -191,8 +191,24 @@ export function getDesktopSessionRestoreUrl(
   return parsed.toString();
 }
 
-function isDesktopMailPath(pathname: string): boolean {
-  return pathname === "/mail" || /^\/[^/]+\/mail\/?$/u.test(pathname);
+const MAIL_ACCOUNT_PATH = /^\/([^/]+)\/mail\/?$/u;
+
+export function isDesktopMailPath(pathname: string): boolean {
+  return pathname === "/mail" || MAIL_ACCOUNT_PATH.test(pathname);
+}
+
+export function getDesktopMailAccountId(
+  url: string,
+  appOrigin: string,
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== appOrigin) return null;
+  return MAIL_ACCOUNT_PATH.exec(parsed.pathname)?.[1] ?? null;
 }
 
 const DESKTOP_WINDOW_BACKGROUND = "#ffffff";

--- a/apps/desktop/src/desktop.ts
+++ b/apps/desktop/src/desktop.ts
@@ -193,7 +193,7 @@ export function getDesktopSessionRestoreUrl(
 
 const MAIL_ACCOUNT_PATH = /^\/([^/]+)\/mail\/?$/u;
 
-export function isDesktopMailPath(pathname: string): boolean {
+function isDesktopMailPath(pathname: string): boolean {
   return pathname === "/mail" || MAIL_ACCOUNT_PATH.test(pathname);
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import {
   getDesktopHomeUrl,
   getDesktopMailAccountId,
   getDesktopPostAuthUrl,
+  getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
   getDesktopWindowDragCss,
   isAllowedDesktopNavigation,
@@ -37,24 +38,17 @@ import {
   isDesktopAuthProvider,
   normalizeDesktopCallbackPath,
   parseDesktopAuthCallback,
-  shouldPersistDesktopUrl,
 } from "./desktop";
 import { createMailNotificationTracker } from "./mail-notifications";
 import {
-  collectDesktopWindowStates,
   DEFAULT_DESKTOP_WINDOW_HEIGHT,
   DEFAULT_DESKTOP_WINDOW_WIDTH,
   type DesktopWindowBounds,
-  type DesktopWindowState,
   fitWindowBoundsToWorkArea,
-  getDesktopUnreadBadgeCount,
-  getLegacyDesktopWindowStates,
-  getRestoredDesktopWindows,
+  MAX_DESKTOP_WINDOWS,
   MIN_DESKTOP_WINDOW_HEIGHT,
   MIN_DESKTOP_WINDOW_WIDTH,
-  offsetWindowBounds,
   parseDesktopWindowStates,
-  shouldReuseSoleHiddenWindow,
 } from "./windows";
 
 const PARTITION = "persist:inbox-zero";
@@ -62,7 +56,7 @@ const PENDING_CALLBACK_PATH_FILE = "pending-auth-callback-path";
 const LAST_APP_URL_FILE = "last-app-url";
 const WINDOWS_STATE_FILE = "windows.json";
 
-const windows = new Set<BrowserWindow>();
+const windows: BrowserWindow[] = [];
 const lastUrlByWindow = new WeakMap<BrowserWindow, string>();
 const unreadByContents = new Map<number, number>();
 let lastFocused: BrowserWindow | null = null;
@@ -91,12 +85,17 @@ function startDesktopApp() {
     if (typeof count !== "number" || !Number.isSafeInteger(count) || count < 0)
       return;
     unreadByContents.set(event.sender.id, count);
-    applyUnreadBadge();
+    setUnreadBadge(Math.max(0, ...unreadByContents.values()));
   });
   ipcMain.on("desktop:new-mail", (event, payload: unknown) => {
     if (!isTrustedDesktopEvent(event)) return;
     const mail = trackNewMail(payload);
-    if (!mail || isAnyWindowFocused() || !Notification.isSupported()) return;
+    if (
+      !mail ||
+      windows.some((window) => window.isFocused()) ||
+      !Notification.isSupported()
+    )
+      return;
     const notification = new Notification({
       title: "Inbox Zero",
       body:
@@ -159,10 +158,7 @@ function startDesktopApp() {
   ipcMain.handle(
     "desktop-auth:start",
     async (event, provider: unknown, options: unknown) => {
-      if (!isTrustedDesktopEvent(event)) {
-        throw new Error("Unsupported sign-in provider");
-      }
-      if (!isDesktopAuthProvider(provider)) {
+      if (!isTrustedDesktopEvent(event) || !isDesktopAuthProvider(provider)) {
         throw new Error("Unsupported sign-in provider");
       }
       const callbackPath = getStartAuthCallbackPath(options);
@@ -188,9 +184,7 @@ function startDesktopApp() {
           isQuitting = true;
         }).catch(logDesktopUpdateError);
       },
-      createWindow: () => {
-        createAppWindow();
-      },
+      createWindow: () => createAppWindow(),
     });
     // Overlap TLS/socket setup with window creation and page load.
     session
@@ -218,17 +212,8 @@ function startDesktopApp() {
 }
 
 function restoreAppWindows() {
-  const restored = getRestoredDesktopWindows(
-    readStoredWindowStates(),
-    appOrigin,
-  );
-  if (restored.length === 0) {
-    createAppWindow();
-    return;
-  }
-  for (const state of restored) {
-    createAppWindow(state);
-  }
+  for (const state of readStoredWindowStates()) createAppWindow(state);
+  if (windows.length === 0) createAppWindow();
 }
 
 function createAppWindow(options?: {
@@ -236,13 +221,11 @@ function createAppWindow(options?: {
   bounds?: DesktopWindowBounds;
   isMaximized?: boolean;
 }) {
-  if (shouldReuseSoleHiddenWindow(windows.size, visibleWindowCount())) {
-    const existing = [...windows][0];
-    if (existing) {
-      if (options?.url) existing.loadURL(options.url).catch(() => {});
-      showWindow(existing);
-      return existing;
-    }
+  const existing = windows[0];
+  if (windows.length === 1 && existing && !existing.isVisible()) {
+    if (options?.url) existing.loadURL(options.url).catch(() => {});
+    showWindow(existing);
+    return existing;
   }
 
   const startUrl = options?.url ?? homeUrl;
@@ -265,7 +248,7 @@ function createAppWindow(options?: {
     },
   });
 
-  windows.add(window);
+  windows.push(window);
   lastFocused = window;
   rememberWindowUrl(window, startUrl);
   if (options?.isMaximized) window.maximize();
@@ -283,24 +266,28 @@ function createAppWindow(options?: {
   // Keep the last window alive on macOS so reopening from the dock is instant
   // instead of a cold page load. Extra windows close for real.
   window.on("close", (event) => {
-    if (process.platform === "darwin" && !isQuitting && windows.size <= 1) {
+    if (process.platform === "darwin" && !isQuitting && windows.length <= 1) {
       event.preventDefault();
       window.hide();
     }
   });
   window.on("closed", () => {
-    windows.delete(window);
+    const index = windows.indexOf(window);
+    if (index !== -1) windows.splice(index, 1);
     unreadByContents.delete(window.webContents.id);
     applyUnreadBadge();
-    if (lastFocused === window) {
-      lastFocused = [...windows][windows.size - 1] ?? null;
-    }
+    if (lastFocused === window) lastFocused = windows.at(-1) ?? null;
     persistWindowsNow();
   });
 
   applyNavigationPolicy(window.webContents);
   applyDesktopWindowDragRegion(window.webContents);
-  trackWindowUrl(window);
+  window.webContents.on("did-navigate", (_event, url) => {
+    rememberWindowUrl(window, url);
+  });
+  window.webContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+    if (isMainFrame) rememberWindowUrl(window, url);
+  });
   installDesktopLoadRecovery(
     window.webContents,
     appOrigin,
@@ -314,28 +301,18 @@ function resolveWindowBounds(
   stored?: DesktopWindowBounds,
 ): DesktopWindowBounds | undefined {
   if (stored) {
-    return fitWindowBoundsToWorkArea(stored, workAreaFor(stored));
+    return fitWindowBoundsToWorkArea(
+      stored,
+      screen.getDisplayMatching(stored).workArea,
+    );
   }
   const source = lastFocused && !lastFocused.isDestroyed() ? lastFocused : null;
   if (!source) return;
+  const bounds = source.getNormalBounds();
   return fitWindowBoundsToWorkArea(
-    offsetWindowBounds(source.getNormalBounds()),
-    workAreaFor(source.getBounds()),
+    { ...bounds, x: bounds.x + 28, y: bounds.y + 28 },
+    screen.getDisplayMatching(source.getBounds()).workArea,
   );
-}
-
-function workAreaFor(bounds: DesktopWindowBounds): DesktopWindowBounds {
-  return screen.getDisplayMatching(bounds).workArea;
-}
-
-function trackWindowUrl(window: BrowserWindow) {
-  const contents = window.webContents;
-  contents.on("did-navigate", (_event, url) => {
-    rememberWindowUrl(window, url);
-  });
-  contents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
-    if (isMainFrame) rememberWindowUrl(window, url);
-  });
 }
 
 function rememberWindowUrl(window: BrowserWindow, url: string) {
@@ -346,20 +323,20 @@ function rememberWindowUrl(window: BrowserWindow, url: string) {
     schedulePersistWindows();
     return;
   }
-  if (shouldPersistDesktopUrl(url, appOrigin)) {
+  if (getDesktopSessionRestoreUrl(appOrigin, url)) {
     lastUrlByWindow.set(window, url);
     schedulePersistWindows();
   }
 }
 
-function readStoredWindowStates(): DesktopWindowState[] {
+function readStoredWindowStates() {
   try {
-    const parsed: unknown = JSON.parse(
-      fs.readFileSync(getWindowsStateFile(), "utf8"),
+    return parseDesktopWindowStates(
+      JSON.parse(fs.readFileSync(userDataFile(WINDOWS_STATE_FILE), "utf8")),
+      appOrigin,
     );
-    return parseDesktopWindowStates(parsed, appOrigin);
   } catch {
-    return getLegacyDesktopWindowStates(readLastAppUrl(), appOrigin);
+    return parseDesktopWindowStates([{ url: readLastAppUrl() }], appOrigin);
   }
 }
 
@@ -371,8 +348,8 @@ function schedulePersistWindows() {
 function persistWindowsNow() {
   clearTimeout(persistWindowsTimer);
   persistWindowsTimer = undefined;
-  const states = collectDesktopWindowStates(
-    [...windows].flatMap((window) => {
+  const states = windows
+    .flatMap((window) => {
       if (window.isDestroyed()) return [];
       const url = lastUrlByWindow.get(window);
       if (!url) return [];
@@ -383,12 +360,15 @@ function persistWindowsNow() {
           isMaximized: window.isMaximized(),
         },
       ];
-    }),
-    appOrigin,
-  );
+    })
+    .slice(0, MAX_DESKTOP_WINDOWS);
   try {
-    fs.writeFileSync(getWindowsStateFile(), JSON.stringify(states), "utf8");
-    fs.rmSync(getLastAppUrlFile(), { force: true });
+    fs.writeFileSync(
+      userDataFile(WINDOWS_STATE_FILE),
+      JSON.stringify(states),
+      "utf8",
+    );
+    fs.rmSync(userDataFile(LAST_APP_URL_FILE), { force: true });
   } catch {
     // Restoring windows is best-effort; never break navigation over it.
   }
@@ -396,14 +376,14 @@ function persistWindowsNow() {
 
 function isTrustedDesktopEvent(event: IpcMainEvent | IpcMainInvokeEvent) {
   return (
-    [...windows].some((window) => event.sender === window.webContents) &&
+    windows.some((window) => event.sender === window.webContents) &&
     event.senderFrame === event.sender.mainFrame &&
     event.senderFrame.origin === appOrigin
   );
 }
 
 function applyUnreadBadge() {
-  setUnreadBadge(getDesktopUnreadBadgeCount(unreadByContents.values()));
+  setUnreadBadge(Math.max(0, ...unreadByContents.values()));
 }
 
 function setUnreadBadge(count: number) {
@@ -421,18 +401,14 @@ function clearMailIndicators() {
 
 function readLastAppUrl(): string | null {
   try {
-    return fs.readFileSync(getLastAppUrlFile(), "utf8");
+    return fs.readFileSync(userDataFile(LAST_APP_URL_FILE), "utf8");
   } catch {
     return null;
   }
 }
 
-function getWindowsStateFile() {
-  return path.join(app.getPath("userData"), WINDOWS_STATE_FILE);
-}
-
-function getLastAppUrlFile() {
-  return path.join(app.getPath("userData"), LAST_APP_URL_FILE);
+function userDataFile(name: string) {
+  return path.join(app.getPath("userData"), name);
 }
 
 function applyDesktopWindowDragRegion(contents: WebContents) {
@@ -465,7 +441,9 @@ function guardNavigation(event: { preventDefault: () => void }, url: string) {
 
 function openAppWindow(url: string) {
   const accountId = getDesktopMailAccountId(url, appOrigin);
-  const existing = accountId ? findWindowForAccount(accountId) : undefined;
+  const existing = accountId
+    ? windows.find((window) => windowAccountId(window) === accountId)
+    : undefined;
   if (existing) {
     showWindow(existing);
     return existing;
@@ -473,44 +451,25 @@ function openAppWindow(url: string) {
   return createAppWindow({ url });
 }
 
-function findWindowForAccount(accountId: string): BrowserWindow | undefined {
-  const isMatch = (window: BrowserWindow) =>
-    getDesktopMailAccountId(windowUrl(window), appOrigin) === accountId;
-  if (lastFocused && !lastFocused.isDestroyed() && isMatch(lastFocused)) {
-    return lastFocused;
-  }
-  return [...windows].find((window) => isMatch(window));
-}
-
-function windowUrl(window: BrowserWindow) {
-  return lastUrlByWindow.get(window) ?? window.webContents.getURL();
+function windowAccountId(window: BrowserWindow) {
+  return getDesktopMailAccountId(
+    lastUrlByWindow.get(window) ?? window.webContents.getURL(),
+    appOrigin,
+  );
 }
 
 function focusAppWindow(): BrowserWindow {
-  if (lastFocused && !lastFocused.isDestroyed()) {
-    showWindow(lastFocused);
-    return lastFocused;
-  }
-  const existing = [...windows][0];
-  if (existing) {
-    showWindow(existing);
-    return existing;
-  }
-  return createAppWindow();
+  const window =
+    (lastFocused && !lastFocused.isDestroyed() ? lastFocused : windows[0]) ??
+    createAppWindow();
+  showWindow(window);
+  return window;
 }
 
 function showWindow(window: BrowserWindow) {
   if (window.isMinimized()) window.restore();
   window.show();
   window.focus();
-}
-
-function visibleWindowCount() {
-  return [...windows].filter((window) => window.isVisible()).length;
-}
-
-function isAnyWindowFocused() {
-  return [...windows].some((window) => window.isFocused());
 }
 
 async function handleAuthCallbackUrl(url: string) {
@@ -580,7 +539,7 @@ function consumePendingCallbackPath(): string | null {
 }
 
 function getPendingCallbackPathFile() {
-  return path.join(app.getPath("userData"), PENDING_CALLBACK_PATH_FILE);
+  return userDataFile(PENDING_CALLBACK_PATH_FILE);
 }
 
 function getStartAuthCallbackPath(options: unknown): string | null {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -7,11 +7,13 @@ import {
   ipcMain,
   nativeTheme,
   Notification,
+  screen,
   session,
   shell,
   type Session,
   type WebContents,
   type IpcMainEvent,
+  type IpcMainInvokeEvent,
 } from "electron";
 import { installDesktopLoadRecovery } from "./load-recovery";
 import { configureDesktopApplicationMenu } from "./application-menu";
@@ -26,8 +28,8 @@ import {
   getDesktopAppOrigin,
   getDesktopBrowserStartUrl,
   getDesktopHomeUrl,
+  getDesktopMailAccountId,
   getDesktopPostAuthUrl,
-  getDesktopSessionRestoreUrl,
   getDesktopWindowChrome,
   getDesktopWindowDragCss,
   isAllowedDesktopNavigation,
@@ -38,12 +40,33 @@ import {
   shouldPersistDesktopUrl,
 } from "./desktop";
 import { createMailNotificationTracker } from "./mail-notifications";
+import {
+  collectDesktopWindowStates,
+  DEFAULT_DESKTOP_WINDOW_HEIGHT,
+  DEFAULT_DESKTOP_WINDOW_WIDTH,
+  type DesktopWindowBounds,
+  type DesktopWindowState,
+  fitWindowBoundsToWorkArea,
+  getDesktopUnreadBadgeCount,
+  getLegacyDesktopWindowStates,
+  getRestoredDesktopWindows,
+  MIN_DESKTOP_WINDOW_HEIGHT,
+  MIN_DESKTOP_WINDOW_WIDTH,
+  offsetWindowBounds,
+  parseDesktopWindowStates,
+  shouldReuseSoleHiddenWindow,
+} from "./windows";
 
 const PARTITION = "persist:inbox-zero";
 const PENDING_CALLBACK_PATH_FILE = "pending-auth-callback-path";
 const LAST_APP_URL_FILE = "last-app-url";
+const WINDOWS_STATE_FILE = "windows.json";
 
-let mainWindow: BrowserWindow | null = null;
+const windows = new Set<BrowserWindow>();
+const lastUrlByWindow = new WeakMap<BrowserWindow, string>();
+const unreadByContents = new Map<number, number>();
+let lastFocused: BrowserWindow | null = null;
+let persistWindowsTimer: ReturnType<typeof setTimeout> | undefined;
 let pendingAuthUrl: string | null = null;
 let pendingCallbackPath: string | null = null;
 let isQuitting = false;
@@ -64,15 +87,16 @@ function startDesktopApp() {
   app.setAppUserModelId("com.getinboxzero.desktop");
 
   ipcMain.on("desktop:unread-count", (event, count: unknown) => {
-    if (!isTrustedMailEvent(event)) return;
+    if (!isTrustedDesktopEvent(event)) return;
     if (typeof count !== "number" || !Number.isSafeInteger(count) || count < 0)
       return;
-    setUnreadBadge(count);
+    unreadByContents.set(event.sender.id, count);
+    applyUnreadBadge();
   });
   ipcMain.on("desktop:new-mail", (event, payload: unknown) => {
-    if (!isTrustedMailEvent(event)) return;
+    if (!isTrustedDesktopEvent(event)) return;
     const mail = trackNewMail(payload);
-    if (!mail || mainWindow?.isFocused() || !Notification.isSupported()) return;
+    if (!mail || isAnyWindowFocused() || !Notification.isSupported()) return;
     const notification = new Notification({
       title: "Inbox Zero",
       body:
@@ -83,10 +107,9 @@ function startDesktopApp() {
     mailNotifications.get(mail.emailAccountId)?.close();
     mailNotifications.set(mail.emailAccountId, notification);
     notification.on("click", () => {
-      focusMainWindow();
-      mainWindow
-        ?.loadURL(new URL(`/${mail.emailAccountId}/mail`, appOrigin).toString())
-        .catch(() => {});
+      openAppWindow(
+        new URL(`/${mail.emailAccountId}/mail`, appOrigin).toString(),
+      );
     });
     const release = () => {
       if (mailNotifications.get(mail.emailAccountId) === notification) {
@@ -97,13 +120,21 @@ function startDesktopApp() {
     notification.on("failed", release);
     notification.show();
   });
+  ipcMain.handle("desktop:open-window", (event, path: unknown) => {
+    if (!isTrustedDesktopEvent(event)) return;
+    const callbackPath = normalizeDesktopCallbackPath(path);
+    if (!callbackPath) return;
+    const url = new URL(callbackPath, appOrigin).toString();
+    if (!isAllowedDesktopNavigation(url, appOrigin)) return;
+    openAppWindow(url);
+  });
 
   app.on("second-instance", (_event, argv) => {
     const protocolUrl = findDesktopProtocolUrl(argv);
     if (protocolUrl) {
       handleAuthCallbackUrl(protocolUrl).catch(showSignInError);
     }
-    focusMainWindow();
+    focusAppWindow();
   });
 
   if (process.defaultApp) {
@@ -127,7 +158,10 @@ function startDesktopApp() {
 
   ipcMain.handle(
     "desktop-auth:start",
-    async (_event, provider: unknown, options: unknown) => {
+    async (event, provider: unknown, options: unknown) => {
+      if (!isTrustedDesktopEvent(event)) {
+        throw new Error("Unsupported sign-in provider");
+      }
       if (!isDesktopAuthProvider(provider)) {
         throw new Error("Unsupported sign-in provider");
       }
@@ -144,19 +178,25 @@ function startDesktopApp() {
 
   app.on("before-quit", () => {
     isQuitting = true;
+    persistWindowsNow();
   });
 
   app.whenReady().then(async () => {
-    configureDesktopApplicationMenu(() => {
-      checkForDesktopUpdatesManually(() => {
-        isQuitting = true;
-      }).catch(logDesktopUpdateError);
+    configureDesktopApplicationMenu({
+      checkForUpdates: () => {
+        checkForDesktopUpdatesManually(() => {
+          isQuitting = true;
+        }).catch(logDesktopUpdateError);
+      },
+      createWindow: () => {
+        createAppWindow();
+      },
     });
     // Overlap TLS/socket setup with window creation and page load.
     session
       .fromPartition(PARTITION)
       .preconnect({ url: appOrigin, numSockets: 2 });
-    createMainWindow();
+    restoreAppWindows();
     const startupAuthUrl =
       pendingAuthUrl ?? findDesktopProtocolUrl(process.argv);
     pendingAuthUrl = null;
@@ -173,16 +213,46 @@ function startDesktopApp() {
   });
 
   app.on("activate", () => {
-    focusMainWindow();
+    focusAppWindow();
   });
 }
 
-function createMainWindow() {
-  mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 840,
-    minWidth: 900,
-    minHeight: 640,
+function restoreAppWindows() {
+  const restored = getRestoredDesktopWindows(
+    readStoredWindowStates(),
+    appOrigin,
+  );
+  if (restored.length === 0) {
+    createAppWindow();
+    return;
+  }
+  for (const state of restored) {
+    createAppWindow(state);
+  }
+}
+
+function createAppWindow(options?: {
+  url?: string;
+  bounds?: DesktopWindowBounds;
+  isMaximized?: boolean;
+}) {
+  if (shouldReuseSoleHiddenWindow(windows.size, visibleWindowCount())) {
+    const existing = [...windows][0];
+    if (existing) {
+      if (options?.url) existing.loadURL(options.url).catch(() => {});
+      showWindow(existing);
+      return existing;
+    }
+  }
+
+  const startUrl = options?.url ?? homeUrl;
+  const bounds = resolveWindowBounds(options?.bounds);
+  const window = new BrowserWindow({
+    width: bounds?.width ?? DEFAULT_DESKTOP_WINDOW_WIDTH,
+    height: bounds?.height ?? DEFAULT_DESKTOP_WINDOW_HEIGHT,
+    ...(bounds ? { x: bounds.x, y: bounds.y } : {}),
+    minWidth: MIN_DESKTOP_WINDOW_WIDTH,
+    minHeight: MIN_DESKTOP_WINDOW_HEIGHT,
     title: "Inbox Zero",
     ...getDesktopWindowChrome(),
     webPreferences: {
@@ -195,70 +265,145 @@ function createMainWindow() {
     },
   });
 
-  mainWindow.on("page-title-updated", (event) => {
+  windows.add(window);
+  lastFocused = window;
+  rememberWindowUrl(window, startUrl);
+  if (options?.isMaximized) window.maximize();
+
+  window.on("page-title-updated", (event) => {
     event.preventDefault();
   });
-  // Keep the window (and the loaded app) alive on macOS so reopening from the
-  // dock is instant instead of a cold page load.
-  mainWindow.on("close", (event) => {
-    if (process.platform === "darwin" && !isQuitting) {
+  window.on("focus", () => {
+    lastFocused = window;
+  });
+  window.on("moved", schedulePersistWindows);
+  window.on("resized", schedulePersistWindows);
+  window.on("maximize", schedulePersistWindows);
+  window.on("unmaximize", schedulePersistWindows);
+  // Keep the last window alive on macOS so reopening from the dock is instant
+  // instead of a cold page load. Extra windows close for real.
+  window.on("close", (event) => {
+    if (process.platform === "darwin" && !isQuitting && windows.size <= 1) {
       event.preventDefault();
-      mainWindow?.hide();
+      window.hide();
     }
   });
-  mainWindow.on("closed", () => {
-    mainWindow = null;
+  window.on("closed", () => {
+    windows.delete(window);
+    unreadByContents.delete(window.webContents.id);
+    applyUnreadBadge();
+    if (lastFocused === window) {
+      lastFocused = [...windows][windows.size - 1] ?? null;
+    }
+    persistWindowsNow();
   });
 
-  applyNavigationPolicy(mainWindow.webContents);
-  applyDesktopWindowDragRegion(mainWindow.webContents);
-  trackLastAppUrl(mainWindow.webContents);
-  installDesktopLoadRecovery(mainWindow.webContents, appOrigin, getStartUrl);
-  mainWindow.loadURL(getStartUrl()).catch(() => {});
+  applyNavigationPolicy(window.webContents);
+  applyDesktopWindowDragRegion(window.webContents);
+  trackWindowUrl(window);
+  installDesktopLoadRecovery(
+    window.webContents,
+    appOrigin,
+    () => lastUrlByWindow.get(window) ?? startUrl,
+  );
+  window.loadURL(startUrl).catch(() => {});
+  return window;
 }
 
-function getStartUrl(): string {
-  return getDesktopSessionRestoreUrl(appOrigin, readLastAppUrl()) ?? homeUrl;
+function resolveWindowBounds(
+  stored?: DesktopWindowBounds,
+): DesktopWindowBounds | undefined {
+  if (stored) {
+    return fitWindowBoundsToWorkArea(stored, workAreaFor(stored));
+  }
+  const source = lastFocused && !lastFocused.isDestroyed() ? lastFocused : null;
+  if (!source) return;
+  return fitWindowBoundsToWorkArea(
+    offsetWindowBounds(source.getNormalBounds()),
+    workAreaFor(source.getBounds()),
+  );
 }
 
-function trackLastAppUrl(contents: WebContents) {
-  contents.on("did-start-navigation", ({ isSameDocument, isMainFrame }) => {
-    if (isMainFrame && !isSameDocument) clearMailIndicators();
-  });
+function workAreaFor(bounds: DesktopWindowBounds): DesktopWindowBounds {
+  return screen.getDisplayMatching(bounds).workArea;
+}
+
+function trackWindowUrl(window: BrowserWindow) {
+  const contents = window.webContents;
   contents.on("did-navigate", (_event, url) => {
-    persistLastAppUrl(url);
+    rememberWindowUrl(window, url);
   });
   contents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
-    if (isMainFrame) {
-      persistLastAppUrl(url);
-    }
+    if (isMainFrame) rememberWindowUrl(window, url);
   });
 }
 
-function persistLastAppUrl(url: string) {
-  // Local load recovery must not erase the last mailbox to restore.
+function rememberWindowUrl(window: BrowserWindow, url: string) {
   if (url.startsWith("data:") || url === "about:blank") return;
-  if (URL.parse(url)?.pathname === "/login") clearMailIndicators();
-  const file = path.join(app.getPath("userData"), LAST_APP_URL_FILE);
-  try {
-    if (shouldPersistDesktopUrl(url, appOrigin)) {
-      fs.writeFileSync(file, url, "utf8");
-    } else {
-      // Landing on /login means the session ended; a stale deep link would
-      // just bounce back there after re-auth.
-      fs.rmSync(file, { force: true });
-    }
-  } catch {
-    // Restoring the last page is best-effort; never break navigation over it.
+  if (URL.parse(url)?.pathname === "/login") {
+    lastUrlByWindow.delete(window);
+    clearMailIndicators();
+    schedulePersistWindows();
+    return;
+  }
+  if (shouldPersistDesktopUrl(url, appOrigin)) {
+    lastUrlByWindow.set(window, url);
+    schedulePersistWindows();
   }
 }
 
-function isTrustedMailEvent(event: IpcMainEvent) {
+function readStoredWindowStates(): DesktopWindowState[] {
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(getWindowsStateFile(), "utf8"),
+    );
+    return parseDesktopWindowStates(parsed, appOrigin);
+  } catch {
+    return getLegacyDesktopWindowStates(readLastAppUrl(), appOrigin);
+  }
+}
+
+function schedulePersistWindows() {
+  clearTimeout(persistWindowsTimer);
+  persistWindowsTimer = setTimeout(persistWindowsNow, 200);
+}
+
+function persistWindowsNow() {
+  clearTimeout(persistWindowsTimer);
+  persistWindowsTimer = undefined;
+  const states = collectDesktopWindowStates(
+    [...windows].flatMap((window) => {
+      if (window.isDestroyed()) return [];
+      const url = lastUrlByWindow.get(window);
+      if (!url) return [];
+      return [
+        {
+          url,
+          bounds: window.getNormalBounds(),
+          isMaximized: window.isMaximized(),
+        },
+      ];
+    }),
+    appOrigin,
+  );
+  try {
+    fs.writeFileSync(getWindowsStateFile(), JSON.stringify(states), "utf8");
+    fs.rmSync(getLastAppUrlFile(), { force: true });
+  } catch {
+    // Restoring windows is best-effort; never break navigation over it.
+  }
+}
+
+function isTrustedDesktopEvent(event: IpcMainEvent | IpcMainInvokeEvent) {
   return (
-    event.sender === mainWindow?.webContents &&
+    [...windows].some((window) => event.sender === window.webContents) &&
     event.senderFrame === event.sender.mainFrame &&
     event.senderFrame.origin === appOrigin
   );
+}
+
+function applyUnreadBadge() {
+  setUnreadBadge(getDesktopUnreadBadgeCount(unreadByContents.values()));
 }
 
 function setUnreadBadge(count: number) {
@@ -268,20 +413,26 @@ function setUnreadBadge(count: number) {
 }
 
 function clearMailIndicators() {
-  setUnreadBadge(0);
+  unreadByContents.clear();
+  applyUnreadBadge();
   for (const notification of mailNotifications.values()) notification.close();
   mailNotifications.clear();
 }
 
 function readLastAppUrl(): string | null {
   try {
-    return fs.readFileSync(
-      path.join(app.getPath("userData"), LAST_APP_URL_FILE),
-      "utf8",
-    );
+    return fs.readFileSync(getLastAppUrlFile(), "utf8");
   } catch {
     return null;
   }
+}
+
+function getWindowsStateFile() {
+  return path.join(app.getPath("userData"), WINDOWS_STATE_FILE);
+}
+
+function getLastAppUrlFile() {
+  return path.join(app.getPath("userData"), LAST_APP_URL_FILE);
 }
 
 function applyDesktopWindowDragRegion(contents: WebContents) {
@@ -295,7 +446,7 @@ function applyDesktopWindowDragRegion(contents: WebContents) {
 function applyNavigationPolicy(contents: WebContents) {
   contents.setWindowOpenHandler(({ url }) => {
     if (isAllowedDesktopNavigation(url, appOrigin)) {
-      contents.loadURL(url).catch(() => {});
+      openAppWindow(url);
     } else {
       openExternal(url).catch(showSignInError);
     }
@@ -312,28 +463,63 @@ function guardNavigation(event: { preventDefault: () => void }, url: string) {
   openExternal(url).catch(showSignInError);
 }
 
-function focusMainWindow() {
-  if (!mainWindow) {
-    createMainWindow();
-    return;
+function openAppWindow(url: string) {
+  const accountId = getDesktopMailAccountId(url, appOrigin);
+  const existing = accountId ? findWindowForAccount(accountId) : undefined;
+  if (existing) {
+    showWindow(existing);
+    return existing;
   }
-  if (mainWindow.isMinimized()) {
-    mainWindow.restore();
+  return createAppWindow({ url });
+}
+
+function findWindowForAccount(accountId: string): BrowserWindow | undefined {
+  const isMatch = (window: BrowserWindow) =>
+    getDesktopMailAccountId(windowUrl(window), appOrigin) === accountId;
+  if (lastFocused && !lastFocused.isDestroyed() && isMatch(lastFocused)) {
+    return lastFocused;
   }
-  mainWindow.show();
-  mainWindow.focus();
+  return [...windows].find((window) => isMatch(window));
+}
+
+function windowUrl(window: BrowserWindow) {
+  return lastUrlByWindow.get(window) ?? window.webContents.getURL();
+}
+
+function focusAppWindow(): BrowserWindow {
+  if (lastFocused && !lastFocused.isDestroyed()) {
+    showWindow(lastFocused);
+    return lastFocused;
+  }
+  const existing = [...windows][0];
+  if (existing) {
+    showWindow(existing);
+    return existing;
+  }
+  return createAppWindow();
+}
+
+function showWindow(window: BrowserWindow) {
+  if (window.isMinimized()) window.restore();
+  window.show();
+  window.focus();
+}
+
+function visibleWindowCount() {
+  return [...windows].filter((window) => window.isVisible()).length;
+}
+
+function isAnyWindowFocused() {
+  return [...windows].some((window) => window.isFocused());
 }
 
 async function handleAuthCallbackUrl(url: string) {
-  focusMainWindow();
+  const window = focusAppWindow();
   const callback = parseDesktopAuthCallback(url);
   if (!callback.ok) {
     dialog.showErrorBox("Sign in failed", callback.error);
     return;
   }
-
-  const window = mainWindow;
-  if (!window) return;
 
   try {
     await exchangeAuthCode(

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld("inboxZeroDesktop", {
     ipcRenderer.send("desktop:unread-count", count),
   notifyNewMail: (payload: unknown) =>
     ipcRenderer.send("desktop:new-mail", payload),
+  openWindow: (path: string) => ipcRenderer.invoke("desktop:open-window", path),
   startAuth: (provider: string, options?: { callbackPath?: string }) =>
     ipcRenderer.invoke("desktop-auth:start", provider, options),
 });

--- a/apps/desktop/src/windows.test.ts
+++ b/apps/desktop/src/windows.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  collectDesktopWindowStates,
   fitWindowBoundsToWorkArea,
-  getDesktopUnreadBadgeCount,
-  getLegacyDesktopWindowStates,
-  getRestoredDesktopWindows,
   MAX_DESKTOP_WINDOWS,
-  offsetWindowBounds,
   parseDesktopWindowStates,
-  shouldReuseSoleHiddenWindow,
 } from "./windows";
 
 const origin = "https://www.getinboxzero.com";
@@ -25,75 +19,37 @@ const mailWindow = {
 };
 
 describe("desktop window state", () => {
-  it("keeps valid mail windows and drops malformed or foreign URLs", () => {
+  it("keeps restorable mail windows and drops everything else", () => {
     expect(
       parseDesktopWindowStates(
         [
           mailWindow,
-          { url: `${origin}/login`, bounds: mailBounds, isMaximized: false },
+          { url: `${origin}/login`, bounds: mailBounds },
+          { url: `${origin}/account-1/automation`, bounds: mailBounds },
           { url: "https://evil.test/account-1/mail", bounds: mailBounds },
           {
             url: `${origin}/account-2/mail`,
             bounds: { x: 40, y: 40, width: 100, height: 80 },
           },
+          { url: `${origin}/account-3/mail` },
           null,
         ],
         origin,
       ),
-    ).toEqual([mailWindow]);
+    ).toEqual([
+      mailWindow,
+      { url: `${origin}/account-3/mail`, isMaximized: false },
+    ]);
   });
 
-  it("caps restored windows and sends utility pages back through a fresh launch", () => {
+  it("caps how many windows are restored", () => {
     const extras = Array.from({ length: MAX_DESKTOP_WINDOWS }, (_, index) => ({
       url: `${origin}/account-${index + 1}/mail`,
       bounds: mailBounds,
-      isMaximized: false,
     }));
     expect(
       parseDesktopWindowStates([...extras, mailWindow], origin),
     ).toHaveLength(MAX_DESKTOP_WINDOWS);
-    expect(
-      getRestoredDesktopWindows(
-        [
-          mailWindow,
-          {
-            url: `${origin}/account-1/automation`,
-            bounds: mailBounds,
-            isMaximized: true,
-          },
-        ],
-        origin,
-      ),
-    ).toEqual([mailWindow]);
-  });
-
-  it("migrates a single last mail URL and ignores a leftover login page", () => {
-    expect(
-      getLegacyDesktopWindowStates(`${origin}/account-1/mail`, origin),
-    ).toEqual([
-      {
-        url: `${origin}/account-1/mail`,
-        bounds: { x: 0, y: 0, width: 1280, height: 840 },
-        isMaximized: false,
-      },
-    ]);
-    expect(getLegacyDesktopWindowStates(`${origin}/login`, origin)).toEqual([]);
-  });
-
-  it("only persists in-app pages that can be restored later", () => {
-    expect(
-      collectDesktopWindowStates(
-        [
-          mailWindow,
-          {
-            url: `${origin}/login`,
-            bounds: mailBounds,
-            isMaximized: false,
-          },
-        ],
-        origin,
-      ),
-    ).toEqual([mailWindow]);
   });
 });
 
@@ -112,27 +68,5 @@ describe("desktop window placement", () => {
         workArea,
       ),
     ).toEqual({ x: 80, y: 55, width: 1280, height: 840 });
-  });
-
-  it("offsets a new window from the focused one", () => {
-    expect(offsetWindowBounds(mailBounds)).toEqual({
-      x: 148,
-      y: 108,
-      width: 1280,
-      height: 840,
-    });
-  });
-});
-
-describe("desktop window targeting", () => {
-  it("uses the highest unread report so a closing window cannot zero the badge", () => {
-    expect(getDesktopUnreadBadgeCount([0, 4, 2])).toBe(4);
-    expect(getDesktopUnreadBadgeCount([])).toBe(0);
-  });
-
-  it("reuses the hidden Mac window instead of stacking a second copy", () => {
-    expect(shouldReuseSoleHiddenWindow(1, 0)).toBe(true);
-    expect(shouldReuseSoleHiddenWindow(1, 1)).toBe(false);
-    expect(shouldReuseSoleHiddenWindow(2, 1)).toBe(false);
   });
 });

--- a/apps/desktop/src/windows.test.ts
+++ b/apps/desktop/src/windows.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectDesktopWindowStates,
+  fitWindowBoundsToWorkArea,
+  getDesktopUnreadBadgeCount,
+  getLegacyDesktopWindowStates,
+  getRestoredDesktopWindows,
+  MAX_DESKTOP_WINDOWS,
+  offsetWindowBounds,
+  parseDesktopWindowStates,
+  shouldReuseSoleHiddenWindow,
+} from "./windows";
+
+const origin = "https://www.getinboxzero.com";
+const mailBounds = {
+  x: 120,
+  y: 80,
+  width: 1280,
+  height: 840,
+};
+const mailWindow = {
+  url: `${origin}/account-1/mail?type=inbox`,
+  bounds: mailBounds,
+  isMaximized: false,
+};
+
+describe("desktop window state", () => {
+  it("keeps valid mail windows and drops malformed or foreign URLs", () => {
+    expect(
+      parseDesktopWindowStates(
+        [
+          mailWindow,
+          { url: `${origin}/login`, bounds: mailBounds, isMaximized: false },
+          { url: "https://evil.test/account-1/mail", bounds: mailBounds },
+          {
+            url: `${origin}/account-2/mail`,
+            bounds: { x: 40, y: 40, width: 100, height: 80 },
+          },
+          null,
+        ],
+        origin,
+      ),
+    ).toEqual([mailWindow]);
+  });
+
+  it("caps restored windows and sends utility pages back through a fresh launch", () => {
+    const extras = Array.from({ length: MAX_DESKTOP_WINDOWS }, (_, index) => ({
+      url: `${origin}/account-${index + 1}/mail`,
+      bounds: mailBounds,
+      isMaximized: false,
+    }));
+    expect(
+      parseDesktopWindowStates([...extras, mailWindow], origin),
+    ).toHaveLength(MAX_DESKTOP_WINDOWS);
+    expect(
+      getRestoredDesktopWindows(
+        [
+          mailWindow,
+          {
+            url: `${origin}/account-1/automation`,
+            bounds: mailBounds,
+            isMaximized: true,
+          },
+        ],
+        origin,
+      ),
+    ).toEqual([mailWindow]);
+  });
+
+  it("migrates a single last mail URL and ignores a leftover login page", () => {
+    expect(
+      getLegacyDesktopWindowStates(`${origin}/account-1/mail`, origin),
+    ).toEqual([
+      {
+        url: `${origin}/account-1/mail`,
+        bounds: { x: 0, y: 0, width: 1280, height: 840 },
+        isMaximized: false,
+      },
+    ]);
+    expect(getLegacyDesktopWindowStates(`${origin}/login`, origin)).toEqual([]);
+  });
+
+  it("only persists in-app pages that can be restored later", () => {
+    expect(
+      collectDesktopWindowStates(
+        [
+          mailWindow,
+          {
+            url: `${origin}/login`,
+            bounds: mailBounds,
+            isMaximized: false,
+          },
+        ],
+        origin,
+      ),
+    ).toEqual([mailWindow]);
+  });
+});
+
+describe("desktop window placement", () => {
+  it("clamps overlapping windows onto the display and recenters off-screen ones", () => {
+    const workArea = { x: 0, y: 25, width: 1440, height: 900 };
+    expect(
+      fitWindowBoundsToWorkArea(
+        { x: -80, y: 40, width: 1280, height: 840 },
+        workArea,
+      ),
+    ).toEqual({ x: 0, y: 40, width: 1280, height: 840 });
+    expect(
+      fitWindowBoundsToWorkArea(
+        { x: 8000, y: 8000, width: 1280, height: 840 },
+        workArea,
+      ),
+    ).toEqual({ x: 80, y: 55, width: 1280, height: 840 });
+  });
+
+  it("offsets a new window from the focused one", () => {
+    expect(offsetWindowBounds(mailBounds)).toEqual({
+      x: 148,
+      y: 108,
+      width: 1280,
+      height: 840,
+    });
+  });
+});
+
+describe("desktop window targeting", () => {
+  it("uses the highest unread report so a closing window cannot zero the badge", () => {
+    expect(getDesktopUnreadBadgeCount([0, 4, 2])).toBe(4);
+    expect(getDesktopUnreadBadgeCount([])).toBe(0);
+  });
+
+  it("reuses the hidden Mac window instead of stacking a second copy", () => {
+    expect(shouldReuseSoleHiddenWindow(1, 0)).toBe(true);
+    expect(shouldReuseSoleHiddenWindow(1, 1)).toBe(false);
+    expect(shouldReuseSoleHiddenWindow(2, 1)).toBe(false);
+  });
+});

--- a/apps/desktop/src/windows.ts
+++ b/apps/desktop/src/windows.ts
@@ -1,0 +1,195 @@
+import {
+  getDesktopSessionRestoreUrl,
+  shouldPersistDesktopUrl,
+} from "./desktop";
+
+export const DEFAULT_DESKTOP_WINDOW_WIDTH = 1280;
+export const DEFAULT_DESKTOP_WINDOW_HEIGHT = 840;
+export const MIN_DESKTOP_WINDOW_WIDTH = 900;
+export const MIN_DESKTOP_WINDOW_HEIGHT = 640;
+export const MAX_DESKTOP_WINDOWS = 8;
+export const NEW_WINDOW_OFFSET = 28;
+
+export type DesktopWindowBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type DesktopWindowState = {
+  url: string;
+  bounds: DesktopWindowBounds;
+  isMaximized: boolean;
+};
+
+export function parseDesktopWindowStates(
+  raw: unknown,
+  appOrigin: string,
+): DesktopWindowState[] {
+  if (!Array.isArray(raw)) return [];
+
+  const states: DesktopWindowState[] = [];
+  for (const item of raw) {
+    if (states.length >= MAX_DESKTOP_WINDOWS) break;
+    const state = parseDesktopWindowState(item, appOrigin);
+    if (state) states.push(state);
+  }
+  return states;
+}
+
+export function getRestoredDesktopWindows(
+  states: readonly DesktopWindowState[],
+  appOrigin: string,
+): DesktopWindowState[] {
+  const restored: DesktopWindowState[] = [];
+  for (const state of states) {
+    if (restored.length >= MAX_DESKTOP_WINDOWS) break;
+    const url = getDesktopSessionRestoreUrl(appOrigin, state.url);
+    if (url) restored.push({ ...state, url });
+  }
+  return restored;
+}
+
+export function getLegacyDesktopWindowStates(
+  lastAppUrl: string | null,
+  appOrigin: string,
+): DesktopWindowState[] {
+  const url = getDesktopSessionRestoreUrl(appOrigin, lastAppUrl);
+  if (!url) return [];
+  return [
+    {
+      url,
+      bounds: {
+        x: 0,
+        y: 0,
+        width: DEFAULT_DESKTOP_WINDOW_WIDTH,
+        height: DEFAULT_DESKTOP_WINDOW_HEIGHT,
+      },
+      isMaximized: false,
+    },
+  ];
+}
+
+export function collectDesktopWindowStates(
+  windows: readonly DesktopWindowState[],
+  appOrigin: string,
+): DesktopWindowState[] {
+  return windows
+    .filter((window) => shouldPersistDesktopUrl(window.url, appOrigin))
+    .slice(0, MAX_DESKTOP_WINDOWS);
+}
+
+export function fitWindowBoundsToWorkArea(
+  bounds: DesktopWindowBounds,
+  workArea: DesktopWindowBounds,
+): DesktopWindowBounds {
+  const width = clamp(
+    Math.round(bounds.width),
+    MIN_DESKTOP_WINDOW_WIDTH,
+    Math.max(MIN_DESKTOP_WINDOW_WIDTH, workArea.width),
+  );
+  const height = clamp(
+    Math.round(bounds.height),
+    MIN_DESKTOP_WINDOW_HEIGHT,
+    Math.max(MIN_DESKTOP_WINDOW_HEIGHT, workArea.height),
+  );
+  const maxX = workArea.x + workArea.width - width;
+  const maxY = workArea.y + workArea.height - height;
+  const overlaps = rectanglesOverlap(bounds, workArea);
+
+  return {
+    x: overlaps
+      ? clamp(Math.round(bounds.x), workArea.x, Math.max(workArea.x, maxX))
+      : workArea.x + Math.round((workArea.width - width) / 2),
+    y: overlaps
+      ? clamp(Math.round(bounds.y), workArea.y, Math.max(workArea.y, maxY))
+      : workArea.y + Math.round((workArea.height - height) / 2),
+    width,
+    height,
+  };
+}
+
+export function offsetWindowBounds(
+  bounds: DesktopWindowBounds,
+  offset = NEW_WINDOW_OFFSET,
+): DesktopWindowBounds {
+  return {
+    x: bounds.x + offset,
+    y: bounds.y + offset,
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+export function getDesktopUnreadBadgeCount(counts: Iterable<number>): number {
+  let max = 0;
+  for (const count of counts) {
+    if (Number.isSafeInteger(count) && count > max) max = count;
+  }
+  return max;
+}
+
+export function shouldReuseSoleHiddenWindow(
+  windowCount: number,
+  visibleCount: number,
+): boolean {
+  return windowCount === 1 && visibleCount === 0;
+}
+
+function parseDesktopWindowState(
+  raw: unknown,
+  appOrigin: string,
+): DesktopWindowState | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  if (!("url" in raw) || typeof raw.url !== "string") return null;
+  if (!shouldPersistDesktopUrl(raw.url, appOrigin)) return null;
+
+  const bounds = parseDesktopWindowBounds(
+    "bounds" in raw ? raw.bounds : undefined,
+  );
+  if (!bounds) return null;
+
+  return {
+    url: raw.url,
+    bounds,
+    isMaximized: "isMaximized" in raw && raw.isMaximized === true,
+  };
+}
+
+function parseDesktopWindowBounds(raw: unknown): DesktopWindowBounds | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const x = readFiniteNumber(raw, "x");
+  const y = readFiniteNumber(raw, "y");
+  const width = readFiniteNumber(raw, "width");
+  const height = readFiniteNumber(raw, "height");
+  if (x === null || y === null || width === null || height === null) {
+    return null;
+  }
+  if (width < MIN_DESKTOP_WINDOW_WIDTH || height < MIN_DESKTOP_WINDOW_HEIGHT) {
+    return null;
+  }
+  return { x, y, width, height };
+}
+
+function readFiniteNumber(raw: object, key: string): number | null {
+  if (!(key in raw)) return null;
+  const value = (raw as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function rectanglesOverlap(
+  left: DesktopWindowBounds,
+  right: DesktopWindowBounds,
+): boolean {
+  return (
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/apps/desktop/src/windows.ts
+++ b/apps/desktop/src/windows.ts
@@ -1,14 +1,10 @@
-import {
-  getDesktopSessionRestoreUrl,
-  shouldPersistDesktopUrl,
-} from "./desktop";
+import { getDesktopSessionRestoreUrl } from "./desktop";
 
 export const DEFAULT_DESKTOP_WINDOW_WIDTH = 1280;
 export const DEFAULT_DESKTOP_WINDOW_HEIGHT = 840;
 export const MIN_DESKTOP_WINDOW_WIDTH = 900;
 export const MIN_DESKTOP_WINDOW_HEIGHT = 640;
 export const MAX_DESKTOP_WINDOWS = 8;
-export const NEW_WINDOW_OFFSET = 28;
 
 export type DesktopWindowBounds = {
   x: number;
@@ -19,8 +15,8 @@ export type DesktopWindowBounds = {
 
 export type DesktopWindowState = {
   url: string;
-  bounds: DesktopWindowBounds;
-  isMaximized: boolean;
+  bounds?: DesktopWindowBounds;
+  isMaximized?: boolean;
 };
 
 export function parseDesktopWindowStates(
@@ -31,53 +27,11 @@ export function parseDesktopWindowStates(
 
   const states: DesktopWindowState[] = [];
   for (const item of raw) {
-    if (states.length >= MAX_DESKTOP_WINDOWS) break;
     const state = parseDesktopWindowState(item, appOrigin);
     if (state) states.push(state);
+    if (states.length >= MAX_DESKTOP_WINDOWS) break;
   }
   return states;
-}
-
-export function getRestoredDesktopWindows(
-  states: readonly DesktopWindowState[],
-  appOrigin: string,
-): DesktopWindowState[] {
-  const restored: DesktopWindowState[] = [];
-  for (const state of states) {
-    if (restored.length >= MAX_DESKTOP_WINDOWS) break;
-    const url = getDesktopSessionRestoreUrl(appOrigin, state.url);
-    if (url) restored.push({ ...state, url });
-  }
-  return restored;
-}
-
-export function getLegacyDesktopWindowStates(
-  lastAppUrl: string | null,
-  appOrigin: string,
-): DesktopWindowState[] {
-  const url = getDesktopSessionRestoreUrl(appOrigin, lastAppUrl);
-  if (!url) return [];
-  return [
-    {
-      url,
-      bounds: {
-        x: 0,
-        y: 0,
-        width: DEFAULT_DESKTOP_WINDOW_WIDTH,
-        height: DEFAULT_DESKTOP_WINDOW_HEIGHT,
-      },
-      isMaximized: false,
-    },
-  ];
-}
-
-export function collectDesktopWindowStates(
-  windows: readonly DesktopWindowState[],
-  appOrigin: string,
-): DesktopWindowState[] {
-  return windows
-    .filter((window) => shouldPersistDesktopUrl(window.url, appOrigin))
-    .slice(0, MAX_DESKTOP_WINDOWS);
 }
 
 export function fitWindowBoundsToWorkArea(
@@ -110,72 +64,43 @@ export function fitWindowBoundsToWorkArea(
   };
 }
 
-export function offsetWindowBounds(
-  bounds: DesktopWindowBounds,
-  offset = NEW_WINDOW_OFFSET,
-): DesktopWindowBounds {
-  return {
-    x: bounds.x + offset,
-    y: bounds.y + offset,
-    width: bounds.width,
-    height: bounds.height,
-  };
-}
-
-export function getDesktopUnreadBadgeCount(counts: Iterable<number>): number {
-  let max = 0;
-  for (const count of counts) {
-    if (Number.isSafeInteger(count) && count > max) max = count;
-  }
-  return max;
-}
-
-export function shouldReuseSoleHiddenWindow(
-  windowCount: number,
-  visibleCount: number,
-): boolean {
-  return windowCount === 1 && visibleCount === 0;
-}
-
 function parseDesktopWindowState(
   raw: unknown,
   appOrigin: string,
 ): DesktopWindowState | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  if (!("url" in raw) || typeof raw.url !== "string") return null;
-  if (!shouldPersistDesktopUrl(raw.url, appOrigin)) return null;
+  if (!isRecord(raw) || typeof raw.url !== "string") return null;
+  const url = getDesktopSessionRestoreUrl(appOrigin, raw.url);
+  if (!url) return null;
 
-  const bounds = parseDesktopWindowBounds(
-    "bounds" in raw ? raw.bounds : undefined,
-  );
+  if (!("bounds" in raw)) return { url, isMaximized: raw.isMaximized === true };
+
+  const bounds = parseDesktopWindowBounds(raw.bounds);
   if (!bounds) return null;
-
-  return {
-    url: raw.url,
-    bounds,
-    isMaximized: "isMaximized" in raw && raw.isMaximized === true,
-  };
+  return { url, bounds, isMaximized: raw.isMaximized === true };
 }
 
 function parseDesktopWindowBounds(raw: unknown): DesktopWindowBounds | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const x = readFiniteNumber(raw, "x");
-  const y = readFiniteNumber(raw, "y");
-  const width = readFiniteNumber(raw, "width");
-  const height = readFiniteNumber(raw, "height");
-  if (x === null || y === null || width === null || height === null) {
-    return null;
-  }
-  if (width < MIN_DESKTOP_WINDOW_WIDTH || height < MIN_DESKTOP_WINDOW_HEIGHT) {
+  if (!isRecord(raw)) return null;
+  const { x, y, width, height } = raw;
+  if (
+    !isFiniteNumber(x) ||
+    !isFiniteNumber(y) ||
+    !isFiniteNumber(width) ||
+    !isFiniteNumber(height) ||
+    width < MIN_DESKTOP_WINDOW_WIDTH ||
+    height < MIN_DESKTOP_WINDOW_HEIGHT
+  ) {
     return null;
   }
   return { x, y, width, height };
 }
 
-function readFiniteNumber(raw: object, key: string): number | null {
-  if (!(key in raw)) return null;
-  const value = (raw as Record<string, unknown>)[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 function rectanglesOverlap(

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -32,10 +32,7 @@ import {
   getShortcutHint,
 } from "@/lib/shortcuts/registry";
 import { getMailAccountUrl } from "@/app/(app)/[emailAccountId]/mail/mail-account-url";
-import {
-  getInboxZeroDesktopApp,
-  shouldOpenDesktopAccountInNewWindow,
-} from "@/utils/desktop-app";
+import { getInboxZeroDesktopApp } from "@/utils/desktop-app";
 import { cn } from "@/utils";
 
 export function MailAccountSwitcher({
@@ -163,22 +160,9 @@ export function MailAccountSwitcher({
           {data.emailAccounts.map((account, index) => (
             <AccountItem
               account={account}
+              isDesktopApp={isDesktopApp}
               key={account.id}
               onSelect={onSelectAccount}
-              onOpenInNewWindow={
-                isDesktopApp
-                  ? (accountId) => {
-                      const openWindow = getInboxZeroDesktopApp()?.openWindow;
-                      if (openWindow) {
-                        openWindow(getMailAccountUrl(accountId, "")).catch(
-                          () => {},
-                        );
-                        return;
-                      }
-                      onSelectAccount(accountId);
-                    }
-                  : undefined
-              }
               shortcutKey={
                 isDesktopApp
                   ? getShortcut("switchAccount").keys[index]
@@ -212,22 +196,25 @@ export function MailAccountSwitcher({
 
 function AccountItem({
   account,
+  isDesktopApp,
   onSelect,
-  onOpenInNewWindow,
   shortcutKey,
 }: {
   account: GetEmailAccountsResponse["emailAccounts"][number];
+  isDesktopApp: boolean;
   onSelect: (accountId: string) => void;
-  onOpenInNewWindow?: (accountId: string) => void;
   shortcutKey: string | undefined;
 }) {
   return (
     <DropdownMenuItem
       className="gap-3 rounded-xl p-3"
       onSelect={(event) => {
-        if (onOpenInNewWindow && shouldOpenDesktopAccountInNewWindow(event)) {
-          onOpenInNewWindow(account.id);
-          return;
+        if (isDesktopApp && isDesktopNewWindowClick(event)) {
+          const openWindow = getInboxZeroDesktopApp()?.openWindow;
+          if (openWindow) {
+            openWindow(getMailAccountUrl(account.id, "")).catch(() => {});
+            return;
+          }
         }
         onSelect(account.id);
       }}
@@ -266,5 +253,12 @@ function AllAccountsIcon() {
       <span className="size-2 rounded-full bg-violet-500" />
       <span className="size-2 rounded-full bg-emerald-500" />
     </span>
+  );
+}
+
+function isDesktopNewWindowClick(event: Event) {
+  return (
+    ("metaKey" in event && event.metaKey === true) ||
+    ("ctrlKey" in event && event.ctrlKey === true)
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/MailAccountSwitcher.tsx
@@ -31,6 +31,11 @@ import {
   getShortcut,
   getShortcutHint,
 } from "@/lib/shortcuts/registry";
+import { getMailAccountUrl } from "@/app/(app)/[emailAccountId]/mail/mail-account-url";
+import {
+  getInboxZeroDesktopApp,
+  shouldOpenDesktopAccountInNewWindow,
+} from "@/utils/desktop-app";
 import { cn } from "@/utils";
 
 export function MailAccountSwitcher({
@@ -160,6 +165,20 @@ export function MailAccountSwitcher({
               account={account}
               key={account.id}
               onSelect={onSelectAccount}
+              onOpenInNewWindow={
+                isDesktopApp
+                  ? (accountId) => {
+                      const openWindow = getInboxZeroDesktopApp()?.openWindow;
+                      if (openWindow) {
+                        openWindow(getMailAccountUrl(accountId, "")).catch(
+                          () => {},
+                        );
+                        return;
+                      }
+                      onSelectAccount(accountId);
+                    }
+                  : undefined
+              }
               shortcutKey={
                 isDesktopApp
                   ? getShortcut("switchAccount").keys[index]
@@ -194,16 +213,24 @@ export function MailAccountSwitcher({
 function AccountItem({
   account,
   onSelect,
+  onOpenInNewWindow,
   shortcutKey,
 }: {
   account: GetEmailAccountsResponse["emailAccounts"][number];
   onSelect: (accountId: string) => void;
+  onOpenInNewWindow?: (accountId: string) => void;
   shortcutKey: string | undefined;
 }) {
   return (
     <DropdownMenuItem
       className="gap-3 rounded-xl p-3"
-      onSelect={() => onSelect(account.id)}
+      onSelect={(event) => {
+        if (onOpenInNewWindow && shouldOpenDesktopAccountInNewWindow(event)) {
+          onOpenInNewWindow(account.id);
+          return;
+        }
+        onSelect(account.id);
+      }}
     >
       <ProfileImage
         className="size-10"

--- a/apps/web/utils/desktop-app.test.ts
+++ b/apps/web/utils/desktop-app.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS,
   shouldCheckForDesktopWebUpdate,
-  shouldOpenDesktopAccountInNewWindow,
 } from "./desktop-app";
 
 describe("shouldCheckForDesktopWebUpdate", () => {
@@ -81,14 +80,5 @@ describe("shouldCheckForDesktopWebUpdate", () => {
         now,
       }),
     ).toBe(true);
-  });
-});
-
-describe("shouldOpenDesktopAccountInNewWindow", () => {
-  it("opens a new window only for modifier clicks", () => {
-    expect(shouldOpenDesktopAccountInNewWindow({ metaKey: true })).toBe(true);
-    expect(shouldOpenDesktopAccountInNewWindow({ ctrlKey: true })).toBe(true);
-    expect(shouldOpenDesktopAccountInNewWindow({ metaKey: false })).toBe(false);
-    expect(shouldOpenDesktopAccountInNewWindow({})).toBe(false);
   });
 });

--- a/apps/web/utils/desktop-app.test.ts
+++ b/apps/web/utils/desktop-app.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS,
   shouldCheckForDesktopWebUpdate,
+  shouldOpenDesktopAccountInNewWindow,
 } from "./desktop-app";
 
 describe("shouldCheckForDesktopWebUpdate", () => {
@@ -80,5 +81,14 @@ describe("shouldCheckForDesktopWebUpdate", () => {
         now,
       }),
     ).toBe(true);
+  });
+});
+
+describe("shouldOpenDesktopAccountInNewWindow", () => {
+  it("opens a new window only for modifier clicks", () => {
+    expect(shouldOpenDesktopAccountInNewWindow({ metaKey: true })).toBe(true);
+    expect(shouldOpenDesktopAccountInNewWindow({ ctrlKey: true })).toBe(true);
+    expect(shouldOpenDesktopAccountInNewWindow({ metaKey: false })).toBe(false);
+    expect(shouldOpenDesktopAccountInNewWindow({})).toBe(false);
   });
 });

--- a/apps/web/utils/desktop-app.ts
+++ b/apps/web/utils/desktop-app.ts
@@ -46,10 +46,3 @@ export function shouldCheckForDesktopWebUpdate({
     now - lastCheckedAt >= DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS
   );
 }
-
-export function shouldOpenDesktopAccountInNewWindow(event: {
-  metaKey?: boolean;
-  ctrlKey?: boolean;
-}): boolean {
-  return event.metaKey === true || event.ctrlKey === true;
-}

--- a/apps/web/utils/desktop-app.ts
+++ b/apps/web/utils/desktop-app.ts
@@ -8,6 +8,7 @@ export type InboxZeroDesktopApi = {
     emailAccountId: string;
     messages: { id: string; receivedAt: number }[];
   }) => void;
+  openWindow?: (path: string) => Promise<void>;
   startAuth: (
     provider: DesktopAuthProvider,
     options?: { callbackPath?: string },
@@ -44,4 +45,11 @@ export function shouldCheckForDesktopWebUpdate({
     now < lastCheckedAt ||
     now - lastCheckedAt >= DESKTOP_WEB_UPDATE_CHECK_INTERVAL_MS
   );
+}
+
+export function shouldOpenDesktopAccountInNewWindow(event: {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+}): boolean {
+  return event.metaKey === true || event.ctrlKey === true;
 }


### PR DESCRIPTION
desktop: Open mailboxes in multiple windows

The desktop shell can keep more than one mailbox window open, so different accounts can stay side by side.

- File → New Window (⌘N / Ctrl+N) opens another window; ⌘/Ctrl-click an account to open that inbox in its own window
- Window positions and mailbox URLs are restored on relaunch
- Notifications focus a window already showing that account, or open one if needed

## Test plan
- [ ] File → New Window opens a second mailbox without replacing the first
- [ ] ⌘-click (Mac) or Ctrl-click (Windows) an account in the switcher opens that inbox in a new window
- [ ] Closing extra windows leaves the others open; the last Mac window still hides instead of quitting
- [ ] Relaunch restores the previous windows and accounts
- [ ] Clicking a new-mail notification focuses the matching account window

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple desktop windows.
  - Open a new window with File → New Window or ⌘N/Ctrl+N.
  - Open an account in a separate window with ⌘/Ctrl-click.
  - Restore open windows, account selection, sizes, and maximized state after relaunch.
  - New-mail notifications focus or open the relevant account window.

- **Bug Fixes**
  - Improved window bounds restoration across displays.
  - Unread indicators are synchronized across all open windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->