### PR TITLE
security: upgrade linkify-it to 5.0.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -171,7 +171,7 @@
     "jose": "6.2.3",
     "jotai": "2.20.2",
     "jsonrepair": "3.15.0",
-    "linkify-it": "5.0.1",
+    "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "lucide-react": "1.44.0",
     "mammoth": "1.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   ioredis: 5.10.1
   js-yaml: 3.14.2
   jws: 4.0.1
-  linkify-it: 5.0.1
+  linkify-it: 5.0.2
   lodash: 4.18.1
   next: 16.3.4
   postcss: 8.5.14
@@ -519,8 +519,8 @@ importers:
         specifier: 3.15.0
         version: 3.15.0
       linkify-it:
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: 5.0.2
+        version: 5.0.2
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -9667,8 +9667,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
@@ -22602,7 +22602,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -22758,7 +22758,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ overrides:
   ioredis: "5.10.1"
   js-yaml: "3.14.2"
   jws: "4.0.1"
-  linkify-it: "5.0.1"
+  linkify-it: "5.0.2"
   lodash: "4.18.1"
   next: "16.3.4"
   postcss: "8.5.14"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch CVE-2026-59887 (`SNYK-JS-LINKIFYIT-17901217`), the remaining Snyk finding from #3555.

- Bump `linkify-it` from `5.0.1` to `5.0.2` in `apps/web/package.json`
- Align the workspace override in `pnpm-workspace.yaml` so transitive `markdown-it` usage cannot stay on `5.0.1`
- Refresh `pnpm-lock.yaml`

The four `undici` issues in #3555 are already on `main` (`8.10.2` via #3651). This PR supersedes #3555, which never updated the lockfile and cannot merge cleanly.

#3555 will be closed in favor of this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-363e348a-7802-4822-8294-8cdb5ccce6e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-363e348a-7802-4822-8294-8cdb5ccce6e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the link detection component to version 5.0.2 for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->