### PR TITLE
command-k: Add Go to Mail navigation

### DIFF
--- a/apps/web/__tests__/playwright/emulated/settings/settings-dialog.spec.ts
+++ b/apps/web/__tests__/playwright/emulated/settings/settings-dialog.spec.ts
@@ -77,3 +77,24 @@ for (const view of ["mail", "settings"]) {
     await expect(page).not.toHaveURL(/settings=open/);
   });
 }
+
+test("opens mail from Command K", async ({ page }, testInfo) => {
+  const { id: emailAccountId } = await getEmailAccount(page);
+  await page.goto("/settings");
+  await expect(
+    page.getByRole("heading", { name: "Settings", exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.press(`${modifier}+KeyK`);
+  const search = page.getByPlaceholder("Type a command or search...");
+  await expect(search).toBeVisible();
+  await search.fill("go to mail");
+  await page.getByRole("option", { name: "Go to Mail", exact: true }).click();
+
+  await expect(page).toHaveURL(new RegExp(`/${emailAccountId}/mail$`));
+  await expect(
+    page.getByRole("listbox", { name: "Conversations" }),
+  ).toBeVisible({ timeout: 60_000 });
+  await capturePlaywrightCheckpoint(page, testInfo, "command-k-go-to-mail");
+});

--- a/apps/web/hooks/useCommandPaletteCommands.ts
+++ b/apps/web/hooks/useCommandPaletteCommands.ts
@@ -14,6 +14,7 @@ import {
   FileTextIcon,
   BrushIcon,
   ZapIcon,
+  InboxIcon,
   MailsIcon,
 } from "lucide-react";
 import type { Command } from "@/lib/commands/types";
@@ -62,6 +63,12 @@ export function useCommandPaletteCommands({
     if (!enabled) return generalSettingsCommands;
 
     const navigationItems = [
+      {
+        name: "Mail",
+        href: prefixPath(emailAccountId, "/mail"),
+        icon: InboxIcon,
+        keywords: ["mail", "inbox", "email"],
+      },
       {
         name: "Assistant",
         href: prefixPath(emailAccountId, "/automation"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
command-k: Add Go to Mail navigation

Add a Command K option that routes to the account mailbox so users can reach `/mail` from any app page.

- Adds a Navigation command labeled **Go to Mail** that pushes `/{emailAccountId}/mail`
- Search keywords include mail, inbox, and email
- Playwright coverage from Settings: Command K → Go to Mail → mailbox conversations

Performance: no extra network or database work. This is a static Command K navigation entry that calls the existing router.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49783496-9b10-46bb-a56d-b1ed4be1d895?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49783496-9b10-46bb-a56d-b1ed4be1d895&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Mail navigation option to the Command K command palette.
  - Users can search for “mail,” “inbox,” or “email” to open their mail view.

- **Tests**
  - Added coverage verifying that Mail navigation works from the Settings page and displays the conversations list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->